### PR TITLE
Add interactive query refinement mode

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -16,6 +16,22 @@ autoresearch query "What are the environmental impacts of lithium mining for EV 
 
 This runs three complete dialectical cycles (Synthesizer → Contrarian → FactChecker), allowing for deeper exploration and refinement of the research question.
 
+### Interactive Query Refinement
+
+When running multiple loops you can refine the query after each cycle:
+
+```bash
+autoresearch search "initial question" --loops 2 --interactive
+```
+
+After the first cycle you'll be prompted:
+
+```
+Refine query or press Enter to continue (q to abort):
+```
+
+Enter an updated query string to guide the next cycle or `q` to abort.
+
 ### Chain of Thought for Step-by-Step Analysis
 
 For problems that benefit from incremental reasoning:

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -222,7 +222,7 @@ def search(
         False,
         "--interactive",
         "-i",
-        help="Prompt for feedback after each agent cycle",
+        help="Refine the query interactively between agent cycles",
     ),
 ) -> None:
     """Run a search query through the orchestrator and format the result.
@@ -258,12 +258,15 @@ def search(
 
         def on_cycle_end(loop: int, state: QueryState) -> None:
             progress.update(task, advance=1)
-            if interactive:
-                feedback = Prompt.ask("Feedback (q to abort)", default="")
-                if feedback.lower() == "q":
+            if interactive and loop < loops - 1:
+                refinement = Prompt.ask(
+                    "Refine query or press Enter to continue (q to abort)",
+                    default="",
+                )
+                if refinement.lower() == "q":
                     state.error_count = getattr(config, "max_errors", 3)
-                elif feedback:
-                    state.claims.append({"type": "feedback", "text": feedback})
+                elif refinement:
+                    state.query = refinement
 
         with Progress() as progress:
             task = progress.add_task("[green]Processing query...", total=loops)

--- a/tests/behavior/features/query_interface.feature
+++ b/tests/behavior/features/query_interface.feature
@@ -17,3 +17,7 @@ Feature: Query Interface
   Scenario: Submit query via MCP tool
     When I run `autoresearch.search("What is Promise Theory?")` via the MCP CLI
     Then I should receive a JSON output matching the defined schema for `answer`, `citations`, `reasoning`, and `metrics`
+
+  Scenario: Refine query interactively via CLI
+    When I run `autoresearch search "What is Promise Theory?" -i` and refine to "Define Promise Theory" then exit
+    Then I should receive a readable Markdown answer with `answer`, `citations`, `reasoning`, and `metrics` sections

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -31,3 +31,31 @@ def test_cli_help_no_ansi(monkeypatch):
     assert result.exit_code == 0
     assert "\x1b[" not in result.stdout
     assert "Usage:" in result.stdout
+
+
+def test_search_help_includes_interactive(monkeypatch):
+    dummy_storage = types.ModuleType("autoresearch.storage")
+
+    class StorageManager:
+        @staticmethod
+        def persist_claim(claim):
+            pass
+
+        @staticmethod
+        def setup(*a, **k):
+            pass
+
+    dummy_storage.StorageManager = StorageManager
+    dummy_storage.setup = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+    from autoresearch.config import ConfigLoader, ConfigModel
+
+    def _load(self):
+        return ConfigModel(loops=1)
+
+    monkeypatch.setattr(ConfigLoader, "load_config", _load)
+    main = importlib.import_module("autoresearch.main")
+    runner = CliRunner()
+    result = runner.invoke(main.app, ["search", "--help"])
+    assert result.exit_code == 0
+    assert "--interactive" in result.stdout


### PR DESCRIPTION
## Summary
- prompt user for query refinement between loops
- document interactive query refinement
- test CLI interactive option
- cover new interactive workflow in BDD scenarios

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Found 47 errors)*
- `poetry run pytest -q` *(fails: tests/unit/test_cache.py::test_search_uses_cache)*
- `poetry run pytest tests/behavior -q` *(fails: StorageError: owlrl missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858bbeaf1948333b32f78223e64e677