### PR TITLE
Refactor orchestrator injection

### DIFF
--- a/tests/integration/test_cli_http.py
+++ b/tests/integration/test_cli_http.py
@@ -1,0 +1,67 @@
+import json
+from typer.testing import CliRunner
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from autoresearch.main import app as cli_app
+from autoresearch.api import app as api_app
+from autoresearch.config import ConfigModel, ConfigLoader
+from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory, StorageManager
+from autoresearch.llm import DummyAdapter
+
+
+class DummyStorage:
+    persisted = []
+
+    @staticmethod
+    def persist_claim(claim):
+        DummyStorage.persisted.append(claim)
+
+
+def _patch_run_query(monkeypatch):
+    original = Orchestrator.run_query
+
+    def wrapper(query, config, callbacks=None, **kwargs):
+        return original(
+            query,
+            config,
+            callbacks,
+            agent_factory=AgentFactory,
+            storage_manager=DummyStorage,
+        )
+
+    monkeypatch.setattr(Orchestrator, "run_query", wrapper)
+
+
+def _common_patches(monkeypatch):
+    cfg = ConfigModel(loops=1)
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setattr(
+        "autoresearch.llm.get_llm_adapter", lambda name: DummyAdapter()
+    )
+    monkeypatch.setattr(
+        "autoresearch.search.Search.external_lookup",
+        lambda q, max_results=5: [{"title": "t", "url": "u"}],
+    )
+    _patch_run_query(monkeypatch)
+
+
+def test_cli_flow(monkeypatch):
+    _common_patches(monkeypatch)
+    runner = CliRunner()
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    result = runner.invoke(cli_app, ["search", "test query"])
+    assert result.exit_code == 0
+    assert "# Answer" in result.stdout
+    assert DummyStorage.persisted
+
+
+def test_http_flow(monkeypatch):
+    _common_patches(monkeypatch)
+    client = TestClient(api_app)
+    resp = client.post("/query", json={"query": "test query"})
+    assert resp.status_code == 200
+    data = resp.json()
+    for key in ["answer", "citations", "reasoning", "metrics"]:
+        assert key in data
+    assert DummyStorage.persisted


### PR DESCRIPTION
## Summary
- enable dependency injection for orchestrator
- add integration tests for CLI and HTTP flows with mocked backends

## Testing
- `flake8 src tests`
- `mypy src` *(fails: missing type stubs, etc.)*
- `pytest -q` *(fails: fixture 'run_cli_query' not found in behavior tests)*

------
https://chatgpt.com/codex/tasks/task_e_6849a26cf4e88333853b145ed10a8ada