### PR TITLE
Add streaming flag and webhook configuration

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -23,6 +23,15 @@ curl -X POST http://localhost:8000/query \
   -d '{"query": "Explain machine learning"}'
 ```
 
+Pass `stream=true` as a query parameter to receive incremental updates instead
+of a single response:
+
+```bash
+curl -X POST 'http://localhost:8000/query?stream=true' \
+  -H "Content-Type: application/json" \
+  -d '{"query": "Explain machine learning"}'
+```
+
 **Response**
 
 ```json
@@ -58,6 +67,9 @@ curl -X POST http://localhost:8000/query \
   -H "Content-Type: application/json" \
   -d '{"query": "hi", "webhook_url": "http://localhost:9000/hook"}'
 ```
+
+Additionally, any URLs listed under `[api].webhooks` in `autoresearch.toml`
+receive the same payload after each query completes.
 
 ### `GET /metrics`
 

--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -200,6 +200,13 @@ class AgentConfig(BaseModel):
     model: Optional[str] = None
 
 
+class APIConfig(BaseModel):
+    """Configuration for HTTP API behaviour."""
+
+    webhooks: List[str] = Field(default_factory=list)
+    webhook_timeout: int = Field(default=5, ge=1)
+
+
 class ConfigModel(BaseSettings):
     """Main configuration model with validation."""
 
@@ -223,6 +230,9 @@ class ConfigModel(BaseSettings):
 
     # Search settings
     search: SearchConfig = Field(default_factory=SearchConfig)
+
+    # API settings
+    api: APIConfig = Field(default_factory=APIConfig)
 
     # Dynamic knowledge graph settings
     graph_eviction_policy: str = Field(default="LRU")
@@ -527,6 +537,8 @@ class ConfigLoader:
             "rdf_path": rdf_cfg.get("path", "rdf_store"),
         }
 
+        api_cfg = raw.get("api", {})
+
         # Extract agent configuration
         agent_cfg = raw.get("agent", {})
         enabled_agents = [
@@ -544,6 +556,9 @@ class ConfigLoader:
 
         # Add storage config
         core_settings["storage"] = StorageConfig(**storage_settings)
+
+        # Add API config
+        core_settings["api"] = APIConfig(**api_cfg)
 
         # Add agent configs
         core_settings["agent_config"] = agent_config_dict

--- a/tests/integration/test_api_streaming.py
+++ b/tests/integration/test_api_streaming.py
@@ -1,0 +1,49 @@
+import responses
+from fastapi.testclient import TestClient
+
+from autoresearch.api import app as api_app
+from autoresearch.config import ConfigModel, ConfigLoader, APIConfig
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.state import QueryState
+
+
+def test_query_stream_param(monkeypatch):
+    """/query should stream when stream=true is passed."""
+
+    def dummy_run_query(query, config, callbacks=None, **kwargs):
+        state = QueryState(query=query)
+        for i in range(2):
+            if callbacks and "on_cycle_end" in callbacks:
+                callbacks["on_cycle_end"](i, state)
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+
+    cfg = ConfigModel(loops=2, api=APIConfig())
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setattr(Orchestrator, "run_query", dummy_run_query)
+    client = TestClient(api_app)
+
+    with client.stream("POST", "/query?stream=true", json={"query": "q"}) as resp:
+        assert resp.status_code == 200
+        chunks = [line for line in resp.iter_lines()]
+    assert len(chunks) == 3
+
+
+def test_config_webhooks(monkeypatch):
+    """Configured webhooks should receive final results."""
+
+    cfg = ConfigModel(api=APIConfig(webhooks=["http://hook"], webhook_timeout=1))
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setattr(
+        Orchestrator,
+        "run_query",
+        lambda q, c, callbacks=None, **k: QueryResponse(answer="ok", citations=[], reasoning=[], metrics={}),
+    )
+    client = TestClient(api_app)
+
+    with responses.RequestsMock() as rsps:
+        rsps.post("http://hook", status=200)
+        resp = client.post("/query", json={"query": "hi"})
+        assert resp.status_code == 200
+        assert len(rsps.calls) == 1
+


### PR DESCRIPTION
## Summary
- support `stream=true` on `/query` to stream newline-delimited JSON
- fire webhooks configured in `[api].webhooks`
- document streaming flag and global webhooks
- integration tests for streaming via flag and webhook config

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 47 errors)*
- `poetry run pytest -q` *(interrupted)*
- `poetry run pytest tests/behavior` *(1 failed: StorageError)*

------
https://chatgpt.com/codex/tasks/task_e_6858dc07d6248333a5dab54fbcfe4d32