### PR TITLE
Remove redundant install for packages

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 python -m pip install --upgrade pip
 pip install poetry
 poetry install --with dev
-poetry run pip install networkx duckdb rdflib
 
 # Create extensions directory if it doesn't exist
 mkdir -p extensions


### PR DESCRIPTION
## Summary
- clean up `scripts/setup.sh`

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: incompatible types and missing stubs)*
- `poetry run pytest -q` *(interrupted: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: StorageError)*

------
https://chatgpt.com/codex/tasks/task_e_685d6b19bbfc8333942e5400eace1949