### PR TITLE
Enhance Streamlit GUI with accessibility and config tests

### DIFF
--- a/tests/behavior/features/streamlit_gui.feature
+++ b/tests/behavior/features/streamlit_gui.feature
@@ -31,6 +31,11 @@ Feature: Streamlit GUI Features
     And I should be able to save changes to the configuration
     And I should see feedback when the configuration is saved
 
+  Scenario: Configuration Updates Persist
+    When I update a configuration value in the GUI
+    Then the configuration should be saved with the new value
+    And the updated configuration should be used for the next query
+
   Scenario: Agent Interaction Trace Visualization
     When I run a query in the Streamlit interface
     Then an interaction trace should be displayed

--- a/tests/integration/test_api_streaming.py
+++ b/tests/integration/test_api_streaming.py
@@ -46,4 +46,3 @@ def test_config_webhooks(monkeypatch):
         resp = client.post("/query", json={"query": "hi"})
         assert resp.status_code == 200
         assert len(rsps.calls) == 1
-

--- a/tests/unit/test_config_reload.py
+++ b/tests/unit/test_config_reload.py
@@ -1,4 +1,3 @@
-import time
 import tomli_w
 from autoresearch.config import ConfigLoader
 

--- a/tests/unit/test_orchestrator_order.py
+++ b/tests/unit/test_orchestrator_order.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 import asyncio
-import pytest
 
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.config import ConfigModel


### PR DESCRIPTION
## Summary
- render query input and add high contrast + keyboard focus styles
- modularize Streamlit GUI with `display_query_input`
- expose high contrast toggle in sidebar
- extend BDD feature for configuration persistence and implement steps
- fix lint issues in unrelated tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: incompatible types and missing stubs)*
- `poetry run pytest -q` *(interrupted due to long runtime)*
- `poetry run pytest tests/behavior -q` *(fails: StorageError from owlrl)*

------
https://chatgpt.com/codex/tasks/task_e_6858e51306808333b3d747c2708e2f03