### PR TITLE
Add incremental update features and eviction tests

### DIFF
--- a/docs/duckdb_compatibility.md
+++ b/docs/duckdb_compatibility.md
@@ -78,6 +78,17 @@ vector_extension_path = "./extensions/vss/vss.duckdb_extension"
 
 Note that the `vector_extension_path` must point to the actual `.duckdb_extension` file, not just the directory.
 
+### Refreshing the Vector Index
+
+When new embeddings are inserted, refresh the HNSW index so that vector search
+includes them:
+
+```python
+from autoresearch.storage import StorageManager
+
+StorageManager.refresh_vector_index()
+```
+
 ### Alternative: Using the Python Package
 
 As an alternative to manually downloading the extension, you can use the `duckdb-extension-vss` Python package, which is included as a dependency in the project. This package automatically provides the correct VSS extension for your platform.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -26,6 +26,15 @@ The diagram below shows the relationships between these classes and their intera
 3. The `vector_search()` method finds similar claims using vector similarity
 4. The `teardown()` method closes connections and cleans up resources
 
+## Incremental Updates
+
+`StorageManager.persist_claim()` supports partial updates. When a claim with an
+existing ID is persisted with `partial_update=True`, only the provided fields are
+merged into the stored record. Vector embeddings are inserted into DuckDB and
+the HNSW index is refreshed using `StorageManager.refresh_vector_index()`. RDF
+triples are updated with `StorageManager.update_rdf_claim()` so that semantic
+queries remain consistent.
+
 ## Local Data Persistence
 
 Search backends that operate on the filesystem or Git repositories generate

--- a/tests/unit/test_incremental_updates.py
+++ b/tests/unit/test_incremental_updates.py
@@ -1,0 +1,57 @@
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autoresearch.storage import StorageManager
+from autoresearch.config import ConfigModel, StorageConfig, ConfigLoader
+
+
+def _basic_config():
+    return ConfigModel(storage=StorageConfig(), ram_budget_mb=0)
+
+
+def test_refresh_vector_index_calls_backend(monkeypatch):
+    backend = MagicMock()
+    monkeypatch.setattr("autoresearch.storage._db_backend", backend, raising=False)
+    monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
+
+    StorageManager.refresh_vector_index()
+
+    backend.refresh_hnsw_index.assert_called_once()
+
+
+def test_persist_claim_triggers_index_refresh(monkeypatch):
+    backend = MagicMock()
+    graph = MagicMock()
+    store = MagicMock()
+    monkeypatch.setattr("autoresearch.storage._db_backend", backend, raising=False)
+    monkeypatch.setattr("autoresearch.storage._graph", graph, raising=False)
+    monkeypatch.setattr("autoresearch.storage._rdf_store", store, raising=False)
+    monkeypatch.setattr(StorageManager, "_enforce_ram_budget", lambda budget: None)
+    monkeypatch.setattr(StorageManager, "has_vss", lambda: True)
+    monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 0)
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: _basic_config())
+    ConfigLoader()._config = None
+
+    called = {}
+
+    def refresh():
+        called["r"] = True
+
+    monkeypatch.setattr(StorageManager, "refresh_vector_index", refresh)
+
+    StorageManager.persist_claim({"id": "n1", "type": "fact", "content": "c", "embedding": [0.1]})
+
+    assert called.get("r") is True
+
+
+def test_update_rdf_claim_wrapper(monkeypatch):
+    store = MagicMock()
+    monkeypatch.setattr("autoresearch.storage._rdf_store", store, raising=False)
+    monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
+
+    with patch("autoresearch.storage.StorageManager._update_rdf_claim") as upd:
+        StorageManager.update_rdf_claim({"id": "x"}, partial_update=True)
+        upd.assert_called_once()
+


### PR DESCRIPTION
## Summary
- extend storage backends with `refresh_hnsw_index`
- add `refresh_vector_index` and `update_rdf_claim` helpers
- refresh vector index after persisting embeddings
- document incremental updates
- unit tests for incremental update helpers

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Found 100 errors)*
- `poetry run pytest tests/unit/test_incremental_updates.py -q` *(fails: KeyboardInterrupt)*
- `poetry run pytest tests/behavior -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6855a1d39630833387488e1e150fd965