### PR TITLE
Add fastmcp interface

### DIFF
--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -12,7 +12,7 @@ from rich.console import Console
 from rich.table import Table
 from rich.prompt import Prompt
 from rich.progress import Progress
-from mcp.server import Server
+from .mcp_interface import create_server
 from datetime import datetime
 import time
 
@@ -529,42 +529,10 @@ def serve(
         # Start the MCP server on a specific host and port
         autoresearch serve --host 0.0.0.0 --port 8888
     """
-    config = _config_loader.load_config()
     console = Console()
 
-    # Create an MCP server
-    server = Server("Autoresearch", host=host, port=port)
-
-    @server.tool
-    def research(query: str) -> Dict[str, Any]:
-        """Run a research query through Autoresearch and return the results.
-
-        Args:
-            query: The natural language query to research
-
-        Returns:
-            A dictionary containing the research results with answer, citations, and reasoning
-        """
-        try:
-            result = Orchestrator.run_query(query, config)
-            # Convert the QueryResponse to a dictionary
-            return {
-                "answer": result.answer,
-                "citations": [citation.dict() for citation in result.citations],
-                "reasoning": result.reasoning,
-                "metrics": result.metrics,
-            }
-        except Exception as e:
-            return {
-                "error": str(e),
-                "answer": f"Error: {str(e)}",
-                "citations": [],
-                "reasoning": [
-                    "An error occurred during processing.",
-                    "Please check the logs for details.",
-                ],
-                "metrics": {"error": str(e)},
-            }
+    # Create an MCP server using the dedicated interface module
+    server = create_server(host=host, port=port)
 
     console.print(f"[bold green]Starting MCP server on {host}:{port}[/bold green]")
     console.print("Available tools:")

--- a/src/autoresearch/mcp_interface.py
+++ b/src/autoresearch/mcp_interface.py
@@ -1,0 +1,59 @@
+"""MCP protocol integration using fastmcp."""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+
+import anyio
+from fastmcp import FastMCP, Client
+
+from .logging_utils import get_logger
+from .orchestration.orchestrator import Orchestrator
+from .config import ConfigLoader
+
+logger = get_logger(__name__)
+
+_config_loader: ConfigLoader = ConfigLoader()
+
+
+def create_server(host: str = "127.0.0.1", port: int = 8080) -> FastMCP:
+    """Create a FastMCP server exposing the research tool."""
+    config = _config_loader.load_config()
+    server: FastMCP = FastMCP("Autoresearch", host=host, port=port)
+
+    @server.tool
+    async def research(query: str) -> Dict[str, Any]:
+        try:
+            result = Orchestrator.run_query(query, config)
+            return {
+                "answer": result.answer,
+                "citations": [
+                    c.model_dump(mode="json") if hasattr(c, "model_dump") else c.dict()
+                    for c in result.citations
+                ],
+                "reasoning": result.reasoning,
+                "metrics": result.metrics,
+            }
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.error("Error processing query", exc_info=exc)
+            return {"error": str(exc)}
+
+    return server
+
+
+def query(
+    query: str,
+    host: str = "127.0.0.1",
+    port: int = 8080,
+    *,
+    transport: FastMCP | None = None,
+) -> Dict[str, Any]:
+    """Send a query to an MCP server and return the result."""
+
+    target = transport or f"http://{host}:{port}"
+
+    async def _call() -> Dict[str, Any]:
+        async with Client(target) as client:
+            return await client.call_tool("research", {"query": query})
+
+    return anyio.run(_call)

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -44,14 +44,14 @@ def test_config_command(monkeypatch):
     assert '"loops"' in result.stdout
 
 
-@patch("autoresearch.main.Server")
-def test_serve_command(mock_server, monkeypatch):
+@patch("autoresearch.mcp_interface.create_server")
+def test_serve_command(mock_create_server, monkeypatch):
     """Test the serve command that starts an MCP server."""
     runner = CliRunner()
 
     # Create mock objects
     mock_server_instance = MagicMock()
-    mock_server.return_value = mock_server_instance
+    mock_create_server.return_value = mock_server_instance
 
     # Mock the config loader
     class Cfg:
@@ -71,7 +71,7 @@ def test_serve_command(mock_server, monkeypatch):
     assert result.exit_code == 0
 
     # Verify the server was created with the correct parameters
-    mock_server.assert_called_once_with("Autoresearch", host="localhost", port=8888)
+    mock_create_server.assert_called_once_with(host="localhost", port=8888)
 
     # Verify the server was started
     mock_server_instance.run.assert_called_once()

--- a/tests/unit/test_mcp_interface.py
+++ b/tests/unit/test_mcp_interface.py
@@ -1,0 +1,23 @@
+from autoresearch import mcp_interface
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.models import QueryResponse
+from autoresearch.config import ConfigModel
+
+
+def _mock_run_query(query, config):
+    return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+
+
+def _mock_load_config():
+    return ConfigModel()
+
+
+def test_client_server_roundtrip(monkeypatch):
+    monkeypatch.setattr(mcp_interface._config_loader, "load_config", _mock_load_config)
+    monkeypatch.setattr(Orchestrator, "run_query", _mock_run_query)
+
+    server = mcp_interface.create_server()
+
+    result = mcp_interface.query("hello", transport=server)
+
+    assert result["answer"] == "ok"


### PR DESCRIPTION
## Summary
- implement `mcp_interface` using `fastmcp`
- wire CLI `serve` command to use the new MCP module
- update unit tests for new interface and add a dedicated test

## Testing
- `poetry run flake8 src/autoresearch/mcp_interface.py tests/unit/test_main_cli.py tests/unit/test_mcp_interface.py`
- `poetry run mypy src/autoresearch/mcp_interface.py`
- `poetry run pytest tests/unit/test_main_cli.py::test_serve_command tests/unit/test_mcp_interface.py -q` *(fails: NameError during CLI execution)*

------
https://chatgpt.com/codex/tasks/task_e_68558c79771c833381f28c8d1d27a085