### PR TITLE
Add performance benchmark integration

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -69,7 +69,7 @@ This document tracks the progress of tasks for the Autoresearch project, organiz
   - [x] Test orchestrator with all agent combinations
   - [x] Verify storage integration with search functionality
   - [x] Test configuration hot-reload with all components
-- [ ] Add performance tests
+  - [x] Add performance tests
   - [x] Implement benchmarks for query processing time
   - [x] Test memory usage under various conditions
   - [x] Verify token usage optimization
@@ -222,4 +222,12 @@ Modules with coverage below 90% based on the latest run:
 - [x] `autoresearch.storage_backends` – 9%
 - [x] `autoresearch.output_format` – 0%
 - [x] `autoresearch.streamlit_app` – 0%
+
+### Performance Baselines
+
+Current benchmark metrics for a single dummy query:
+
+- Duration: ~0.003s
+- Memory delta: ~0 MB
+- Tokens: {"Dummy": {"in": 2, "out": 7}}
 

--- a/scripts/benchmark_token_memory.py
+++ b/scripts/benchmark_token_memory.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+"""Run a token and memory benchmark for a typical query."""
+
+from __future__ import annotations
+
+import sys
+
+# Avoid heavy optional dependencies during benchmarks
+sys.modules.setdefault("bertopic", None)
+sys.modules.setdefault("sentence_transformers", None)
+
+import json
+import time
+from pathlib import Path
+
+from autoresearch.config import ConfigModel
+from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
+from autoresearch.storage import StorageManager
+
+
+class DummyAgent:
+    """Minimal agent used for benchmarks."""
+
+    def __init__(self, name: str, llm_adapter=None) -> None:
+        self.name = name
+
+    def can_execute(self, state, config) -> bool:  # type: ignore[override]
+        return True
+
+    def execute(self, state, config, adapter=None):  # type: ignore[override]
+        adapter.generate("hello world")
+        state.results[self.name] = "ok"
+        state.results["final_answer"] = "answer"
+        return {"results": {self.name: "ok"}}
+
+
+def run_benchmark() -> dict[str, float | dict[str, dict[str, int]]]:
+    """Execute a benchmark query and return metrics."""
+    AgentFactory.get = lambda name, llm_adapter=None: DummyAgent(name)  # type: ignore
+    cfg = ConfigModel(agents=["Dummy"], loops=1, llm_backend="dummy")
+
+    memory_before = StorageManager._current_ram_mb()
+    start = time.perf_counter()
+    response = Orchestrator.run_query("benchmark query", cfg)
+    duration = time.perf_counter() - start
+    memory_after = StorageManager._current_ram_mb()
+
+    tokens = response.metrics["execution_metrics"]["agent_tokens"]
+    return {
+        "duration_seconds": duration,
+        "memory_delta_mb": memory_after - memory_before,
+        "tokens": tokens,
+    }
+
+
+def main() -> None:
+    metrics = run_benchmark()
+    path = Path("tests/integration/baselines/token_memory.json")
+    path.write_text(json.dumps(metrics, indent=2))
+    print(json.dumps(metrics, indent=2))
+    print(f"Baseline written to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/baselines/token_memory.json
+++ b/tests/integration/baselines/token_memory.json
@@ -1,0 +1,10 @@
+{
+  "duration_seconds": 0.003289357000085147,
+  "memory_delta_mb": 0.0,
+  "tokens": {
+    "Dummy": {
+      "in": 2,
+      "out": 7
+    }
+  }
+}

--- a/tests/integration/test_performance.py
+++ b/tests/integration/test_performance.py
@@ -1,5 +1,18 @@
+import json
+from pathlib import Path
+
 from autoresearch.storage import StorageManager
 from autoresearch.search import Search
+import importlib.util
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "benchmark_token_memory.py"
+spec = importlib.util.spec_from_file_location("benchmark_token_memory", SCRIPT_PATH)
+benchmark_module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(benchmark_module)  # type: ignore
+run_benchmark = benchmark_module.run_benchmark
+
+BASELINE_PATH = Path(__file__).resolve().parent / "baselines" / "token_memory.json"
 
 
 def test_query_latency_and_memory(benchmark):
@@ -12,3 +25,8 @@ def test_query_latency_and_memory(benchmark):
     benchmark(run)
     memory_after = StorageManager._current_ram_mb()
     assert memory_after - memory_before < 10
+
+    metrics = run_benchmark()
+    baseline = json.loads(BASELINE_PATH.read_text())
+    assert metrics["tokens"] == baseline["tokens"]
+    assert metrics["memory_delta_mb"] <= baseline["memory_delta_mb"] + 5


### PR DESCRIPTION
## Summary
- add a benchmark script for token usage and memory
- integrate benchmark into performance integration test
- store baseline metrics
- document baseline numbers in TASK_PROGRESS

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Item "None" of "str | Any | None" has no attribute "split" etc.)*
- `poetry run pytest -q` *(interrupted)*
- `poetry run pytest tests/behavior` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685db3209988833383bcc05e632f5bc9