### PR TITLE
Fix parallel orchestrator error info handling

### DIFF
--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -1264,17 +1264,22 @@ class Orchestrator:
         # Add error and timeout information to final state
         if errors or timeouts:
             error_info = {
+                "claims": [],
                 "metadata": {
                     "errors": [f"{group}: {error}" for group, error in errors],
-                    "timeouts": [f"{group}" for group in timeouts]
-                }
+                    "timeouts": [f"{group}" for group in timeouts],
+                },
             }
 
             if errors:
-                error_info["claims"] = [f"Error in agent group {group}: {error}" for group, error in errors]
+                error_info["claims"].extend(
+                    [f"Error in agent group {group}: {error}" for group, error in errors]
+                )
 
             if timeouts:
-                error_info["claims"] = error_info.get("claims", []) + [f"Agent group {group} timed out" for group in timeouts]
+                error_info["claims"].extend(
+                    [f"Agent group {group} timed out" for group in timeouts]
+                )
 
             final_state.update(error_info)
 


### PR DESCRIPTION
## Summary
- ensure `error_info['claims']` holds a list and extend it
- add regression tests for error and timeout claims in parallel execution

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src/autoresearch/orchestration/orchestrator.py` *(fails: Interrupted)*
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685dae40005c83338c14260e74994671