### PR TITLE
Guard path insertion in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,12 @@ import types
 from uuid import uuid4
 from pathlib import Path
 from unittest.mock import patch, MagicMock
+import importlib.util
 
 # Ensure package can be imported without installation
-src_path = Path(__file__).resolve().parents[1] / "src"
-sys.path.insert(0, str(src_path))  # noqa: E402
+if importlib.util.find_spec("autoresearch") is None:
+    src_path = Path(__file__).resolve().parents[1] / "src"
+    sys.path.insert(0, str(src_path))  # noqa: E402
 
 import pytest  # noqa: E402
 


### PR DESCRIPTION
## Summary
- install package in editable mode
- guard sys.path insertion logic in tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Item "None" of "str | Any | None" has no attribute "split")*
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685d5c99468483338d7562fdfeafbf7f