### PR TITLE
Add terminal knowledge graph visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ autoresearch search "Explain AI ethics" --interactive
 ```
 Press `q` at the feedback prompt to abort early.
 
-To visualize the resulting knowledge graph directly in the terminal, use:
+To visualize the resulting knowledge graph directly in the terminal as a small
+table, use:
 
 ```bash
 autoresearch search "Explain AI ethics" --visualize

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -279,6 +279,14 @@ autoresearch kg query "MATCH (c:Claim) WHERE c.topic CONTAINS 'climate change' R
 autoresearch kg query "MATCH p=shortestPath((a:Concept)-[*]-(b:Concept)) WHERE a.name = 'renewable energy' AND b.name = 'carbon emissions' RETURN p"
 ```
 
+### Inline Graph Visualization
+
+Display a condensed view of the knowledge graph built during a search:
+
+```bash
+autoresearch search "Explain AI ethics" --visualize
+```
+
 ## API Integration
 
 ### Running as a Service

--- a/src/autoresearch/cli_utils.py
+++ b/src/autoresearch/cli_utils.py
@@ -275,3 +275,11 @@ def visualize_query_cli(query: str, output_path: str) -> None:
 
     metrics = {**result.metrics, **_collect_system_metrics()}
     console.print(_render_metrics(metrics))
+
+
+def visualize_graph_cli() -> None:
+    """Display an inline view of the knowledge graph."""
+    from .monitor import _collect_graph_data, _render_graph
+
+    data = _collect_graph_data()
+    console.print(_render_graph(data))

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -14,7 +14,7 @@ from rich.table import Table
 from rich.prompt import Prompt
 from rich.progress import Progress
 from .mcp_interface import create_server
-from .monitor import monitor_app, _collect_graph_data, _render_graph
+from .monitor import monitor_app
 from datetime import datetime
 import time
 
@@ -40,6 +40,7 @@ from .cli_utils import (
     Verbosity,
     visualize_rdf_cli as _cli_visualize,
     visualize_query_cli as _cli_visualize_query,
+    visualize_graph_cli,
     sparql_query_cli as _cli_sparql,
 )
 from .error_utils import get_error_info, format_error_for_cli
@@ -312,8 +313,7 @@ def search(
 
         OutputFormatter.format(result, fmt)
         if visualize:
-            graph_data = _collect_graph_data()
-            console.print(_render_graph(graph_data))
+            visualize_graph_cli()
     except Exception as e:
         # Create a valid QueryResponse object with error information
         from .models import QueryResponse


### PR DESCRIPTION
## Summary
- add `visualize_graph_cli` helper
- hook search command to use new helper for `--visualize`
- document `--visualize` in the README and advanced usage docs

## Testing
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: missing stubs and attribute errors)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: tinydb)*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError: tinydb)*

------
https://chatgpt.com/codex/tasks/task_e_68600a63b45c8333ae5058fc719ef839