### PR TITLE
Fix sqlite RDF store initialization

### DIFF
--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -75,12 +75,12 @@ def setup(db_path: Optional[str] = None) -> None:
         _db_backend.setup(db_path)
 
         # Initialize RDF store
-        store_name = (
-            "Sleepycat" if cfg.rdf_backend == "berkeleydb" else "SQLAlchemy"
-        )
-        rdf_path = cfg.rdf_path
-        if store_name == "SQLAlchemy" and "://" not in rdf_path:
-            rdf_path = f"sqlite:///{rdf_path}"
+        if cfg.rdf_backend == "berkeleydb":
+            store_name = "Sleepycat"
+            rdf_path = cfg.rdf_path
+        else:
+            store_name = "SQLAlchemy"
+            rdf_path = f"sqlite:///{cfg.rdf_path}"
         try:
             _rdf_store = rdflib.Graph(store=store_name)
             _rdf_store.open(rdf_path, create=True)

--- a/tests/integration/test_rdf_persistence.py
+++ b/tests/integration/test_rdf_persistence.py
@@ -75,4 +75,5 @@ def test_sqlalchemy_backend_initializes(tmp_path, monkeypatch):
     StorageManager.setup()
 
     store = StorageManager.get_rdf_store()
-    assert store.store.name == "SQLAlchemy"
+    assert store.store.__class__.__name__ == "SQLAlchemy"
+    assert str(store.store.engine.url).startswith("sqlite:///")


### PR DESCRIPTION
## Summary
- ensure StorageManager uses SQLAlchemy store when `rdf_backend` is `sqlite`
- verify that the SQLAlchemy store opens correctly without plugin errors

## Testing
- `poetry run flake8 src/autoresearch/storage.py tests/integration/test_rdf_persistence.py`
- `poetry run mypy src/autoresearch/storage.py` *(failed: interrupted)*
- `poetry run pytest tests/integration/test_rdf_persistence.py::test_sqlalchemy_backend_initializes -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68518c5a2d88833380201517992cfc44