### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/src/autoresearch/distributed.py
+++ b/src/autoresearch/distributed.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Callable, Any, List
+from typing import Dict, Callable, Any
 import os
 
 import ray

--- a/src/autoresearch/streamlit_app.py
+++ b/src/autoresearch/streamlit_app.py
@@ -126,6 +126,29 @@ def apply_accessibility_settings() -> None:
         )
 
 
+def apply_theme_settings() -> None:
+    """Apply light or dark theme based on session state."""
+    if st.session_state.get("dark_mode"):
+        st.markdown(
+            """
+            <style>
+            body, .stApp {background-color:#222 !important; color:#eee !important;}
+            .stButton>button {background-color:#444 !important; color:#fff !important;}
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
+    else:
+        st.markdown(
+            """
+            <style>
+            body, .stApp {background-color:#fff !important; color:#000 !important;}
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
+
+
 def display_guided_tour() -> None:
     """Show a short help overlay explaining the interface."""
     if "show_tour" not in st.session_state:
@@ -1299,6 +1322,12 @@ def main():
             help="Improve readability with a high contrast color scheme",
         )
 
+        st.session_state.dark_mode = st.checkbox(
+            "Dark Mode",
+            value=st.session_state.get("dark_mode", False),
+            help="Toggle between light and dark themes",
+        )
+
         # Display current configuration
         st.markdown("### Current Settings")
         st.markdown(f"**LLM Backend:** {st.session_state.config.llm_backend}")
@@ -1331,7 +1360,8 @@ def main():
         with st.expander("Edit Configuration"):
             display_config_editor()
 
-    # Apply accessibility styles based on sidebar settings
+    # Apply theme and accessibility styles based on sidebar settings
+    apply_theme_settings()
     apply_accessibility_settings()
 
     # Create tabs for main content, metrics dashboard, logs, and history

--- a/tests/behavior/features/streamlit_gui.feature
+++ b/tests/behavior/features/streamlit_gui.feature
@@ -46,3 +46,8 @@ Feature: Streamlit GUI Features
     And I change a user preference value
     Then the preference should be saved
     And the sidebar should reflect the updated preference
+
+  Scenario: Theme Toggle Switch
+    When I toggle dark mode
+    Then the page background should change according to the selected mode
+    And text color should adjust for readability

--- a/tests/behavior/steps/streamlit_gui_steps.py
+++ b/tests/behavior/steps/streamlit_gui_steps.py
@@ -392,3 +392,36 @@ def check_progress_metrics(bdd_context):
 def test_agent_trace():
     """Test the Agent Interaction Trace Visualization scenario."""
     pass
+
+
+@when("I toggle dark mode")
+def toggle_dark_mode(bdd_context):
+    """Simulate toggling dark mode."""
+    with patch("streamlit.markdown") as mock_markdown:
+        import streamlit as st
+
+        st.session_state["dark_mode"] = True
+        from autoresearch.streamlit_app import apply_theme_settings
+
+        apply_theme_settings()
+        bdd_context["theme_calls"] = mock_markdown.call_args_list
+
+
+@then("the page background should change according to the selected mode")
+def check_background_change(bdd_context):
+    """Verify background style was updated for dark mode."""
+    css = "".join(call.args[0] for call in bdd_context["theme_calls"])
+    assert "background-color" in css
+
+
+@then("text color should adjust for readability")
+def check_text_color(bdd_context):
+    """Verify text color was set for dark mode."""
+    css = "".join(call.args[0] for call in bdd_context["theme_calls"])
+    assert "color:#eee" in css
+
+
+@scenario("../features/streamlit_gui.feature", "Theme Toggle Switch")
+def test_theme_toggle_switch():
+    """Test the Theme Toggle Switch scenario."""
+    pass

--- a/tests/integration/test_distributed_orchestration.py
+++ b/tests/integration/test_distributed_orchestration.py
@@ -36,4 +36,3 @@ def test_ray_executor_multi_process(monkeypatch):
     # Expect at least two distinct worker processes
     assert len(set(pids)) > 1
     ray.shutdown()
-


### PR DESCRIPTION
## Summary
- support dark mode in streamlit UI
- apply theme CSS based on sidebar toggle
- cover theme toggle with BDD scenario
- fix flake8 issues in distributed module and integration test

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: library stubs not installed, missing attributes)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'ray')*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError: No module named 'ray')*

------
https://chatgpt.com/codex/tasks/task_e_68602a0406ac833381f710a23f04b13b