### PR TITLE
Add F-21 offline indexing requirement

### DIFF
--- a/docs/requirements_tracability_matrix.md
+++ b/docs/requirements_tracability_matrix.md
@@ -22,3 +22,4 @@
 | F-18 | Accessibility of output | `output_format.py` | manual review |
 | F-19 | Local directory search | `search/`, `search_backends/local_files.py` | `tests/unit/test_local_search.py`, `tests/behavior/features/local_file_search.feature` |
 | F-20 | Local Git repository search by path | `search/`, `search_backends/local_git.py` | `tests/unit/test_git_search.py`, `tests/behavior/features/git_repository_search.feature` |
+| F-21 | Maintain local indexes for directories and Git repositories | `search.py`, `storage.py` | `tests/unit/test_indexing.py`, `tests/behavior/features/offline_indexing.feature` |


### PR DESCRIPTION
## Summary
- extend requirements traceability matrix with F-21

## Testing
- `poetry run flake8 src tests` *(fails: line too long)*
- `poetry run mypy src` *(fails: several type errors)*
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6854467e3738833380d84baf90a805ec