### PR TITLE
Add ontology reasoning utilities and graph visualization

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -116,3 +116,24 @@ This indicates that the RDFLib SQLAlchemy plugin is not properly registered. To 
    [storage]
    rdf_backend = "memory"
    ```
+
+## Ontology Reasoning and Visualization
+
+The RDF store supports optional ontology-based reasoning using the
+`owlrl` package. Load an ontology file and expand the graph:
+
+```python
+from autoresearch.storage import StorageManager
+
+StorageManager.load_ontology("ontology.ttl")
+StorageManager.apply_ontology_reasoning()
+results = StorageManager.query_rdf("""SELECT ?s ?o WHERE { ?s a <http://example.com/B> . }""")
+```
+
+To visualize the current RDF graph as a PNG image, run:
+
+```bash
+poetry run python scripts/visualize_rdf.py graph.png
+```
+
+The script writes `graph.png` containing a simple diagram of all triples.

--- a/scripts/visualize_rdf.py
+++ b/scripts/visualize_rdf.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+"""Visualize the RDF knowledge graph as a PNG image."""
+
+from pathlib import Path
+import argparse
+
+from autoresearch.storage import StorageManager
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Visualize RDF store")
+    parser.add_argument("output", nargs="?", default="rdf_graph.png", help="Output PNG path")
+    args = parser.parse_args()
+
+    StorageManager.setup()
+    StorageManager.visualize_rdf(args.output)
+    print(f"Graph written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_ontology_reasoning.py
+++ b/tests/integration/test_ontology_reasoning.py
@@ -1,0 +1,78 @@
+"""Integration tests for ontology reasoning utilities."""
+
+import rdflib
+import pytest
+
+from autoresearch.storage import StorageManager, teardown
+from autoresearch.config import ConfigModel, StorageConfig, ConfigLoader
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    teardown(remove_db=True)
+    if hasattr(ConfigLoader, "_instance"):
+        ConfigLoader._instance = None
+
+
+def _configure(tmp_path, monkeypatch):
+    cfg = ConfigModel(
+        storage=StorageConfig(
+            rdf_backend="memory",
+            rdf_path=str(tmp_path / "rdf"),
+        )
+    )
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+
+
+def test_reasoning_infers_subclass(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    StorageManager.setup()
+
+    onto = tmp_path / "onto.ttl"
+    onto.write_text(
+        """
+@prefix ex: <http://example.com/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+ex:A rdfs:subClassOf ex:B .
+"""
+    )
+    StorageManager.load_ontology(str(onto))
+
+    store = StorageManager.get_rdf_store()
+    store.add(
+        (
+            rdflib.URIRef("http://example.com/x"),
+            rdflib.RDF.type,
+            rdflib.URIRef("http://example.com/A"),
+        )
+    )
+
+    StorageManager.apply_ontology_reasoning()
+
+    res = StorageManager.query_rdf(
+        "ASK { <http://example.com/x> a <http://example.com/B> }"
+    )
+    assert res.askAnswer, "Subclass inference failed"
+
+
+def test_visualization_creates_file(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    StorageManager.setup()
+
+    pytest.importorskip("matplotlib")
+
+    store = StorageManager.get_rdf_store()
+    store.add(
+        (
+            rdflib.URIRef("urn:a"),
+            rdflib.URIRef("urn:rel"),
+            rdflib.URIRef("urn:b"),
+        )
+    )
+
+    out = tmp_path / "graph.png"
+    StorageManager.visualize_rdf(str(out))
+    assert out.exists() and out.stat().st_size > 0
+


### PR DESCRIPTION
## Summary
- implement ontology-based reasoning helpers in `StorageManager`
- add visualization helper and `scripts/visualize_rdf.py`
- document ontology reasoning and visualization usage in docs
- test ontology reasoning and visualization generation

## Testing
- `poetry run flake8 src tests` *(fails: E501 line too long)*
- `poetry run mypy src` *(fails: found 107 errors)*
- `poetry run pytest tests/integration/test_ontology_reasoning.py -q`
- `poetry run pytest tests/behavior -q` *(fails: StepDefinitionNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6854dd20ae308333b1ad07b74bdc13ae