### PR TITLE
Update codex setup script

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -7,5 +7,7 @@ apt-get install -y \
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 
-poetry sync --all-groups --all-extras
+poetry env use $(which python3)
+poetry install --with dev
+poetry run pip install -e .
 poetry run python -m spacy download en_core_web_sm


### PR DESCRIPTION
## Summary
- switch codex setup to use `poetry env use $(which python3)`
- install deps with `poetry install --with dev`
- install package in editable mode

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: incompatible types)*
- `poetry run pytest -q` *(interrupted due to time)*
- `poetry run pytest tests/behavior` *(fails: owlrl package missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c57f54504833392bde17605276680