### PR TITLE
Add tomli_w dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,22 @@ For a detailed breakdown of the requirements and architecture, see
 [docs/requirements.md](docs/requirements.md) and
 [docs/specification.md](docs/specification.md).
 
-## Running tests
+## Development setup
 
-Install development dependencies and execute all tests:
+Install the development dependencies:
 
 ```bash
 poetry install --with dev
+```
+
+This installs tools such as `flake8`, `mypy`, `pytest` and `tomli_w` which is
+used to write TOML files during testing.
+
+## Running tests
+
+Execute all tests once the development environment is ready:
+
+```bash
 poetry run flake8 src tests
 poetry run mypy src
 poetry run pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -4704,6 +4704,18 @@ docs = ["setuptools-rust", "sphinx", "sphinx-rtd-theme"]
 testing = ["black (==22.3)", "datasets", "numpy", "pytest", "requests", "ruff"]
 
 [[package]]
+name = "tomli-w"
+version = "1.2.0"
+description = "A lil' TOML writer"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"},
+    {file = "tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021"},
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 description = "Fast, Extensible Progress Meter"
@@ -5656,4 +5668,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.13,>=3.11"
-content-hash = "022ab11b6a42f440b5154597369569a342f0746ae7cd160375c981f99cf1881c"
+content-hash = "6b8472d43b752df21bae3e148b24b30b8ee296b6734d18db30d5c056eee3a9e2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ pytest-bdd = "^8.1.0"
 pytest-cov = "^6.1.1"
 flake8 = "^7.2.0"
 mypy = "^1.16.0"
+tomli-w = "^1.2.0"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
## Summary
- add `tomli_w` to dev dependencies in `pyproject.toml`
- update `poetry.lock`
- document the new dev dependency in README

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q`
- `poetry run pytest tests/behavior`


------
https://chatgpt.com/codex/tasks/task_e_684916d567708333805787b978868432