### PR TITLE
Add commented local search sections

### DIFF
--- a/examples/autoresearch.toml
+++ b/examples/autoresearch.toml
@@ -48,15 +48,15 @@ history_weight = 0.2
 max_history_items = 10  # Maximum number of queries to keep in history
 
 # Local file search settings
-[search.local_file]
-path = "/path/to/research_docs"
-file_types = ["md", "pdf", "txt"]
+# [search.local_file]
+# path = "/path/to/research_docs"
+# file_types = ["md", "pdf", "txt"]
 
 # Local Git repository search settings
-[search.local_git]
-repo_path = "/path/to/repo"
-branches = ["main"]
-history_depth = 50
+# [search.local_git]
+# repo_path = "/path/to/repo"
+# branches = ["main"]
+# history_depth = 50
 
 [storage.duckdb]
 path = "data/research.duckdb"


### PR DESCRIPTION
## Summary
- disable local search sections in example config

## Testing
- `poetry run flake8 src tests` *(fails: E501 line too long)*
- `poetry run mypy src` *(fails: 78 errors in 10 files)*
- `poetry run pytest -q` *(fails: AssertionError in test_config_reload_on_change)*
- `poetry run pytest tests/behavior` *(fails: StepDefinitionNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685354aae25483338c491ae7ed6783ad