### PR TITLE
Add plain text output formatting

### DIFF
--- a/src/autoresearch/output_format.py
+++ b/src/autoresearch/output_format.py
@@ -15,8 +15,22 @@ class OutputFormatter:
         except ValidationError as exc:  # pragma: no cover - handled by caller
             raise ValueError(f"Invalid response: {exc}") from exc
 
-        if format_type.lower() == "json":
+        fmt = format_type.lower()
+
+        if fmt == "json":
             sys.stdout.write(response.model_dump_json(indent=2) + "\n")
+        elif fmt in {"plain", "text"}:
+            sys.stdout.write("Answer:\n")
+            sys.stdout.write(response.answer + "\n\n")
+            sys.stdout.write("Citations:\n")
+            for c in response.citations:
+                sys.stdout.write(f"{c}\n")
+            sys.stdout.write("\nReasoning:\n")
+            for r in response.reasoning:
+                sys.stdout.write(f"{r}\n")
+            sys.stdout.write("\nMetrics:\n")
+            for k, v in response.metrics.items():
+                sys.stdout.write(f"{k}: {v}\n")
         else:
             # Markdown output
             sys.stdout.write("# Answer\n")

--- a/tests/unit/test_output_format.py
+++ b/tests/unit/test_output_format.py
@@ -22,3 +22,20 @@ def test_format_markdown(capsys):
     assert "- c" in captured
     assert "## Reasoning" in captured
     assert "## Metrics" in captured
+
+
+def test_format_plain(capsys):
+    resp = QueryResponse(answer="a", citations=["c"], reasoning=["r"], metrics={"m":1})
+    OutputFormatter.format(resp, "plain")
+    captured = capsys.readouterr().out
+    assert captured.startswith("Answer:")
+    assert "Citations:" in captured
+    assert "- c" not in captured
+    assert "#" not in captured
+
+
+def test_format_text_alias(capsys):
+    resp = QueryResponse(answer="a", citations=["c"], reasoning=["r"], metrics={"m":1})
+    OutputFormatter.format(resp, "text")
+    captured = capsys.readouterr().out
+    assert captured.startswith("Answer:")


### PR DESCRIPTION
## Summary
- support `plain`/`text` output in `OutputFormatter`
- test new behaviour

## Testing
- `poetry run flake8 src/autoresearch/output_format.py tests/unit/test_output_format.py`
- `poetry run mypy src`
- `poetry run pytest -q`
- `poetry run pytest tests/behavior`

------
https://chatgpt.com/codex/tasks/task_e_684a0e8676548333a728d3a362f7160c