### PR TITLE
Add basic CLI and storage tests

### DIFF
--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -1,0 +1,43 @@
+from typer.testing import CliRunner
+from autoresearch.main import app
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import Orchestrator
+
+
+def _mock_run_query(query, config):
+    return QueryResponse(answer="a", citations=[], reasoning=[], metrics={})
+
+
+def test_search_default_output_tty(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr(Orchestrator, "run_query", _mock_run_query)
+    result = runner.invoke(app, ["search", "q"])
+    assert result.exit_code == 0
+    assert "# Answer" in result.stdout
+
+
+def test_search_default_output_json(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr(Orchestrator, "run_query", _mock_run_query)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    result = runner.invoke(app, ["search", "q"])
+    assert result.exit_code == 0
+    assert result.stdout.strip().startswith("{")
+
+
+def test_config_command(monkeypatch):
+    runner = CliRunner()
+
+    class Cfg:
+        def json(self, indent=2):
+            return "{\n  \"loops\": 1\n}"
+
+    monkeypatch.setattr(
+        "autoresearch.main._config_loader.load_config",
+        lambda: Cfg(),
+    )
+    result = runner.invoke(app, ["config"])
+    assert result.exit_code == 0
+    assert '"loops"' in result.stdout

--- a/tests/unit/test_storage_utils.py
+++ b/tests/unit/test_storage_utils.py
@@ -1,0 +1,24 @@
+from collections import OrderedDict
+import autoresearch.storage as storage
+from autoresearch.storage import StorageManager, setup, teardown
+
+
+def test_touch_node_updates_lru(monkeypatch):
+    monkeypatch.setattr(
+        'autoresearch.storage._lru',
+        OrderedDict([('a', 1), ('b', 2)]),
+        raising=False,
+    )
+    StorageManager.touch_node('a')
+    assert list(storage._lru.keys()) == ['b', 'a']
+
+
+def test_clear_all(tmp_path):
+    db_file = tmp_path / 'kg.duckdb'
+    setup(str(db_file))
+    StorageManager.persist_claim({'id': 'n1', 'type': 'fact', 'content': 'c'})
+    StorageManager.clear_all()
+    assert StorageManager.get_graph().number_of_nodes() == 0
+    conn = StorageManager.get_duckdb_conn()
+    assert conn.execute('SELECT COUNT(*) FROM nodes').fetchone()[0] == 0
+    teardown(remove_db=True)

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -1,0 +1,19 @@
+from autoresearch import tracing
+
+
+def test_setup_tracing_idempotent():
+    tracing._tracer_provider = None
+    tracing.setup_tracing(True)
+    first = tracing._tracer_provider
+    tracing.setup_tracing(True)
+    assert tracing._tracer_provider is first
+    assert tracing.get_tracer("t")
+    if tracing._tracer_provider:
+        tracing._tracer_provider.shutdown()
+    tracing._tracer_provider = None
+
+
+def test_setup_tracing_disabled():
+    tracing._tracer_provider = None
+    tracing.setup_tracing(False)
+    assert tracing._tracer_provider is None


### PR DESCRIPTION
## Summary
- create tests for CLI defaults, tracing, and storage helpers
- skip behavior tests which require network access

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `pytest -q tests/unit/test_main_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_684b37949abc8333bbb659dc9ef8d414