### PR TITLE
Use ConfigLoader singleton

### DIFF
--- a/src/autoresearch/api.py
+++ b/src/autoresearch/api.py
@@ -4,7 +4,7 @@ FastAPI API for Autoresearch.
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import PlainTextResponse
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
-from .config import ConfigLoader
+from .config import get_config
 from .orchestration.orchestrator import Orchestrator
 from .models import QueryResponse
 
@@ -18,7 +18,7 @@ def query_endpoint(payload: dict):
         raise HTTPException(
             status_code=400, detail="`query` field is required"
         )
-    config = ConfigLoader.load_config()
+    config = get_config()
     result = Orchestrator.run_query(query, config)
     return result
 

--- a/tests/behavior/steps/test_behavior_steps.py
+++ b/tests/behavior/steps/test_behavior_steps.py
@@ -141,7 +141,7 @@ def modify_config_enable_agent(file, tmp_path):
 @then('the orchestrator should reload the configuration automatically')
 def check_hot_reload(monkeypatch):
     # Watcher not implemented; simulate reload
-    new_cfg = ConfigLoader.load_config()
+    new_cfg = ConfigLoader().load_config()
     assert 'NewAgent' in new_cfg.agents
 
 @then('the new agent should be visible in the next iteration cycle')


### PR DESCRIPTION
## Summary
- refactor API to call `get_config()`
- update behavior tests to use instance method

## Testing
- `poetry run flake8 src tests` *(fails: E302, E501, F401, etc.)*
- `poetry run mypy src` *(fails: Found 19 errors in 7 files)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tomli_w')*
- `pytest tests/behavior -q` *(fails: ModuleNotFoundError: No module named 'tomli_w')*

------
https://chatgpt.com/codex/tasks/task_e_6849097e3b448333be28d1cb7a4f75ad