### PR TITLE
Add config watcher to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Send a request once the server is running:
 curl -X POST http://localhost:8000/query -d '{"query": "explain machine learning"}' -H "Content-Type: application/json"
 ```
 
+### Configuration hot reload
+
+When you run any CLI command, Autoresearch starts watching `autoresearch.toml`
+and `.env` for changes. Updates to these files are picked up automatically and
+the configuration is reloaded on the fly. The watcher shuts down gracefully when
+the process exits.
+
 For a detailed breakdown of the requirements and architecture, see
 [docs/requirements.md](docs/requirements.md) and
 [docs/specification.md](docs/specification.md).


### PR DESCRIPTION
## Summary
- watch configuration files when the CLI starts
- stop watcher on process exit
- document config hot reloading

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Need type annotation for "structure"; ModuleNotFoundError for libraries, etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru', ParserException: syntax error in tests)*
- `pytest tests/behavior -q` *(fails: ParserException: syntax error in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6848b8785bac83339a68baa10bbc3e01