### PR TITLE
Enhance search embeddings and git backend

### DIFF
--- a/tests/behavior/features/local_sources.feature
+++ b/tests/behavior/features/local_sources.feature
@@ -22,3 +22,8 @@ Feature: Search Local Sources
     Given a local Git repository with diffs containing "FIXME"
     When I search the repository for "FIXME"
     Then I should see commit diff results with metadata
+
+  Scenario: Searching commit diffs with code context
+    Given a local Git repository with diffs containing "CONTEXT"
+    When I search the repository for "CONTEXT"
+    Then the diff results should include surrounding code context

--- a/tests/behavior/steps/local_sources_steps.py
+++ b/tests/behavior/steps/local_sources_steps.py
@@ -145,6 +145,18 @@ def check_git_diff_results(bdd_context):
     assert any(r.get("author") and r.get("date") for r in results if r.get("diff"))
 
 
+@then("the diff results should include surrounding code context")
+def check_diff_code_context(bdd_context):
+    results = bdd_context["search_results"]
+    term = bdd_context["term"]
+    for r in results:
+        if r.get("diff"):
+            assert term.lower() in r["snippet"].lower()
+            assert "\n" in r["snippet"]
+            return
+    assert False, "No diff result with context found"
+
+
 @scenario("../features/local_sources.feature", "Searching a directory for text files")
 def test_search_directory():
     pass
@@ -168,4 +180,12 @@ def test_search_document_directory():
     "Searching commit diffs and metadata in a local Git repository",
 )
 def test_search_git_diffs():
+    pass
+
+
+@scenario(
+    "../features/local_sources.feature",
+    "Searching commit diffs with code context",
+)
+def test_search_git_diff_context():
     pass


### PR DESCRIPTION
## Summary
- compute embeddings for all backend results in `Search.external_lookup`
- expose `Search.add_embeddings` helper
- enrich local git search with code context using diffs
- verify embedding presence and code context via integration and BDD tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 41 errors)*
- `poetry run pytest -q` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685777a6aedc8333911a387b44ff58e0