### PR TITLE
Stub network in tests

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -1,4 +1,13 @@
+import os
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def enable_real_vss(monkeypatch):
+    """Allow real VSS extension loading in behavior tests."""
+    monkeypatch.setenv("REAL_VSS_TEST", "1")
+    yield
+    monkeypatch.delenv("REAL_VSS_TEST", raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import sys
+import os
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -18,6 +19,23 @@ from autoresearch.llm.registry import LLMFactory  # noqa: E402
 from autoresearch.storage import (  # noqa: E402
     set_delegate as set_storage_delegate,
 )
+from autoresearch.extensions import VSSExtensionLoader
+
+
+@pytest.fixture(autouse=True)
+def stub_vss_extension_download(monkeypatch):
+    """Prevent network calls when loading the DuckDB VSS extension."""
+    if os.getenv("REAL_VSS_TEST"):
+        yield
+        return
+
+    monkeypatch.setattr(VSSExtensionLoader, "load_extension", lambda _c: False)
+    monkeypatch.setattr(
+        VSSExtensionLoader,
+        "verify_extension",
+        lambda _c, verbose=True: False,
+    )
+    yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_context_aware_search.py
+++ b/tests/unit/test_context_aware_search.py
@@ -90,13 +90,14 @@ def test_initialize_nlp(mock_spacy, reset_search_context):
 @patch("autoresearch.search.spacy")
 def test_initialize_nlp_downloads_model_when_env_set(mock_spacy, reset_search_context):
     """spaCy model is downloaded if missing and env var is set."""
-    mock_spacy.load.side_effect = [OSError(), MagicMock()]
+    second_load = MagicMock()
+    mock_spacy.load.side_effect = [OSError(), second_load]
 
     context = SearchContext.get_instance()
 
     mock_spacy.cli.download.assert_called_once_with("en_core_web_sm")
     assert mock_spacy.load.call_count == 2
-    assert context.nlp is mock_spacy.load.return_value
+    assert context.nlp is second_load
 
 
 @patch.dict(os.environ, {}, clear=True)


### PR DESCRIPTION
## Summary
- prevent DuckDB extension download during most tests
- allow real extension handling in behavior tests
- fix spaCy download test by capturing the mocked return value

## Testing
- `poetry run flake8 src tests` *(fails: E501 line too long)*
- `poetry run mypy src` *(fails: errors in source files)*
- `poetry run pytest tests/unit/test_context_aware_search.py::test_initialize_nlp_downloads_model_when_env_set -q`
- `poetry run pytest -q` *(failed: KeyboardInterrupt)*
- `poetry run pytest tests/behavior -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ea79e73c83339d2703b8af91e823