### PR TITLE
Update search requirements

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -41,6 +41,7 @@ Must     | BDD/unit tests; plugin registration.       |
 | **F-18** | **Accessibility**: Output is screen-reader friendly, avoids color-only cues, and is actionable for all users.                                    | Must     | Accessibility review/manual test.          |
 | **F-19** | Search local directories. User can select a path to index text and code files. Results must cite the file path and snippet so provenance is clear. | Should   | Unit tests for local file indexing; BDD scenario. |
 | **F-20** | Search Git repositories by path. The system scans working tree and commit history, indexing commit messages and diffs. Results return commit hash, file path, and snippet for provenance. | Should   | Unit tests for git repository search; BDD scenario. |
+| **F-21** | Maintain local indexes for directories and Git repositories. Indexing occurs at startup or on user command, capturing file contents and commit history for offline queries. | Should   | Unit tests verifying incremental updates; BDD scenario. |
 
 ---
 
@@ -53,10 +54,12 @@ Must     | BDD/unit tests; plugin registration.       |
 | **Extensibility** | Agents, databases, protocols registered via entry-points; config-driven.    |
 | **Observability** | JSON logs (structlog), Prometheus metrics, OpenTelemetry traces.            |
 | **Security**      | No outbound HTTP except user-enabled search/LLM; secrets only via env/TOML. |
+| **Security (Indexing)** | Local indexing never transmits file contents externally and respects OS permissions. |
 | **Licensing**     | All first-party code MIT/AGPL-compatible; closed LLMs optional.             |
 | **Usability**     | CLI `--help`, OpenAPI docs, Markdown-formatted answers for humans, JSON for automation. |
 | **Accessibility** | Output is readable and actionable for humans by default; dialectical structure is visually distinct and accessible. |
 | **Testability**   | 90%+ code coverage, including error paths and output adaptation.             |
+| **Performance (Indexing)** | Indexing up to 10k files or commits completes within 2 min; queries from the index respond in under 1 s. |
 
 ---
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -70,6 +70,12 @@
   files directly. Specify `path` and `file_types` in `[search.local_files]`.
 - `local_git` scans repositories configured with `repo_path`, `branches`, and
   `history_depth`, indexing commit messages, diffs, and file revisions.
+
+Local directories are ingested using **ripgrep** when available for fast content extraction. Each file is chunked, embedded, and stored in DuckDB with its path and modification time. On subsequent runs only changed files are re-indexed to keep the index fresh.
+
+Git repositories are processed via **GitPython**. The backend walks the commit history, storing commit metadata and file snapshots so queries can reference the exact revision. Incremental indexing keeps the database in sync with the repository without reprocessing unchanged commits.
+
+Queries against these local indexes leverage DuckDB vector search. Matches return the snippet, file path, and commit hash when applicable so every result is fully attributable.
 - Results from all backends are persisted via `storage.py` and inserted into the
   knowledge graph for later reasoning.
 


### PR DESCRIPTION
## Summary
- clarify local search requirements in docs
- explain local source indexing in non-functional requirements
- expand specification search section with more details on local indexing

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q`
- `poetry run pytest tests/behavior`

------
https://chatgpt.com/codex/tasks/task_e_68531df55eb88333abe7d5f6a607fa16