### PR TITLE
Add local search backends

### DIFF
--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -61,6 +61,21 @@ class ContextAwareSearchConfig(BaseModel):
     max_history_items: int = Field(default=10, ge=1, le=100)
 
 
+class LocalFileConfig(BaseModel):
+    """Configuration for the local_file search backend."""
+
+    path: str = ""
+    file_types: List[str] = Field(default_factory=lambda: ["txt"])
+
+
+class LocalGitConfig(BaseModel):
+    """Configuration for the local_git search backend."""
+
+    repo_path: str = ""
+    branches: List[str] = Field(default_factory=lambda: ["main"])
+    history_depth: int = Field(default=50, ge=1)
+
+
 class SearchConfig(BaseModel):
     """Configuration for search functionality."""
 
@@ -87,6 +102,10 @@ class SearchConfig(BaseModel):
     context_aware: ContextAwareSearchConfig = Field(
         default_factory=ContextAwareSearchConfig
     )
+
+    # Local search backends
+    local_file: LocalFileConfig = Field(default_factory=LocalFileConfig)
+    local_git: LocalGitConfig = Field(default_factory=LocalGitConfig)
 
     @field_validator(
         "semantic_similarity_weight", "bm25_weight", "source_credibility_weight"


### PR DESCRIPTION
## Summary
- implement local_file and local_git search backends
- load paths and repo details from the config
- register backends with Search
- unit test coverage for new backends
- BDD steps updated to use built-in local search

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Item "None" of "DuckDBStorageBackend | None" has no attribute "update_claim")*
- `poetry run pytest -q` *(interrupted)*
- `poetry run pytest tests/behavior` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6854c99a83f48333a99d313160e5f208