### PR TITLE
Improve documentation on reasoning modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ LLM adapters communicate with their backends over HTTP. Select one with
 `llm_backend` in `autoresearch.toml` (e.g. `lmstudio` or `openai`).
 Prometheus counters expose query and token statistics at `/metrics`.
 
+Example metrics output:
+
+```
+# HELP autoresearch_queries_total Total number of queries processed
+# TYPE autoresearch_queries_total counter
+autoresearch_queries_total 1.0
+# HELP autoresearch_tokens_total Total tokens consumed by direction
+# TYPE autoresearch_tokens_total counter
+autoresearch_tokens_total{direction="input"} 14.0
+autoresearch_tokens_total{direction="output"} 29.0
+```
+
+Set the reasoning mode with `reasoning_mode` under `[core]` in
+`autoresearch.toml`. Valid values are `direct`, `dialectical` (default), and
+`chain-of-thought`.
+
 ### Configuration hot reload
 
 When you run any CLI command, Autoresearch starts watching `autoresearch.toml`

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -12,14 +12,20 @@
 ## 2. Modules
 
 - **config.py**: Loads, validates, and hot-reloads configuration from `.env`, environment, and TOML.
-- **agentic_serper_search_v2.py**: Contains agent, search, and synthesis logic (to be split).
 - **main.py**: CLI entry point, parses args, loads config, runs agent, outputs context-adaptive results.
-- **output_format.py**: Adapts output for human (Markdown/plaintext) or machine (JSON) context.
+- **api.py**: FastAPI server exposing query and metrics endpoints.
 - **logging_utils.py**: Logging setup and helpers.
-- **agent.py**: Agent orchestration, dialectical reasoning, agent cycling.
-- **search.py**: Search execution, result processing, source metadata.
-- **synthesis.py**: Answer/rationale synthesis, schema validation.
-- **utils.py**: Shared helpers/utilities.
+- **output_format.py**: Adapts output for human (Markdown/plaintext) or machine (JSON) context.
+- **storage.py**: Persistence for search results and knowledge graph.
+- **models.py**: Pydantic models for structured data.
+- **tracing.py**: OpenTelemetry tracing configuration helpers.
+- **orchestration/orchestrator.py**: Coordinates multi-agent cycles.
+- **orchestration/state.py**: Tracks query state between agents.
+- **orchestration/reasoning.py**: Reasoning mode definitions and strategies.
+- **orchestration/metrics.py**: Prometheus metrics collection utilities.
+- **orchestration/phases.py**: Agent execution phases.
+- **agents/**: Implementations of Synthesizer, Contrarian, FactChecker, etc.
+- **llm/**: Backend adapters for language models.
 
 ## 3. Configuration
 

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -19,7 +19,15 @@ from .output_format import OutputFormatter
 from .logging_utils import configure_logging
 from .storage import StorageManager
 
-app = typer.Typer(help="Autoresearch CLI entry point", name="autoresearch")
+app = typer.Typer(
+    help=(
+        "Autoresearch CLI entry point.\n\n"
+        "Set the reasoning mode in autoresearch.toml under "
+        "[core.reasoning_mode]. Valid values: direct, dialectical, "
+        "chain-of-thought."
+    ),
+    name="autoresearch",
+)
 configure_logging()
 _config_loader: ConfigLoader = ConfigLoader()
 


### PR DESCRIPTION
## Summary
- mention `direct`, `dialectical`, and `chain-of-thought` in CLI help
- show Prometheus metrics example and reasoning mode setting in README
- link new modules in docs/specification.md

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `pytest -q`
- `pytest tests/behavior -q`


------
https://chatgpt.com/codex/tasks/task_e_684cb1352608833392a99b6b6ae52abc