### PR TITLE
Add tests for formatter and storage

### DIFF
--- a/tests/behavior/features/dkg_persistence.feature
+++ b/tests/behavior/features/dkg_persistence.feature
@@ -20,3 +20,9 @@ Feature: Hybrid Dynamic Knowledge Graph (DKG) Persistence
     When the system writes provenance data
     Then a new quad should appear in the RDFlib store
     And queries should return the quad via SPARQL
+
+  Scenario: Clear DKG removes persisted data
+    When an agent commits a new claim
+    And I clear the knowledge graph
+    Then the NetworkX graph should be empty
+    And the DuckDB tables should be empty

--- a/tests/behavior/features/interactive_monitor.feature
+++ b/tests/behavior/features/interactive_monitor.feature
@@ -9,3 +9,7 @@ Feature: Interactive Monitoring
   Scenario: Interactive monitoring
     When I start `autoresearch monitor` and enter "test"
     Then the monitor should exit successfully
+
+  Scenario: Exit immediately
+    When I start `autoresearch monitor` and enter "q"
+    Then the monitor should exit successfully

--- a/tests/behavior/steps/dkg_persistence_steps.py
+++ b/tests/behavior/steps/dkg_persistence_steps.py
@@ -139,3 +139,30 @@ def test_persist_duckdb():
 @scenario("../features/dkg_persistence.feature", "Persist claim in RDF quad-store")
 def test_persist_rdf():
     pass
+
+
+@when("I clear the knowledge graph")
+def clear_knowledge_graph():
+    from autoresearch.storage import StorageManager
+
+    StorageManager.clear_all()
+
+
+@then("the NetworkX graph should be empty")
+def graph_should_be_empty():
+    from autoresearch.storage import StorageManager
+
+    assert StorageManager.get_graph().number_of_nodes() == 0
+
+
+@then("the DuckDB tables should be empty")
+def duckdb_tables_empty():
+    from autoresearch.storage import StorageManager
+
+    conn = StorageManager.get_duckdb_conn()
+    assert conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0] == 0
+
+
+@scenario("../features/dkg_persistence.feature", "Clear DKG removes persisted data")
+def test_clear_dkg():
+    pass

--- a/tests/behavior/steps/interactive_monitor_steps.py
+++ b/tests/behavior/steps/interactive_monitor_steps.py
@@ -20,3 +20,8 @@ def monitor_exit_successfully(bdd_context):
 @scenario("../features/interactive_monitor.feature", "Interactive monitoring")
 def test_interactive_monitor():
     pass
+
+
+@scenario("../features/interactive_monitor.feature", "Exit immediately")
+def test_monitor_exit_immediately():
+    pass

--- a/tests/unit/test_output_format.py
+++ b/tests/unit/test_output_format.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 from autoresearch.models import QueryResponse
 from autoresearch.output_format import OutputFormatter
 
@@ -66,3 +67,23 @@ def test_markdown_no_ansi(capsys):
     OutputFormatter.format(resp, "markdown")
     out = capsys.readouterr().out
     assert "\x1b[" not in out
+
+
+@pytest.mark.parametrize(
+    "fmt, start",
+    [
+        ("json", "{"),
+        ("markdown", "# Answer"),
+        ("plain", "Answer:"),
+    ],
+)
+def test_format_dict_input(fmt, start, capsys):
+    data = {
+        "answer": "a",
+        "citations": ["c"],
+        "reasoning": ["r"],
+        "metrics": {"m": 1},
+    }
+    OutputFormatter.format(data, fmt)
+    out = capsys.readouterr().out
+    assert out.startswith(start)

--- a/tests/unit/test_reasoning_strategy.py
+++ b/tests/unit/test_reasoning_strategy.py
@@ -1,0 +1,29 @@
+from autoresearch.config import ConfigModel
+from autoresearch.orchestration.reasoning import ChainOfThoughtStrategy
+
+
+class DummySynth:
+    def __init__(self):
+        self.calls = 0
+
+    def can_execute(self, state, config):
+        return True
+
+    def execute(self, state, config):
+        self.calls += 1
+        return {"results": {"final_answer": f"step-{self.calls}"}}
+
+
+def test_chain_of_thought_strategy_loops(monkeypatch):
+    synth = DummySynth()
+    monkeypatch.setattr(
+        "autoresearch.agents.registry.AgentFactory.get",
+        lambda name: synth,
+    )
+    cfg = ConfigModel(loops=2)
+    strategy = ChainOfThoughtStrategy()
+    resp = strategy.run_query("q", cfg)
+    assert synth.calls == 2
+    assert resp.answer == "step-2"
+    metrics = resp.metrics.get("execution_metrics", {})
+    assert metrics.get("cycles_completed") == 2

--- a/tests/unit/test_storage_persistence_eviction.py
+++ b/tests/unit/test_storage_persistence_eviction.py
@@ -1,0 +1,24 @@
+from autoresearch.storage import StorageManager
+from autoresearch.config import ConfigModel, ConfigLoader
+from autoresearch.orchestration import metrics
+
+
+def test_persistence_and_eviction(storage_manager, tmp_path, monkeypatch):
+    cfg = ConfigModel(ram_budget_mb=1)
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+    monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 1000)
+
+    start = metrics.EVICTION_COUNTER._value.get()
+    claim = {"id": "p1", "type": "fact", "content": "c"}
+    StorageManager.persist_claim(claim)
+
+    db_file = tmp_path / "kg.duckdb"
+    assert db_file.exists()
+    conn = StorageManager.get_duckdb_conn()
+    result = conn.execute(
+        "SELECT COUNT(*) FROM nodes WHERE id='p1'"
+    ).fetchone()[0]
+    assert result == 1
+    assert "p1" not in StorageManager.get_graph().nodes
+    assert metrics.EVICTION_COUNTER._value.get() >= start + 1


### PR DESCRIPTION
## Summary
- exercise monitor exit and DKG clear scenarios
- check OutputFormatter with dict input
- add unit test for ChainOfThoughtStrategy
- test storage persistence with eviction

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q`
- `poetry run pytest -q tests/behavior`
- `poetry run pytest --cov=src -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4d47e2d883338d9e3e0f0081e94f