### PR TITLE
Add search backend registry with serper implementation

### DIFF
--- a/src/autoresearch/search.py
+++ b/src/autoresearch/search.py
@@ -1,6 +1,11 @@
 """Utility functions for query generation and external lookups."""
-from typing import List, Dict
+from __future__ import annotations
+
+import os
+from typing import Callable, List, Dict
 import requests
+
+from .config import get_config
 
 from .logging_utils import get_logger
 
@@ -10,6 +15,19 @@ log = get_logger(__name__)
 class Search:
     """Search utilities."""
 
+    # Registry mapping backend name to callable
+    backends: Dict[str, Callable[[str, int], List[Dict[str, str]]]] = {}
+
+    @classmethod
+    def register_backend(cls, name: str) -> Callable[[Callable[[str, int], List[Dict[str, str]]]], Callable[[str, int], List[Dict[str, str]]]]:
+        """Decorator to register a search backend."""
+
+        def decorator(func: Callable[[str, int], List[Dict[str, str]]]) -> Callable[[str, int], List[Dict[str, str]]]:
+            cls.backends[name] = func
+            return func
+
+        return decorator
+
     @staticmethod
     def generate_queries(query: str) -> List[str]:
         """Return a list of search queries derived from the user query."""
@@ -17,29 +35,64 @@ class Search:
 
     @staticmethod
     def external_lookup(query: str, max_results: int = 5) -> List[Dict[str, str]]:
-        """Perform an external search and return simplified results."""
-        url = "https://api.duckduckgo.com/"
-        params = {
-            "q": query,
-            "format": "json",
-            "no_redirect": 1,
-            "no_html": 1,
-        }
-        try:
-            response = requests.get(url, params=params, timeout=5)
-            data = response.json()
-            results = []
-            for item in data.get("RelatedTopics", [])[:max_results]:
-                if isinstance(item, dict):
-                    results.append({
-                        "title": item.get("Text", ""),
-                        "url": item.get("FirstURL", ""),
-                    })
-            if results:
-                return results
-        except Exception as exc:  # pragma: no cover - network errors
-            log.warning(f"External search failed: {exc}")
+        """Perform an external search using configured backends."""
+        cfg = get_config()
+
+        results = []
+        for name in cfg.search_backends:
+            backend = Search.backends.get(name)
+            if not backend:
+                log.warning(f"Unknown search backend '{name}'")
+                continue
+            try:
+                results.extend(backend(query, max_results))
+            except Exception as exc:  # pragma: no cover - network errors
+                log.warning(f"{name} search failed: {exc}")
+
+        if results:
+            return results
+
+        # Fallback results when all backends fail
         return [
             {"title": f"Result {i+1} for {query}", "url": ""} for i in range(max_results)
         ]
+
+
+@Search.register_backend("duckduckgo")
+def _duckduckgo_backend(query: str, max_results: int = 5) -> List[Dict[str, str]]:
+    """Retrieve results from the DuckDuckGo API."""
+    url = "https://api.duckduckgo.com/"
+    params = {
+        "q": query,
+        "format": "json",
+        "no_redirect": 1,
+        "no_html": 1,
+    }
+    response = requests.get(url, params=params, timeout=5)
+    data = response.json()
+    results: List[Dict[str, str]] = []
+    for item in data.get("RelatedTopics", [])[:max_results]:
+        if isinstance(item, dict):
+            results.append({
+                "title": item.get("Text", ""),
+                "url": item.get("FirstURL", ""),
+            })
+    return results
+
+
+@Search.register_backend("serper")
+def _serper_backend(query: str, max_results: int = 5) -> List[Dict[str, str]]:
+    """Retrieve results from the Serper API."""
+    api_key = os.getenv("SERPER_API_KEY", "")
+    url = "https://google.serper.dev/search"
+    headers = {"X-API-KEY": api_key}
+    response = requests.post(url, json={"q": query}, headers=headers, timeout=5)
+    data = response.json()
+    results: List[Dict[str, str]] = []
+    for item in data.get("organic", [])[:max_results]:
+        results.append({
+            "title": item.get("title", ""),
+            "url": item.get("link", ""),
+        })
+    return results
 

--- a/tests/integration/test_search_backends.py
+++ b/tests/integration/test_search_backends.py
@@ -1,0 +1,29 @@
+import pytest
+
+from autoresearch.search import Search
+from autoresearch.config import ConfigModel
+
+
+def test_multiple_backends_called_and_merged(monkeypatch):
+    calls = []
+
+    def backend1(query, max_results=5):
+        calls.append("b1")
+        return [{"title": "t1", "url": "u1"}]
+
+    def backend2(query, max_results=5):
+        calls.append("b2")
+        return [{"title": "t2", "url": "u2"}]
+
+    monkeypatch.setitem(Search.backends, "b1", backend1)
+    monkeypatch.setitem(Search.backends, "b2", backend2)
+
+    cfg = ConfigModel(loops=1, search_backends=["b1", "b2"])
+    monkeypatch.setattr("autoresearch.search.get_config", lambda: cfg)
+
+    results = Search.external_lookup("q", max_results=1)
+    assert calls == ["b1", "b2"]
+    assert results == [
+        {"title": "t1", "url": "u1"},
+        {"title": "t2", "url": "u2"},
+    ]

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1,11 +1,14 @@
 import responses
 from responses import matchers
+from autoresearch.config import ConfigModel
 
 from autoresearch.search import Search
 
 
 @responses.activate
-def test_external_lookup():
+def test_external_lookup(monkeypatch):
+    cfg = ConfigModel(search_backends=["duckduckgo"], loops=1)
+    monkeypatch.setattr("autoresearch.search.get_config", lambda: cfg)
     query = "python"
     url = "https://api.duckduckgo.com/"
     params = {"q": query, "format": "json", "no_redirect": "1", "no_html": "1"}
@@ -20,7 +23,9 @@ def test_external_lookup():
 
 
 @responses.activate
-def test_external_lookup_special_chars():
+def test_external_lookup_special_chars(monkeypatch):
+    cfg = ConfigModel(search_backends=["duckduckgo"], loops=1)
+    monkeypatch.setattr("autoresearch.search.get_config", lambda: cfg)
     query = "C++ tutorial & basics"
     url = "https://api.duckduckgo.com/"
     params = {"q": query, "format": "json", "no_redirect": "1", "no_html": "1"}


### PR DESCRIPTION
## Summary
- create a registry for search backends and add a Serper backend
- combine results from all configured search backends
- adjust unit tests for new registry logic
- add integration test for multiple backend usage

## Testing
- `poetry run flake8 src/autoresearch/search.py tests/unit/test_search.py tests/integration/test_search_backends.py`
- `poetry run mypy src`
- `poetry run pytest -q`
- `poetry run pytest tests/behavior -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ad3fc160833392b1cb452311c53c