### PR TITLE
Add DuckDB vector search integration test

### DIFF
--- a/tests/integration/test_vector_extension.py
+++ b/tests/integration/test_vector_extension.py
@@ -1,0 +1,43 @@
+import pytest
+
+from autoresearch.storage import StorageManager
+from autoresearch.config import (
+    ConfigModel,
+    StorageConfig,
+    ConfigLoader,
+)
+
+
+def test_vector_search_with_real_duckdb(
+    storage_manager, tmp_path, monkeypatch
+):
+    cfg = ConfigModel(
+        storage=StorageConfig(
+            vector_extension=True,
+            duckdb_path=str(tmp_path / "kg.duckdb"),
+        )
+    )
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+
+    StorageManager.clear_all()
+
+    conn = StorageManager.get_duckdb_conn()
+    for idx, vec in enumerate([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]]):
+        StorageManager.persist_claim(
+            {
+                "id": f"n{idx}",
+                "type": "fact",
+                "content": str(idx),
+                "embedding": vec,
+            }
+        )
+
+    indexes = conn.execute(
+        "SELECT index_name FROM duckdb_indexes() WHERE table_name='embeddings'"
+    ).fetchall()
+    if not indexes:
+        pytest.skip("vector extension not available")
+
+    results = StorageManager.vector_search([0.0, 0.0], k=1)
+    assert results[0]["node_id"] == "n0"


### PR DESCRIPTION
## Summary
- add integration test to exercise StorageManager.vector_search against DuckDB
- ensure vector index creation logic is triggered

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `pytest -q` *(fails: FAILED tests/behavior/steps/agent_orchestration_steps.py::test_reasoning_direct)*

------
https://chatgpt.com/codex/tasks/task_e_684b967ba7288333b9e77fb399820554