### PR TITLE
Fix VSS extension test patching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ python_files = ["test_*.py", "*_steps.py"]
 markers = [
     "behavior: mark behavior (BDD) tests",
     "integration: mark integration tests",
-    "unit: mark unit tests"
+    "unit: mark unit tests",
+    "real_vss: enable actual VSS extension logic"
 ]
 
 [tool.mypy]

--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -137,7 +137,7 @@ def claim_factory():
                 ]
 
             if embedding is None:
-                embedding = [0.1, 0.2, 0.3, 0.4]
+                embedding = [0.1] * 384
 
             claim = {
                 "id": claim_id,
@@ -177,7 +177,7 @@ def claim_factory():
                 claim = self.create_valid_claim(
                     claim_id=f"test-claim-{i}",
                     content=f"This is test claim {i}",
-                    embedding=[0.1 * i, 0.2 * i, 0.3 * i, 0.4 * i],
+                    embedding=[0.1 * i] * 384,
                 )
                 claims.append(claim)
             return claims

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,9 +23,9 @@ from autoresearch.extensions import VSSExtensionLoader
 
 
 @pytest.fixture(autouse=True)
-def stub_vss_extension_download(monkeypatch):
+def stub_vss_extension_download(monkeypatch, request):
     """Prevent network calls when loading the DuckDB VSS extension."""
-    if os.getenv("REAL_VSS_TEST"):
+    if os.getenv("REAL_VSS_TEST") or request.node.get_closest_marker("real_vss"):
         yield
         return
 

--- a/tests/unit/test_vss_extension_loader.py
+++ b/tests/unit/test_vss_extension_loader.py
@@ -9,6 +9,7 @@ from autoresearch.errors import StorageError
 class TestVSSExtensionLoader:
     """Test the VSSExtensionLoader class."""
 
+    @pytest.mark.real_vss
     def test_verify_extension_success(self):
         """Test that verify_extension returns True when the extension is loaded."""
         # Create a mock connection that successfully executes the verification query
@@ -23,6 +24,7 @@ class TestVSSExtensionLoader:
             "SELECT * FROM duckdb_extensions() WHERE extension_name = 'vss'"
         )
 
+    @pytest.mark.real_vss
     def test_verify_extension_failure(self):
         """Test that verify_extension returns False when the extension is not loaded."""
         # Create a mock connection that raises an exception when executing the verification query


### PR DESCRIPTION
## Summary
- avoid stubbing the VSS extension for tests marked `real_vss`
- mark VSS extension tests accordingly
- use 384‑dimensional embeddings for behavior claims
- document the new pytest marker

## Testing
- `poetry run flake8 src tests` *(fails: W293 blank line contains whitespace …)*
- `poetry run mypy src` *(fails: src/autoresearch/storage.py:834: error: Item "None" of "Graph | None" has no attribute "triples"  [union-attr])*

------
https://chatgpt.com/codex/tasks/task_e_6855f907139c83338dc661e018d62a99