### PR TITLE
Add CLI visualization command

### DIFF
--- a/docs/quickstart_guides.md
+++ b/docs/quickstart_guides.md
@@ -43,6 +43,12 @@ autoresearch query "What is the capital of France?" --output json > result.json
 autoresearch query "What is the capital of France?" --output markdown > result.md
 ```
 
+4. **Visualize query results:**
+
+```bash
+autoresearch visualize "What is the capital of France?" graph.png
+```
+
 ### Configuration
 
 1. **View current configuration:**

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -39,6 +39,7 @@ from .cli_utils import (
     get_verbosity,
     Verbosity,
     visualize_rdf_cli as _cli_visualize,
+    visualize_query_cli as _cli_visualize_query,
     sparql_query_cli as _cli_sparql,
 )
 from .error_utils import get_error_info, format_error_for_cli
@@ -1380,6 +1381,20 @@ def test_a2a(
     # Format and display the results
     formatted_results = format_test_results(results, fmt)
     print(formatted_results)
+
+
+@app.command("visualize")
+def visualize(
+    query: str = typer.Argument(..., help="Query to visualize"),
+    output: str = typer.Argument(
+        "query_graph.png", help="Output PNG path for the visualization"
+    ),
+) -> None:
+    """Run a query and render a knowledge graph."""
+    try:
+        _cli_visualize_query(query, output)
+    except Exception:
+        raise typer.Exit(1)
 
 
 @app.command("visualize-rdf")

--- a/src/autoresearch/visualization.py
+++ b/src/autoresearch/visualization.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+"""Utilities for generating graphical representations of query results."""
+
+from typing import Any
+
+import networkx as nx
+import matplotlib
+import matplotlib.pyplot as plt
+
+from .models import QueryResponse
+
+matplotlib.use("Agg")
+
+
+def save_knowledge_graph(result: QueryResponse, output_path: str) -> None:
+    """Save a simple knowledge graph visualization to ``output_path``.
+
+    Parameters
+    ----------
+    result:
+        The query response to visualize.
+    output_path:
+        Path to the PNG file to create.
+    """
+    G: nx.DiGraph[Any] = nx.DiGraph()
+    main_query = "Query"
+    G.add_node(main_query, type="query")
+    answer = "Answer"
+    G.add_node(answer, type="answer")
+    G.add_edge(main_query, answer)
+
+    for i, _ in enumerate(result.citations):
+        cid = f"Citation {i + 1}"
+        G.add_node(cid, type="citation")
+        G.add_edge(answer, cid)
+
+    for i, _ in enumerate(result.reasoning):
+        rid = f"Reasoning {i + 1}"
+        G.add_node(rid, type="reasoning")
+        if i == 0:
+            G.add_edge(main_query, rid)
+        else:
+            G.add_edge(f"Reasoning {i}", rid)
+        if i == len(result.reasoning) - 1:
+            G.add_edge(rid, answer)
+
+    plt.figure(figsize=(10, 8))
+    pos = nx.spring_layout(G, seed=42)
+    nx.draw(G, pos, with_labels=True, node_color="lightblue", font_size=8)
+    plt.tight_layout()
+    plt.savefig(output_path)
+    plt.close()

--- a/tests/behavior/features/query_interface.feature
+++ b/tests/behavior/features/query_interface.feature
@@ -21,3 +21,7 @@ Feature: Query Interface
   Scenario: Refine query interactively via CLI
     When I run `autoresearch search "What is Promise Theory?" -i` and refine to "Define Promise Theory" then exit
     Then I should receive a readable Markdown answer with `answer`, `citations`, `reasoning`, and `metrics` sections
+
+  Scenario: Visualize query results via CLI
+    When I run `autoresearch visualize "What is Promise Theory?" graph.png`
+    Then the visualization file "graph.png" should exist

--- a/tests/behavior/steps/query_interface_steps.py
+++ b/tests/behavior/steps/query_interface_steps.py
@@ -75,6 +75,20 @@ def run_interactive_query(query, refined, monkeypatch, bdd_context):
     bdd_context["cli_result"] = result
 
 
+@when(parsers.re(r'I run `autoresearch visualize "(?P<query>.+)" (?P<file>.+)`'))
+def run_visualize_cli(query, file, tmp_path, bdd_context):
+    out = tmp_path / file
+    result = runner.invoke(cli_app, ["visualize", query, str(out)])
+    bdd_context["viz_result"] = result
+    bdd_context["viz_path"] = out
+
+
+@then(parsers.parse('the visualization file "{file}" should exist'))
+def check_viz_file(file, bdd_context):
+    path = bdd_context["viz_path"]
+    assert path.exists() and path.stat().st_size > 0
+
+
 @then(
     "I should receive a JSON output matching the defined schema for `answer`, `citations`, `reasoning`, and `metrics`",
 )
@@ -111,4 +125,9 @@ def test_mcp_query():
 
 @scenario("../features/query_interface.feature", "Refine query interactively via CLI")
 def test_interactive_query():
+    pass
+
+
+@scenario("../features/query_interface.feature", "Visualize query results via CLI")
+def test_visualize_query():
     pass


### PR DESCRIPTION
## Summary
- add `visualize` command to render knowledge graph PNGs
- expose visualization utility via `cli_utils`
- document CLI visualization in quickstart guide
- extend BDD scenarios for new command

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: incompatible types and missing stubs)*
- `poetry run pytest -q` *(fails: KeyboardInterrupt during imports)*
- `poetry run pytest tests/behavior` *(fails: KeyboardInterrupt during imports)*

------
https://chatgpt.com/codex/tasks/task_e_685d8c945a108333892c568cae84cbb0