### PR TITLE
Improve search caching by backend

### DIFF
--- a/src/autoresearch/cache.py
+++ b/src/autoresearch/cache.py
@@ -41,16 +41,24 @@ def get_db() -> TinyDB:
     return setup()
 
 
-def cache_results(query: str, results: List[Dict[str, Any]]) -> None:
-    """Store search results for a query."""
+def cache_results(
+    query: str, backend: str, results: List[Dict[str, Any]]
+) -> None:
+    """Store search results for a query/backend combination."""
     db = get_db()
-    db.upsert({"query": query, "results": results}, Query().query == query)
+    db.upsert(
+        {"query": query, "backend": backend, "results": results},
+        (Query().query == query) & (Query().backend == backend),
+    )
 
 
-def get_cached_results(query: str) -> Optional[List[Dict[str, Any]]]:
-    """Retrieve cached results for a query if present."""
+def get_cached_results(
+    query: str, backend: str
+) -> Optional[List[Dict[str, Any]]]:
+    """Retrieve cached results for a query/backend if present."""
     db = get_db()
-    row = db.get(Query().query == query)
+    condition = (Query().query == query) & (Query().backend == backend)
+    row = db.get(condition)
     if row:
         return list(row.get("results", []))
     return None

--- a/tests/integration/test_search_backends.py
+++ b/tests/integration/test_search_backends.py
@@ -1,8 +1,10 @@
 from autoresearch.search import Search
+from autoresearch import cache
 from autoresearch.config import ConfigModel
 
 
 def test_multiple_backends_called_and_merged(monkeypatch):
+    cache.clear()
     calls = []
 
     def backend1(query, max_results=5):


### PR DESCRIPTION
## Summary
- store cached search results per backend
- lookup cache per backend when running searches
- reset cache in integration tests
- add regression test ensuring backend-specific caching

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `pytest -q` *(fails: test_reasoning_direct)*
- `pytest tests/behavior -q` *(fails: test_load_config_startup)*

------
https://chatgpt.com/codex/tasks/task_e_684b86f0824083339b2cce48e8a5c789