### PR TITLE
Ensure ConfigLoader threads cleaned up

### DIFF
--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sys
 import os
-import atexit
 from typing import Optional
 
 import typer
@@ -36,8 +35,9 @@ _config_loader: ConfigLoader = ConfigLoader()
 def start_watcher(ctx: typer.Context) -> None:
     """Start configuration watcher before executing commands."""
     StorageManager.setup()
-    _config_loader.watch_changes()
-    atexit.register(_config_loader.stop_watching)
+    watch_ctx = _config_loader.watching()
+    watch_ctx.__enter__()
+    ctx.call_on_close(lambda: watch_ctx.__exit__(None, None, None))
 
 
 @app.command()

--- a/tests/unit/test_config_watcher_cleanup.py
+++ b/tests/unit/test_config_watcher_cleanup.py
@@ -1,0 +1,35 @@
+import threading
+from typer.testing import CliRunner
+from fastapi.testclient import TestClient
+
+from autoresearch.main import app as cli_app
+from autoresearch.api import app as api_app
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.models import QueryResponse
+
+
+def _mock_run_query(query, config):
+    return QueryResponse(answer="a", citations=[], reasoning=[], metrics={})
+
+
+def test_cli_watcher_cleanup(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr(Orchestrator, "run_query", _mock_run_query)
+    result = runner.invoke(cli_app, ["search", "q"])
+    assert result.exit_code == 0
+    assert not any(
+        t.name == "ConfigWatcher" and t.is_alive()
+        for t in threading.enumerate()
+    )
+
+
+def test_api_watcher_cleanup(monkeypatch):
+    monkeypatch.setattr(Orchestrator, "run_query", _mock_run_query)
+    with TestClient(api_app) as client:
+        resp = client.post("/query", json={"query": "q"})
+        assert resp.status_code == 200
+    assert not any(
+        t.name == "ConfigWatcher" and t.is_alive()
+        for t in threading.enumerate()
+    )


### PR DESCRIPTION
## Summary
- automatically stop ConfigLoader watcher via `atexit`
- expose `ConfigLoader.watching` context manager
- manage watch threads in CLI/API using the context manager
- test that CLI and API leave no dangling ConfigWatcher threads

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `pytest -q`
- `pytest tests/behavior -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc2d70d388333a1a1f4269a0ff647