### PR TITLE
Improve test isolation fixtures

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -1,13 +1,7 @@
 import pytest
 
-from autoresearch import storage
-
 
 @pytest.fixture(autouse=True)
-def storage_manager(tmp_path):
-    """Provide isolated storage for behavior tests."""
-    db_file = tmp_path / "kg.duckdb"
-    storage.teardown(remove_db=True)
-    storage.setup(str(db_file))
-    yield
-    storage.teardown(remove_db=True)
+def bdd_storage_manager(storage_manager):
+    """Use the global temporary storage fixture for behavior tests."""
+    yield storage_manager

--- a/tests/integration/test_rdf_persistence.py
+++ b/tests/integration/test_rdf_persistence.py
@@ -1,9 +1,9 @@
 import rdflib
-from autoresearch.storage import StorageManager, setup, teardown
+from autoresearch.storage import StorageManager
 from autoresearch.config import ConfigModel, StorageConfig, ConfigLoader
 
 
-def test_rdf_persistence(tmp_path, monkeypatch):
+def test_rdf_persistence(storage_manager, tmp_path, monkeypatch):
     cfg = ConfigModel(
         storage=StorageConfig(
             rdf_backend="sqlite",
@@ -12,8 +12,6 @@ def test_rdf_persistence(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader()._config = None
-    teardown(remove_db=True)
-    setup(str(tmp_path / "kg.duckdb"))
     claim = {
         "id": "n1",
         "type": "fact",
@@ -25,4 +23,3 @@ def test_rdf_persistence(tmp_path, monkeypatch):
     subj = rdflib.URIRef("urn:claim:n1")
     results = list(store.triples((subj, None, None)))
     assert results
-    teardown(remove_db=True)

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -3,9 +3,7 @@ from autoresearch.search import Search
 from autoresearch.config import ConfigModel
 
 
-def test_search_uses_cache(tmp_path, monkeypatch):
-    db_path = tmp_path / "cache.json"
-    cache.setup(str(db_path))
+def test_search_uses_cache(monkeypatch):
     cache.clear()
 
     calls = {"count": 0}
@@ -29,5 +27,4 @@ def test_search_uses_cache(tmp_path, monkeypatch):
     assert calls["count"] == 1
     assert results2 == results1
 
-    cache.teardown(remove_file=True)
     Search.backends = old_backends

--- a/tests/unit/test_config_reload.py
+++ b/tests/unit/test_config_reload.py
@@ -1,26 +1,20 @@
 import time
 import tomli_w
 
-from autoresearch.config import ConfigLoader
 
-
-def test_config_reload_on_change(tmp_path, monkeypatch):
+def test_config_reload_on_change(config_watcher, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     cfg_path = tmp_path / "autoresearch.toml"
     cfg_path.write_text(tomli_w.dumps({"core": {"loops": 1}}))
 
-    loader = ConfigLoader()
-    loader.stop_watching()
+    loader = config_watcher
     loader._config = loader.load_config()
     loader.watch_changes()
-    try:
-        assert loader.config.loops == 1
-        cfg_path.write_text(tomli_w.dumps({"core": {"loops": 2}}))
-        # Wait for watcher thread to pick up the change
-        for _ in range(30):
-            if loader.config.loops == 2:
-                break
-            time.sleep(0.1)
-        assert loader.config.loops == 2
-    finally:
-        loader.stop_watching()
+    assert loader.config.loops == 1
+    cfg_path.write_text(tomli_w.dumps({"core": {"loops": 2}}))
+    # Wait for watcher thread to pick up the change
+    for _ in range(30):
+        if loader.config.loops == 2:
+            break
+        time.sleep(0.1)
+    assert loader.config.loops == 2

--- a/tests/unit/test_eviction.py
+++ b/tests/unit/test_eviction.py
@@ -3,7 +3,7 @@ from autoresearch.config import ConfigModel, ConfigLoader
 from autoresearch.orchestration import metrics
 
 
-def test_ram_eviction(monkeypatch):
+def test_ram_eviction(storage_manager, monkeypatch):
     StorageManager.clear_all()
     config = ConfigModel(ram_budget_mb=1)
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: config)
@@ -17,7 +17,7 @@ def test_ram_eviction(monkeypatch):
     assert "c1" not in StorageManager.get_graph().nodes
 
 
-def test_score_eviction(monkeypatch):
+def test_score_eviction(storage_manager, monkeypatch):
     StorageManager.clear_all()
     config = ConfigModel(ram_budget_mb=1, graph_eviction_policy="score")
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: config)

--- a/tests/unit/test_storage_utils.py
+++ b/tests/unit/test_storage_utils.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 import autoresearch.storage as storage
-from autoresearch.storage import StorageManager, setup, teardown
+from autoresearch.storage import StorageManager
 
 
 def test_touch_node_updates_lru(monkeypatch):
@@ -13,12 +13,9 @@ def test_touch_node_updates_lru(monkeypatch):
     assert list(storage._lru.keys()) == ['b', 'a']
 
 
-def test_clear_all(tmp_path):
-    db_file = tmp_path / 'kg.duckdb'
-    setup(str(db_file))
+def test_clear_all(storage_manager):
     StorageManager.persist_claim({'id': 'n1', 'type': 'fact', 'content': 'c'})
     StorageManager.clear_all()
     assert StorageManager.get_graph().number_of_nodes() == 0
     conn = StorageManager.get_duckdb_conn()
     assert conn.execute('SELECT COUNT(*) FROM nodes').fetchone()[0] == 0
-    teardown(remove_db=True)


### PR DESCRIPTION
## Summary
- add fixtures for temporary config/cache paths and storage setup
- reset agent and LLM registries between tests
- use new fixtures in unit and integration tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `pytest -q`
- `pytest tests/behavior -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4b40f2888333bfe586f395c3ac4b