### PR TITLE
Switch to project.scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,8 @@ hypothesis = "^6.100"
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.poetry.scripts]
+
+[project.scripts]
 autoresearch = "autoresearch.main:app"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
- remove the obsolete `[tool.poetry.scripts]` section
- use PEP 621 `[project.scripts]` for the console entry point
- confirm `poetry install` still exposes `autoresearch`

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Module "aut. ..." has no attribute)*
- `poetry run pytest -q` *(interrupted: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: StorageError)*

------
https://chatgpt.com/codex/tasks/task_e_685c7b9b86308333910896060c8d6753