### PR TITLE
Add reasoning mode enum and integration

### DIFF
--- a/src/autoresearch/agents/dialectical/contrarian.py
+++ b/src/autoresearch/agents/dialectical/contrarian.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 from ...agents.base import Agent, AgentRole
 from ...config import ConfigModel
 from ...orchestration.phases import DialoguePhase
+from ...orchestration.reasoning import ReasoningMode
 from ...orchestration.state import QueryState
 from ...logging_utils import get_logger
 from ...llm import get_llm_adapter
@@ -44,6 +45,8 @@ class ContrarianAgent(Agent):
         }
 
     def can_execute(self, state: QueryState, config: ConfigModel) -> bool:
-        """Only execute if there's at least one thesis claim."""
+        """Only execute in dialectical mode when there's a thesis."""
+        if config.reasoning_mode != ReasoningMode.DIALECTICAL:
+            return False
         has_thesis = any(claim.get("type") == "thesis" for claim in state.claims)
         return super().can_execute(state, config) and has_thesis

--- a/src/autoresearch/agents/dialectical/fact_checker.py
+++ b/src/autoresearch/agents/dialectical/fact_checker.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 from ...agents.base import Agent, AgentRole
 from ...config import ConfigModel
 from ...orchestration.phases import DialoguePhase
+from ...orchestration.reasoning import ReasoningMode
 from ...orchestration.state import QueryState
 from ...logging_utils import get_logger
 from ...search import Search
@@ -58,6 +59,8 @@ class FactChecker(Agent):
         }
 
     def can_execute(self, state: QueryState, config: ConfigModel) -> bool:
-        """Only execute if there are claims to check."""
+        """Only execute in dialectical mode if there are claims."""
+        if config.reasoning_mode != ReasoningMode.DIALECTICAL:
+            return False
         has_claims = len(state.claims) > 0
         return super().can_execute(state, config) and has_claims

--- a/src/autoresearch/orchestration/__init__.py
+++ b/src/autoresearch/orchestration/__init__.py
@@ -1,2 +1,5 @@
 """Orchestration module for agent coordination."""
 
+from .reasoning import ReasoningMode, ReasoningStrategy
+
+__all__ = ["ReasoningMode", "ReasoningStrategy"]

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 
 from ..agents.registry import AgentFactory
 from ..config import ConfigModel
+from .reasoning import ReasoningMode
 from ..models import QueryResponse
 from ..storage import StorageManager
 from .state import QueryState
@@ -50,10 +51,17 @@ class Orchestrator:
         # Setup callbacks
         callbacks = callbacks or {}
 
-        # Get enabled agents from config
+        # Get enabled agents and reasoning mode from config
         agents = getattr(config, 'agents', ["Synthesizer", "Contrarian", "FactChecker"])
         primus_index = 0 if not hasattr(config, 'primus_start') else config.primus_start
         loops = config.loops if hasattr(config, 'loops') else 2
+        mode = getattr(config, 'reasoning_mode', ReasoningMode.DIALECTICAL)
+
+        if mode == ReasoningMode.DIRECT:
+            agents = ["Synthesizer"]
+            loops = 1
+        elif mode == ReasoningMode.CHAIN_OF_THOUGHT:
+            agents = ["Synthesizer"]
         max_errors = config.max_errors if hasattr(config, 'max_errors') else 3
 
         # Initialize query state

--- a/src/autoresearch/orchestration/reasoning.py
+++ b/src/autoresearch/orchestration/reasoning.py
@@ -1,0 +1,26 @@
+"""Reasoning mode definitions and protocol interface."""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Protocol, TYPE_CHECKING
+
+from ..models import QueryResponse
+
+if TYPE_CHECKING:
+    from ..config import ConfigModel
+
+
+class ReasoningMode(str, Enum):
+    """Supported reasoning modes."""
+
+    DIRECT = "direct"
+    DIALECTICAL = "dialectical"
+    CHAIN_OF_THOUGHT = "chain-of-thought"
+
+
+class ReasoningStrategy(Protocol):
+    """Interface for reasoning strategies."""
+
+    def run_query(self, query: str, config: ConfigModel) -> QueryResponse:
+        """Execute reasoning for a query."""
+        raise NotImplementedError

--- a/tests/behavior/features/reasoning_mode.feature
+++ b/tests/behavior/features/reasoning_mode.feature
@@ -1,0 +1,17 @@
+Feature: Reasoning Mode Selection
+  As a user
+  I want to choose how the system reasons
+  So that agent execution adapts accordingly
+
+  Background:
+    Given loops is set to 2 in configuration
+
+  Scenario: Direct mode runs Synthesizer only
+    Given reasoning mode is "direct"
+    When I run the orchestrator on query "mode test"
+    Then the agents executed should be "Synthesizer"
+
+  Scenario: Chain-of-thought mode loops Synthesizer
+    Given reasoning mode is "chain-of-thought"
+    When I run the orchestrator on query "mode test"
+    Then the agents executed should be "Synthesizer, Synthesizer"

--- a/tests/unit/test_reasoning_modes.py
+++ b/tests/unit/test_reasoning_modes.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+from autoresearch.config import ConfigModel
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration import ReasoningMode
+
+
+class DummyAgent:
+    def __init__(self, name, record):
+        self.name = name
+        self.record = record
+
+    def can_execute(self, state, config):
+        return True
+
+    def execute(self, state, config):
+        self.record.append(self.name)
+        return {}
+
+
+def _run(cfg):
+    record = []
+
+    def get_agent(name):
+        return DummyAgent(name, record)
+
+    with patch("autoresearch.orchestration.orchestrator.AgentFactory.get", side_effect=get_agent):
+        Orchestrator.run_query("q", cfg)
+
+    return record
+
+
+def test_direct_mode_executes_once():
+    cfg = ConfigModel(loops=3, reasoning_mode=ReasoningMode.DIRECT)
+    record = _run(cfg)
+    assert record == ["Synthesizer"]
+
+
+def test_chain_of_thought_mode_loops():
+    cfg = ConfigModel(loops=2, reasoning_mode=ReasoningMode.CHAIN_OF_THOUGHT)
+    record = _run(cfg)
+    assert record == ["Synthesizer", "Synthesizer"]


### PR DESCRIPTION
## Summary
- support ReasoningMode enum and interface
- validate reasoning mode in configuration
- adapt orchestrator and dialectical agents for different modes
- cover new modes with unit and BDD tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849a913d7ec8333a1385ad16ddc527b