### PR TITLE
Improve contribution docs and add deployment guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,12 @@ By participating in this project, you agree to maintain a respectful and inclusi
 
 ### Setting Up
 
-1. Install the dependencies using Poetry (recommended):
+1. Configure Poetry to use Python 3.12 or newer:
+   ```bash
+   poetry env use $(which python3)
+   ```
+
+2. Install the dependencies using Poetry:
    ```bash
    poetry install --with dev
    ```
@@ -47,6 +52,12 @@ By participating in this project, you agree to maintain a respectful and inclusi
    If OpenMP support causes build errors, disable it by setting
    `HDBSCAN_NO_OPENMP=1` in your environment when installing.
 
+   Optional packages enable extra features such as diagram rendering and
+   video previews. Install them with:
+   ```bash
+   sudo apt-get install graphviz ffmpeg
+   ```
+
    Alternatively, you can use the helper script:
    ```bash
    ./scripts/setup.sh
@@ -57,7 +68,7 @@ By participating in this project, you agree to maintain a respectful and inclusi
    pip install -e .
    ```
 
-2. Configure your editor to use the project's linting and formatting settings
+3. Configure your editor to use the project's linting and formatting settings
    - For VSCode, the recommended settings are included in `.vscode/settings.json`
    - For PyCharm, import the code style settings from `.idea/codeStyles`
 
@@ -143,7 +154,7 @@ def function_name(param1: str, param2: int) -> bool:
 
 ## Testing Requirements
 
-Autoresearch follows a BDD/TDD approach to development. All new features and bug fixes should include appropriate tests.
+Autoresearch follows a BDD/TDD approach to development. All new features and bug fixes should include appropriate tests. Additional recommendations are provided in [docs/testing_guidelines.md](docs/testing_guidelines.md).
 
 ### Test Organization
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,43 @@
+# Deployment Scenarios
+
+Autoresearch can be deployed in several ways depending on your needs. This guide outlines common approaches.
+
+## Local Installation
+
+For personal use, run Autoresearch directly on your machine. Install the dependencies and invoke the CLI or API:
+
+```bash
+poetry install --with dev
+poetry run autoresearch search "example query"
+```
+
+Start the API service with Uvicorn for HTTP access:
+
+```bash
+poetry run uvicorn autoresearch.api:app --reload
+```
+
+## Running as a Service
+
+On a dedicated server you can run the API in the background using a process manager such as `systemd` or `supervisord`. Configure environment variables in `.env` and set the working directory to the project root.
+
+## Containerized Deployment (Docker)
+
+Autoresearch can also be containerized. A minimal `Dockerfile` might look like:
+
+```Dockerfile
+FROM python:3.12-slim
+WORKDIR /app
+COPY . /app
+RUN pip install poetry && poetry install --with dev
+CMD ["poetry", "run", "uvicorn", "autoresearch.api:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+Build and run the image:
+
+```bash
+docker build -t autoresearch .
+docker run -p 8000:8000 autoresearch
+```
+
+This exposes the API on port 8000 inside the container.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
   - Orchestration: docs/orchestration.md
   - API Usage: docs/api.md
   - Advanced Usage: docs/advanced_usage.md
+  - Deployment: docs/deployment.md
   - Agent System: docs/agent_system.md
   - Component Interactions: docs/component_interactions.md
   - API Reference:


### PR DESCRIPTION
## Summary
- expand setup instructions in `CONTRIBUTING.md`
- cross-reference testing docs
- document deployment scenarios
- expose deployment guide in mkdocs navigation

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Incompatible default for argument)*
- `poetry run pytest -q` *(execution interrupted)*
- `poetry run pytest tests/behavior` *(execution interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68599b120d5883338850b0828ac721b6