### PR TITLE
Add ontology reasoning features and RDF visualization CLI

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -162,20 +162,35 @@ This indicates that the RDFLib SQLAlchemy plugin is not properly registered. To 
 ## Ontology Reasoning and Visualization
 
 The RDF store supports optional ontology-based reasoning using the
-`owlrl` package. Load an ontology file and expand the graph:
+`owlrl` package. The following tutorial walks through a typical
+ontology workflow.
 
-```python
-from autoresearch.storage import StorageManager
+1. **Load an ontology file** to add schema triples:
 
-StorageManager.load_ontology("ontology.ttl")
-StorageManager.apply_ontology_reasoning()
-results = StorageManager.query_rdf("""SELECT ?s ?o WHERE { ?s a <http://example.com/B> . }""")
-```
+   ```python
+   from autoresearch.storage import StorageManager
 
-To visualize the current RDF graph as a PNG image, run:
+   StorageManager.load_ontology("ontology.ttl")
+   ```
 
-```bash
-poetry run python scripts/visualize_rdf.py graph.png
-```
+2. **Apply reasoning** to materialize OWL‑RL inferences:
 
-The script writes `graph.png` containing a simple diagram of all triples.
+   ```python
+   StorageManager.apply_ontology_reasoning()
+   ```
+
+3. **Query the inferred graph** using SPARQL:
+
+   ```python
+   results = StorageManager.query_rdf(
+       "SELECT ?s WHERE { ?s a <http://example.com/B> }"
+   )
+   ```
+
+4. **Visualize the graph** as a PNG image:
+
+   ```bash
+   poetry run autoresearch visualize-rdf graph.png
+   ```
+
+The command writes `graph.png` containing a simple diagram of all triples.

--- a/poetry.lock
+++ b/poetry.lock
@@ -4118,6 +4118,21 @@ files = [
 ]
 
 [[package]]
+name = "owlrl"
+version = "6.0.2"
+description = "OWL-RL and RDFS based RDF Closure inferencing for Python"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "owlrl-6.0.2-py3-none-any.whl", hash = "sha256:57eca06b221edbbc682376c8d42e2ddffc99f61e82c0da02e26735592f08bacc"},
+    {file = "owlrl-6.0.2.tar.gz", hash = "sha256:904e3310ff4df15101475776693d2427d1f8244ee9a6a9f9e13c3c57fae90b74"},
+]
+
+[package.dependencies]
+rdflib = ">=6.0.2"
+
+[[package]]
 name = "packaging"
 version = "24.2"
 description = "Core utilities for Python packages"
@@ -8132,4 +8147,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "d5154561ac5f885187db62706cc0f3b986960bd8198d3673f9674fafd3098f24"
+content-hash = "44182050fa73e708af9ce5fd78ee32c65bd0fe4ae5441c5deff9386c9990cda8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "duckdb (>=1.2.2,<2.0.0)",
     "rdflib (>=7.1.4,<8.0.0)",
     "rdflib-sqlalchemy (>=0.5.0,<0.6.0)",
+    "owlrl (>=6.0.2,<7.0.0)",
     "fastapi (>=0.115.12)",
     "loguru (>=0.7.2,<0.8.0)",
     "prometheus_client (>=0.20.0,<0.21.0)",

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -1392,6 +1392,27 @@ def test_a2a(
     print(formatted_results)
 
 
+@app.command("visualize-rdf")
+def visualize_rdf_cli(
+    output: str = typer.Argument(
+        "rdf_graph.png",
+        help="Output PNG path for the RDF graph visualization",
+    ),
+) -> None:
+    """Generate a PNG visualization of the RDF knowledge graph."""
+    from .streamlit_app import visualize_rdf as _visualize
+
+    try:
+        _visualize(output)
+        print_success(f"Graph written to {output}")
+    except Exception as e:  # pragma: no cover - optional dependency
+        print_error(
+            f"Failed to visualize RDF graph: {e}",
+            suggestion="Ensure matplotlib is installed",
+        )
+        raise typer.Exit(1)
+
+
 @app.command("gui")
 def gui(
     port: int = typer.Option(

--- a/src/autoresearch/streamlit_app.py
+++ b/src/autoresearch/streamlit_app.py
@@ -1548,6 +1548,15 @@ def format_result_as_json(result: QueryResponse) -> str:
     return json.dumps(result_dict, indent=2)
 
 
+def visualize_rdf(output_path: str = "rdf_graph.png") -> None:
+    """Generate a PNG visualization of the current RDF graph."""
+    from .storage import StorageManager
+
+    StorageManager.setup()
+    StorageManager.visualize_rdf(output_path)
+    print(f"Graph written to {output_path}")
+
+
 def display_results(result: QueryResponse):
     """Display the query results in a formatted way.
 

--- a/tests/behavior/features/dkg_persistence.feature
+++ b/tests/behavior/features/dkg_persistence.feature
@@ -41,3 +41,14 @@ Feature: Hybrid Dynamic Knowledge Graph (DKG) Persistence
     Given I have persisted claims with embeddings
     When I perform a vector search with a query embedding
     Then I should receive the nearest claims by vector similarity
+
+  Scenario: Ontology reasoning infers subclass relationships
+    Given I have loaded an ontology defining subclasses
+    And I have an instance of the subclass
+    When I apply ontology reasoning
+    Then querying for the superclass should include the instance
+
+  Scenario: RDF graph visualization
+    Given the RDF store has some triples
+    When I visualize the RDF graph to "graph.png"
+    Then the visualization file "graph.png" should exist


### PR DESCRIPTION
## Summary
- enable owlrl in dependencies for ontology reasoning
- add `visualize_rdf` helper in Streamlit app
- expose `visualize-rdf` command in CLI
- expand ontology tutorial in storage docs
- extend BDD scenarios for ontology reasoning and visualization

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(failed: Incompatible default for argument)*
- `poetry run pytest -q` *(interrupted)*
- `poetry run pytest tests/behavior`

------
https://chatgpt.com/codex/tasks/task_e_6856e9ec31fc8333a95a1c83f75ed46a