### PR TITLE
Update contribution docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,20 @@
 # Contribution Guidelines
 
-- Install dependencies with `poetry install` or `pip install -e .` before running tests.
-- Check style with `poetry run flake8 src tests` and type hints with `poetry run mypy src`.
-- Run `pytest -q` and the BDD tests in `tests/behavior` before opening a pull request.
-- Keep commits focused and provide clear messages describing your changes.
+Adopt a multi-disciplinary, dialectical approach: propose solutions, critically evaluate them, and refine based on evidence. Combine best practices from software engineering, documentation, and research methodology.
+
+## Environment setup
+- Use **Poetry** for all project interactions.
+  - Select the Python interpreter with `poetry env use $(which python3)` (Python 3.12 or newer).
+  - Install dependencies with `poetry install --with dev`.
+  - Activate the environment using `poetry shell` or prefix commands with `poetry run`.
+  - Avoid system-level Python or `pip`. Run `pip install -e .` only inside the Poetry virtual environment using `poetry shell` or `poetry run pip`.
+
+## Verification steps
+- Check code style with `poetry run flake8 src tests`.
+- Verify type hints with `poetry run mypy src`.
+- Run the unit suite: `poetry run pytest -q`.
+- Execute BDD tests in `tests/behavior`: `poetry run pytest tests/behavior`.
+
+## Commit etiquette
+- Keep commits focused and write clear messages detailing your reasoning.
 - Remove temporary files and keep the repository tidy.

--- a/README.md
+++ b/README.md
@@ -227,15 +227,15 @@ Execute all tests once the development environment is ready:
 ```bash
 poetry run flake8 src tests
 poetry run mypy src
-pytest -q
-pytest tests/behavior
+poetry run pytest -q
+poetry run pytest tests/behavior
 ```
 
 Maintain at least 90% test coverage and remove temporary files before submitting a pull request.
 
 ### Troubleshooting
 
-- If tests fail with `ModuleNotFoundError`, ensure all dependencies are installed using `pip install -e .` or `poetry install --with dev`.
+- If tests fail with `ModuleNotFoundError`, ensure all dependencies are installed inside the Poetry environment using `poetry install --with dev` or `poetry run pip install -e .`.
 - When starting the API with `uvicorn autoresearch.api:app --reload`, install `uvicorn` if the command is not found and verify that port `8000` is free.
 
 ## Building the documentation

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,8 +19,8 @@ Execute the commands below before opening a pull request:
 ```bash
 poetry run flake8 src tests
 poetry run mypy src
-pytest -q
-pytest tests/behavior
+poetry run pytest -q
+poetry run pytest tests/behavior
 ```
 
 Maintain at least 90% test coverage and remove temporary files before submitting your changes.


### PR DESCRIPTION
## Summary
- clarify environment usage in `AGENTS.md`
- document running `pytest` through Poetry in the README
- update developer guide with Poetry-based test commands

## Testing
- `poetry run flake8 src tests` *(fails: style violations)*
- `poetry run mypy src` *(fails: various typing errors)*
- `poetry run pytest -q` *(fails: interrupted)*
- `poetry run pytest tests/behavior` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6850fd1c5e2083338b9cbb9218744fbe