### PR TITLE
Explicit storage setup

### DIFF
--- a/src/autoresearch/api.py
+++ b/src/autoresearch/api.py
@@ -12,10 +12,18 @@ from .config import ConfigLoader, get_config
 from .orchestration.orchestrator import Orchestrator
 from .tracing import get_tracer, setup_tracing
 from .models import QueryResponse
+from .storage import StorageManager
 from pydantic import ValidationError
 
 config_loader = ConfigLoader()
 app = FastAPI()
+
+
+@app.on_event("startup")
+def _startup() -> None:
+    """Initialize storage on API startup."""
+    StorageManager.setup()
+
 
 # Start watching the main configuration file so that changes
 # to ``autoresearch.toml`` are picked up while the API is running.

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -16,6 +16,7 @@ from .config import ConfigLoader
 from .orchestration.orchestrator import Orchestrator
 from .output_format import OutputFormatter
 from .logging_utils import configure_logging
+from .storage import StorageManager
 
 app = typer.Typer(help="Autoresearch CLI entry point", name="autoresearch")
 configure_logging()
@@ -25,6 +26,7 @@ _config_loader = ConfigLoader()
 @app.callback(invoke_without_command=False)
 def start_watcher(ctx: typer.Context):
     """Start configuration watcher before executing commands."""
+    StorageManager.setup()
     _config_loader.watch_changes()
     atexit.register(_config_loader.stop_watching)
 

--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -106,6 +106,11 @@ def teardown(remove_db: bool = False) -> None:
 
 class StorageManager:
     @staticmethod
+    def setup(db_path: Optional[str] = None) -> None:
+        """Proxy to module-level setup function."""
+        setup(db_path)
+
+    @staticmethod
     def _current_ram_mb() -> float:
         """Return approximate RAM usage of the current process in MB."""
         try:
@@ -306,7 +311,3 @@ class StorageManager:
                 _db_conn.execute("DELETE FROM embeddings")
             if _rdf_store is not None:
                 _rdf_store.remove((None, None, None))
-
-
-# Initialise storage on module import using default path
-setup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,7 @@ def config_watcher():
 @pytest.fixture(autouse=True)
 def stop_config_watcher():
     """Ensure ConfigLoader watcher threads are cleaned up."""
+    ConfigLoader().stop_watching()
     yield
     ConfigLoader().stop_watching()
 

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -12,6 +12,10 @@ def test_cli_help_no_ansi(monkeypatch):
         def persist_claim(claim):
             pass
 
+        @staticmethod
+        def setup(*a, **k):
+            pass
+
     dummy_storage.StorageManager = StorageManager
     dummy_storage.setup = lambda *a, **k: None
     monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)


### PR DESCRIPTION
## Summary
- stop initializing storage on import
- load storage explicitly during API and CLI startup
- tweak CLI test to handle explicit setup
- ensure config watcher cleanup fixture stops watchers before and after tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `pytest -q` *(fails: tests/behavior/steps/agent_orchestration_steps.py::test_reasoning_direct)*

------
https://chatgpt.com/codex/tasks/task_e_684bb3b2e9f483339d2a2f4cce526e47