### PR TITLE
Refactor BDD fixtures

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -1,4 +1,9 @@
 import pytest
+from typer.testing import CliRunner
+from fastapi.testclient import TestClient
+
+from autoresearch.main import app as cli_app
+from autoresearch.api import app as api_app
 
 
 @pytest.fixture(autouse=True)
@@ -13,6 +18,28 @@ def enable_real_vss(monkeypatch):
 def bdd_storage_manager(storage_manager):
     """Use the global temporary storage fixture for behavior tests."""
     yield storage_manager
+
+
+@pytest.fixture
+def cli_runner():
+    """Provide a Typer CliRunner instance for invoking the CLI."""
+    return CliRunner()
+
+
+@pytest.fixture
+def invoke_cli(cli_runner):
+    """Helper to invoke the CLI with the given arguments."""
+
+    def _invoke(*args: str):
+        return cli_runner.invoke(cli_app, list(args))
+
+    return _invoke
+
+
+@pytest.fixture
+def api_client():
+    """Provide a FastAPI TestClient for the API app."""
+    return TestClient(api_app)
 
 
 @pytest.fixture

--- a/tests/behavior/steps/agent_orchestration_steps.py
+++ b/tests/behavior/steps/agent_orchestration_steps.py
@@ -89,7 +89,7 @@ def check_agents_executed(run_orchestrator_on_query, order):
     parsers.parse('I submit a query via CLI `autoresearch search "{query}"`'),
     target_fixture="submit_query_via_cli",
 )
-def submit_query_via_cli(query, monkeypatch):
+def submit_query_via_cli(query, monkeypatch, invoke_cli):
     from autoresearch.models import QueryResponse
 
     original_run_query = Orchestrator.run_query
@@ -115,7 +115,7 @@ def submit_query_via_cli(query, monkeypatch):
     main_mod._config_loader = ConfigLoader()
     main_mod._config_loader._config = cfg
 
-    result = runner.invoke(cli_app, ["search", query])
+    result = invoke_cli("search", query)
 
     monkeypatch.setattr(Orchestrator, "run_query", original_run_query)
 

--- a/tests/behavior/steps/common_steps.py
+++ b/tests/behavior/steps/common_steps.py
@@ -1,15 +1,8 @@
 # flake8: noqa
-import os
-import json
-from typer.testing import CliRunner
-from fastapi.testclient import TestClient
 from pytest_bdd import given
 
 from autoresearch.main import app as cli_app
 from autoresearch.api import app as api_app
-
-runner = CliRunner()
-client = TestClient(api_app)
 
 
 @given("the Autoresearch application is running")

--- a/tests/behavior/steps/interactive_monitor_steps.py
+++ b/tests/behavior/steps/interactive_monitor_steps.py
@@ -5,21 +5,21 @@ from .common_steps import *  # noqa: F401,F403
 
 
 @when(parsers.parse('I start `autoresearch monitor run` and enter "{text}"'))
-def start_monitor(text, monkeypatch, bdd_context):
+def start_monitor(text, monkeypatch, bdd_context, invoke_cli):
     responses = iter([text, "", "q"])
     monkeypatch.setattr("autoresearch.main.Prompt.ask", lambda *a, **k: next(responses))
     monkeypatch.setattr("autoresearch.monitor.Prompt.ask", lambda *a, **k: next(responses))
-    result = runner.invoke(cli_app, ["monitor", "run"])
+    result = invoke_cli("monitor", "run")
     bdd_context["monitor_result"] = result
 
 
 @when('I run `autoresearch monitor metrics`')
-def run_metrics(monkeypatch, bdd_context):
+def run_metrics(monkeypatch, bdd_context, invoke_cli):
     monkeypatch.setattr(
         "autoresearch.monitor._collect_system_metrics",
         lambda: {"cpu_percent": 10.0, "memory_percent": 5.0},
     )
-    result = runner.invoke(cli_app, ["monitor", "metrics"])
+    result = invoke_cli("monitor", "metrics")
     bdd_context["monitor_result"] = result
 
 

--- a/tests/behavior/steps/output_formatting_steps.py
+++ b/tests/behavior/steps/output_formatting_steps.py
@@ -6,9 +6,9 @@ from .common_steps import *  # noqa: F401,F403
 
 
 @when(parsers.parse('I run `autoresearch search "{query}"` in TTY mode'))
-def run_in_terminal(query, monkeypatch, bdd_context):
+def run_in_terminal(query, monkeypatch, bdd_context, invoke_cli):
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    result = runner.invoke(cli_app, ["search", query])
+    result = invoke_cli("search", query)
     bdd_context["terminal_result"] = result
 
 
@@ -24,10 +24,10 @@ def check_markdown_output(bdd_context):
 
 
 @when(parsers.parse('I run `autoresearch search "{query}" | cat`'))
-def run_piped(query, monkeypatch, bdd_context):
+def run_piped(query, monkeypatch, bdd_context, invoke_cli):
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
-    result = runner.invoke(cli_app, ["search", query])
+    result = invoke_cli("search", query)
     bdd_context["piped_result"] = result
 
 
@@ -44,8 +44,8 @@ def check_json_output(bdd_context):
 
 
 @when(parsers.re(r'I run `autoresearch search "(?P<query>.+)" --output json`'))
-def run_with_json_flag(query, monkeypatch, bdd_context):
-    result = runner.invoke(cli_app, ["search", query, "--output", "json"])
+def run_with_json_flag(query, monkeypatch, bdd_context, invoke_cli):
+    result = invoke_cli("search", query, "--output", "json")
     bdd_context["json_flag_result"] = result
 
 
@@ -60,8 +60,8 @@ def check_json_output_with_flag(bdd_context):
 
 
 @when(parsers.re(r'I run `autoresearch search "(?P<query>.+)" --output markdown`'))
-def run_with_markdown_flag(query, monkeypatch, bdd_context):
-    result = runner.invoke(cli_app, ["search", query, "--output", "markdown"])
+def run_with_markdown_flag(query, monkeypatch, bdd_context, invoke_cli):
+    result = invoke_cli("search", query, "--output", "markdown")
     bdd_context["markdown_flag_result"] = result
 
 

--- a/tests/behavior/steps/query_interface_steps.py
+++ b/tests/behavior/steps/query_interface_steps.py
@@ -6,9 +6,9 @@ from .common_steps import *  # noqa: F401,F403
 
 
 @when(parsers.parse('I run `autoresearch search "{query}"` in a terminal'))
-def run_cli_query(query, monkeypatch, bdd_context):
+def run_cli_query(query, monkeypatch, bdd_context, invoke_cli):
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    result = runner.invoke(cli_app, ["search", query])
+    result = invoke_cli("search", query)
     bdd_context["cli_result"] = result
 
 
@@ -31,8 +31,8 @@ def check_cli_output(bdd_context):
         'I send a POST request to `/query` with JSON `{ "query": "{query}" }`'
     )
 )
-def send_http_query(query, bdd_context):
-    response = client.post("/query", json={"query": query})
+def send_http_query(query, bdd_context, api_client):
+    response = api_client.post("/query", json={"query": query})
     bdd_context["http_response"] = response
 
 
@@ -48,10 +48,10 @@ def check_http_response(bdd_context):
 
 
 @when(parsers.re(r'I run `autoresearch\.search\("(?P<query>.+)"\)` via the MCP CLI'))
-def run_mcp_cli_query(query, monkeypatch, bdd_context):
+def run_mcp_cli_query(query, monkeypatch, bdd_context, invoke_cli):
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
-    result = runner.invoke(cli_app, ["search", query])
+    result = invoke_cli("search", query)
     bdd_context["mcp_result"] = result
 
 
@@ -60,7 +60,7 @@ def run_mcp_cli_query(query, monkeypatch, bdd_context):
         'I run `autoresearch search "{query}" -i` and refine to "{refined}" then exit'
     )
 )
-def run_interactive_query(query, refined, monkeypatch, bdd_context):
+def run_interactive_query(query, refined, monkeypatch, bdd_context, invoke_cli):
     from autoresearch.config import ConfigModel, ConfigLoader
 
     monkeypatch.setattr(
@@ -71,7 +71,7 @@ def run_interactive_query(query, refined, monkeypatch, bdd_context):
     responses = iter([refined, "q"])
     monkeypatch.setattr("autoresearch.main.Prompt.ask", lambda *a, **k: next(responses))
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    result = runner.invoke(cli_app, ["search", query, "--interactive"])
+    result = invoke_cli("search", query, "--interactive")
     bdd_context["cli_result"] = result
 
 


### PR DESCRIPTION
## Summary
- centralize CLI helpers and API client in `tests/behavior/conftest.py`
- update step modules to use the shared fixtures

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: found errors)*
- `timeout 20 poetry run pytest -q`
- `timeout 20 poetry run pytest tests/behavior`

------
https://chatgpt.com/codex/tasks/task_e_685b6c9ef7108333b2011f0975c0469e