### PR TITLE
Document local_file and local_git backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ curl -X POST http://localhost:8000/query -d '{"query": "Explain machine learning
 curl http://localhost:8000/metrics
 ```
 
+To search your own documents or repositories, enable the `local_file` or
+`local_git` backends in `autoresearch.toml`.
+
 ## Configuration
 
 Autoresearch uses a TOML configuration file (`autoresearch.toml`) and environment variables (`.env`). A starter configuration is available under [`examples/autoresearch.toml`](examples/autoresearch.toml).
@@ -128,14 +131,15 @@ max_results_per_query = 5
 
 ### Enabling Local File and Git Search
 
-Add the `local_files` or `local_git` backends in `autoresearch.toml` to search
-documents on your machine or a Git repository:
+Add the `local_file` or `local_git` backends in `autoresearch.toml` to search
+documents on your machine or a Git repository. Results from these backends are
+ranked together with web search results:
 
 ```toml
 [search]
-backends = ["serper", "local_files", "local_git"]
+backends = ["serper", "local_file", "local_git"]
 
-[search.local_files]
+[search.local_file]
 path = "/path/to/docs"
 file_types = ["md", "pdf", "txt"]
 

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -119,14 +119,16 @@ history_weight = 0.3
 
 ### Local File Backend
 
-The `local_files` backend searches documents stored on disk. Provide a `path`
-to the root directory and specify which `file_types` should be indexed. All
-matching files are scanned recursively.
+The `local_file` backend searches documents stored on disk. Enable this backend
+when you have notes, PDFs, or other reference materials you want included in
+results. Provide a `path` to the root directory and specify which `file_types`
+should be indexed. All matching files are scanned recursively and merged with
+web search results during ranking.
 
 ```toml
 # autoresearch.toml
-[search.local_files]
-path = "/path/to/research_docs"
+[search.local_file]
+path = "/path/to/docs"
 file_types = ["md", "pdf", "txt"]
 ```
 
@@ -145,9 +147,10 @@ search results.
 
 ### Local Git Backend
 
-The `local_git` backend indexes the history of a Git repository. Set
-`repo_path` to your repository, list the `branches` you want indexed, and limit
-how far back in history to search with `history_depth`.
+The `local_git` backend indexes the history of a Git repository. Enable this
+when you want search results to include commit messages and file snapshots from
+your own projects. Set `repo_path` to your repository, list the `branches` you
+want indexed, and limit how far back in history to search with `history_depth`.
 
 ```toml
 # autoresearch.toml
@@ -165,9 +168,13 @@ To enable both local backends along with other providers:
 ```toml
 # autoresearch.toml
 [search]
-backends = ["serper", "local_files", "local_git"]
+backends = ["serper", "local_file", "local_git"]
 results_per_backend = 5
 ```
+
+When multiple backends are enabled, Autoresearch merges the top
+`results_per_backend` entries from each provider into a single ranked list so
+local documents appear alongside web results.
 
 ## Storage and Knowledge Graph
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -57,10 +57,11 @@ autoresearch search "What is quantum computing?"
 Enable local search backends in `autoresearch.toml`:
 
 ```toml
-[search]
-backends = ["serper", "local_files", "local_git"]
 
-[search.local_files]
+[search]
+backends = ["serper", "local_file", "local_git"]
+
+[search.local_file]
 path = "/path/to/docs"
 file_types = ["md", "pdf", "txt"]
 
@@ -69,6 +70,9 @@ repo_path = "/path/to/repo"
 branches = ["main"]
 history_depth = 50
 ```
+
+Local search results are merged with those from web backends so your documents
+and code appear alongside external sources.
 
 Then query your directory or repository just like any other search:
 


### PR DESCRIPTION
## Summary
- show how to configure `local_file` and `local_git` search backends
- explain when to enable local search and how results are merged
- mention local backends in README quick start

## Testing
- `poetry run flake8 src tests` *(fails: E501 line too long)*
- `poetry run mypy src` *(fails: found 78 errors)*
- `poetry run pytest -q` *(fails: TestDuckDBStorageBackend::test_create_tables)*
- `poetry run pytest tests/behavior` *(fails: StepDefinitionNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6853480ccf108333a518587eada73dad