### PR TITLE
Add local search examples

### DIFF
--- a/examples/autoresearch.toml
+++ b/examples/autoresearch.toml
@@ -47,6 +47,17 @@ use_search_history = true
 history_weight = 0.2
 max_history_items = 10  # Maximum number of queries to keep in history
 
+# Local file search settings
+[search.local_file]
+path = "/path/to/research_docs"
+file_types = ["md", "pdf", "txt"]
+
+# Local Git repository search settings
+[search.local_git]
+repo_path = "/path/to/repo"
+branches = ["main"]
+history_depth = 50
+
 [storage.duckdb]
 path = "data/research.duckdb"
 vector_extension = true


### PR DESCRIPTION
## Summary
- show example configuration for local file and git search

## Testing
- `poetry run flake8 src tests` *(fails: E501 line too long)*
- `poetry run mypy src` *(fails: found errors)*
- `poetry run pytest -q` *(interrupted: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(interrupted: KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_68531145740c8333b249f79281939e1c