### PR TITLE
Add file loader and git repo indexer components

### DIFF
--- a/docs/diagrams/storage.puml
+++ b/docs/diagrams/storage.puml
@@ -1,7 +1,7 @@
 @startuml
-title Storage Component
+title Storage & Search Component
 
-package "Storage" {
+package "Storage & Search" {
   class StorageManager {
     + {static} setup(db_path): void
     + {static} teardown(remove_db): void
@@ -24,6 +24,18 @@ package "Storage" {
     - {static} _persist_to_rdf(claim): void
     - {static} _validate_vector_search_params(query_embedding, k): void
     - {static} _format_vector_literal(query_embedding): str
+  }
+
+  class FileLoader {
+    + load_files(path): List[str]
+  }
+
+  class GitRepoIndexer {
+    + index_repo(path): void
+  }
+
+  class Search {
+    + external_lookup(query, max_results): List[Dict]
   }
 
   class "Global Storage State" as GlobalState {
@@ -103,6 +115,9 @@ StorageManager --> NetworkX : uses for graph storage
 StorageManager --> DuckDB : uses for vector storage
 StorageManager --> RDFLib : uses for semantic storage
 StorageManager --> EvictionCounter : increments on eviction
+
+Search --> FileLoader : load_files
+Search --> GitRepoIndexer : index_repo
 
 ConfigLoader --> ConfigModel : provides
 ConfigModel --> StorageConfig : contains

--- a/docs/diagrams/system_architecture.puml
+++ b/docs/diagrams/system_architecture.puml
@@ -37,6 +37,8 @@ package "Storage & Search" {
   component "Storage Manager" as StorageManager
   component "Search" as Search
   component "Vector Search" as VectorSearch
+  component "File Loader" as FileLoader
+  component "Git Repo Indexer" as GitRepoIndexer
 
   database "NetworkX Graph" as NX
   database "DuckDB Store" as DuckDB
@@ -93,6 +95,8 @@ StorageManager -> TinyDB : insert
 
 Orchestrator -> Search : search()
 Search -> VectorSearch : vector_search()
+Search -> FileLoader : load_files()
+Search -> GitRepoIndexer : index_repo()
 VectorSearch -> DuckDB : query
 
 Orchestrator -> OutputFormatter : format_result()


### PR DESCRIPTION
## Summary
- expand diagrams with File Loader and Git Repo Indexer
- connect Search component to them
- remove generated PNG and SVG files

## Testing
- `poetry run flake8 src tests` *(fails: E501 line too long)*
- `poetry run mypy src` *(fails: several errors)*
- `poetry run pytest -q` *(interrupted)*
- `poetry run pytest tests/behavior` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68536f8445608333a24d6ec073f17cfa