### PR TITLE
Add property tests and orchestrator integration

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -291,7 +291,7 @@ version = "25.3.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3"},
     {file = "attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"},
@@ -2178,6 +2178,40 @@ tensorflow-testing = ["keras (<3.0)", "tensorflow"]
 testing = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "authlib (>=1.3.2)", "fastapi", "gradio (>=4.0.0)", "httpx", "itsdangerous", "jedi", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
 torch = ["safetensors[torch]", "torch"]
 typing = ["types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)"]
+
+[[package]]
+name = "hypothesis"
+version = "6.135.14"
+description = "A library for property-based testing"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "hypothesis-6.135.14-py3-none-any.whl", hash = "sha256:0dd5b8095e36bd288367c631f864a16c30500b01b17943dcea681233f7421860"},
+    {file = "hypothesis-6.135.14.tar.gz", hash = "sha256:2666df50b3cc40ea08b161a5389d6a1cd5aa3cab0dd8fde0ae339389714a4f67"},
+]
+
+[package.dependencies]
+attrs = ">=22.2.0"
+sortedcontainers = ">=2.1.0,<3.0.0"
+
+[package.extras]
+all = ["black (>=19.10b0)", "click (>=7.0)", "crosshair-tool (>=0.0.88)", "django (>=4.2)", "dpcontracts (>=0.4)", "hypothesis-crosshair (>=0.0.23)", "lark (>=0.10.1)", "libcst (>=0.3.16)", "numpy (>=1.19.3)", "pandas (>=1.1)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "tzdata (>=2025.2) ; sys_platform == \"win32\" or sys_platform == \"emscripten\"", "watchdog (>=4.0.0)"]
+cli = ["black (>=19.10b0)", "click (>=7.0)", "rich (>=9.0.0)"]
+codemods = ["libcst (>=0.3.16)"]
+crosshair = ["crosshair-tool (>=0.0.88)", "hypothesis-crosshair (>=0.0.23)"]
+dateutil = ["python-dateutil (>=1.4)"]
+django = ["django (>=4.2)"]
+dpcontracts = ["dpcontracts (>=0.4)"]
+ghostwriter = ["black (>=19.10b0)"]
+lark = ["lark (>=0.10.1)"]
+numpy = ["numpy (>=1.19.3)"]
+pandas = ["pandas (>=1.1)"]
+pytest = ["pytest (>=4.6)"]
+pytz = ["pytz (>=2014.1)"]
+redis = ["redis (>=3.0.0)"]
+watchdog = ["watchdog (>=4.0.0)"]
+zoneinfo = ["tzdata (>=2025.2) ; sys_platform == \"win32\" or sys_platform == \"emscripten\""]
 
 [[package]]
 name = "idna"
@@ -6178,6 +6212,18 @@ files = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+
+[[package]]
 name = "spacy"
 version = "3.7.5"
 description = "Industrial-strength Natural Language Processing (NLP) in Python"
@@ -8333,4 +8379,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "37e7ac66cce869659ae6f0a3e2651697ce941ab7f502896b157f0f6affcf5ffa"
+content-hash = "4a5cfe18aa7e5f43f34e726ab2f64abbedb2a44fd477d7ebb4ca0af63dc015ca"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ tomli-w = "^1.2.0"
 types-requests = "^2.32.0"
 types-networkx = "^3.4.0"
 types-protobuf = "^6.30.2.20250516"
+hypothesis = "^6.100"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/tests/integration/test_orchestrator_combinations.py
+++ b/tests/integration/test_orchestrator_combinations.py
@@ -1,0 +1,47 @@
+from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
+from autoresearch.search import Search
+from autoresearch.storage import StorageManager
+from autoresearch.config import ConfigModel, ConfigLoader
+from autoresearch.models import QueryResponse
+
+
+def make_agent(name, calls, search_calls, store_calls):
+    class DummyAgent:
+        def __init__(self, name, llm_adapter=None):
+            self.name = name
+
+        def can_execute(self, state, config):
+            return True
+
+        def execute(self, state, config, **kwargs):
+            Search.rank_results("q", [{"title": "t", "url": "https://example.com"}])
+            StorageManager.persist_claim({"id": self.name, "type": "fact", "content": self.name})
+            calls.append(self.name)
+            search_calls.append(self.name)
+            store_calls.append(self.name)
+            state.update({"results": {self.name: "ok"}, "claims": [{"type": "fact", "content": self.name}]})
+            if self.name == "Synthesizer":
+                state.results["final_answer"] = f"Answer from {self.name}"
+            return {"results": {self.name: "ok"}}
+
+    return DummyAgent(name)
+
+
+def test_orchestrator_agent_combinations(monkeypatch):
+    calls = []
+    search_calls = []
+    store_calls = []
+    monkeypatch.setattr(Search, "rank_results", lambda q, r: r)
+    monkeypatch.setattr(StorageManager, "persist_claim", lambda claim: store_calls.append(claim))
+    monkeypatch.setattr(AgentFactory, "get", lambda name: make_agent(name, calls, search_calls, store_calls))
+
+    cfg = ConfigModel(agents=["AgentA", "Synthesizer"], loops=1)
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+
+    response = Orchestrator.run_query("q", cfg)
+    assert isinstance(response, QueryResponse)
+    assert calls == ["AgentA", "Synthesizer"]
+    assert search_calls == calls
+    assert len(store_calls) == 2
+    assert response.answer == "Answer from Synthesizer"

--- a/tests/unit/test_property_ranking_weights.py
+++ b/tests/unit/test_property_ranking_weights.py
@@ -1,0 +1,63 @@
+from hypothesis import given, strategies as st
+import pytest
+
+from autoresearch.search import Search
+from autoresearch.config import ConfigModel, SearchConfig, ConfigLoader, ConfigError
+
+
+@given(
+    w1=st.floats(min_value=0, max_value=1),
+    w2=st.floats(min_value=0, max_value=1),
+    w3=st.floats(min_value=0, max_value=1),
+)
+def test_search_config_weight_validation(w1, w2, w3):
+    total = w1 + w2 + w3
+    if abs(total - 1.0) <= 0.001:
+        cfg = SearchConfig(
+            bm25_weight=w1,
+            semantic_similarity_weight=w2,
+            source_credibility_weight=w3,
+        )
+        assert pytest.approx(cfg.bm25_weight + cfg.semantic_similarity_weight + cfg.source_credibility_weight, 0.001) == 1.0
+    else:
+        with pytest.raises(ConfigError):
+            SearchConfig(
+                bm25_weight=w1,
+                semantic_similarity_weight=w2,
+                source_credibility_weight=w3,
+            )
+
+
+@given(
+    results=st.lists(
+        st.fixed_dictionaries({"title": st.text(min_size=1), "url": st.just("https://example.com")}),
+        min_size=1,
+        max_size=5,
+    ),
+    weights=st.tuples(
+        st.floats(min_value=0, max_value=1),
+        st.floats(min_value=0, max_value=1),
+        st.floats(min_value=0, max_value=1),
+    ).filter(lambda t: sum(t) > 0),
+)
+def test_rank_results_sorted(monkeypatch, results, weights):
+    w1, w2, w3 = weights
+    total = w1 + w2 + w3
+    cfg = ConfigModel(
+        search=SearchConfig(
+            bm25_weight=w1 / total,
+            semantic_similarity_weight=w2 / total,
+            source_credibility_weight=w3 / total,
+        )
+    )
+
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+
+    monkeypatch.setattr(Search, "calculate_bm25_scores", lambda q, r: [1.0] * len(r))
+    monkeypatch.setattr(Search, "calculate_semantic_similarity", lambda q, r, query_embedding=None: [1.0] * len(r))
+    monkeypatch.setattr(Search, "assess_source_credibility", lambda r: [1.0] * len(r))
+
+    ranked = Search.rank_results("q", results)
+    scores = [res["relevance_score"] for res in ranked]
+    assert scores == sorted(scores, reverse=True)


### PR DESCRIPTION
## Summary
- property-based tests for relevance ranking and config weight validation
- integration test covering orchestrator with dummy agents
- add Hypothesis to development dependencies

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: need type annotations in src)*
- `poetry run pytest -q` *(incomplete due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68598290b1a48333b9dd7d850d82a634