### PR TITLE
Document new search backends

### DIFF
--- a/docs/api_reference/search.md
+++ b/docs/api_reference/search.md
@@ -46,3 +46,21 @@ The `BraveBackend` class provides integration with the Brave Search API.
 The `LocalBackend` class provides search functionality for local documents.
 
 ::: autoresearch.search.LocalBackend
+
+### Local File Backend
+
+The `LocalFileBackend` class indexes documents from local directories. Configure the backend in `[search.local_file]` with a `path` to the root directory and a list of allowed `file_types`.
+
+Results contain a text `snippet` and the absolute `path` to the file.
+
+Caching avoids reprocessing unchanged files by storing a modification timestamp in the index. Only new or updated files are re-indexed on subsequent runs.
+
+::: autoresearch.search.LocalFileBackend
+
+### Git Backend
+
+The `GitBackend` class searches a local Git repository. Configure it in `[search.local_git]` with `repo_path`, `branches`, and `history_depth` to limit indexing depth.
+
+Each indexed entry stores the file `path`, commit `hash`, and a brief `snippet`. Incremental indexing keeps the database synced with the repository without reprocessing unchanged commits.
+
+::: autoresearch.search.GitBackend


### PR DESCRIPTION
## Summary
- add documentation for `LocalFileBackend` and `GitBackend`
- explain configuration options, result format, and indexing behaviour

## Testing
- `poetry run flake8 src tests` *(fails: E501 line too long)*
- `poetry run mypy src` *(fails with type errors)*
- `poetry run pytest -q` *(interrupted: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: StepDefinitionNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68533b064fa48333ae1a5728521ff9b3