### PR TITLE
Add Git repo search requirement

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -39,6 +39,7 @@ Must     | BDD/unit tests; plugin registration.       |
 | **F-16** | System is extensible for new backends, reasoning modes, and agent types via config/plugins.                                                      | Must     | Plugin test; config reload.                |
 | **F-17** | **CLI output adapts to context**: Markdown/plaintext for humans (TTY), JSON for automation (pipe/flag); dialectical structure is visually distinct for humans and explicit in JSON for machines. | Must | BDD/manual review/unit tests.              |
 | **F-18** | **Accessibility**: Output is screen-reader friendly, avoids color-only cues, and is actionable for all users.                                    | Must     | Accessibility review/manual test.          |
+| **F-19** | Search local Git repositories by path, with results referencing files, commit messages, or diffs. | Should   | Unit tests for git repository search; BDD scenario. |
 
 ---
 

--- a/docs/requirements_tracability_matrix.md
+++ b/docs/requirements_tracability_matrix.md
@@ -20,3 +20,4 @@
 | F-16 | Extensible plugin architecture | `agents/registry.py` | `tests/unit/test_agents_llm.py` |
 | F-17 | Adaptive CLI output | `output_format.py` | `tests/unit/test_output_format.py`, `tests/behavior/features/output_formatting.feature` |
 | F-18 | Accessibility of output | `output_format.py` | manual review |
+| F-19 | Local Git repository search by path | `search.py` | `tests/unit/test_git_search.py` |


### PR DESCRIPTION
## Summary
- document that users can search local Git repos by path and results may include files, commit messages or diffs
- connect new requirement to modules and tests in the requirements traceability matrix

## Testing
- `poetry run flake8 src tests` *(fails: E501 line too long)*
- `poetry run mypy src` *(fails: found 80 errors in 10 files)*
- `poetry run pytest -q` *(interrupted: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6852cadb7aec8333ab31c67ae7de0248