### PR TITLE
Fix config watcher cleanup in BDD tests

### DIFF
--- a/tests/behavior/steps/configuration_hot_reload_steps.py
+++ b/tests/behavior/steps/configuration_hot_reload_steps.py
@@ -17,19 +17,18 @@ def modify_config_enable_agent(file, tmp_path):
     def _observer(cfg: ConfigModel) -> None:
         reloaded.append(cfg)
 
-    loader.watch_changes(_observer)
-
     cfg = {
         "core": {"backend": "lmstudio", "loops": 1, "ram_budget_mb": 512},
         "agent": {"NewAgent": {"enabled": True}},
     }
     import tomli_w
 
-    with open(file, "w") as f:
-        f.write(tomli_w.dumps(cfg))
+    with loader.watching(_observer):
+        with open(file, "w") as f:
+            f.write(tomli_w.dumps(cfg))
 
-    new_cfg = loader.load_config()
-    loader.stop_watching()
+        new_cfg = loader.load_config()
+
     return new_cfg
 
 


### PR DESCRIPTION
## Summary
- ensure ConfigLoader watcher threads always stop quickly
- use ConfigLoader.watching context manager when modifying configs
- stub out `sentence_transformers` to avoid heavy imports in tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Found 46 errors)*
- `poetry run pytest -q` *(fails: tests/unit/test_cache.py::test_search_uses_cache)*
- `poetry run pytest tests/behavior` *(fails: tests/behavior/steps/dkg_persistence_steps.py::test_persist_ram)*

------
https://chatgpt.com/codex/tasks/task_e_6858175ba0488333beb310b546b81f13