### PR TITLE
Add BDD test for interactive monitor

### DIFF
--- a/tests/behavior/steps/interactive_monitor_steps.py
+++ b/tests/behavior/steps/interactive_monitor_steps.py
@@ -1,0 +1,22 @@
+# flake8: noqa
+from pytest_bdd import scenario, when, then, parsers
+
+from .common_steps import *  # noqa: F401,F403
+
+
+@when(parsers.parse('I start `autoresearch monitor` and enter "{text}"'))
+def start_monitor(text, monkeypatch, bdd_context):
+    responses = iter([text, "", "q"])
+    monkeypatch.setattr("autoresearch.main.Prompt.ask", lambda *a, **k: next(responses))
+    result = runner.invoke(cli_app, ["monitor"])
+    bdd_context["monitor_result"] = result
+
+
+@then("the monitor should exit successfully")
+def monitor_exit_successfully(bdd_context):
+    assert bdd_context["monitor_result"].exit_code == 0
+
+
+@scenario("../features/interactive_monitor.feature", "Interactive monitoring")
+def test_interactive_monitor():
+    pass


### PR DESCRIPTION
## Summary
- add interactive monitor behavior steps

## Testing
- `flake8 src tests`
- `mypy src`
- `pytest tests/behavior/steps/interactive_monitor_steps.py::test_interactive_monitor -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_684bb3a06e1483338eec308c33908251