### PR TITLE
Refactor storage initialization for tests

### DIFF
--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -2,28 +2,64 @@
 Hybrid DKG persistence: NetworkX, DuckDB, RDFLib.
 """
 import os
-import networkx as nx
-import duckdb
-import rdflib
 from threading import Lock
+from typing import Optional
 
-# Initialize persistent components
-_graph = nx.DiGraph()
-_db_path = os.getenv("DUCKDB_PATH", "kg.duckdb")
-_db_conn = duckdb.connect(_db_path)
-_rdf_store = rdflib.Graph()
+import duckdb
+import networkx as nx
+import rdflib
+
+# Global containers initialised in `setup`
+_graph: Optional[nx.DiGraph] = None
+_db_path: Optional[str] = None
+_db_conn: Optional[duckdb.DuckDBPyConnection] = None
+_rdf_store: Optional[rdflib.Graph] = None
 _lock = Lock()
 
-# Ensure required DuckDB tables exist
-_db_conn.execute("CREATE TABLE IF NOT EXISTS nodes(id VARCHAR, type VARCHAR, content VARCHAR, conf DOUBLE, ts TIMESTAMP)")
-_db_conn.execute("CREATE TABLE IF NOT EXISTS edges(src VARCHAR, dst VARCHAR, rel VARCHAR, w DOUBLE)")
-_db_conn.execute("CREATE TABLE IF NOT EXISTS embeddings(node_id VARCHAR, embedding LIST<DOUBLE>)")
+
+def setup(db_path: Optional[str] = None) -> None:
+    """Initialise storage components if not already initialised."""
+    global _graph, _db_path, _db_conn, _rdf_store
+    with _lock:
+        if _db_conn is not None:
+            return
+
+        _graph = nx.DiGraph()
+        _db_path = db_path or os.getenv("DUCKDB_PATH", "kg.duckdb")
+        _db_conn = duckdb.connect(_db_path)
+        _rdf_store = rdflib.Graph()
+
+        # Ensure required tables exist
+        _db_conn.execute(
+            "CREATE TABLE IF NOT EXISTS nodes(id VARCHAR, type VARCHAR, content VARCHAR, conf DOUBLE, ts TIMESTAMP)"
+        )
+        _db_conn.execute(
+            "CREATE TABLE IF NOT EXISTS edges(src VARCHAR, dst VARCHAR, rel VARCHAR, w DOUBLE)"
+        )
+        _db_conn.execute(
+            "CREATE TABLE IF NOT EXISTS embeddings(node_id VARCHAR, embedding DOUBLE[])"
+        )
+
+
+def teardown(remove_db: bool = False) -> None:
+    """Close connections and optionally remove the DuckDB file."""
+    global _graph, _db_path, _db_conn, _rdf_store
+    with _lock:
+        if _db_conn is not None:
+            _db_conn.close()
+        if remove_db and _db_path and os.path.exists(_db_path):
+            os.remove(_db_path)
+        _graph = None
+        _db_conn = None
+        _rdf_store = None
 
 class StorageManager:
     @staticmethod
     def persist_claim(claim: dict):
         """Persist claim to NetworkX, DuckDB, and RDFLib."""
         with _lock:
+            if _db_conn is None:
+                setup()
             # NetworkX
             _graph.add_node(claim['id'], **claim.get('attributes', {}))
             for rel in claim.get('relations', []):
@@ -32,17 +68,27 @@ class StorageManager:
             # insert node row
             _db_conn.execute(
                 "INSERT INTO nodes VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
-                [claim['id'], claim.get('type',''), claim.get('content',''), claim.get('confidence',0.0)]
+                [
+                    claim['id'],
+                    claim.get('type', ''),
+                    claim.get('content', ''),
+                    claim.get('confidence', 0.0),
+                ]
             )
             # insert edges
             for rel in claim.get('relations', []):
                 _db_conn.execute(
                     "INSERT INTO edges VALUES (?, ?, ?, ?)",
-                    [rel['src'], rel['dst'], rel.get('rel',''), rel.get('weight',1.0)]
+                    [
+                        rel['src'],
+                        rel['dst'],
+                        rel.get('rel', ''),
+                        rel.get('weight', 1.0),
+                    ]
                 )
             # insert embedding
             embedding = claim.get('embedding')
-            if embedding:
+            if embedding is not None:
                 _db_conn.execute(
                     "INSERT INTO embeddings VALUES (?, ?)",
                     [claim['id'], embedding]
@@ -56,22 +102,38 @@ class StorageManager:
 
     @staticmethod
     def get_graph():
-        return _graph
+        with _lock:
+            if _graph is None:
+                setup()
+            return _graph
 
     @staticmethod
     def get_duckdb_conn():
-        return _db_conn
+        with _lock:
+            if _db_conn is None:
+                setup()
+            return _db_conn
 
     @staticmethod
     def get_rdf_store():
-        return _rdf_store
+        with _lock:
+            if _rdf_store is None:
+                setup()
+            return _rdf_store
 
     @staticmethod
     def clear_all():
         with _lock:
-            _graph.clear()
-            _db_conn.execute("DELETE FROM nodes")
-            _db_conn.execute("DELETE FROM edges")
-            _db_conn.execute("DELETE FROM embeddings")
-            _rdf_store.remove((None, None, None))
+            if _graph is not None:
+                _graph.clear()
+            if _db_conn is not None:
+                _db_conn.execute("DELETE FROM nodes")
+                _db_conn.execute("DELETE FROM edges")
+                _db_conn.execute("DELETE FROM embeddings")
+            if _rdf_store is not None:
+                _rdf_store.remove((None, None, None))
+
+
+# Initialise storage on module import using default path
+setup()
 

--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from autoresearch import storage
+
+
+@pytest.fixture(autouse=True)
+def storage_manager(tmp_path):
+    """Provide isolated storage for behavior tests."""
+    db_file = tmp_path / "kg.duckdb"
+    storage.teardown(remove_db=True)
+    storage.setup(str(db_file))
+    yield
+    storage.teardown(remove_db=True)

--- a/tests/behavior/steps/test_behavior_steps.py
+++ b/tests/behavior/steps/test_behavior_steps.py
@@ -21,72 +21,72 @@ runner = CliRunner()
 client = TestClient(api_app)
 
 # Scenario: Submit query via CLI
-@scenario('../../features/query_interface.feature', 'Submit query via CLI')
+@scenario('../features/query_interface.feature', 'Submit query via CLI')
 def test_cli_query():
     pass
 
 # Scenario: Submit query via HTTP API
-@scenario('../../features/query_interface.feature', 'Submit query via HTTP API')
+@scenario('../features/query_interface.feature', 'Submit query via HTTP API')
 def test_http_query():
     pass
 
 # Scenario: Submit query via MCP tool
-@scenario('../../features/query_interface.feature', 'Submit query via MCP tool')
+@scenario('../features/query_interface.feature', 'Submit query via MCP tool')
 def test_mcp_query():
     pass
 
 # Scenario: Load configuration on startup
-@scenario('../../features/configuration_hot_reload.feature', 'Load configuration on startup')
+@scenario('../features/configuration_hot_reload.feature', 'Load configuration on startup')
 def test_load_config_startup():
     pass
 
 # Scenario: Hot-reload on config change
-@scenario('../../features/configuration_hot_reload.feature', 'Hot-reload on config change')
+@scenario('../features/configuration_hot_reload.feature', 'Hot-reload on config change')
 def test_hot_reload_config():
     pass
 
 # Scenario: Persist claim in RAM
-@scenario('../../features/dkg_persistence.feature', 'Persist claim in RAM')
+@scenario('../features/dkg_persistence.feature', 'Persist claim in RAM')
 def test_persist_ram():
     pass
 
 # Scenario: Persist claim in DuckDB
-@scenario('../../features/dkg_persistence.feature', 'Persist claim in DuckDB')
+@scenario('../features/dkg_persistence.feature', 'Persist claim in DuckDB')
 def test_persist_duckdb():
     pass
 
 # Scenario: Persist claim in RDF quad-store
-@scenario('../../features/dkg_persistence.feature', 'Persist claim in RDF quad-store')
+@scenario('../features/dkg_persistence.feature', 'Persist claim in RDF quad-store')
 def test_persist_rdf():
     pass
 
 # Scenario: One dialectical cycle
-@scenario('../../features/agent_orchestration.feature', 'One dialectical cycle')
+@scenario('../features/agent_orchestration.feature', 'One dialectical cycle')
 def test_one_cycle():
     pass
 
 # Scenario: Rotating Primus across loops
-@scenario('../../features/agent_orchestration.feature', 'Rotating Primus across loops')
+@scenario('../features/agent_orchestration.feature', 'Rotating Primus across loops')
 def test_rotating_primus():
     pass
 
 # Scenario: Default TTY output
-@scenario('../../features/output_formatting.feature', 'Default TTY output')
+@scenario('../features/output_formatting.feature', 'Default TTY output')
 def test_default_tty_output():
     pass
 
 # Scenario: Piped output defaults to JSON
-@scenario('../../features/output_formatting.feature', 'Piped output defaults to JSON')
+@scenario('../features/output_formatting.feature', 'Piped output defaults to JSON')
 def test_piped_json_output():
     pass
 
 # Scenario: Explicit JSON flag
-@scenario('../../features/output_formatting.feature', 'Explicit JSON flag')
+@scenario('../features/output_formatting.feature', 'Explicit JSON flag')
 def test_explicit_json_flag():
     pass
 
 # Scenario: Explicit Markdown flag
-@scenario('../../features/output_formatting.feature', 'Explicit Markdown flag')
+@scenario('../features/output_formatting.feature', 'Explicit Markdown flag')
 def test_explicit_markdown_flag():
     pass
 


### PR DESCRIPTION
## Summary
- add setup/teardown utilities in `storage`
- support custom DuckDB path for easier testing
- guard storage access with locks
- update behaviour test config

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f593f2348333a6eb1b52f5ee3e56