### PR TITLE
Add in-memory RDF backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ hnsw_metric = "l2"
 # see docs/duckdb_compatibility.md
 
 [storage.rdf]
-# RDF backend (sqlite or berkeleydb)
+# RDF backend (sqlite, berkeleydb, or memory)
 backend = "sqlite"
 
 # Path to RDF store

--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -146,7 +146,7 @@ class StorageConfig(BaseModel):
         Raises:
             ConfigError: If the specified backend is not in the list of valid backends
         """
-        valid_backends = ["sqlite", "berkeleydb"]
+        valid_backends = ["sqlite", "berkeleydb", "memory"]
         if v not in valid_backends:
             raise ConfigError(f"Invalid RDF backend", 
                              valid_backends=valid_backends, 

--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -75,22 +75,25 @@ def setup(db_path: Optional[str] = None) -> None:
         _db_backend.setup(db_path)
 
         # Initialize RDF store
-        if cfg.rdf_backend == "berkeleydb":
-            store_name = "Sleepycat"
-            rdf_path = cfg.rdf_path
-        else:
-            store_name = "SQLAlchemy"
-            rdf_path = f"sqlite:///{cfg.rdf_path}"
-        try:
-            _rdf_store = rdflib.Graph(store=store_name)
-            _rdf_store.open(rdf_path, create=True)
-        except Exception as e:  # pragma: no cover - store may fail
-            log.error(f"Failed to open RDF store: {e}")
+        if cfg.rdf_backend == "memory":
             _rdf_store = rdflib.Graph()
-            # Don't raise if it's a plugin registration issue, as this is a common case
-            # in test environments where the full RDF dependencies might not be installed
-            if "No plugin registered" not in str(e):
-                raise StorageError("Failed to open RDF store", cause=e)
+        else:
+            if cfg.rdf_backend == "berkeleydb":
+                store_name = "Sleepycat"
+                rdf_path = cfg.rdf_path
+            else:
+                store_name = "SQLAlchemy"
+                rdf_path = f"sqlite:///{cfg.rdf_path}"
+            try:
+                _rdf_store = rdflib.Graph(store=store_name)
+                _rdf_store.open(rdf_path, create=True)
+            except Exception as e:  # pragma: no cover - store may fail
+                log.error(f"Failed to open RDF store: {e}")
+                _rdf_store = rdflib.Graph()
+                # Don't raise if it's a plugin registration issue, as this is a common case
+                # in test environments where the full RDF dependencies might not be installed
+                if "No plugin registered" not in str(e):
+                    raise StorageError("Failed to open RDF store", cause=e)
 
 
 def teardown(remove_db: bool = False) -> None:

--- a/tests/integration/test_rdf_persistence.py
+++ b/tests/integration/test_rdf_persistence.py
@@ -77,3 +77,21 @@ def test_sqlalchemy_backend_initializes(tmp_path, monkeypatch):
     store = StorageManager.get_rdf_store()
     assert store.store.__class__.__name__ == "SQLAlchemy"
     assert str(store.store.engine.url).startswith("sqlite:///")
+
+
+def test_memory_backend_initializes(tmp_path, monkeypatch):
+    """RDF store should use in-memory backend when configured."""
+    cfg = ConfigModel(
+        storage=StorageConfig(
+            rdf_backend="memory",
+            rdf_path=str(tmp_path / "rdf_store"),
+        )
+    )
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+
+    StorageManager.teardown(remove_db=True)
+    StorageManager.setup()
+
+    store = StorageManager.get_rdf_store()
+    assert store.store.__class__.__name__ == "IOMemory"


### PR DESCRIPTION
## Summary
- support `memory` rdf_backend option
- handle memory backend with `rdflib.Graph()`
- document the new option
- test memory backend initialization

## Testing
- `poetry run flake8 src tests` *(fails: E501 line too long, etc.)*
- `poetry run mypy src` *(fails: union-attr errors)*
- `poetry run pytest -q` *(fails: can't find spaCy model)*

------
https://chatgpt.com/codex/tasks/task_e_685196391580833392067519392ffc3e