### PR TITLE
Add distributed Ray execution

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,6 +227,19 @@ tracing_enabled = true
 
 The same option can be set via the environment variable `CORE__TRACING_ENABLED=true`.
 
+## Distributed Execution
+
+To run agents across multiple processes or machines, configure the `[distributed]` section:
+
+```toml
+[distributed]
+enabled = true
+address = "auto"
+num_cpus = 2
+```
+
+When enabled, `RayExecutor` dispatches agents to Ray workers for each cycle.
+
 ## API Keys
 
 API keys for external services (OpenAI, Serper, Brave Search, etc.) should be set in the `.env` file:

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -51,9 +51,9 @@ integrated into an asynchronous application you can use
 `concurrent=True` will dispatch each agent within a cycle to background
 threads, allowing I/O bound agents to overlap.
 
-For large scale deployments, set `distributed=True` in the configuration to
-indicate that agent execution may occur in separate processes or on remote
-workers.  The current implementation keeps this flag for deployment tooling and
-does not change behaviour by itself, but future versions may use it to route
-calls over RPC frameworks or multiprocessing pools.
+For large scale deployments, set `distributed=true` and configure the
+`[distributed]` section to enable multi-process orchestration via Ray. When
+enabled, agents within a cycle are dispatched to Ray workers and combined back
+into a single `QueryState`. See `autoresearch.distributed.RayExecutor` for the
+implementation details.
 

--- a/examples/autoresearch.toml
+++ b/examples/autoresearch.toml
@@ -66,3 +66,8 @@ enabled = true
 
 [agent.FactChecker]
 enabled = true
+
+[distributed]
+enabled = false
+address = "auto"
+num_cpus = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "scipy (>=1.16.0,<2.0.0)",
     "transformers (>=4.53.0,<5.0.0)",
     "slowapi (==0.1.9)",
+    "ray (>=2.10.0,<3.0.0)"
 ]
 
 [tool.poetry.group.dev.dependencies]

--- a/src/autoresearch/__init__.py
+++ b/src/autoresearch/__init__.py
@@ -3,3 +3,7 @@
 This package provides a local-first research assistant with multiple
 interfaces and a modular architecture.
 """
+
+from .distributed import RayExecutor
+
+__all__ = ["RayExecutor"]

--- a/src/autoresearch/distributed.py
+++ b/src/autoresearch/distributed.py
@@ -1,0 +1,52 @@
+"""Utilities for distributed agent execution using Ray."""
+
+from __future__ import annotations
+
+from typing import Dict, Callable, Any, List
+import os
+
+import ray
+
+from .config import ConfigModel
+from .orchestration.state import QueryState
+from .orchestration.orchestrator import AgentFactory
+from .models import QueryResponse
+
+
+@ray.remote
+def _execute_agent_remote(agent_name: str, state: QueryState, config: ConfigModel) -> Dict[str, Any]:
+    """Execute a single agent in a Ray worker."""
+    agent = AgentFactory.get(agent_name)
+    result = agent.execute(state, config)
+    return {"agent": agent_name, "result": result, "pid": os.getpid()}
+
+
+class RayExecutor:
+    """Simple distributed orchestrator that dispatches agents via Ray."""
+
+    def __init__(self, config: ConfigModel) -> None:
+        self.config = config
+        address = None
+        num_cpus = None
+        if hasattr(config, "distributed_config"):
+            cfg = config.distributed_config
+            address = cfg.address
+            num_cpus = cfg.num_cpus
+        ray.init(address=address, num_cpus=num_cpus, ignore_reinit_error=True, configure_logging=False)
+
+    def run_query(self, query: str, callbacks: Dict[str, Callable[..., None]] | None = None) -> QueryResponse:
+        """Run agents in parallel across processes."""
+        callbacks = callbacks or {}
+        state = QueryState(query=query, primus_index=getattr(self.config, "primus_start", 0))
+        for loop in range(self.config.loops):
+            futures = [
+                _execute_agent_remote.remote(name, state, self.config)
+                for name in self.config.agents
+            ]
+            results = ray.get(futures)
+            for res in results:
+                state.update(res["result"])
+            if callbacks.get("on_cycle_end"):
+                callbacks["on_cycle_end"](loop, state)
+            state.cycle += 1
+        return state.synthesize()

--- a/tests/integration/test_distributed_orchestration.py
+++ b/tests/integration/test_distributed_orchestration.py
@@ -1,0 +1,39 @@
+import os
+import ray
+from autoresearch.distributed import RayExecutor
+from autoresearch.config import ConfigModel, DistributedConfig
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import AgentFactory
+from autoresearch.orchestration.state import QueryState
+
+
+class DummyAgent:
+    def __init__(self, name: str, pid_list: list[int]):
+        self.name = name
+        self._pids = pid_list
+
+    def can_execute(self, state: QueryState, config: ConfigModel) -> bool:  # pragma: no cover - dummy
+        return True
+
+    def execute(self, state: QueryState, config: ConfigModel, **_: object) -> dict:
+        self._pids.append(os.getpid())
+        state.update({"results": {self.name: "ok"}})
+        return {"results": {self.name: "ok"}}
+
+
+def test_ray_executor_multi_process(monkeypatch):
+    pids: list[int] = []
+    monkeypatch.setattr(AgentFactory, "get", lambda name: DummyAgent(name, pids))
+    cfg = ConfigModel(
+        agents=["A", "B"],
+        loops=1,
+        distributed=True,
+        distributed_config=DistributedConfig(enabled=True, num_cpus=2),
+    )
+    executor = RayExecutor(cfg)
+    resp = executor.run_query("q")
+    assert isinstance(resp, QueryResponse)
+    # Expect at least two distinct worker processes
+    assert len(set(pids)) > 1
+    ray.shutdown()
+


### PR DESCRIPTION
## Summary
- integrate a minimal Ray-based executor
- expose new configuration section `[distributed]`
- document distributed execution
- provide example configuration
- test distributed orchestration via Ray

## Testing
- `poetry run flake8 src tests` *(fails: Command not found: flake8)*
- `poetry run mypy src` *(fails: Found 34 errors in 10 files)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'ray')*

------
https://chatgpt.com/codex/tasks/task_e_68601216873083339e3ecc13e817a1d1