### PR TITLE
Register default agents

### DIFF
--- a/src/autoresearch/agents/__init__.py
+++ b/src/autoresearch/agents/__init__.py
@@ -6,5 +6,18 @@ This module provides the agent infrastructure for the dialectical reasoning syst
 
 from .base import Agent, AgentRole
 from .registry import AgentRegistry, AgentFactory
+from .dialectical import SynthesizerAgent, ContrarianAgent, FactChecker
 
-__all__ = ["Agent", "AgentRole", "AgentRegistry", "AgentFactory"]
+# Register default dialectical agents on import
+AgentFactory.register("Synthesizer", SynthesizerAgent)
+AgentFactory.register("Contrarian", ContrarianAgent)
+AgentFactory.register("FactChecker", FactChecker)
+__all__ = [
+    "Agent",
+    "AgentRole",
+    "AgentRegistry",
+    "AgentFactory",
+    "SynthesizerAgent",
+    "ContrarianAgent",
+    "FactChecker",
+]


### PR DESCRIPTION
## Summary
- register SynthesizerAgent, ContrarianAgent and FactChecker with AgentFactory

## Testing
- `poetry run flake8 src tests` *(fails: E501 line too long, F401 unused imports, etc.)*
- `poetry run mypy src` *(fails: found 20 errors in 8 files)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tomli_w')*

------
https://chatgpt.com/codex/tasks/task_e_6849070220208333b0c3aedbc38b3e00