### PR TITLE
Update diagrams and usage docs

### DIFF
--- a/docs/component_interactions.md
+++ b/docs/component_interactions.md
@@ -19,9 +19,12 @@ The Autoresearch system is composed of several interconnected components that wo
 
 ### User Interaction Flow
 
-1. **User → Client Interfaces**: Users interact with the system through one of three interfaces:
+1. **User → Client Interfaces**: Users interact with the system through several interfaces:
    - Command Line Interface (CLI)
    - HTTP API (FastAPI)
+   - A2A API
+   - MCP Interface
+   - Streamlit GUI
    - Interactive Monitor
 
 2. **Client Interfaces → Orchestrator**: All client interfaces forward user queries to the Orchestrator, which is the central coordination component.

--- a/docs/diagrams/orchestration.puml
+++ b/docs/diagrams/orchestration.puml
@@ -69,6 +69,10 @@ package "Storage" {
   class StorageManager {
     + persist_claim(claim): void
   }
+
+  class KGReasoning {
+    + run_ontology_reasoner(store, engine): None
+  }
 }
 
 package "Models" {
@@ -77,6 +81,10 @@ package "Models" {
     + citations: List
     + reasoning: List
     + metrics: Dict
+  }
+
+  class Visualization {
+    + save_knowledge_graph(result, path): None
   }
 }
 
@@ -101,8 +109,11 @@ Orchestrator --> ChainOfThoughtStrategy: delegates to
 Orchestrator --> Agent: executes
 Orchestrator --> AgentFactory: gets agents from
 Orchestrator --> StorageManager: persists claims
+StorageManager --> KGReasoning: run_ontology_reasoner
+Orchestrator --> KGReasoning: run_reasoner
 Orchestrator --> QueryResponse: returns
 Orchestrator --> TokenCountingAdapter: uses for token counting
+Orchestrator --> Visualization: visualize_results
 Orchestrator --> OrchestrationError: throws
 Orchestrator --> AgentError: throws
 Orchestrator --> NotFoundError: throws

--- a/docs/diagrams/storage.puml
+++ b/docs/diagrams/storage.puml
@@ -2,7 +2,7 @@
 title Storage & Search Component
 
 package "Storage & Search" {
-  class StorageManager {
+    class StorageManager {
     + {static} setup(db_path): void
     + {static} teardown(remove_db): void
     + {static} persist_claim(claim): void
@@ -25,7 +25,25 @@ package "Storage & Search" {
     - {static} _persist_to_rdf(claim): void
     - {static} _validate_vector_search_params(query_embedding, k): void
     - {static} _format_vector_literal(query_embedding): str
-  }
+    }
+
+    class DuckDBStorageBackend {
+      + setup(path): void
+      + execute(query): Any
+    }
+
+    class VSSExtensionLoader {
+      + load_extension(conn): bool
+    }
+
+    class StorageBackup {
+      + create_backup(path): str
+      + restore_backup(path): None
+    }
+
+    class KGReasoning {
+      + run_ontology_reasoner(store, engine): None
+    }
 
   class FileLoader {
     + load_files(path): List[str]
@@ -116,6 +134,10 @@ StorageManager --> NetworkX : uses for graph storage
 StorageManager --> DuckDB : uses for vector storage
 StorageManager --> RDFLib : uses for semantic storage
 StorageManager --> EvictionCounter : increments on eviction
+StorageManager --> DuckDBStorageBackend : manages
+StorageManager --> VSSExtensionLoader : loads VSS
+StorageManager --> StorageBackup : backup/restore
+StorageManager --> KGReasoning : runs ontology reasoning
 
 Search --> FileLoader : load_files
 Search --> GitRepoIndexer : index_repo

--- a/docs/diagrams/system_architecture.puml
+++ b/docs/diagrams/system_architecture.puml
@@ -4,7 +4,9 @@
 node "Client Interfaces" {
   component "CLI" as CLI
   component "FastAPI API" as FastAPI
+  component "A2A API" as A2A
   component "FastMCP" as FastMCP
+  component "Streamlit GUI" as Streamlit
   component "Monitor" as Monitor
 }
 
@@ -14,6 +16,8 @@ node "Core Components" {
   component "Error Hierarchy" as Errors
   component "Metrics Collector" as Metrics
   component "Tracing" as Tracing
+  component "KG Reasoning" as KGReasoning
+  component "Visualization" as Visualization
 }
 
 package "Agents" {
@@ -36,12 +40,15 @@ package "LLM Integration" {
 
 package "Storage & Search" {
   component "Storage Manager" as StorageManager
+  component "DuckDB Backend" as DuckDBBackend
   component "Search" as Search
   component "Vector Search" as VectorSearch
   component "File Loader" as FileLoader
   component "Git Repo Indexer" as GitRepoIndexer
   component "Local File Backend" as LocalFileBackend
   component "Git Backend" as GitBackend
+  component "VSS Extension Loader" as VSSExtensionLoader
+  component "Storage Backup" as StorageBackup
 
   database "NetworkX Graph" as NX
   database "DuckDB Store" as DuckDB
@@ -59,6 +66,12 @@ CLI -> Orchestrator : run_query(query)
 
 user -> FastAPI : POST /query
 FastAPI -> Orchestrator : run_query(query)
+
+user -> A2A : POST /query
+A2A -> Orchestrator : run_query(query)
+
+user -> Streamlit : interactive query
+Streamlit -> Orchestrator : run_query(query)
 
 user -> FastMCP : MCP message
 FastMCP -> Orchestrator : run_query(query)
@@ -98,6 +111,10 @@ StorageManager -> NX : add_node/add_edge
 StorageManager -> DuckDB : insert
 StorageManager -> RDF : add
 StorageManager -> TinyDB : insert
+StorageManager -> DuckDBBackend : use_backend()
+StorageManager -> VSSExtensionLoader : load_extension()
+StorageManager -> StorageBackup : backup()
+StorageManager -> KGReasoning : run_reasoner()
 
 Orchestrator -> Search : search()
 Search -> VectorSearch : vector_search()
@@ -109,4 +126,5 @@ VectorSearch -> DuckDB : query
 
 Orchestrator -> OutputFormatter : format_result()
 OutputFormatter -> Synthesis : build_answer()/build_rationale()
+Orchestrator -> Visualization : visualize_results()
 @enduml


### PR DESCRIPTION
## Summary
- add new interfaces and components to system architecture diagram
- extend storage diagram with extension and backup modules
- expand orchestration diagram with reasoning and visualization
- document new client interfaces in component interactions

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: several typing errors)*
- `poetry run pytest -q` *(fails: KeyboardInterrupt during import)*
- `poetry run pytest tests/behavior` *(fails: KeyboardInterrupt during import)*

------
https://chatgpt.com/codex/tasks/task_e_685d96307848833381a61d7f608d3d8d