### PR TITLE
Update docs for Poetry usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ By participating in this project, you agree to maintain a respectful and inclusi
 
    If you prefer pip:
    ```bash
-   pip install -e .
+   poetry run pip install -e .
    ```
 
 3. Configure your editor to use the project's linting and formatting settings

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ poetry install
 
 ### Using pip
 ```bash
-pip install -e .
+poetry run pip install -e .
 ```
 
 ## Quick start
@@ -299,6 +299,9 @@ poetry run pytest -q
 poetry run pytest tests/behavior
 ```
 
+All testing commands should be run through `poetry run` to ensure the correct
+virtual environment is used.
+
 Maintain at least 90% test coverage and remove temporary files before submitting a pull request.
 
 ### Troubleshooting
@@ -311,7 +314,7 @@ Maintain at least 90% test coverage and remove temporary files before submitting
 Install MkDocs and generate the static site:
 
 ```bash
-pip install mkdocs
+poetry run pip install mkdocs
 mkdocs build
 ```
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -18,7 +18,7 @@ This guide describes how to set up a development environment and the expected wo
 ## Code Style
 
 - Run code format and style checks before committing:
-  ```bash
+ ```bash
   poetry run flake8 src tests
   poetry run mypy src
   ```
@@ -33,6 +33,8 @@ This guide describes how to set up a development environment and the expected wo
    poetry run pytest -q
    poetry run pytest tests/behavior
    ```
+   All testing commands should be executed with `poetry run` to use the
+   project's virtual environment.
 3. Update or add documentation when needed.
 4. Open a pull request explaining the rationale for the change.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -41,7 +41,7 @@ export HDBSCAN_NO_OPENMP=1
 Alternatively install via pip:
 
 ```bash
-pip install -e .
+poetry run pip install -e .
 ```
 
 ## First search

--- a/docs/ui_testing_procedures.md
+++ b/docs/ui_testing_procedures.md
@@ -31,7 +31,7 @@ cd autoresearch
 poetry install --with dev
 
 # Alternatively, use pip
-pip install -e ".[dev]"
+poetry run pip install -e ".[dev]"
 ```
 
 ## Unit Testing UI Components
@@ -378,45 +378,45 @@ def test_consistent_error_handling():
 
 ```bash
 # Run all tests
-pytest
+poetry run pytest
 
 # Run with verbose output
-pytest -v
+poetry run pytest -v
 
 # Run with coverage report
-pytest --cov=autoresearch
+poetry run pytest --cov=autoresearch
 ```
 
 ### Running Specific Test Categories
 
 ```bash
 # Run unit tests
-pytest tests/unit/
+poetry run pytest tests/unit/
 
 # Run integration tests
-pytest tests/integration/
+poetry run pytest tests/integration/
 
 # Run behavior tests
-pytest tests/behavior/
+poetry run pytest tests/behavior/
 
 # Run tests for a specific file
-pytest tests/unit/test_output_format.py
+poetry run pytest tests/unit/test_output_format.py
 
 # Run a specific test
-pytest tests/unit/test_output_format.py::test_format_error
+poetry run pytest tests/unit/test_output_format.py::test_format_error
 ```
 
 ### Running BDD Tests
 
 ```bash
 # Run all BDD tests
-pytest tests/behavior/
+poetry run pytest tests/behavior/
 
 # Run tests for a specific feature
-pytest tests/behavior/steps/streamlit_gui_steps.py
+poetry run pytest tests/behavior/steps/streamlit_gui_steps.py
 
 # Run a specific scenario
-pytest tests/behavior/steps/streamlit_gui_steps.py::test_formatted_answer_display
+poetry run pytest tests/behavior/steps/streamlit_gui_steps.py::test_formatted_answer_display
 ```
 
 ## Continuous Integration


### PR DESCRIPTION
## Summary
- recommend `poetry run pip install -e .`
- use `poetry run pip install mkdocs`
- run tests with `poetry run`

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: KeyboardInterrupt)*
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685d78b52de88333bca474ab23cf3455