### PR TITLE
Add semantic score normalization and embedding config

### DIFF
--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -85,6 +85,10 @@ class SearchConfig(BaseModel):
         default=True,
         description="Combine keyword and semantic search when true",
     )
+    embedding_model: str = Field(
+        default="all-MiniLM-L6-v2",
+        description="SentenceTransformer model used for semantic search",
+    )
 
     # Enhanced relevance ranking settings
     use_semantic_similarity: bool = Field(default=True)

--- a/tests/unit/test_relevance_ranking.py
+++ b/tests/unit/test_relevance_ranking.py
@@ -131,13 +131,13 @@ def test_calculate_semantic_similarity(sample_results):
         )
 
     # Check that scores are in the expected range
-    assert all(-1 <= score <= 1 for score in scores)
+    assert all(0 <= score <= 1 for score in scores)
 
     # Check that similar documents have higher scores
     assert scores[0] > 0.9  # Very similar
     assert scores[2] > 0.9  # Very similar
     assert 0 < scores[1] < 1  # Somewhat similar
-    assert scores[3] < 0  # Negative similarity
+    assert scores[3] < 0.5  # Dissimilar
 
 
 def test_assess_source_credibility(sample_results):


### PR DESCRIPTION
## Summary
- support configurable embedding model for sentence transformer
- normalize semantic similarity scores to 0..1
- test ranking with vector results combined with backend results
- adjust ranking unit tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: various type errors)*
- `poetry run pytest -q` *(fails: attempted model download)*

------
https://chatgpt.com/codex/tasks/task_e_6855bd15d0dc8333bbd28fc059c57171