### PR TITLE
Add targeted unit tests

### DIFF
--- a/tests/targeted/test_metrics_extra.py
+++ b/tests/targeted/test_metrics_extra.py
@@ -1,0 +1,20 @@
+import types
+import pytest
+from autoresearch.orchestration import metrics
+
+
+def test_cycle_and_agent_metrics(monkeypatch):
+    fake_time = types.SimpleNamespace(time=lambda: 1.0)
+    monkeypatch.setattr(metrics, "time", fake_time)
+    m = metrics.OrchestrationMetrics()
+    m.start_cycle()
+    m.record_agent_timing("agent", 0.5)
+    m.record_tokens("agent", 2, 3)
+    m.record_error("agent")
+    m.end_cycle()
+    summary = m.get_summary()
+    assert summary["cycles_completed"] == 1
+    assert summary["agent_timings"]["agent"] == [0.5]
+    assert summary["agent_tokens"]["agent"]["in"] == 2
+    assert summary["agent_tokens"]["agent"]["out"] == 3
+    assert summary["errors"]["total"] == 1

--- a/tests/targeted/test_orchestrator_extra.py
+++ b/tests/targeted/test_orchestrator_extra.py
@@ -1,0 +1,18 @@
+import types
+import sys
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.models import QueryResponse
+
+
+def test_get_memory_usage_psutil(monkeypatch):
+    mock_proc = types.SimpleNamespace(memory_info=lambda: types.SimpleNamespace(rss=1024*1024))
+    mock_psutil = types.SimpleNamespace(Process=lambda: mock_proc)
+    monkeypatch.setitem(sys.modules, 'psutil', mock_psutil)
+    assert Orchestrator._get_memory_usage() == 1.0
+
+
+def test_calculate_result_confidence_bounds():
+    resp = QueryResponse(answer='a', citations=['c']*3, reasoning=['r']*10,
+                         metrics={'token_usage': {'total': 50, 'max_tokens': 100}, 'errors': []})
+    score = Orchestrator._calculate_result_confidence(resp)
+    assert 0.5 < score <= 1.0

--- a/tests/targeted/test_output_format_extra.py
+++ b/tests/targeted/test_output_format_extra.py
@@ -1,0 +1,9 @@
+from autoresearch.output_format import FormatTemplate, TemplateRegistry
+from autoresearch.models import QueryResponse
+
+
+def test_custom_template_render():
+    template = FormatTemplate(name='t', template='A:${answer}')
+    TemplateRegistry.register(template)
+    resp = QueryResponse(answer='hi', citations=[], reasoning=[], metrics={})
+    assert TemplateRegistry.get('t').render(resp) == 'A:hi'

--- a/tests/targeted/test_search_extra.py
+++ b/tests/targeted/test_search_extra.py
@@ -1,0 +1,7 @@
+from autoresearch.search import Search
+
+
+def test_preprocess_text_simple():
+    text = "Hello, World! 123"
+    tokens = Search.preprocess_text(text)
+    assert tokens == ["hello", "world"]

--- a/tests/targeted/test_storage_backends_extra.py
+++ b/tests/targeted/test_storage_backends_extra.py
@@ -1,0 +1,10 @@
+from unittest.mock import MagicMock, patch
+from autoresearch.storage_backends import DuckDBStorageBackend
+
+
+def test_has_vss_property():
+    backend = DuckDBStorageBackend()
+    with patch.object(backend, '_conn', MagicMock()):
+        with patch('autoresearch.extensions.VSSExtensionLoader.load_extension', return_value=True):
+            backend._has_vss = True
+            assert backend.has_vss() is True

--- a/tests/targeted/test_storage_extra.py
+++ b/tests/targeted/test_storage_extra.py
@@ -1,0 +1,12 @@
+import networkx as nx
+from autoresearch import storage
+
+
+def test_pop_low_score(monkeypatch):
+    g = nx.DiGraph()
+    g.add_node('a', confidence=0.2)
+    g.add_node('b', confidence=0.5)
+    monkeypatch.setattr(storage, '_graph', g)
+    monkeypatch.setattr(storage, '_lru', storage.OrderedDict())
+    popped = storage.StorageManager._pop_low_score()
+    assert popped == 'a'

--- a/tests/targeted/test_streamlit_extra.py
+++ b/tests/targeted/test_streamlit_extra.py
@@ -1,0 +1,25 @@
+import sys
+from types import ModuleType, SimpleNamespace
+import types
+
+# Provide fake streamlit and matplotlib modules
+fake_st = ModuleType("streamlit")
+fake_st.markdown = lambda *a, **k: None
+fake_st.set_page_config = lambda *a, **k: None
+fake_st.session_state = {}
+sys.modules.setdefault("streamlit", fake_st)
+fake_matplotlib = ModuleType("matplotlib")
+fake_matplotlib.use = lambda *a, **k: None
+sys.modules.setdefault("matplotlib", fake_matplotlib)
+sys.modules.setdefault("matplotlib.pyplot", ModuleType("pyplot"))
+
+from autoresearch import streamlit_app
+
+
+def test_apply_accessibility(monkeypatch):
+    calls = []
+    fake_st = types.SimpleNamespace(markdown=lambda *a, **k: calls.append(a))
+    fake_st.session_state = {'high_contrast': True}
+    monkeypatch.setattr(streamlit_app, 'st', fake_st)
+    streamlit_app.apply_accessibility_settings()
+    assert len(calls) == 2

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,4 +1,3 @@
-import importlib
 from fastapi.testclient import TestClient
 
 from autoresearch.api import app, dynamic_limit
@@ -39,7 +38,7 @@ def test_api_key_roles(monkeypatch):
 
 
 def test_batch_query_invalid_page(monkeypatch):
-    cfg = _setup(monkeypatch)
+    _setup(monkeypatch)
     client = TestClient(app)
     payload = {"queries": [{"query": "q1"}]}
     resp = client.post("/query/batch?page=0&page_size=1", json=payload)


### PR DESCRIPTION
## Summary
- add focused tests for metrics, orchestrator, search, storage, storage_backends, output formatting and streamlit modules
- fix flake8 issues in existing API tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Library stubs not installed for `tabulate` and other issues)*
- `poetry run pytest -q tests/targeted tests/unit/test_metrics.py tests/unit/test_metrics_summary.py`

------
https://chatgpt.com/codex/tasks/task_e_686040f91a7c8333b935db336375e825