### PR TITLE
Add chain-of-thought reasoning strategy

### DIFF
--- a/src/autoresearch/orchestration/__init__.py
+++ b/src/autoresearch/orchestration/__init__.py
@@ -1,5 +1,5 @@
 """Orchestration module for agent coordination."""
 
-from .reasoning import ReasoningMode, ReasoningStrategy
+from .reasoning import ReasoningMode, ReasoningStrategy, ChainOfThoughtStrategy
 
-__all__ = ["ReasoningMode", "ReasoningStrategy"]
+__all__ = ["ReasoningMode", "ReasoningStrategy", "ChainOfThoughtStrategy"]

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 
 from ..agents.registry import AgentFactory
 from ..config import ConfigModel
-from .reasoning import ReasoningMode
+from .reasoning import ReasoningMode, ChainOfThoughtStrategy
 from ..models import QueryResponse
 from ..storage import StorageManager
 from .state import QueryState
@@ -61,7 +61,8 @@ class Orchestrator:
             agents = ["Synthesizer"]
             loops = 1
         elif mode == ReasoningMode.CHAIN_OF_THOUGHT:
-            agents = ["Synthesizer"]
+            strategy = ChainOfThoughtStrategy()
+            return strategy.run_query(query, config, agent_factory=agent_factory)
         max_errors = config.max_errors if hasattr(config, 'max_errors') else 3
 
         # Initialize query state

--- a/src/autoresearch/orchestration/reasoning.py
+++ b/src/autoresearch/orchestration/reasoning.py
@@ -8,6 +8,7 @@ from ..models import QueryResponse
 
 if TYPE_CHECKING:
     from ..config import ConfigModel
+    from ..agents.registry import AgentFactory
 
 
 class ReasoningMode(str, Enum):
@@ -24,3 +25,48 @@ class ReasoningStrategy(Protocol):
     def run_query(self, query: str, config: ConfigModel) -> QueryResponse:
         """Execute reasoning for a query."""
         raise NotImplementedError
+
+
+class ChainOfThoughtStrategy:
+    """Simple strategy that records intermediate thoughts at each loop."""
+
+    def run_query(
+        self,
+        query: str,
+        config: "ConfigModel",
+        *,
+        agent_factory: type["AgentFactory"] | None = None,
+    ) -> QueryResponse:
+        """Run the query using repeated synthesizer steps."""
+        from .state import QueryState
+        from .metrics import OrchestrationMetrics
+        from ..agents.registry import AgentFactory
+
+        factory = agent_factory or AgentFactory
+        synthesizer = factory.get("Synthesizer")
+
+        loops = getattr(config, "loops", 1)
+
+        state = QueryState(query=query)
+        metrics = OrchestrationMetrics()
+        thoughts: list[str] = []
+
+        for _ in range(loops):
+            metrics.start_cycle()
+            result = synthesizer.execute(state, config)
+            metrics.end_cycle()
+            state.update(result)
+
+            step = (
+                result.get("results", {}).get("thesis")
+                or result.get("results", {}).get("synthesis")
+                or result.get("results", {}).get("final_answer")
+            )
+            if step:
+                thoughts.append(step)
+            state.cycle += 1
+
+        state.metadata["execution_metrics"] = metrics.get_summary()
+        state.results["chain_of_thought"] = thoughts
+
+        return state.synthesize()

--- a/tests/unit/test_reasoning_modes.py
+++ b/tests/unit/test_reasoning_modes.py
@@ -40,3 +40,30 @@ def test_chain_of_thought_mode_loops():
     cfg = ConfigModel(loops=2, reasoning_mode=ReasoningMode.CHAIN_OF_THOUGHT)
     record = _run(cfg)
     assert record == ["Synthesizer", "Synthesizer"]
+
+
+def test_chain_of_thought_records_steps():
+    cfg = ConfigModel(loops=3, reasoning_mode=ReasoningMode.CHAIN_OF_THOUGHT)
+
+    class DummySynth:
+        def __init__(self):
+            self.idx = 0
+
+        def can_execute(self, state, config):
+            return True
+
+        def execute(self, state, config):
+            self.idx += 1
+            content = f"step-{self.idx}"
+            return {
+                "claims": [{"id": str(self.idx), "type": "thought", "content": content}],
+                "results": {"final_answer": content},
+            }
+
+    agent = DummySynth()
+    with patch("autoresearch.orchestration.orchestrator.AgentFactory.get", return_value=agent):
+        resp = Orchestrator.run_query("q", cfg)
+
+    steps = [c["content"] for c in resp.reasoning]
+    assert steps == ["step-1", "step-2", "step-3"]
+    assert resp.answer == "step-3"


### PR DESCRIPTION
## Summary
- implement `ChainOfThoughtStrategy` to capture intermediate steps
- invoke the strategy when `ReasoningMode.CHAIN_OF_THOUGHT` is selected
- test that chain-of-thought outputs all reasoning steps

## Testing
- `poetry run flake8 src tests` *(fails: E501 etc.)*
- `poetry run mypy src`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tomli_w')*


------
https://chatgpt.com/codex/tasks/task_e_684a10e8dba08333b4560ab7702f93e8