### PR TITLE
Document hdbscan build prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,18 @@ By participating in this project, you agree to maintain a respectful and inclusi
    poetry install --with dev
    ```
 
+   Some packages such as `hdbscan` require compilation. Make sure GCC, G++, and
+   the Python development headers are available before running the command
+   above. On Debian/Ubuntu-based systems you can install them with:
+
+   ```bash
+   sudo apt-get update
+   sudo apt-get install build-essential python3-dev
+   ```
+
+   If OpenMP support causes build errors, disable it by setting
+   `HDBSCAN_NO_OPENMP=1` in your environment when installing.
+
    Alternatively, you can use the helper script:
    ```bash
    ./scripts/setup.sh

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -24,6 +24,20 @@ Use `poetry install` to set up a development environment:
 poetry install
 ```
 
+`hdbscan` is built from source and needs compilation tools. Install `gcc`, `g++`,
+and the Python development headers first. On Debian/Ubuntu run:
+
+```bash
+sudo apt-get update
+sudo apt-get install build-essential python3-dev
+```
+
+If OpenMP support causes build issues you can disable it with:
+
+```bash
+export HDBSCAN_NO_OPENMP=1
+```
+
 Alternatively install via pip:
 
 ```bash


### PR DESCRIPTION
## Summary
- mention `gcc`, `g++`, and Python headers for hdbscan in the installation instructions
- show apt commands to install the toolchain
- include `HDBSCAN_NO_OPENMP` hint for build issues

## Testing
- `poetry run flake8 src tests` *(fails: E501 line too long, etc.)*
- `poetry run mypy src` *(fails: Found 117 errors in 13 files)*
- `poetry run pytest -q` *(fails: NameError in tests/unit/test_context_aware_search.py)*
- `poetry run pytest tests/behavior` *(fails: 1 failed, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685204da056c833381f93526b63b2c11