### PR TITLE
Add file and git backend subsection

### DIFF
--- a/docs/component_interactions.md
+++ b/docs/component_interactions.md
@@ -115,6 +115,16 @@ Key interactions:
 - TinyDB provides caching
 - Vector search enables semantic retrieval
 
+#### File and Git Backends
+
+The **LocalFileBackend** and **GitBackend** extend the search pipeline with local
+sources. The Orchestrator invokes the Search module, which uses the
+FileLoader and GitRepoIndexer to crawl directories and repositories. Retrieved
+snippets flow back to the Orchestrator and are persisted by the StorageManager.
+The updated *Storage & Search* and *System Architecture* diagrams illustrate
+this interaction chain:
+Orchestrator → Search → FileLoader/GitRepoIndexer → StorageManager.
+
 ## Component Interaction Scenarios
 
 ### Query Execution Scenario


### PR DESCRIPTION
## Summary
- explain how local file and Git search backends interact with orchestration and storage

## Testing
- `poetry run flake8 src tests` *(fails: E501 line too long)*
- `poetry run mypy src` *(fails with type errors and interrupted)*
- `poetry run pytest -q` *(interrupted)*
- `poetry run pytest tests/behavior` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685441f9fed48333ba6ee23e0d769c2d