### PR TITLE
Add accessibility tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,7 @@ mkdocs build
 ```
 
 Use `mkdocs serve` to preview the documentation locally.
+
+## Accessibility
+
+CLI output uses Markdown headings and plain-text lists so screen readers can navigate sections. Help messages avoid color-only cues and respect the `NO_COLOR` environment variable for ANSI-free output.

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -1,0 +1,29 @@
+import importlib
+import sys
+import types
+from typer.testing import CliRunner
+
+
+def test_cli_help_no_ansi(monkeypatch):
+    dummy_storage = types.ModuleType("autoresearch.storage")
+
+    class StorageManager:
+        @staticmethod
+        def persist_claim(claim):
+            pass
+
+    dummy_storage.StorageManager = StorageManager
+    dummy_storage.setup = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+    from autoresearch.config import ConfigLoader, ConfigModel
+
+    def _load(self):
+        return ConfigModel(loops=1)
+
+    monkeypatch.setattr(ConfigLoader, "load_config", _load)
+    main = importlib.import_module("autoresearch.main")
+    runner = CliRunner()
+    result = runner.invoke(main.app, ["--help"])
+    assert result.exit_code == 0
+    assert "\x1b[" not in result.stdout
+    assert "Usage:" in result.stdout

--- a/tests/unit/test_output_format.py
+++ b/tests/unit/test_output_format.py
@@ -48,3 +48,21 @@ def test_format_text_alias(capsys):
     OutputFormatter.format(resp, "text")
     captured = capsys.readouterr().out
     assert captured.startswith("Answer:")
+
+
+def test_json_no_ansi(capsys):
+    resp = QueryResponse(
+        answer="a", citations=["c"], reasoning=["r"], metrics={"m": 1}
+    )
+    OutputFormatter.format(resp, "json")
+    out = capsys.readouterr().out
+    assert "\x1b[" not in out
+
+
+def test_markdown_no_ansi(capsys):
+    resp = QueryResponse(
+        answer="a", citations=["c"], reasoning=["r"], metrics={"m": 1}
+    )
+    OutputFormatter.format(resp, "markdown")
+    out = capsys.readouterr().out
+    assert "\x1b[" not in out


### PR DESCRIPTION
## Summary
- document CLI accessibility options
- ensure Markdown and JSON outputs have no ANSI codes
- check CLI help output is ANSI-free

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q`
- `poetry run pytest tests/behavior`

------
https://chatgpt.com/codex/tasks/task_e_684b5ddff09483339d5eb45e30a76352