### PR TITLE
Ensure QueryResponse validation on output

### DIFF
--- a/src/autoresearch/output_format.py
+++ b/src/autoresearch/output_format.py
@@ -2,26 +2,32 @@
 Adaptive output formatting for CLI and automation contexts.
 """
 import sys
-import json
+from typing import Any
+from pydantic import ValidationError
 from .models import QueryResponse
 
 class OutputFormatter:
     @staticmethod
-    def format(result: QueryResponse, format_type: str) -> None:
-        """Print result as JSON or Markdown based on format_type."""
+    def format(result: Any, format_type: str) -> None:
+        """Validate and print result as JSON or Markdown based on format_type."""
+        try:
+            response = result if isinstance(result, QueryResponse) else QueryResponse.model_validate(result)
+        except ValidationError as exc:  # pragma: no cover - handled by caller
+            raise ValueError(f"Invalid response: {exc}") from exc
+
         if format_type.lower() == "json":
-            sys.stdout.write(result.json(indent=2) + "\n")
+            sys.stdout.write(response.model_dump_json(indent=2) + "\n")
         else:
             # Markdown output
             sys.stdout.write("# Answer\n")
-            sys.stdout.write(result.answer + "\n\n")
+            sys.stdout.write(response.answer + "\n\n")
             sys.stdout.write("## Citations\n")
-            for c in result.citations:
+            for c in response.citations:
                 sys.stdout.write(f"- {c}\n")
             sys.stdout.write("\n## Reasoning\n")
-            for r in result.reasoning:
+            for r in response.reasoning:
                 sys.stdout.write(f"- {r}\n")
             sys.stdout.write("\n## Metrics\n")
-            for k, v in result.metrics.items():
+            for k, v in response.metrics.items():
                 sys.stdout.write(f"- **{k}**: {v}\n")
 


### PR DESCRIPTION
## Summary
- validate result before formatting in `OutputFormatter`
- check and validate orchestrator response in API handler

## Testing
- `flake8 src tests`
- `mypy src` *(fails: missing stubs and type issues)*
- `pytest -q` *(fails: test_cli_query)*
- `pytest tests/behavior -q` *(fails: test_cli_query)*

------
https://chatgpt.com/codex/tasks/task_e_68492957bf9083339a9029c4bf953731