### PR TITLE
Add docs structure and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,14 @@ poetry run mypy src
 poetry run pytest
 poetry run pytest tests/behavior
 ```
+
+## Building the documentation
+
+Install MkDocs and generate the static site:
+
+```bash
+pip install mkdocs
+mkdocs build
+```
+
+Use `mkdocs serve` to preview the documentation locally.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,9 @@
+# Agents
+
+Autoresearch orchestrates multiple agents in a dialectical cycle. The default roster includes:
+
+- **Synthesizer** – proposes initial answers.
+- **Contrarian** – challenges assumptions and provides counter arguments.
+- **Fact Checker** – verifies claims against reliable sources.
+
+Agents communicate via a shared state object and can be customized in `autoresearch.toml`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,13 @@
+# API Usage
+
+The HTTP API is served via FastAPI. Start the server with Uvicorn:
+
+```bash
+uvicorn autoresearch.api:app --reload
+```
+
+Once running you can send a POST request:
+
+```bash
+curl -X POST http://localhost:8000/query -d '{"query": "explain machine learning"}' -H "Content-Type: application/json"
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,12 @@
+# Configuration
+
+Autoresearch is configured via `autoresearch.toml` and environment variables in `.env`. Changes to these files are detected automatically while the tool is running and the configuration is hot reloaded.
+
+## Example
+
+```toml
+[llm]
+provider = "openai"
+```
+
+See `src/autoresearch/config.py` for all available options.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,13 @@
+# Contributing
+
+We welcome contributions via pull requests. To get started, install the development dependencies and run the tests:
+
+```bash
+poetry install --with dev
+poetry run flake8 src tests
+poetry run mypy src
+poetry run pytest
+poetry run pytest tests/behavior
+```
+
+Please keep commits focused and descriptive.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,25 @@
+# Getting Started
+
+This guide walks you through installing the project dependencies and running your first search.
+
+## Installation
+
+Use `poetry install` to set up a development environment:
+
+```bash
+poetry install
+```
+
+Alternatively install via pip:
+
+```bash
+pip install -e .
+```
+
+## First search
+
+Run a search from the command line:
+
+```bash
+autoresearch search "What is quantum computing?"
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,14 @@
+site_name: Autoresearch
+nav:
+  - Getting Started: docs/getting_started.md
+  - Configuration: docs/configuration.md
+  - Agents: docs/agents.md
+  - API Usage: docs/api.md
+  - Contributing: docs/contributing.md
+  - Requirements: docs/requirements.md
+  - Specification: docs/specification.md
+  - Plan: docs/plan.md
+  - Pseudocode: docs/pseudocode.md
+  - Requirements Tracability Matrix: docs/requirements_tracability_matrix.md
+markdown_extensions:
+  - toc


### PR DESCRIPTION
## Summary
- document how to build the documentation with mkdocs
- create starter docs for Getting Started, Configuration, Agents, API usage and Contributing
- configure mkdocs navigation and site name

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: incompatible types, missing stubs)*
- `poetry run pytest -q`
- `poetry run pytest tests/behavior`

------
https://chatgpt.com/codex/tasks/task_e_6848f49832bc83339767d4bc50c9fc5e