### PR TITLE
Fix logging after shutdown

### DIFF
--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set
 import threading
 import logging
+import sys
 
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -265,7 +266,8 @@ class ConfigLoader:
         if self._watch_thread and self._watch_thread.is_alive():
             self._stop_event.set()
             self._watch_thread.join(timeout=1.0)
-            logger.info("Stopped config watcher")
+            if not getattr(sys.stderr, "closed", False):
+                logger.info("Stopped config watcher")
 
     def _watch_config_files(self) -> None:
         """Watch for changes in config files (runs in separate thread)."""

--- a/src/autoresearch/logging_utils.py
+++ b/src/autoresearch/logging_utils.py
@@ -14,6 +14,13 @@ class InterceptHandler(logging.Handler):
     """Redirect standard logging messages to loguru."""
 
     def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover
+        if getattr(sys.stderr, "closed", False):
+            return
+        handlers = logger._core.handlers.values()  # type: ignore[attr-defined]
+        for handler in handlers:
+            stream = getattr(getattr(handler, "_sink", None), "_stream", None)
+            if getattr(stream, "closed", False):
+                return
         try:
             level: int | str = logger.level(record.levelname).name
         except ValueError:

--- a/tests/unit/test_logging_shutdown.py
+++ b/tests/unit/test_logging_shutdown.py
@@ -1,0 +1,17 @@
+import logging
+import time
+from autoresearch.logging_utils import configure_logging
+from autoresearch.config import ConfigLoader
+
+
+def test_stop_watching_after_logging_shutdown(tmp_path):
+    configure_logging()
+    loader = ConfigLoader()
+    loader.watch_paths.clear()
+    loader.watch_paths.append(str(tmp_path / "config.toml"))
+    loader.watch_changes()
+    # ensure thread started
+    time.sleep(0.1)
+    logging.shutdown()
+    # should not raise even though logging is shut down
+    loader.stop_watching()


### PR DESCRIPTION
## Summary
- guard logging in `InterceptHandler` against closed streams
- avoid logging in `ConfigLoader.stop_watching` if stderr is closed
- add regression test to ensure stopping watcher after `logging.shutdown` is safe

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb11a1f848333b2b1e16588480922