### PR TITLE
Add setup script and dev dependency docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install poetry
-        poetry install --with dev
-        poetry run pip install networkx duckdb rdflib
+        ./scripts/setup.sh
     - name: Lint with flake8
       run: |
         poetry run flake8 src tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Thank you for considering a contribution! Follow these steps to set up the development environment and run the test suite.
+
+1. Install the dependencies:
+   ```bash
+   poetry install --with dev
+   ```
+   Alternatively you can execute the helper script:
+   ```bash
+   ./scripts/setup.sh
+   ```
+   If you prefer pip, run `pip install -e .` instead.
+
+2. Lint and type check the code:
+   ```bash
+   poetry run flake8 src tests
+   poetry run mypy src
+   ```
+
+3. Run the tests:
+   ```bash
+   poetry run pytest
+   poetry run pytest tests/behavior
+   ```
+
+Please keep commits focused and descriptive.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Install the development dependencies:
 poetry install --with dev
 ```
 
+Alternatively you can run the helper script:
+
+```bash
+./scripts/setup.sh
+```
+
 This installs tools such as `flake8`, `mypy`, `pytest` and `tomli_w` which is
 used to write TOML files during testing.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,4 +10,10 @@ poetry run pytest
 poetry run pytest tests/behavior
 ```
 
+You can alternatively run the helper script to install all dependencies:
+
+```bash
+./scripts/setup.sh
+```
+
 Please keep commits focused and descriptive.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pip install --upgrade pip
+pip install poetry
+poetry install --with dev
+poetry run pip install networkx duckdb rdflib


### PR DESCRIPTION
## Summary
- add `scripts/setup.sh` for installing dev dependencies
- document installation steps in README and new CONTRIBUTING guide
- mention helper script in docs/contributing.md
- run setup script during CI

## Testing
- `poetry install --with dev`
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'tinydb')*
- `poetry run pytest tests/behavior -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684b853fe4948333a65e88e27842291b