### PR TITLE
Enhance behavior tests

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -84,8 +84,8 @@ This document tracks the progress of tasks for the Autoresearch project, organiz
 - [ ] Enhance test step definitions
   - [x] Add more detailed assertions
   - [x] Implement better test isolation
-  - [ ] Create more comprehensive test contexts
-  - _Next:_ reuse fixtures to speed up scenario setup
+  - [x] Create more comprehensive test contexts
+  - _Next:_ introduce reusable fixtures for CLI and API clients
 
 ### 4.1 Code Documentation
 

--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -1,4 +1,26 @@
 import pytest
+from typer.testing import CliRunner
+from fastapi.testclient import TestClient
+
+from autoresearch.api import app as api_app
+
+
+@pytest.fixture
+def cli_runner():
+    """Provide a Typer CLI runner for behavior tests."""
+    return CliRunner()
+
+
+@pytest.fixture
+def api_client():
+    """Provide a FastAPI test client for behavior tests."""
+    return TestClient(api_app)
+
+
+@pytest.fixture
+def test_context():
+    """Mutable mapping for sharing state in behavior tests."""
+    return {}
 
 
 @pytest.fixture(autouse=True)

--- a/tests/behavior/features/interactive_monitor.feature
+++ b/tests/behavior/features/interactive_monitor.feature
@@ -17,3 +17,4 @@ Feature: Interactive Monitoring
   Scenario: Display metrics
     When I run `autoresearch monitor metrics`
     Then the monitor should exit successfully
+    And the monitor output should display system metrics


### PR DESCRIPTION
## Summary
- add generic CLI runner and API client fixtures for behavior tests
- verify monitor command outputs metrics
- check metrics output in feature file
- update task progress tracker

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Found 41 errors in 8 files)*
- `poetry run pytest tests/behavior -q` *(fails: StorageError in dkg_persistence_steps)*

------
https://chatgpt.com/codex/tasks/task_e_685c3dd3566c8333bfb8261ebbfd7d48