### PR TITLE
Add HTTP Bearer auth and SlowAPI rate limiting

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -111,11 +111,24 @@ curl -H "X-API-Key: $AUTORESEARCH_API__API_KEY" \
   -d '{"query": "test"}' http://localhost:8000/query
 ```
 
+Alternatively, set `[api].bearer_token` or `AUTORESEARCH_API__BEARER_TOKEN` to
+enable bearer token authentication. Pass this token in the `Authorization` header:
+
+```bash
+export AUTORESEARCH_API__BEARER_TOKEN=mytoken
+curl -H "Authorization: Bearer $AUTORESEARCH_API__BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "test"}' http://localhost:8000/query
+```
+
 ## Throttling
 
 Rate limiting is configured via `[api].rate_limit` or the environment variable
 `AUTORESEARCH_API__RATE_LIMIT`. This value specifies the number of requests per
 minute allowed for each client IP. Set to `0` to disable throttling.
+
+The implementation uses [SlowAPI](https://pypi.org/project/slowapi/), so limits
+are enforced per client IP address.
 
 ```bash
 export AUTORESEARCH_API__RATE_LIMIT=2

--- a/poetry.lock
+++ b/poetry.lock
@@ -1126,6 +1126,24 @@ torch = ["torch"]
 vision = ["Pillow (>=9.4.0)"]
 
 [[package]]
+name = "deprecated"
+version = "1.2.18"
+description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+groups = ["main", "dev"]
+files = [
+    {file = "Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec"},
+    {file = "deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d"},
+]
+
+[package.dependencies]
+wrapt = ">=1.10,<2"
+
+[package.extras]
+dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "setuptools ; python_version >= \"3.12\"", "tox"]
+
+[[package]]
 name = "dill"
 version = "0.3.8"
 description = "serialize all of Python"
@@ -1445,38 +1463,11 @@ pydantic = {version = ">=1.8.0", extras = ["email"]}
 
 [[package]]
 name = "fastmcp"
-version = "2.9.1"
-description = "The fast, Pythonic way to build MCP servers."
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-markers = "python_version == \"3.12\""
-files = [
-    {file = "fastmcp-2.9.1-py3-none-any.whl", hash = "sha256:bd60ba054d56885c5d5eb9cf524c62a5114ad2c6bcaf6da868479cb8b55a4a06"},
-    {file = "fastmcp-2.9.1.tar.gz", hash = "sha256:1cc74bb2a61f4cd38592e51b2105343243021740543a1a87edcfa0934fb854f8"},
-]
-
-[package.dependencies]
-authlib = ">=1.5.2"
-exceptiongroup = ">=1.2.2"
-httpx = ">=0.28.1"
-mcp = ">=1.9.4,<2.0.0"
-openapi-pydantic = ">=0.5.1"
-python-dotenv = ">=1.1.0"
-rich = ">=13.9.4"
-typer = ">=0.15.2"
-
-[package.extras]
-websockets = ["websockets (>=15.0.1)"]
-
-[[package]]
-name = "fastmcp"
 version = "2.9.2"
 description = "The fast, Pythonic way to build MCP servers."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.13\""
 files = [
     {file = "fastmcp-2.9.2-py3-none-any.whl", hash = "sha256:3626a3d9b1fa6325756273b6d1fe1ec610baafec957ac22f7aa1dc17c1db8b93"},
     {file = "fastmcp-2.9.2.tar.gz", hash = "sha256:c000eb0a2d50afcc7d26be4c867abf5c995ca0e0119f17417d50f61e2e17347c"},
@@ -2803,6 +2794,35 @@ build = ["build", "twine"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "limits"
+version = "5.4.0"
+description = "Rate limiting utilities"
+optional = false
+python-versions = ">=3.10"
+groups = ["main", "dev"]
+files = [
+    {file = "limits-5.4.0-py3-none-any.whl", hash = "sha256:1afb03c0624cf004085532aa9524953f2565cf8b0a914e48dda89d172c13ceb7"},
+    {file = "limits-5.4.0.tar.gz", hash = "sha256:27ebf55118e3c9045f0dbc476f4559b26d42f4b043db670afb8963f36cf07fd9"},
+]
+
+[package.dependencies]
+deprecated = ">=1.2"
+packaging = ">=21,<26"
+typing_extensions = "*"
+
+[package.extras]
+all = ["coredis (>=3.4.0,<5)", "memcachio (>=0.3)", "motor (>=3,<4)", "pymemcache (>3,<5.0.0)", "pymongo (>4.1,<5)", "redis (>3,!=4.5.2,!=4.5.3,<6.0.0)", "redis (>=4.2.0,!=4.5.2,!=4.5.3)", "valkey (>=6)", "valkey (>=6)"]
+async-memcached = ["memcachio (>=0.3)"]
+async-mongodb = ["motor (>=3,<4)"]
+async-redis = ["coredis (>=3.4.0,<5)"]
+async-valkey = ["valkey (>=6)"]
+memcached = ["pymemcache (>3,<5.0.0)"]
+mongodb = ["pymongo (>4.1,<5)"]
+redis = ["redis (>3,!=4.5.2,!=4.5.3,<6.0.0)"]
+rediscluster = ["redis (>=4.2.0,!=4.5.2,!=4.5.3)"]
+valkey = ["valkey (>=6)"]
+
+[[package]]
 name = "litellm"
 version = "1.63.14"
 description = "Library to easily interface with LLM API providers"
@@ -3279,7 +3299,6 @@ description = "Model Context Protocol SDK"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.13\""
 files = [
     {file = "mcp-1.9.4-py3-none-any.whl", hash = "sha256:7fcf36b62936adb8e63f89346bccca1268eeca9bf6dfb562ee10b1dfbda9dac0"},
     {file = "mcp-1.9.4.tar.gz", hash = "sha256:cfb0bcd1a9535b42edaef89947b9e18a8feb49362e1cc059d6e7fc636f2cb09f"},
@@ -3289,38 +3308,6 @@ files = [
 anyio = ">=4.5"
 httpx = ">=0.27"
 httpx-sse = ">=0.4"
-pydantic = ">=2.7.2,<3.0.0"
-pydantic-settings = ">=2.5.2"
-python-dotenv = {version = ">=1.0.0", optional = true, markers = "extra == \"cli\""}
-python-multipart = ">=0.0.9"
-sse-starlette = ">=1.6.1"
-starlette = ">=0.27"
-typer = {version = ">=0.12.4", optional = true, markers = "extra == \"cli\""}
-uvicorn = {version = ">=0.23.1", markers = "sys_platform != \"emscripten\""}
-
-[package.extras]
-cli = ["python-dotenv (>=1.0.0)", "typer (>=0.12.4)"]
-rich = ["rich (>=13.9.4)"]
-ws = ["websockets (>=15.0.1)"]
-
-[[package]]
-name = "mcp"
-version = "1.10.0"
-description = "Model Context Protocol SDK"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-markers = "python_version == \"3.12\""
-files = [
-    {file = "mcp-1.10.0-py3-none-any.whl", hash = "sha256:925c45482d75b1b6f11febddf9736d55edf7739c7ea39b583309f6651cbc9e5c"},
-    {file = "mcp-1.10.0.tar.gz", hash = "sha256:91fb1623c3faf14577623d14755d3213db837c5da5dae85069e1b59124cbe0e9"},
-]
-
-[package.dependencies]
-anyio = ">=4.5"
-httpx = ">=0.27"
-httpx-sse = ">=0.4"
-jsonschema = ">=4.20.0"
 pydantic = ">=2.7.2,<3.0.0"
 pydantic-settings = ">=2.5.2"
 python-dotenv = {version = ">=1.0.0", optional = true, markers = "extra == \"cli\""}
@@ -6155,6 +6142,24 @@ files = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.9"
+description = "A rate limiting extension for Starlette and Fastapi"
+optional = false
+python-versions = ">=3.7,<4.0"
+groups = ["main", "dev"]
+files = [
+    {file = "slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36"},
+    {file = "slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77"},
+]
+
+[package.dependencies]
+limits = ">=2.3"
+
+[package.extras]
+redis = ["redis (>=3.4.1,<4.0.0)"]
+
+[[package]]
 name = "smart-open"
 version = "7.1.0"
 description = "Utils for streaming large files (S3, HDFS, GCS, Azure Blob Storage, gzip, bz2...)"
@@ -7902,7 +7907,7 @@ version = "1.17.2"
 description = "Module for decorators, wrappers and monkey patching."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "wrapt-1.17.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d57c572081fed831ad2d26fd430d565b76aa277ed1d30ff4d40670b1c0dd984"},
     {file = "wrapt-1.17.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b5e251054542ae57ac7f3fba5d10bfff615b6c2fb09abeb37d2f1463f841ae22"},
@@ -8373,4 +8378,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "9a7ee5fd71c9941da991693cd18ea7547790d123734163599dc205844a857f47"
+content-hash = "f9af286a61716eb701cea07140f8e133ca639a232ead21094905af1305a77195"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "pynndescent (>=0.5.13,<0.6.0)",
     "scipy (>=1.16.0,<2.0.0)",
     "transformers (>=4.53.0,<5.0.0)",
+    "slowapi (==0.1.9)",
 ]
 
 [tool.poetry.group.dev.dependencies]

--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -209,6 +209,10 @@ class APIConfig(BaseModel):
         default=None,
         description="Shared secret required in the X-API-Key header when set",
     )
+    bearer_token: str | None = Field(
+        default=None,
+        description="Token required in the Authorization header when set",
+    )
     rate_limit: int = Field(
         default=0,
         ge=0,


### PR DESCRIPTION
## Summary
- add `bearer_token` configuration option
- secure API with FastAPI HTTPBearer middleware
- apply SlowAPI-based application rate limiting
- document bearer token usage and mention SlowAPI
- test bearer token auth and rate limiting

## Testing
- `poetry run flake8 src tests`
- `timeout 60 poetry run mypy src` *(failed: no output)*
- `timeout 60 poetry run pytest -q tests/integration/test_api_auth.py`
- `timeout 60 poetry run pytest tests/behavior` *(failed: StorageError)*

------
https://chatgpt.com/codex/tasks/task_e_685de639f23c8333b0f04f3240616900