### PR TITLE
Add token budget to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ llm_backend = "lmstudio"
 
 # Number of reasoning loops to perform
 loops = 3
+# Maximum token budget per run
+token_budget = 4000
 
 # Enable distributed tracing
 tracing_enabled = false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,7 @@ These options are set in the `[core]` section of the configuration file.
 | `llm_backend` | string | `"lmstudio"` | The LLM adapter to use | `"lmstudio"`, `"openai"`, `"openrouter"`, `"dummy"` |
 | `loops` | integer | `2` | Number of reasoning cycles to run | ≥ 1 |
 | `ram_budget_mb` | integer | `1024` | Memory budget in megabytes | ≥ 0 |
+| `token_budget` | integer | `null` | Maximum tokens allowed per run | ≥ 1 or `null` |
 | `agents` | list of strings | `["Synthesizer", "Contrarian", "FactChecker"]` | Agents to use in the reasoning process | Any valid agent names |
 | `primus_start` | integer | `0` | Index of the starting agent in the agents list | ≥ 0 |
 | `reasoning_mode` | string | `"dialectical"` | The reasoning mode to use | `"dialectical"`, `"direct"`, `"chain-of-thought"` |

--- a/examples/autoresearch.toml
+++ b/examples/autoresearch.toml
@@ -1,6 +1,7 @@
 [core]
 llm_backend = "lmstudio"
 loops = 3
+token_budget = 4000
 tracing_enabled = false
 
 [search]

--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -224,6 +224,11 @@ class ConfigModel(BaseSettings):
     llm_backend: str = Field(default="lmstudio")
     loops: int = Field(default=2, ge=1)
     ram_budget_mb: int = Field(default=1024, ge=0)
+    token_budget: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Maximum tokens available for a single run",
+    )
     agents: List[str] = Field(default=["Synthesizer", "Contrarian", "FactChecker"])
     primus_start: int = Field(default=0)
     reasoning_mode: ReasoningMode = Field(default=ReasoningMode.DIALECTICAL)
@@ -300,6 +305,17 @@ class ConfigModel(BaseSettings):
                 suggestion=f"Try using one of the valid modes: {', '.join(valid_modes)}",
                 cause=exc,
             ) from exc
+
+    @field_validator("token_budget")
+    def validate_token_budget(cls, v: int | None) -> int | None:
+        """Ensure the token budget is positive when provided."""
+        if v is not None and v <= 0:
+            raise ConfigError(
+                "token_budget must be positive",
+                provided=v,
+                suggestion="Set token_budget to a positive integer or omit it",
+            )
+        return v
 
     @field_validator("graph_eviction_policy")
     def validate_eviction_policy(cls, v: str) -> str:


### PR DESCRIPTION
## Summary
- add optional `token_budget` to `ConfigModel`
- validate `token_budget` via pydantic validator
- document the new option
- include example usage in `autoresearch.toml`

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Found 42 errors)*
- `poetry run pytest -q` *(fails: import file mismatch)*
- `poetry run pytest tests/behavior` *(fails: StorageError from owlrl)*

------
https://chatgpt.com/codex/tasks/task_e_685b23e8343c83338dd6cf7d5a3a5a34