### PR TITLE
Improve BDD step assertions

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -221,6 +221,22 @@ def test_persist_claim_valid_input(mock_graph):
             mock_graph.add_edge.assert_called_once_with("claim1", "claim2")
 ```
 
+## Behavior-Driven Tests
+
+Behavior tests in `tests/behavior/` use **pytest-bdd**. Steps share
+state via the `bdd_context` fixture and scenarios end with assertions
+that validate this context. When writing scenario functions:
+
+* Use `@scenario` to map a Gherkin scenario to the test.
+* Accept `bdd_context` (and other fixtures if needed) and assert that
+  steps populated expected values.
+* Capture CLI or GUI logs with `caplog` to verify accessibility or
+  logging output.
+
+This pattern keeps the feature files expressive while ensuring the
+Python tests make concrete assertions about CLI behaviour, GUI
+accessibility, and log messages.
+
 ## Conclusion
 
 Following these guidelines will ensure that the test suite is consistent, maintainable, and reliable. If you have any questions or suggestions, please open an issue or pull request.

--- a/tests/behavior/steps/interactive_monitor_steps.py
+++ b/tests/behavior/steps/interactive_monitor_steps.py
@@ -18,10 +18,10 @@ def monitor_exit_successfully(bdd_context):
 
 
 @scenario("../features/interactive_monitor.feature", "Interactive monitoring")
-def test_interactive_monitor():
-    pass
+def test_interactive_monitor(bdd_context):
+    assert bdd_context["monitor_result"].exit_code == 0
 
 
 @scenario("../features/interactive_monitor.feature", "Exit immediately")
-def test_monitor_exit_immediately():
-    pass
+def test_monitor_exit_immediately(bdd_context):
+    assert bdd_context["monitor_result"].exit_code == 0

--- a/tests/behavior/steps/local_sources_steps.py
+++ b/tests/behavior/steps/local_sources_steps.py
@@ -158,34 +158,34 @@ def check_diff_code_context(bdd_context):
 
 
 @scenario("../features/local_sources.feature", "Searching a directory for text files")
-def test_search_directory():
-    pass
+def test_search_directory(bdd_context):
+    assert bdd_context["search_results"]
 
 
 @scenario(
     "../features/local_sources.feature",
     "Searching a local Git repository for code snippets or commit messages",
 )
-def test_search_git_repo():
-    pass
+def test_search_git_repo(bdd_context):
+    assert bdd_context["search_results"]
 
 
 @scenario("../features/local_sources.feature", "Searching a directory for PDF and DOCX files")
-def test_search_document_directory():
-    pass
+def test_search_document_directory(bdd_context):
+    assert bdd_context["search_results"]
 
 
 @scenario(
     "../features/local_sources.feature",
     "Searching commit diffs and metadata in a local Git repository",
 )
-def test_search_git_diffs():
-    pass
+def test_search_git_diffs(bdd_context):
+    assert bdd_context["search_results"]
 
 
 @scenario(
     "../features/local_sources.feature",
     "Searching commit diffs with code context",
 )
-def test_search_git_diff_context():
-    pass
+def test_search_git_diff_context(bdd_context):
+    assert bdd_context["search_results"]

--- a/tests/behavior/steps/output_formatting_steps.py
+++ b/tests/behavior/steps/output_formatting_steps.py
@@ -75,20 +75,20 @@ def check_markdown_output_with_flag(bdd_context):
 
 
 @scenario("../features/output_formatting.feature", "Default TTY output")
-def test_default_tty_output():
-    pass
+def test_default_tty_output(bdd_context):
+    assert bdd_context["terminal_result"].exit_code == 0
 
 
 @scenario("../features/output_formatting.feature", "Piped output defaults to JSON")
-def test_piped_json_output():
-    pass
+def test_piped_json_output(bdd_context):
+    assert bdd_context["piped_result"].exit_code == 0
 
 
 @scenario("../features/output_formatting.feature", "Explicit JSON flag")
-def test_explicit_json_flag():
-    pass
+def test_explicit_json_flag(bdd_context):
+    assert bdd_context["json_flag_result"].exit_code == 0
 
 
 @scenario("../features/output_formatting.feature", "Explicit Markdown flag")
-def test_explicit_markdown_flag():
-    pass
+def test_explicit_markdown_flag(bdd_context):
+    assert bdd_context["markdown_flag_result"].exit_code == 0

--- a/tests/behavior/steps/ui_accessibility_steps.py
+++ b/tests/behavior/steps/ui_accessibility_steps.py
@@ -28,35 +28,35 @@ def streamlit_app_running(monkeypatch, bdd_context, tmp_path):
 
 
 @scenario("../features/ui_accessibility.feature", "CLI Color Alternatives")
-def test_cli_color_alternatives():
+def test_cli_color_alternatives(bdd_context):
     """Test CLI color alternatives."""
-    pass
+    assert bdd_context.get("use_symbols") is True
 
 
 @scenario("../features/ui_accessibility.feature", "CLI Screen Reader Compatibility")
-def test_cli_screen_reader_compatibility():
+def test_cli_screen_reader_compatibility(bdd_context):
     """Test CLI screen reader compatibility."""
-    pass
+    assert bdd_context.get("screen_reader_mode") is True
 
 
 @scenario("../features/ui_accessibility.feature", "Streamlit GUI Keyboard Navigation")
-def test_streamlit_keyboard_navigation():
+def test_streamlit_keyboard_navigation(bdd_context):
     """Test Streamlit GUI keyboard navigation."""
-    pass
+    assert "mock_text_input" in bdd_context and "mock_button" in bdd_context
 
 
 @scenario(
     "../features/ui_accessibility.feature", "Streamlit GUI Screen Reader Compatibility"
 )
-def test_streamlit_screen_reader_compatibility():
+def test_streamlit_screen_reader_compatibility(bdd_context):
     """Test Streamlit GUI screen reader compatibility."""
-    pass
+    assert bdd_context.get("screen_reader_mode") is True
 
 
 @scenario("../features/ui_accessibility.feature", "High Contrast Mode")
-def test_high_contrast_mode():
+def test_high_contrast_mode(bdd_context):
     """Test high contrast mode."""
-    pass
+    assert "mock_markdown" in bdd_context
 
 
 @when("I use the CLI with color output disabled")


### PR DESCRIPTION
## Summary
- flesh out UI accessibility scenario functions
- assert agent logging output when running the orchestrator
- verify CLI output exit codes for output formatting scenarios
- assert monitor exit codes for interactive monitor
- check search results in local sources scenarios
- document how to write BDD tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError and type errors)*
- `poetry run pytest -q` *(fails: test_cache::test_search_uses_cache)*
- `poetry run pytest tests/behavior` *(fails: dkg_persistence_steps::test_persist_ram)*

------
https://chatgpt.com/codex/tasks/task_e_685851510ffc8333a26e02fcaf348eb1