### PR TITLE
Fix feature step names for BDD tests

### DIFF
--- a/tests/behavior/features/output_formatting.feature
+++ b/tests/behavior/features/output_formatting.feature
@@ -7,7 +7,7 @@ Feature: Adaptive Output Formatting
     Given the application is running
 
   Scenario: Default TTY output
-    When I run `autoresearch search "Test formatting"` in a terminal
+    When I run `autoresearch search "Test formatting"` in TTY mode
     Then the output should be in Markdown with sections `# Answer`, `## Citations`, `## Reasoning`, and `## Metrics`
 
   Scenario: Piped output defaults to JSON


### PR DESCRIPTION
## Summary
- update Output Formatting feature to reference a unique step
- adapt step definitions to parse CLI JSON output reliably

## Testing
- `flake8 src tests`
- `mypy src` *(fails: Library stubs not installed for "networkx", "requests")*
- `pytest -q tests/behavior` *(fails: No JSON found in CLI output)*

------
https://chatgpt.com/codex/tasks/task_e_684a4d73293c8333aaff7a3b922db70d