### PR TITLE
Fix DuckDB table creation test

### DIFF
--- a/tests/unit/test_duckdb_storage_backend.py
+++ b/tests/unit/test_duckdb_storage_backend.py
@@ -109,7 +109,7 @@ class TestDuckDBStorageBackend:
                 "CREATE TABLE IF NOT EXISTS edges(src VARCHAR, dst VARCHAR, rel VARCHAR, w DOUBLE)"
             ),
             call(
-                "CREATE TABLE IF NOT EXISTS embeddings(node_id VARCHAR, embedding DOUBLE[])"
+                "CREATE TABLE IF NOT EXISTS embeddings(node_id VARCHAR, embedding FLOAT[384])"
             ),
             call("CREATE TABLE IF NOT EXISTS metadata(key VARCHAR, value VARCHAR)"),
         ]


### PR DESCRIPTION
## Summary
- update expected embeddings SQL in `test_duckdb_storage_backend.py`

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Incompatible defaults and other type errors)*
- `poetry run pytest -q` *(fails: interrupted during imports)*
- `poetry run pytest tests/behavior -q` *(fails: interrupted during imports)*

------
https://chatgpt.com/codex/tasks/task_e_6857356a22748333be89c9a82403b07a