### PR TITLE
Add reset_instance for ConfigLoader and tests fixture

### DIFF
--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -113,6 +113,18 @@ class ConfigLoader:
     _instance = None
     _lock = threading.Lock()
 
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset the singleton instance for testing purposes."""
+        with cls._lock:
+            if cls._instance is not None:
+                try:
+                    cls._instance.stop_watching()
+                except Exception:
+                    pass
+                cls._instance._config = None
+                cls._instance = None
+
     def __new__(cls):
         """Singleton pattern implementation."""
         with cls._lock:

--- a/tests/behavior/steps/agent_orchestration_steps.py
+++ b/tests/behavior/steps/agent_orchestration_steps.py
@@ -5,6 +5,7 @@ from pytest_bdd import scenario, given, when, then, parsers
 from .common_steps import *  # noqa: F401,F403
 from autoresearch.config import ConfigLoader, ConfigModel
 from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration import ReasoningMode
 
 
 @given("the agents Synthesizer, Contrarian, and Fact-Checker are enabled")
@@ -34,7 +35,7 @@ def set_loops(loops: int, monkeypatch):
 
 @given(parsers.parse('reasoning mode is "{mode}"'))
 def set_reasoning_mode(mode, set_loops):
-    set_loops.reasoning_mode = mode
+    set_loops.reasoning_mode = ReasoningMode(mode)
     return set_loops
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,14 @@ from autoresearch.llm.registry import LLMFactory  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
+def reset_config_loader_instance():
+    """Reset ConfigLoader singleton before each test."""
+    ConfigLoader.reset_instance()
+    yield
+    ConfigLoader.reset_instance()
+
+
+@pytest.fixture(autouse=True)
 def isolate_paths(tmp_path, monkeypatch):
     """Use temporary working directory and cache file for each test."""
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary
- add `ConfigLoader.reset_instance()` to clear singleton state
- reset ConfigLoader before tests
- ensure reasoning mode string is converted to enum in BDD steps

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `pytest -q`
- `pytest tests/behavior`

------
https://chatgpt.com/codex/tasks/task_e_684c45077f148333ae486f5b17063d3c