### PR TITLE
Add explicit local search requirements

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -39,8 +39,8 @@ Must     | BDD/unit tests; plugin registration.       |
 | **F-16** | System is extensible for new backends, reasoning modes, and agent types via config/plugins.                                                      | Must     | Plugin test; config reload.                |
 | **F-17** | **CLI output adapts to context**: Markdown/plaintext for humans (TTY), JSON for automation (pipe/flag); dialectical structure is visually distinct for humans and explicit in JSON for machines. | Must | BDD/manual review/unit tests.              |
 | **F-18** | **Accessibility**: Output is screen-reader friendly, avoids color-only cues, and is actionable for all users.                                    | Must     | Accessibility review/manual test.          |
-| **F-19** | Search local directories. User can select a path to index text and code files. Results must cite the file path and snippet so provenance is clear. | Should   | Unit tests for local file indexing; BDD scenario. |
-| **F-20** | Search Git repositories by path. The system scans working tree and commit history, indexing commit messages and diffs. Results return commit hash, file path, and snippet for provenance. | Should   | Unit tests for git repository search; BDD scenario. |
+| **F-19** | Search local directories for text and code. Users choose a path to index and results must cite the file path and snippet for provenance. | Should   | Unit tests for local file indexing; BDD scenario. |
+| **F-20** | Search local Git repositories by path. The system scans the working tree and commit history, indexing commit messages and diffs. Results return commit hash, file path, and snippet for provenance. | Should   | Unit tests for git repository search; BDD scenario. |
 | **F-21** | Maintain local indexes for directories and Git repositories. Indexing occurs at startup or on user command, capturing file contents and commit history for offline queries. | Should   | Unit tests verifying incremental updates; BDD scenario. |
 
 ---

--- a/docs/requirements_tracability_matrix.md
+++ b/docs/requirements_tracability_matrix.md
@@ -20,5 +20,5 @@
 | F-16 | Extensible plugin architecture | `agents/registry.py` | `tests/unit/test_agents_llm.py` |
 | F-17 | Adaptive CLI output | `output_format.py` | `tests/unit/test_output_format.py`, `tests/behavior/features/output_formatting.feature` |
 | F-18 | Accessibility of output | `output_format.py` | manual review |
-| F-19 | Local directory search | `search_backends/local_files.py` | `tests/unit/test_local_search.py`, `tests/behavior/features/local_file_search.feature` |
-| F-20 | Local Git repository search by path | `search_backends/local_git.py` | `tests/unit/test_git_search.py`, `tests/behavior/features/git_repository_search.feature` |
+| F-19 | Local directory search | `search/`, `search_backends/local_files.py` | `tests/unit/test_local_search.py`, `tests/behavior/features/local_file_search.feature` |
+| F-20 | Local Git repository search by path | `search/`, `search_backends/local_git.py` | `tests/unit/test_git_search.py`, `tests/behavior/features/git_repository_search.feature` |


### PR DESCRIPTION
## Summary
- clarify local directory and git repository search requirements
- map new requirements to search modules in the traceability matrix

## Testing
- `poetry run markdown-formatter docs/requirements.md docs/requirements_tracability_matrix.md` *(fails: Command not found)*
- `poetry run flake8 src tests` *(fails: E501 line too long)*
- `poetry run mypy src` *(failed: interrupted)*
- `poetry run pytest -q` *(failed: interrupted during heavy dependency load)*
- `poetry run pytest tests/behavior -q` *(failed: interrupted during heavy dependency load)*

------
https://chatgpt.com/codex/tasks/task_e_6853591d30cc8333918fe60ce31f0bbb