### PR TITLE
Add Hypothesis tests and fixtures

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -196,3 +196,16 @@ This document tracks the progress of tasks for the Autoresearch project, organiz
   - [ ] Create deployment scripts
   - [ ] Implement configuration validation
   - [ ] Add health check mechanisms
+
+### Coverage Report
+
+Modules with coverage below 90% based on the latest run:
+
+- `autoresearch.orchestration.metrics` – 37%
+- `autoresearch.orchestration.orchestrator` – 0%
+- `autoresearch.search` – 15%
+- `autoresearch.storage` – 22%
+- `autoresearch.storage_backends` – 9%
+- `autoresearch.output_format` – 0%
+- `autoresearch.streamlit_app` – 0%
+

--- a/tests/unit/test_property_vector_search.py
+++ b/tests/unit/test_property_vector_search.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock
+from hypothesis import given, strategies as st, settings, HealthCheck
+import pytest
+
+
+from autoresearch.storage import StorageManager
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    st.lists(st.floats(allow_nan=False, allow_infinity=False), min_size=1, max_size=5),
+    st.integers(min_value=1, max_value=5)
+)
+def test_vector_search_calls_backend(monkeypatch, query_embedding, k):
+    backend = MagicMock()
+    backend.vector_search.return_value = [{"node_id": "n", "embedding": [0.1]}]
+    monkeypatch.setattr("autoresearch.storage._db_backend", backend, raising=False)
+    monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
+    monkeypatch.setattr(StorageManager, "has_vss", lambda: True)
+
+    result = StorageManager.vector_search(query_embedding, k)
+    backend.vector_search.assert_called_once_with(query_embedding, k)
+    assert isinstance(result, list)
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    st.one_of(st.none(), st.text(), st.integers(), st.lists(st.text())),
+    st.integers(max_value=0)
+)
+def test_vector_search_invalid(monkeypatch, query_embedding, k):
+    monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
+    monkeypatch.setattr(StorageManager, "has_vss", lambda: True)
+    with pytest.raises(Exception):
+        StorageManager.vector_search(query_embedding, k)

--- a/tests/unit/test_property_watch_changes.py
+++ b/tests/unit/test_property_watch_changes.py
@@ -1,0 +1,14 @@
+import threading
+from hypothesis import given, strategies as st, settings, HealthCheck
+from autoresearch.config import ConfigLoader
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(n=st.integers(min_value=1, max_value=5))
+def test_watch_changes_idempotent(config_watcher, n):
+    loader = ConfigLoader()
+    for _ in range(n):
+        loader.watch_changes()
+    threads = [t for t in threading.enumerate() if t.name == "ConfigWatcher"]
+    assert len(threads) <= 1
+    loader.stop_watching()


### PR DESCRIPTION
## Summary
- add claim and LLM helper fixtures
- create Hypothesis-based property tests for ConfigLoader.watch_changes and StorageManager.vector_search
- document low coverage modules in TASK_PROGRESS

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Module "tabulate" etc.)*
- `poetry run pytest tests/unit/test_property_vector_search.py tests/unit/test_property_watch_changes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f84d5cdc8333b0c84cfb80210118