### PR TITLE
Improve testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ Execute all tests once the development environment is ready:
 ```bash
 poetry run flake8 src tests
 poetry run mypy src
-poetry run pytest
-poetry run pytest tests/behavior
+pytest -q
+pytest tests/behavior
 ```
+
+Maintain at least 90% test coverage and remove temporary files before submitting a pull request.
 
 ### Troubleshooting
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,13 +1,9 @@
 # Contributing
 
-We welcome contributions via pull requests. To get started, install the development dependencies and run the tests:
+We welcome contributions via pull requests. Install the development dependencies first:
 
 ```bash
 poetry install --with dev
-poetry run flake8 src tests
-poetry run mypy src
-poetry run pytest
-poetry run pytest tests/behavior
 ```
 
 You can alternatively run the helper script to install all dependencies:
@@ -15,5 +11,18 @@ You can alternatively run the helper script to install all dependencies:
 ```bash
 ./scripts/setup.sh
 ```
+
+## Running tests
+
+Execute the commands below before opening a pull request:
+
+```bash
+poetry run flake8 src tests
+poetry run mypy src
+pytest -q
+pytest tests/behavior
+```
+
+Maintain at least 90% test coverage and remove temporary files before submitting your changes.
 
 Please keep commits focused and descriptive.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,9 @@ from autoresearch.agents.registry import (  # noqa: E402
     AgentRegistry,
 )
 from autoresearch.llm.registry import LLMFactory  # noqa: E402
-from autoresearch.storage import set_delegate as set_storage_delegate
+from autoresearch.storage import (  # noqa: E402
+    set_delegate as set_storage_delegate,
+)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- document how to run tests in docs/contributing
- refine test commands in README
- fix flake8 warning in tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `pytest -q`
- `pytest tests/behavior`


------
https://chatgpt.com/codex/tasks/task_e_684c6a7fdb2083338ba369a4a121bbe8