### PR TITLE
Add ontology reasoning helpers and CLI

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -382,6 +382,16 @@ This research was conducted using dialectical reasoning with {{loops}} cycles.
 """
 ```
 
+## Knowledge Graph Queries
+
+Persisted claims trigger ontology reasoning so that inferred triples are stored automatically. Use the `sparql` command to inspect the graph:
+
+```bash
+poetry run autoresearch sparql "SELECT ?s WHERE { ?s a <http://example.com/B> }"
+```
+
+The command applies the configured reasoner before executing the query, returning any inferred relationships.
+
 Use the custom template:
 
 ```bash

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -33,7 +33,8 @@ existing ID is persisted with `partial_update=True`, only the provided fields ar
 merged into the stored record. Vector embeddings are inserted into DuckDB and
 the HNSW index is refreshed using `StorageManager.refresh_vector_index()`. RDF
 triples are updated with `StorageManager.update_rdf_claim()` so that semantic
-queries remain consistent.
+queries remain consistent. The update operation now also triggers ontology
+reasoning so inferred relationships are immediately available for queries.
 
 ### Updating Existing Claims
 
@@ -196,7 +197,13 @@ The following tutorial walks through a typical ontology workflow.
    )
    ```
 
-4. **Visualize the graph** as a PNG image:
+4. **Run SPARQL queries with reasoning** directly from the CLI:
+
+   ```bash
+   poetry run autoresearch sparql "SELECT ?s WHERE { ?s a <http://example.com/B> }"
+   ```
+
+5. **Visualize the graph** as a PNG image:
 
    ```bash
    poetry run autoresearch visualize-rdf graph.png

--- a/src/autoresearch/cli_utils.py
+++ b/src/autoresearch/cli_utils.py
@@ -205,3 +205,32 @@ def print_command_example(
             console.print(f"[cyan]{command}[/cyan] - {description}")
         else:
             console.print(f"[cyan]{command}[/cyan]")
+
+
+def visualize_rdf_cli(output_path: str) -> None:
+    """Visualize the RDF graph and report the output path."""
+    from .storage import StorageManager
+
+    try:  # pragma: no cover - optional dependency
+        StorageManager.visualize_rdf(output_path)
+        print_success(f"Graph written to {output_path}")
+    except Exception as e:  # pragma: no cover - optional dependency
+        print_error(
+            f"Failed to visualize RDF graph: {e}",
+            suggestion="Ensure matplotlib is installed",
+        )
+
+
+def sparql_query_cli(query: str) -> None:
+    """Run a SPARQL query with reasoning and display the results."""
+    from .storage import StorageManager
+    from tabulate import tabulate
+
+    res = StorageManager.query_with_reasoning(query)
+    if hasattr(res, "askAnswer"):
+        print_info(f"ASK result: {res.askAnswer}")
+        return
+
+    rows = [list(r) for r in res]
+    headers = [str(v) for v in res.vars]
+    console.print(tabulate(rows, headers=headers, tablefmt="github"))

--- a/src/autoresearch/kg_reasoning.py
+++ b/src/autoresearch/kg_reasoning.py
@@ -1,0 +1,44 @@
+"""Helper utilities for ontology reasoning and advanced SPARQL queries."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Optional
+
+import rdflib
+
+from .config import ConfigLoader
+from .errors import StorageError
+
+
+def run_ontology_reasoner(store: rdflib.Graph, engine: Optional[str] = None) -> None:
+    """Apply ontology reasoning over ``store`` using the configured engine."""
+    reasoner = engine or getattr(ConfigLoader().config.storage, "ontology_reasoner", "owlrl")
+    if reasoner == "owlrl":
+        try:  # pragma: no cover - optional dependency
+            import owlrl  # type: ignore
+
+            owlrl.DeductiveClosure(owlrl.OWLRL_Semantics).expand(store)
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise StorageError(
+                "Failed to apply owlrl reasoning",
+                cause=exc,
+                suggestion="Ensure the owlrl package is installed",
+            )
+    else:  # pragma: no cover - external reasoners optional
+        try:
+            module, func = reasoner.split(":", maxsplit=1)
+            mod = import_module(module)
+            getattr(mod, func)(store)
+        except Exception as exc:
+            raise StorageError(
+                "Failed to run external ontology reasoner",
+                cause=exc,
+                suggestion="Check storage.ontology_reasoner configuration",
+            )
+
+
+def query_with_reasoning(store: rdflib.Graph, query: str, engine: Optional[str] = None):
+    """Run a SPARQL query after applying ontology reasoning."""
+    run_ontology_reasoner(store, engine)
+    return store.query(query)

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -38,6 +38,8 @@ from .cli_utils import (
     set_verbosity,
     get_verbosity,
     Verbosity,
+    visualize_rdf_cli as _cli_visualize,
+    sparql_query_cli as _cli_sparql,
 )
 from .error_utils import get_error_info, format_error_for_cli
 
@@ -1400,16 +1402,18 @@ def visualize_rdf_cli(
     ),
 ) -> None:
     """Generate a PNG visualization of the RDF knowledge graph."""
-    from .streamlit_app import visualize_rdf as _visualize
-
     try:
-        _visualize(output)
-        print_success(f"Graph written to {output}")
-    except Exception as e:  # pragma: no cover - optional dependency
-        print_error(
-            f"Failed to visualize RDF graph: {e}",
-            suggestion="Ensure matplotlib is installed",
-        )
+        _cli_visualize(output)
+    except Exception:
+        raise typer.Exit(1)
+
+
+@app.command("sparql")
+def sparql_query(query: str = typer.Argument(..., help="SPARQL query to run")) -> None:
+    """Execute a SPARQL query with ontology reasoning."""
+    try:
+        _cli_sparql(query)
+    except Exception:
         raise typer.Exit(1)
 
 

--- a/tests/unit/test_rdf_update.py
+++ b/tests/unit/test_rdf_update.py
@@ -5,10 +5,14 @@ from unittest.mock import MagicMock, patch
 from autoresearch.storage import StorageManager
 
 
+def _patch_reasoner():
+    return patch("autoresearch.storage.run_ontology_reasoner")
+
+
 def test_update_rdf_claim_replace():
     store = MagicMock()
     store.triples.return_value = [("s", "p", "o"), ("s", "p2", "o2")]
-    with patch("autoresearch.storage._rdf_store", store):
+    with patch("autoresearch.storage._rdf_store", store), _patch_reasoner() as r:
         with patch("rdflib.URIRef", side_effect=lambda x: x), patch(
             "rdflib.Literal", side_effect=lambda x: x
         ):
@@ -19,12 +23,13 @@ def test_update_rdf_claim_replace():
     # ensure existing triples were removed and new one added
     assert store.remove.call_count == 2
     store.add.assert_called_once_with(("urn:claim:x", "urn:prop:a", 1))
+    r.assert_called_once_with(store)
 
 
 def test_update_rdf_claim_partial():
     store = MagicMock()
     store.triples.return_value = [("s", "p", "o")]
-    with patch("autoresearch.storage._rdf_store", store):
+    with patch("autoresearch.storage._rdf_store", store), _patch_reasoner() as r:
         with patch("rdflib.URIRef", side_effect=lambda x: x), patch(
             "rdflib.Literal", side_effect=lambda x: x
         ):
@@ -35,3 +40,4 @@ def test_update_rdf_claim_partial():
     # ensure no removal happened for partial update
     store.remove.assert_not_called()
     store.add.assert_called_once_with(("urn:claim:x", "urn:prop:b", 2))
+    r.assert_called_once_with(store)


### PR DESCRIPTION
## Summary
- support ontology reasoning in RDF claim updates
- expose reasoning helpers in new `kg_reasoning` module
- add SPARQL query helper commands
- document ontology workflow and query CLI usage

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src/autoresearch/kg_reasoning.py src/autoresearch/storage.py src/autoresearch/cli_utils.py` *(fails: several type errors)*
- `poetry run pytest -q tests/unit/test_rdf_update.py`

------
https://chatgpt.com/codex/tasks/task_e_68579f39ebc88333be43551aab517cbc