### PR TITLE
Add cleanup task and instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,4 +24,9 @@ Thank you for considering a contribution! Follow these steps to set up the devel
    poetry run pytest tests/behavior
    ```
 
+4. Remove Python cache directories:
+   ```bash
+   task clean
+   ```
+
 Please keep commits focused and descriptive.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,3 +25,9 @@ tasks:
       - pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=xml --cov-report=term-missing tests
     desc: "Run full test suite with coverage reporting"
 
+  clean:
+    cmds:
+      - find . -type d -name '__pycache__' -exec rm -rf {} +
+      - find . -type d -name '.mypy_cache' -exec rm -rf {} +
+    desc: "Remove Python cache directories"
+


### PR DESCRIPTION
## Summary
- add a `clean` task to remove Python cache directories
- document how to run cache cleanup in CONTRIBUTING

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q`
- `poetry run pytest -q tests/behavior`


------
https://chatgpt.com/codex/tasks/task_e_684cb13cfbc483338574ba1fcdeb1215