### PR TITLE
Improve monitor command interactivity

### DIFF
--- a/src/autoresearch/api.py
+++ b/src/autoresearch/api.py
@@ -4,7 +4,10 @@ FastAPI API for Autoresearch.
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import PlainTextResponse
-from prometheus_client import CONTENT_TYPE_LATEST, generate_latest  # type: ignore[import]
+from prometheus_client import (  # type: ignore[import]
+    CONTENT_TYPE_LATEST,
+    generate_latest,
+)
 from .config import ConfigLoader, get_config
 from .orchestration.orchestrator import Orchestrator
 from .tracing import get_tracer, setup_tracing

--- a/src/autoresearch/tracing.py
+++ b/src/autoresearch/tracing.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from typing import Optional
 
 from opentelemetry import trace  # type: ignore[import]
-from opentelemetry.sdk.resources import SERVICE_NAME, Resource  # type: ignore[import]
-from opentelemetry.sdk.trace import TracerProvider  # type: ignore[import]
+from opentelemetry.sdk.resources import (  # type: ignore[import]
+    SERVICE_NAME,
+    Resource,
+)
+from opentelemetry.sdk.trace import (  # type: ignore[import]
+    TracerProvider,
+)
 from opentelemetry.sdk.trace.export import (  # type: ignore[import]
     BatchSpanProcessor,
     ConsoleSpanExporter,

--- a/tests/behavior/features/interactive_monitor.feature
+++ b/tests/behavior/features/interactive_monitor.feature
@@ -1,0 +1,11 @@
+Feature: Interactive Monitoring
+  As a user
+  I want to watch each cycle interactively
+  So that I can provide feedback and exit cleanly
+
+  Background:
+    Given the application is running
+
+  Scenario: Interactive monitoring
+    When I start `autoresearch monitor` and enter "test"
+    Then the monitor should exit successfully

--- a/tests/unit/test_monitor_cli.py
+++ b/tests/unit/test_monitor_cli.py
@@ -1,0 +1,37 @@
+from typer.testing import CliRunner
+from autoresearch.main import app
+from autoresearch.config import ConfigLoader, ConfigModel
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.models import QueryResponse
+
+
+def dummy_run_query(query, config, callbacks=None, **kwargs):
+    assert callbacks is not None and "on_cycle_end" in callbacks
+    dummy_state = type(
+        "S",
+        (),
+        {
+            "metadata": {"execution_metrics": {}},
+            "claims": [],
+            "error_count": 0,
+        },
+    )()
+    callbacks["on_cycle_end"](0, dummy_state)
+    return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+
+
+def test_monitor_prompts_and_passes_callbacks(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr(
+        ConfigLoader,
+        "load_config",
+        lambda self: ConfigModel(loops=1, output_format="json"),
+    )
+    responses = iter(["test", "", "q"])
+    monkeypatch.setattr(
+        "autoresearch.main.Prompt.ask",
+        lambda *a, **k: next(responses),
+    )
+    monkeypatch.setattr(Orchestrator, "run_query", dummy_run_query)
+    result = runner.invoke(app, ["monitor"])
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- loop in monitor command for repeated queries with exit
- show cycle metrics and collect feedback each loop
- ensure clean formatting for long imports
- test monitor CLI interaction
- document new interactive monitoring scenario

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: StepDefinitionNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684b9c76880483338448bda79d269e64