### PR TITLE
Fix agent ordering with config

### DIFF
--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -43,7 +43,7 @@ class Orchestrator:
         callbacks = callbacks or {}
 
         # Get enabled agents from config
-        agents = config.agent_roster if hasattr(config, 'agent_roster') else ["Synthesizer", "Contrarian", "FactChecker"]
+        agents = getattr(config, 'agents', ["Synthesizer", "Contrarian", "FactChecker"])
         primus_index = 0 if not hasattr(config, 'primus_start') else config.primus_start
         loops = config.loops if hasattr(config, 'loops') else 2
         max_errors = config.max_errors if hasattr(config, 'max_errors') else 3
@@ -170,7 +170,7 @@ class Orchestrator:
         def run_group(group):
             # Create a config copy for this group
             group_config = config.model_copy()
-            group_config.agent_roster = group
+            group_config.agents = group
 
             # Run the group
             result = Orchestrator.run_query(query, group_config)

--- a/tests/unit/test_orchestrator_order.py
+++ b/tests/unit/test_orchestrator_order.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.config import ConfigModel
+
+
+class DummyAgent:
+    def __init__(self, name, record):
+        self.name = name
+        self.record = record
+
+    def can_execute(self, state, config):
+        return True
+
+    def execute(self, state, config):
+        self.record.append(self.name)
+        return {}
+
+def test_custom_agents_order():
+    record = []
+
+    def get_agent(name):
+        return DummyAgent(name, record)
+
+    cfg = ConfigModel(agents=["A1", "A2", "A3"], loops=1)
+    with patch("autoresearch.orchestration.orchestrator.AgentFactory.get", side_effect=get_agent):
+        Orchestrator.run_query("q", cfg)
+
+    assert record == ["A1", "A2", "A3"]


### PR DESCRIPTION
## Summary
- reference `config.agents` when ordering agents
- set agent list for groups in `run_parallel_query`
- add unit test for agent order

## Testing
- `poetry run flake8 src tests` *(fails: line length, unused variables, etc.)*
- `poetry run mypy src` *(fails: various typing issues)*
- `pytest -q` *(fails: BDD test fixture error)*

------
https://chatgpt.com/codex/tasks/task_e_68490c52975c8333b1864e9fe51f7961