### PR TITLE
Add interactive CLI monitor and metrics commands

### DIFF
--- a/src/autoresearch/monitor.py
+++ b/src/autoresearch/monitor.py
@@ -1,0 +1,116 @@
+"""Interactive monitoring commands for Autoresearch."""
+
+from __future__ import annotations
+
+import sys
+import time
+from typing import Any, Dict
+
+import typer
+from rich.console import Console
+from rich.table import Table
+from rich.prompt import Prompt
+from rich.progress import Progress
+from rich.live import Live
+
+from .config import ConfigLoader
+from .orchestration.orchestrator import Orchestrator
+from .orchestration.state import QueryState
+from .output_format import OutputFormatter
+
+monitor_app = typer.Typer(help="Monitoring utilities")
+_loader = ConfigLoader()
+
+
+def _collect_system_metrics() -> Dict[str, Any]:
+    """Collect basic CPU and memory metrics."""
+    metrics: Dict[str, Any] = {}
+    try:
+        import psutil  # type: ignore
+
+        metrics["cpu_percent"] = psutil.cpu_percent(interval=None)
+        mem = psutil.virtual_memory()
+        metrics["memory_percent"] = mem.percent
+        metrics["memory_used_mb"] = mem.used / (1024 * 1024)
+    except Exception:
+        pass
+    return metrics
+
+
+def _render_metrics(data: Dict[str, Any]) -> Table:
+    table = Table(title="System Metrics")
+    table.add_column("Metric")
+    table.add_column("Value")
+    for k, v in data.items():
+        table.add_row(str(k), f"{v:.2f}" if isinstance(v, float) else str(v))
+    return table
+
+
+@monitor_app.command("metrics")
+def metrics(watch: bool = typer.Option(False, "--watch", "-w", help="Refresh continuously")) -> None:
+    """Display system metrics in real time."""
+    console = Console()
+
+    def refresh() -> Table:
+        return _render_metrics(_collect_system_metrics())
+
+    if watch:
+        with Live(refresh(), console=console, refresh_per_second=1) as live:
+            try:
+                while True:
+                    time.sleep(1)
+                    live.update(refresh())
+            except KeyboardInterrupt:
+                pass
+    else:
+        console.print(refresh())
+
+
+@monitor_app.command("run")
+def run() -> None:
+    """Start the interactive monitor."""
+    console = Console()
+    config = _loader.load_config()
+
+    abort_flag = {"stop": False}
+
+    def on_cycle_end(loop: int, state: QueryState) -> None:
+        metrics = state.metadata.get("execution_metrics", {})
+        table = Table(title=f"Cycle {loop + 1} Metrics")
+        table.add_column("Metric")
+        table.add_column("Value")
+        for k, v in metrics.items():
+            table.add_row(str(k), str(v))
+        console.print(table)
+        feedback = Prompt.ask("Feedback (q to stop)", default="")
+        if feedback.lower() == "q":
+            state.error_count = getattr(config, "max_errors", 3)
+            abort_flag["stop"] = True
+        elif feedback:
+            state.claims.append({"type": "feedback", "text": feedback})
+
+    while True:
+        query = Prompt.ask("Enter query (q to quit)")
+        if not query or query.lower() == "q":
+            break
+
+        try:
+            loops = getattr(config, "loops", 1)
+            with Progress() as progress:
+                task = progress.add_task("[green]Processing query...", total=loops)
+
+                def wrapped_on_cycle(loop: int, state: QueryState) -> None:
+                    progress.update(task, advance=1)
+                    on_cycle_end(loop, state)
+
+                result = Orchestrator.run_query(
+                    query, config, {"on_cycle_end": wrapped_on_cycle}
+                )
+            fmt = config.output_format or (
+                "json" if not sys.stdout.isatty() else "markdown"
+            )
+            OutputFormatter.format(result, fmt)
+        except Exception as e:
+            console.print(f"[bold red]Error:[/bold red] {str(e)}")
+        if abort_flag["stop"]:
+            break

--- a/tests/behavior/features/interactive_monitor.feature
+++ b/tests/behavior/features/interactive_monitor.feature
@@ -7,9 +7,13 @@ Feature: Interactive Monitoring
     Given the application is running
 
   Scenario: Interactive monitoring
-    When I start `autoresearch monitor` and enter "test"
+    When I start `autoresearch monitor run` and enter "test"
     Then the monitor should exit successfully
 
   Scenario: Exit immediately
-    When I start `autoresearch monitor` and enter "q"
+    When I start `autoresearch monitor run` and enter "q"
+    Then the monitor should exit successfully
+
+  Scenario: Display metrics
+    When I run `autoresearch monitor metrics`
     Then the monitor should exit successfully

--- a/tests/behavior/steps/interactive_monitor_steps.py
+++ b/tests/behavior/steps/interactive_monitor_steps.py
@@ -4,11 +4,22 @@ from pytest_bdd import scenario, when, then, parsers
 from .common_steps import *  # noqa: F401,F403
 
 
-@when(parsers.parse('I start `autoresearch monitor` and enter "{text}"'))
+@when(parsers.parse('I start `autoresearch monitor run` and enter "{text}"'))
 def start_monitor(text, monkeypatch, bdd_context):
     responses = iter([text, "", "q"])
     monkeypatch.setattr("autoresearch.main.Prompt.ask", lambda *a, **k: next(responses))
-    result = runner.invoke(cli_app, ["monitor"])
+    monkeypatch.setattr("autoresearch.monitor.Prompt.ask", lambda *a, **k: next(responses))
+    result = runner.invoke(cli_app, ["monitor", "run"])
+    bdd_context["monitor_result"] = result
+
+
+@when('I run `autoresearch monitor metrics`')
+def run_metrics(monkeypatch, bdd_context):
+    monkeypatch.setattr(
+        "autoresearch.monitor._collect_system_metrics",
+        lambda: {"cpu_percent": 10.0, "memory_percent": 5.0},
+    )
+    result = runner.invoke(cli_app, ["monitor", "metrics"])
     bdd_context["monitor_result"] = result
 
 
@@ -24,4 +35,9 @@ def test_interactive_monitor(bdd_context):
 
 @scenario("../features/interactive_monitor.feature", "Exit immediately")
 def test_monitor_exit_immediately(bdd_context):
+    assert bdd_context["monitor_result"].exit_code == 0
+
+
+@scenario("../features/interactive_monitor.feature", "Display metrics")
+def test_monitor_metrics(bdd_context):
     assert bdd_context["monitor_result"].exit_code == 0

--- a/tests/integration/test_monitor_metrics.py
+++ b/tests/integration/test_monitor_metrics.py
@@ -29,7 +29,7 @@ def test_monitor_cli_increments_counter(monkeypatch):
     setup_patches(monkeypatch)
     runner = CliRunner()
     start = metrics.QUERY_COUNTER._value.get()
-    result = runner.invoke(cli_app, ["monitor"])
+    result = runner.invoke(cli_app, ["monitor", "run"])
     assert result.exit_code == 0
     assert metrics.QUERY_COUNTER._value.get() == start + 1
     client = TestClient(api_app)


### PR DESCRIPTION
## Summary
- introduce `monitor_app` with `run` and `metrics` commands
- wire new monitor app into the main CLI
- update behavior tests for the new monitor usage
- adjust integration tests for updated monitor command

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src/autoresearch/monitor.py`
- `poetry run pytest -q` *(fails: ImportError/KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68598e42a1848333b68541d6f8738180