### PR TITLE
Fix Search query encoding

### DIFF
--- a/src/autoresearch/search.py
+++ b/src/autoresearch/search.py
@@ -18,11 +18,15 @@ class Search:
     @staticmethod
     def external_lookup(query: str, max_results: int = 5) -> List[Dict[str, str]]:
         """Perform an external search and return simplified results."""
-        url = (
-            f"https://api.duckduckgo.com/?q={query}&format=json&no_redirect=1&no_html=1"
-        )
+        url = "https://api.duckduckgo.com/"
+        params = {
+            "q": query,
+            "format": "json",
+            "no_redirect": 1,
+            "no_html": 1,
+        }
         try:
-            response = requests.get(url, timeout=5)
+            response = requests.get(url, params=params, timeout=5)
             data = response.json()
             results = []
             for item in data.get("RelatedTopics", [])[:max_results]:

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1,4 +1,5 @@
 import responses
+from responses import matchers
 
 from autoresearch.search import Search
 
@@ -6,10 +7,31 @@ from autoresearch.search import Search
 @responses.activate
 def test_external_lookup():
     query = "python"
-    url = f"https://api.duckduckgo.com/?q={query}&format=json&no_redirect=1&no_html=1"
-    responses.add(responses.GET, url, json={"RelatedTopics": [{"Text": "Python", "FirstURL": "https://python.org"}]})
+    url = "https://api.duckduckgo.com/"
+    params = {"q": query, "format": "json", "no_redirect": "1", "no_html": "1"}
+    responses.add(
+        responses.GET,
+        url,
+        match=[matchers.query_param_matcher(params)],
+        json={"RelatedTopics": [{"Text": "Python", "FirstURL": "https://python.org"}]},
+    )
     results = Search.external_lookup(query, max_results=1)
     assert results == [{"title": "Python", "url": "https://python.org"}]
+
+
+@responses.activate
+def test_external_lookup_special_chars():
+    query = "C++ tutorial & basics"
+    url = "https://api.duckduckgo.com/"
+    params = {"q": query, "format": "json", "no_redirect": "1", "no_html": "1"}
+    responses.add(
+        responses.GET,
+        url,
+        match=[matchers.query_param_matcher(params)],
+        json={"RelatedTopics": [{"Text": "C++", "FirstURL": "https://cplusplus.com"}]},
+    )
+    results = Search.external_lookup(query, max_results=1)
+    assert results == [{"title": "C++", "url": "https://cplusplus.com"}]
 
 
 def test_generate_queries():


### PR DESCRIPTION
## Summary
- safely encode queries in `Search.external_lookup`
- extend `test_external_lookup` and add special-character coverage

## Testing
- `poetry run flake8 src tests` *(fails: E501 and others)*
- `poetry run mypy src` *(fails: various type errors)*
- `poetry run pytest -q tests/behavior/steps/test_behavior_steps.py::test_cli_query -vv` *(fails: fixture 'result' not found)*
- `poetry run pytest -q` *(fails: fixture 'result' not found)*

------
https://chatgpt.com/codex/tasks/task_e_684912486ec483339ca36c2010602d99