### PR TITLE
Fix RDF storage plugin configuration

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -68,10 +68,10 @@ This occurs because HNSW indexes in DuckDB require special handling for persiste
 If you encounter an error like:
 
 ```
-Failed to open RDF store: No plugin registered for (SQLite, <class 'rdflib.store.Store'>)
+Failed to open RDF store: No plugin registered for (SQLAlchemy, <class 'rdflib.store.Store'>)
 ```
 
-This indicates that the RDFLib SQLite plugin is not properly registered. To fix this:
+This indicates that the RDFLib SQLAlchemy plugin is not properly registered. To fix this:
 
 1. Ensure the `rdflib-sqlalchemy` package is installed:
    ```bash

--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -29,6 +29,7 @@ from typing import Any, Optional, cast
 import duckdb
 import networkx as nx
 import rdflib
+import rdflib_sqlalchemy
 from .config import ConfigLoader
 from .errors import StorageError, NotFoundError
 from .extensions import VSSExtensionLoader
@@ -75,11 +76,14 @@ def setup(db_path: Optional[str] = None) -> None:
 
         # Initialize RDF store
         store_name = (
-            "Sleepycat" if cfg.rdf_backend == "berkeleydb" else "SQLite"
+            "Sleepycat" if cfg.rdf_backend == "berkeleydb" else "SQLAlchemy"
         )
+        rdf_path = cfg.rdf_path
+        if store_name == "SQLAlchemy" and "://" not in rdf_path:
+            rdf_path = f"sqlite:///{rdf_path}"
         try:
             _rdf_store = rdflib.Graph(store=store_name)
-            _rdf_store.open(cfg.rdf_path, create=True)
+            _rdf_store.open(rdf_path, create=True)
         except Exception as e:  # pragma: no cover - store may fail
             log.error(f"Failed to open RDF store: {e}")
             _rdf_store = rdflib.Graph()

--- a/tests/integration/test_rdf_persistence.py
+++ b/tests/integration/test_rdf_persistence.py
@@ -58,3 +58,21 @@ def test_rdf_persistence(storage_manager, tmp_path, monkeypatch):
     subj = rdflib.URIRef("urn:claim:n1")
     results = list(store.triples((subj, None, None)))
     assert results, "Claim was not persisted to the RDF store"
+
+
+def test_sqlalchemy_backend_initializes(tmp_path, monkeypatch):
+    """RDF store should use SQLAlchemy backend when configured."""
+    cfg = ConfigModel(
+        storage=StorageConfig(
+            rdf_backend="sqlite",
+            rdf_path=str(tmp_path / "rdf_store"),
+        )
+    )
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+
+    StorageManager.teardown(remove_db=True)
+    StorageManager.setup()
+
+    store = StorageManager.get_rdf_store()
+    assert store.store.name == "SQLAlchemy"


### PR DESCRIPTION
## Summary
- import `rdflib_sqlalchemy` so RDF plugin registers
- switch to the SQLAlchemy RDF store by default
- auto-convert RDF path to a valid SQLAlchemy URL
- update troubleshooting docs for SQLAlchemy plugin
- add integration test for SQLAlchemy backend

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q`
- `poetry run pytest tests/behavior`

------
https://chatgpt.com/codex/tasks/task_e_6851060bf3648333bd5e75933fbb5070