### PR TITLE
Update docs for new interfaces and agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Start the HTTP API with Uvicorn:
 ```bash
 uvicorn autoresearch.api:app --reload
 ```
+Start the FastMCP server to allow other agents to call Autoresearch as a tool:
+```bash
+autoresearch serve
+```
+Then send a request with the helper client:
+```python
+from autoresearch.mcp_interface import query
+print(query("What is quantum computing?")["answer"])
+```
 Send a query and check collected metrics:
 ```bash
 curl -X POST http://localhost:8000/query -d '{"query": "Explain machine learning"}' -H "Content-Type: application/json"
@@ -118,6 +127,10 @@ enabled = true
 model = "gpt-3.5-turbo"
 ```
 
+Additional specialized agents such as `Researcher`, `Critic`, `Summarizer`,
+`Planner`, `Moderator`, `DomainSpecialist`, and `UserAgent` can be enabled by
+adding corresponding `[agent.AgentName]` sections.
+
 ### Search Configuration
 
 ```toml
@@ -128,6 +141,10 @@ backends = ["serper"]
 # Maximum results per query
 max_results_per_query = 5
 ```
+
+Ranking now mixes keyword and semantic similarity. Adjust the weights for
+embedding scores, BM25 matching and source credibility in `[search]` to fine
+tune the hybrid algorithm.
 
 ### Enabling Local File and Git Search
 

--- a/docs/a2a_mcp_integration.md
+++ b/docs/a2a_mcp_integration.md
@@ -200,6 +200,10 @@ print(f"Answer: {result['answer']}")
 
 The Multi-Agent Communication Protocol (MCP) is designed for more complex integration scenarios where agents need to communicate with each other in a structured way.
 
+Autoresearch exposes this protocol via a **FastMCP** server. Start it with
+`autoresearch serve` and send messages to the `/mcp` endpoint using the
+`fastmcp` Python client or any MCP-compatible agent.
+
 ### Protocol Overview
 
 MCP is a message-based protocol where each message has a type, content, and metadata. Messages are exchanged via the `/mcp` endpoint.

--- a/docs/agent_system.md
+++ b/docs/agent_system.md
@@ -48,6 +48,9 @@ Additional specialized agents extend the system's capabilities:
 2. **Critic**: Evaluates the quality of research and provides constructive feedback
 3. **Summarizer**: Generates concise summaries of complex information
 4. **Planner**: Structures complex research tasks into manageable steps
+5. **Moderator**: Facilitates productive discussions between agents
+6. **Domain Specialist**: Provides deep expertise in a specific field
+7. **User Agent**: Represents user intent and preferences
 
 ## Reasoning Modes
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -6,6 +6,16 @@ Autoresearch orchestrates multiple agents in a dialectical cycle. The default ro
 - **Contrarian** – challenges assumptions and provides counter arguments.
 - **Fact Checker** – verifies claims against reliable sources.
 
+Additional specialized agents extend these roles:
+
+- **Researcher** – performs in-depth information gathering.
+- **Critic** – evaluates research quality and methodology.
+- **Summarizer** – condenses complex information into short summaries.
+- **Planner** – breaks down large tasks into manageable steps.
+- **Moderator** – manages multi-agent discussions.
+- **Domain Specialist** – provides expert knowledge for a field.
+- **User Agent** – represents user preferences in the dialogue.
+
 Agents communicate via a shared state object and can be customized in `autoresearch.toml`.
 
 ## Architecture

--- a/docs/diagrams/agents.puml
+++ b/docs/diagrams/agents.puml
@@ -82,6 +82,34 @@ package "Agents" {
     + execute(state, config): Dict
     + can_execute(state, config): bool
   }
+  class ResearcherAgent {
+    + role: AgentRole = AgentRole.SPECIALIST
+    + execute(state, config): Dict
+  }
+  class CriticAgent {
+    + role: AgentRole = AgentRole.SPECIALIST
+    + execute(state, config): Dict
+  }
+  class SummarizerAgent {
+    + role: AgentRole = AgentRole.SPECIALIST
+    + execute(state, config): Dict
+  }
+  class PlannerAgent {
+    + role: AgentRole = AgentRole.SPECIALIST
+    + execute(state, config): Dict
+  }
+  class ModeratorAgent {
+    + role: AgentRole = AgentRole.MODERATOR
+    + execute(state, config): Dict
+  }
+  class DomainSpecialistAgent {
+    + role: AgentRole = AgentRole.SPECIALIST
+    + execute(state, config): Dict
+  }
+  class UserAgent {
+    + role: AgentRole = AgentRole.USER
+    + execute(state, config): Dict
+  }
 }
 
 package "Prompts" {
@@ -133,6 +161,13 @@ Agent --|> ResultGeneratorMixin
 SynthesizerAgent --|> Agent
 ContrarianAgent --|> Agent
 FactChecker --|> Agent
+ResearcherAgent --|> Agent
+CriticAgent --|> Agent
+SummarizerAgent --|> Agent
+PlannerAgent --|> Agent
+ModeratorAgent --|> Agent
+DomainSpecialistAgent --|> Agent
+UserAgent --|> Agent
 
 ' Associations
 Agent --> AgentRole : has role

--- a/docs/diagrams/storage.puml
+++ b/docs/diagrams/storage.puml
@@ -6,6 +6,7 @@ package "Storage & Search" {
     + {static} setup(db_path): void
     + {static} teardown(remove_db): void
     + {static} persist_claim(claim): void
+    + {static} update_claim(claim, partial_update): void
     + {static} create_hnsw_index(): void
     + {static} vector_search(query_embedding, k): List[Dict]
     + {static} get_graph(): nx.DiGraph

--- a/docs/diagrams/system_architecture.puml
+++ b/docs/diagrams/system_architecture.puml
@@ -4,6 +4,7 @@
 node "Client Interfaces" {
   component "CLI" as CLI
   component "FastAPI API" as FastAPI
+  component "FastMCP" as FastMCP
   component "Monitor" as Monitor
 }
 
@@ -58,6 +59,9 @@ CLI -> Orchestrator : run_query(query)
 
 user -> FastAPI : POST /query
 FastAPI -> Orchestrator : run_query(query)
+
+user -> FastMCP : MCP message
+FastMCP -> Orchestrator : run_query(query)
 
 user -> Monitor : interactive session
 Monitor -> Orchestrator : run_query(query)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,8 +8,8 @@ Autoresearch uses a modular architecture with several key components:
 
 ![System Architecture](diagrams/system_architecture.png)
 
-The system consists of:
-- **Client Interfaces**: CLI, API, and Monitor
+- The system consists of:
+- **Client Interfaces**: CLI, API, Monitor, and FastMCP
 - **Core Components**: Orchestrator, ConfigLoader, Error Hierarchy, Metrics, and Tracing
 - **Agents**: Synthesizer, Contrarian, and Fact-Checker
 - **LLM Integration**: Adapters for different LLM backends
@@ -78,4 +78,22 @@ Then query your directory or repository just like any other search:
 
 ```bash
 autoresearch search "neural networks in docs"
+```
+
+## MCP Interface
+
+Autoresearch also exposes a **FastMCP** server so other agents can use it as a
+tool. Start the server with:
+
+```bash
+autoresearch serve
+```
+
+Send a query using the provided client helper:
+
+```python
+from autoresearch.mcp_interface import query
+
+result = query("What is the capital of France?")
+print(result["answer"])
 ```

--- a/docs/quickstart_guides.md
+++ b/docs/quickstart_guides.md
@@ -145,6 +145,12 @@ This will start the Streamlit server and open the GUI in your default web browse
 uvicorn autoresearch.api:app --host 0.0.0.0 --port 8000
 ```
 
+### Starting the FastMCP Server
+
+```bash
+autoresearch serve
+```
+
 ### Basic Usage with Python
 
 ```python

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -35,6 +35,13 @@ the HNSW index is refreshed using `StorageManager.refresh_vector_index()`. RDF
 triples are updated with `StorageManager.update_rdf_claim()` so that semantic
 queries remain consistent.
 
+### Updating Existing Claims
+
+Existing claims can be modified directly using `StorageManager.update_claim()`.
+Set `partial_update=True` to merge only the supplied fields or `False` to
+replace the stored record entirely. The method automatically refreshes the
+vector index and updates RDF triples so all search modalities remain in sync.
+
 ## Local Data Persistence
 
 Search backends that operate on the filesystem or Git repositories generate


### PR DESCRIPTION
## Summary
- document FastMCP server and new specialized agents
- sync README and getting started guide
- add update_claim docs in storage
- refresh system diagrams for FastMCP and agents
- mention FastMCP and hybrid ranking in quickstart guides

## Testing
- `poetry run flake8 src tests` *(fails: F811, W293, W291, etc.)*
- `poetry run mypy src` *(fails: found 77 errors)*
- `poetry run pytest -q` *(interrupted)*
- `poetry run pytest tests/behavior` *(fails: 1 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6856171e4c208333b4c9818418012f12