### PR TITLE
Mock heavy dependencies in tests

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -110,20 +110,36 @@ Use mocking to isolate the code being tested:
 
 Example:
 
+
 ```python
 def test_function_with_mocking():
     """Test function behavior with mocking."""
     # Setup
     with patch('module.function') as mock_function:
         mock_function.return_value = 'mocked value'
-        
+
         # Execute
         result = function_under_test()
-        
+
         # Verify
         assert result == 'expected value'
         mock_function.assert_called_once_with('expected argument')
 ```
+
+## Heavy Dependency Mocking
+
+Some optional libraries, such as `bertopic` and Hugging Face `transformers`,
+can trigger large downloads when imported. Tests mock these modules in
+`tests/conftest.py` to keep execution lightweight:
+
+```python
+sys.modules.setdefault("bertopic", MagicMock())
+sys.modules.setdefault("transformers", MagicMock())
+```
+
+If a test requires functionality from these packages, provide more specific
+mocks within the test itself. This approach ensures the unit suite runs without
+attempting to download heavy models.
 
 ## Parameterization
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,10 @@ class DummySentenceTransformer:
 dummy_st_module.SentenceTransformer = DummySentenceTransformer
 sys.modules.setdefault("sentence_transformers", dummy_st_module)
 
+# Mock heavy optional dependencies to avoid model downloads during tests.
+sys.modules.setdefault("bertopic", MagicMock())
+sys.modules.setdefault("transformers", MagicMock())
+
 from autoresearch import cache, storage  # noqa: E402
 from autoresearch.config import ConfigLoader  # noqa: E402
 from autoresearch.agents.registry import (  # noqa: E402


### PR DESCRIPTION
## Summary
- mock `bertopic` and `transformers` in `tests/conftest.py`
- add documentation for heavy dependency mocking in the testing guidelines

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: many type errors)*
- `poetry run pytest -q` *(fails: interrupted due to KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: 1 failed, 19 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685ddb8c23b08333a2a5f83adc8ef636