### PR TITLE
Add test for local search backends

### DIFF
--- a/tests/integration/test_search_backends.py
+++ b/tests/integration/test_search_backends.py
@@ -1,8 +1,10 @@
 """Tests for search backend integration.
 
-This module contains tests for the integration between different search backends
-and the main search functionality.
+This module contains tests for the integration between different search
+backends and the main search functionality.
 """
+
+import subprocess
 
 import pytest
 from autoresearch.search import Search
@@ -71,3 +73,59 @@ def test_multiple_backends_called_and_merged(monkeypatch):
     assert "t2" in titles
     assert "u1" in urls
     assert "u2" in urls
+
+
+def _init_git_repo(repo_path):
+    """Initialize a git repo with a single file."""
+    subprocess.run(["git", "init"], cwd=repo_path, check=True)
+    subprocess.run(["git", "config", "user.email", "you@example.com"],
+                   cwd=repo_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Your Name"],
+                   cwd=repo_path, check=True)
+    (repo_path / "README.md").write_text("hello from git")
+    subprocess.run(["git", "add", "README.md"], cwd=repo_path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo_path, check=True)
+
+
+def test_local_file_and_git_backends_called(monkeypatch, tmp_path):
+    """Invoke local_file and local_git backends when configured."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    file_path = docs_dir / "note.txt"
+    file_path.write_text("hello from file")
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    _init_git_repo(repo_path)
+
+    calls = []
+
+    def local_file(query, max_results=5):
+        calls.append("file")
+        results = []
+        for f in docs_dir.rglob("*.txt"):
+            if query in f.read_text():
+                results.append({"title": f.name, "url": str(f)})
+        return results[:max_results]
+
+    def local_git(query, max_results=5):
+        calls.append("git")
+        readme = repo_path / "README.md"
+        if query in readme.read_text():
+            return [{"title": readme.name, "url": str(readme)}]
+        return []
+
+    monkeypatch.setitem(Search.backends, "local_file", local_file)
+    monkeypatch.setitem(Search.backends, "local_git", local_git)
+
+    cfg = ConfigModel(loops=1)
+    cfg.search.backends = ["local_file", "local_git"]
+    cfg.search.context_aware.enabled = False
+    monkeypatch.setattr("autoresearch.search.get_config", lambda: cfg)
+
+    results = Search.external_lookup("hello", max_results=5)
+
+    assert calls == ["file", "git"]
+    urls = [r["url"] for r in results]
+    assert str(file_path) in urls
+    assert str(repo_path / "README.md") in urls


### PR DESCRIPTION
## Summary
- expand integration tests for Search.external_lookup
- verify local_file and local_git backends are invoked

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest tests/integration/test_search_backends.py::test_local_file_and_git_backends_called -q`

------
https://chatgpt.com/codex/tasks/task_e_685386db48a48333a4cfa2ee6e77286a