### PR TITLE
Update dev setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,10 +272,11 @@ For a detailed breakdown of the requirements and architecture, see
 
 ## Development setup
 
-Install the development dependencies:
+Install the development dependencies and link the package in editable mode:
 
 ```bash
 poetry install --with dev
+poetry run pip install -e .
 ```
 
 Alternatively you can run the helper script:


### PR DESCRIPTION
## Summary
- stress running `poetry run pip install -e .` after installing dev deps

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Item "None" has no attribute "split" and more)*
- `poetry run pytest -q` *(fails: ImportError while loading conftest)*
- `poetry run pytest tests/behavior` *(fails: ImportError while loading conftest)*


------
https://chatgpt.com/codex/tasks/task_e_685c8c86329083338c71931793fb5e81