### PR TITLE
Implement LLM adapter and dynamic agents

### DIFF
--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -38,7 +38,8 @@ class AgentConfig(BaseModel):
 class ConfigModel(BaseSettings):
     """Main configuration model with validation."""
     # Core settings
-    backend: str = Field(default="lmstudio")
+    backend: str = Field(default="lmstudio")  # backward compatibility
+    llm_backend: str = Field(default="lmstudio")
     loops: int = Field(default=2, ge=1)
     ram_budget_mb: int = Field(default=1024, ge=0)
     agents: List[str] = Field(default=["Synthesizer", "Contrarian", "FactChecker"])
@@ -137,6 +138,9 @@ class ConfigLoader:
 
         # Extract core settings
         core_settings = raw.get("core", {})
+        # Map legacy `backend` to `llm_backend` if provided
+        if "backend" in core_settings and "llm_backend" not in core_settings:
+            core_settings["llm_backend"] = core_settings["backend"]
 
         # Handle storage settings
         storage_cfg = raw.get("storage", {})

--- a/src/autoresearch/llm/__init__.py
+++ b/src/autoresearch/llm/__init__.py
@@ -1,0 +1,16 @@
+from .registry import LLMFactory, get_llm_adapter
+from .adapters import LLMAdapter, DummyAdapter, LMStudioAdapter, OpenAIAdapter
+
+# Register default backends
+LLMFactory.register("dummy", DummyAdapter)
+LLMFactory.register("lmstudio", LMStudioAdapter)
+LLMFactory.register("openai", OpenAIAdapter)
+
+__all__ = [
+    "LLMAdapter",
+    "LLMFactory",
+    "get_llm_adapter",
+    "DummyAdapter",
+    "LMStudioAdapter",
+    "OpenAIAdapter",
+]

--- a/src/autoresearch/llm/adapters.py
+++ b/src/autoresearch/llm/adapters.py
@@ -1,0 +1,53 @@
+"""LLM adapter implementations for various backends."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+import requests
+
+
+class LLMAdapter(ABC):
+    """Abstract LLM adapter interface."""
+
+    @abstractmethod
+    def generate(self, prompt: str, model: str | None = None, **kwargs: Any) -> str:
+        """Generate text from the given prompt using the specified model."""
+
+
+class DummyAdapter(LLMAdapter):
+    """Simple adapter used for testing."""
+
+    def generate(self, prompt: str, model: str | None = None, **kwargs: Any) -> str:
+        return f"Dummy response for {prompt}"
+
+
+class LMStudioAdapter(LLMAdapter):
+    """Adapter for the LM Studio local API."""
+
+    endpoint: str = "http://localhost:1234/v1/chat/completions"
+
+    def generate(self, prompt: str, model: str | None = None, **kwargs: Any) -> str:
+        payload = {
+            "model": model or "lmstudio",
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        try:
+            resp = requests.post(self.endpoint, json=payload, timeout=30)
+            resp.raise_for_status()
+            data: Dict[str, Any] = resp.json()
+            return data.get("choices", [{}])[0].get("message", {}).get("content", "")
+        except Exception as exc:  # pragma: no cover - network errors
+            return f"Error: {exc}"
+
+
+class OpenAIAdapter(LLMAdapter):
+    """Adapter for the OpenAI API."""
+
+    def generate(self, prompt: str, model: str | None = None, **kwargs: Any) -> str:
+        import openai
+
+        response = openai.ChatCompletion.create(
+            model=model or "gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message["content"]

--- a/src/autoresearch/llm/registry.py
+++ b/src/autoresearch/llm/registry.py
@@ -1,0 +1,31 @@
+"""Registry and factory for LLM adapters."""
+from __future__ import annotations
+
+from typing import Dict, Type
+from threading import Lock
+
+from .adapters import LLMAdapter
+
+
+class LLMFactory:
+    """Factory to register and retrieve LLM adapters."""
+
+    _registry: Dict[str, Type[LLMAdapter]] = {}
+    _lock = Lock()
+
+    @classmethod
+    def register(cls, name: str, adapter_cls: Type[LLMAdapter]) -> None:
+        with cls._lock:
+            cls._registry[name] = adapter_cls
+
+    @classmethod
+    def get(cls, name: str) -> LLMAdapter:
+        with cls._lock:
+            if name not in cls._registry:
+                raise ValueError(f"Unknown LLM backend: {name}")
+            return cls._registry[name]()
+
+
+def get_llm_adapter(name: str) -> LLMAdapter:
+    """Convenience wrapper to fetch adapter instance."""
+    return LLMFactory.get(name)

--- a/tests/unit/test_agents_llm.py
+++ b/tests/unit/test_agents_llm.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch
+
+from autoresearch.agents.dialectical.synthesizer import SynthesizerAgent
+from autoresearch.agents.dialectical.contrarian import ContrarianAgent
+from autoresearch.agents.dialectical.fact_checker import FactChecker
+from autoresearch.orchestration.state import QueryState
+from autoresearch.config import ConfigModel
+
+
+class MockAdapter:
+    def generate(self, prompt: str, model: str | None = None, **kwargs):
+        return f"mocked:{prompt}"
+
+
+@patch("autoresearch.agents.dialectical.synthesizer.get_llm_adapter")
+def test_synthesizer_dynamic(mock_get):
+    mock_get.return_value = MockAdapter()
+    state = QueryState(query="q")
+    cfg = ConfigModel()
+    agent = SynthesizerAgent(name="Synthesizer")
+    result = agent.execute(state, cfg)
+    assert result["claims"][0]["content"].startswith("mocked:")
+
+
+@patch("autoresearch.agents.dialectical.contrarian.get_llm_adapter")
+def test_contrarian_dynamic(mock_get):
+    mock_get.return_value = MockAdapter()
+    state = QueryState(query="q", claims=[{"id": "1", "type": "thesis", "content": "a"}])
+    cfg = ConfigModel()
+    agent = ContrarianAgent(name="Contrarian")
+    result = agent.execute(state, cfg)
+    assert result["claims"][0]["type"] == "antithesis"
+    assert result["claims"][0]["content"].startswith("mocked:")
+
+
+@patch("autoresearch.agents.dialectical.fact_checker.get_llm_adapter")
+@patch("autoresearch.agents.dialectical.fact_checker.Search.external_lookup")
+def test_fact_checker_sources(mock_search, mock_get):
+    mock_get.return_value = MockAdapter()
+    mock_search.return_value = [{"title": "t", "url": "u"}]
+    state = QueryState(query="q", claims=[{"id": "1", "type": "thesis", "content": "a"}])
+    cfg = ConfigModel()
+    agent = FactChecker(name="FactChecker")
+    result = agent.execute(state, cfg)
+    assert result["sources"][0]["checked_claims"] == ["1"]
+    assert result["metadata"]["source_count"] == 1

--- a/tests/unit/test_llm_adapter.py
+++ b/tests/unit/test_llm_adapter.py
@@ -1,0 +1,8 @@
+from autoresearch.llm import get_llm_adapter, DummyAdapter
+
+
+def test_dummy_adapter_generation():
+    adapter = get_llm_adapter("dummy")
+    assert isinstance(adapter, DummyAdapter)
+    result = adapter.generate("test prompt")
+    assert "Dummy response" in result


### PR DESCRIPTION
## Summary
- add new LLM adapter interface with LM Studio, OpenAI, and dummy implementations
- update dialectical agents to call the adapter
- capture source metadata in FactChecker
- extend configuration with `llm_backend`
- add unit tests with mocked LLM calls

## Testing
- `flake8 src tests`
- `mypy src` *(fails: missing stubs, parsing errors)*
- `pytest -q` *(fails: ModuleNotFoundError / duckdb ParserError)*
- `pytest tests/behavior -q` *(fails: duckdb ParserError)*

------
https://chatgpt.com/codex/tasks/task_e_6848b53502408333bfb470ab05bebcff