### PR TITLE
Improve API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ Start the HTTP API with Uvicorn:
 ```bash
 uvicorn autoresearch.api:app --reload
 ```
-Send a request once the server is running:
+Send a query and check collected metrics:
 ```bash
-curl -X POST http://localhost:8000/query -d '{"query": "explain machine learning"}' -H "Content-Type: application/json"
+curl -X POST http://localhost:8000/query -d '{"query": "Explain machine learning"}' -H "Content-Type: application/json"
+curl http://localhost:8000/metrics
 ```
 
 ### Configuration hot reload

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,8 +6,52 @@ The HTTP API is served via FastAPI. Start the server with Uvicorn:
 uvicorn autoresearch.api:app --reload
 ```
 
-Once running you can send a POST request:
+Once the server is running you can interact with the endpoints described below.
+
+## Endpoints
+
+### `POST /query`
+
+Send a research question and receive the answer, citations, reasoning steps and
+a metrics summary.
+
+**Request**
 
 ```bash
-curl -X POST http://localhost:8000/query -d '{"query": "explain machine learning"}' -H "Content-Type: application/json"
+curl -X POST http://localhost:8000/query \
+  -H "Content-Type: application/json" \
+  -d '{"query": "Explain machine learning"}'
+```
+
+**Response**
+
+```json
+{
+  "answer": "Machine learning is ...",
+  "citations": ["https://example.com"],
+  "reasoning": ["step 1", "step 2"],
+  "metrics": {
+    "cycles_completed": 1,
+    "total_tokens": {"input": 5, "output": 7, "total": 12}
+  }
+}
+```
+
+### `GET /metrics`
+
+Return Prometheus metrics collected during query processing.
+
+**Request**
+
+```bash
+curl http://localhost:8000/metrics
+```
+
+**Response**
+
+```
+# HELP autoresearch_queries_total Total number of queries processed
+# TYPE autoresearch_queries_total counter
+autoresearch_queries_total 1.0
+...
 ```


### PR DESCRIPTION
## Summary
- document `/query` and `/metrics` endpoints with request/response examples
- add curl example for fetching metrics in README

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: StepDefinitionNotFoundError)*
- `poetry run pytest tests/behavior -q` *(fails: StepDefinitionNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684ba4e6f1408333ac64be1a66eb03a0