### PR TITLE
Ignore cache.json and ensure test cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,7 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Autoresearch cache
+cache.json
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,8 @@ def isolate_paths(tmp_path, monkeypatch):
     cache.setup(str(cache_path))
     yield
     cache.teardown(remove_file=True)
+    if cache_path.exists():
+        cache_path.unlink()
     monkeypatch.delenv("TINYDB_PATH", raising=False)
 
 


### PR DESCRIPTION
## Summary
- ignore `cache.json` in version control
- remove `cache.json` in tests teardown

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `pytest tests/unit/test_cli_help.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7c14c8b48333b35712104bf735e3