### PR TITLE
Add visualization option to search command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ autoresearch search "Explain AI ethics" --interactive
 ```
 Press `q` at the feedback prompt to abort early.
 
+To visualize the resulting knowledge graph directly in the terminal, use:
+
+```bash
+autoresearch search "Explain AI ethics" --visualize
+```
+
 Start the HTTP API with Uvicorn:
 ```bash
 uvicorn autoresearch.api:app --reload

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -14,7 +14,7 @@ from rich.table import Table
 from rich.prompt import Prompt
 from rich.progress import Progress
 from .mcp_interface import create_server
-from .monitor import monitor_app
+from .monitor import monitor_app, _collect_graph_data, _render_graph
 from datetime import datetime
 import time
 
@@ -235,6 +235,11 @@ def search(
         "--primus-start",
         help="Starting agent index for dialectical reasoning",
     ),
+    visualize: bool = typer.Option(
+        False,
+        "--visualize",
+        help="Render an inline knowledge graph after the query completes",
+    ),
 ) -> None:
     """Run a search query through the orchestrator and format the result.
 
@@ -250,6 +255,9 @@ def search(
 
         # Query with plain text output format
         autoresearch search "Who was Albert Einstein?" -o plain
+
+        # Display a simple knowledge graph in the terminal
+        autoresearch search "What is quantum computing?" --visualize
     """
     config = _config_loader.load_config()
 
@@ -303,6 +311,9 @@ def search(
         print_success("Query processed successfully")
 
         OutputFormatter.format(result, fmt)
+        if visualize:
+            graph_data = _collect_graph_data()
+            console.print(_render_graph(graph_data))
     except Exception as e:
         # Create a valid QueryResponse object with error information
         from .models import QueryResponse

--- a/tests/behavior/features/interactive_monitor.feature
+++ b/tests/behavior/features/interactive_monitor.feature
@@ -23,3 +23,8 @@ Feature: Interactive Monitoring
     When I run `autoresearch monitor graph`
     Then the monitor should exit successfully
     And the monitor output should display graph data
+
+  Scenario: Visualize search results
+    When I run `autoresearch search "Test graph" --visualize`
+    Then the search command should exit successfully
+    And the search output should display graph data

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -59,3 +59,31 @@ def test_search_help_includes_interactive(monkeypatch):
     result = runner.invoke(main.app, ["search", "--help"])
     assert result.exit_code == 0
     assert "--interactive" in result.stdout
+
+
+def test_search_help_includes_visualize(monkeypatch):
+    dummy_storage = types.ModuleType("autoresearch.storage")
+
+    class StorageManager:
+        @staticmethod
+        def persist_claim(claim):
+            pass
+
+        @staticmethod
+        def setup(*a, **k):
+            pass
+
+    dummy_storage.StorageManager = StorageManager
+    dummy_storage.setup = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+    from autoresearch.config import ConfigLoader, ConfigModel
+
+    def _load(self):
+        return ConfigModel(loops=1)
+
+    monkeypatch.setattr(ConfigLoader, "load_config", _load)
+    main = importlib.import_module("autoresearch.main")
+    runner = CliRunner()
+    result = runner.invoke(main.app, ["search", "--help"])
+    assert result.exit_code == 0
+    assert "--visualize" in result.stdout


### PR DESCRIPTION
## Summary
- extend search command with a `--visualize` flag
- show a small knowledge graph when the flag is used
- document new flag in README
- verify help output and behaviour in tests

## Testing
- `poetry install --with dev` *(failed: pyproject.lock mismatch / heavy deps)*
- `poetry run flake8 src tests` *(failed: module not found)*
- `poetry run mypy src` *(failed: module not found)*
- `pytest -q` *(failed: installation stuck)*
- `pytest tests/behavior` *(failed: installation stuck)*

------
https://chatgpt.com/codex/tasks/task_e_685f4e9124c08333919fd6152222d198