### PR TITLE
Improve search query and synthesis functions

### DIFF
--- a/src/autoresearch/search.py
+++ b/src/autoresearch/search.py
@@ -36,9 +36,36 @@ class Search:
         return decorator
 
     @staticmethod
-    def generate_queries(query: str) -> List[str]:
-        """Return a list of search queries derived from the user query."""
-        return [query]
+    def generate_queries(
+        query: str, return_embeddings: bool = False
+    ) -> List[Any]:
+        """Generate search query variants or a simple embedding.
+
+        Parameters
+        ----------
+        query:
+            The raw user query string.
+        return_embeddings:
+            When ``True`` return a numeric embedding instead of query strings.
+        """
+
+        cleaned = query.strip()
+
+        if return_embeddings:
+            # Create a trivial embedding using character codes. This keeps the
+            # implementation lightweight and deterministic for unit tests.
+            return [float(ord(c)) for c in cleaned][:10]
+
+        queries = [cleaned]
+
+        # Add a simple variation emphasising examples or tutorials
+        if len(cleaned.split()) > 1:
+            queries.append(f"{cleaned} examples")
+
+        # Include a question style variant
+        queries.append(f"What is {cleaned}?")
+
+        return queries
 
     @staticmethod
     def external_lookup(

--- a/src/autoresearch/synthesis.py
+++ b/src/autoresearch/synthesis.py
@@ -8,11 +8,25 @@ log = get_logger(__name__)
 
 
 def build_answer(query: str, claims: List[Dict[str, str]]) -> str:
-    """Create a brief answer given a query and supporting claims."""
+    """Create a concise answer incorporating provided claim content."""
+
     log.info("Generating answer")
-    return f"Answer for '{query}' using {len(claims)} claims."
+
+    if not claims:
+        return f"No answer found for '{query}'."
+
+    summary = "; ".join(c.get("content", "") for c in claims[:3])
+    if len(claims) > 3:
+        summary += f" ... ({len(claims)} claims total)"
+
+    return summary
 
 
 def build_rationale(claims: List[Dict[str, str]]) -> str:
     """Summarize reasoning based on the provided claims."""
-    return f"Rationale derived from {len(claims)} claims."
+
+    if not claims:
+        return "No rationale available."
+
+    bullet_points = "\n".join(f"- {c.get('content', '')}" for c in claims)
+    return f"The reasoning is based on:\n{bullet_points}"

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -48,4 +48,11 @@ def test_external_lookup_special_chars(monkeypatch):
 
 
 def test_generate_queries():
-    assert Search.generate_queries("q") == ["q"]
+    queries = Search.generate_queries("some topic")
+    assert "some topic" in queries
+    assert any(q.startswith("What is") for q in queries)
+    assert len(queries) >= 2
+
+    emb = Search.generate_queries("abc", return_embeddings=True)
+    assert isinstance(emb, list)
+    assert all(isinstance(v, float) for v in emb)

--- a/tests/unit/test_synthesis.py
+++ b/tests/unit/test_synthesis.py
@@ -2,8 +2,9 @@ from autoresearch.synthesis import build_answer, build_rationale
 
 
 def test_build_answer_and_rationale():
-    claims = [{"content": "a"}, {"content": "b"}]
+    claims = [{"content": "first"}, {"content": "second"}]
     answer = build_answer("query", claims)
     rationale = build_rationale(claims)
-    assert "2" in answer
-    assert "2" in rationale
+
+    assert "first" in answer and "second" in answer
+    assert "- first" in rationale and "- second" in rationale


### PR DESCRIPTION
## Summary
- expand `Search.generate_queries` with variants and embedding option
- make `build_answer` and `build_rationale` use claim content
- add unit tests for new logic

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: duckdb extension download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684cb12d5a4c8333864314e20c4b3650