### PR TITLE
Add compression utilities and adaptive token budgeting

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -167,13 +167,13 @@ This document tracks the progress of tasks for the Autoresearch project, organiz
 
 - [ ] Complete token usage optimization
   - [x] Implement prompt compression techniques
-  - [ ] Add context pruning for long conversations
+  - [x] Add context pruning for long conversations
   - [x] Create adaptive token budget management
 - [x] Enhance memory management
   - [x] Implement efficient caching strategies
   - [x] Add support for memory-constrained environments
   - [ ] Create resource monitoring tools
-  - _Next:_ finalize token budget heuristics
+  - _Next:_ create resource monitoring tools
 
 ### 5.2 Scalability Enhancements
 

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -483,6 +483,10 @@ autoresearch query "What are the implications of AI on labor markets?"
 
 The monitor shows real-time information about agent execution, token usage, and system state.
 
+## Prompt Compression
+
+When prompts grow too long they may exceed the available token budget. The `autoresearch.synthesis` module provides utilities that shorten prompts by truncating the middle section and inserting an ellipsis. This keeps essential context while staying under the limit.
+
 ## Guided Tour and Help Overlay
 
 When you first launch the Streamlit interface a short guided tour explains the main controls. Use the **Got it** button to dismiss the overlay. You can reopen the tour at any time from the sidebar via **Show Help**. The overlay highlights the query input, configuration sidebar and run button so you know where to start.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,7 @@ These options are set in the `[core]` section of the configuration file.
 | `llm_backend` | string | `"lmstudio"` | The LLM adapter to use | `"lmstudio"`, `"openai"`, `"openrouter"`, `"dummy"` |
 | `loops` | integer | `2` | Number of reasoning cycles to run | ≥ 1 |
 | `ram_budget_mb` | integer | `1024` | Memory budget in megabytes | ≥ 0 |
-| `token_budget` | integer | `null` | Maximum tokens allowed per run | ≥ 1 or `null` |
+| `token_budget` | integer | `null` | Maximum tokens allowed per run. When set, the orchestrator adapts this value based on query length to avoid wasting tokens. | ≥ 1 or `null` |
 | `agents` | list of strings | `["Synthesizer", "Contrarian", "FactChecker"]` | Agents to use in the reasoning process | Any valid agent names |
 | `primus_start` | integer | `0` | Index of the starting agent in the agents list | ≥ 0 |
 | `reasoning_mode` | string | `"dialectical"` | The reasoning mode to use | `"dialectical"`, `"direct"`, `"chain-of-thought"` |

--- a/src/autoresearch/orchestration/state.py
+++ b/src/autoresearch/orchestration/state.py
@@ -74,3 +74,30 @@ class QueryState(BaseModel):
                 structure["synthesis"] = claim
 
         return structure
+
+    def prune_context(self, max_claims: int = 50, max_sources: int = 20) -> None:
+        """Prune stored context to keep the state manageable.
+
+        This method removes the oldest claims and sources when their count
+        exceeds the provided limits. A summary of the number of items pruned
+        is stored under ``metadata['pruned']``.
+
+        Args:
+            max_claims: Maximum number of claims to keep.
+            max_sources: Maximum number of sources to keep.
+        """
+
+        pruned = {"claims": 0, "sources": 0}
+
+        if len(self.claims) > max_claims:
+            excess = len(self.claims) - max_claims
+            del self.claims[0:excess]
+            pruned["claims"] = excess
+
+        if len(self.sources) > max_sources:
+            excess = len(self.sources) - max_sources
+            del self.sources[0:excess]
+            pruned["sources"] = excess
+
+        if pruned["claims"] or pruned["sources"]:
+            self.metadata.setdefault("pruned", []).append(pruned)

--- a/tests/unit/test_token_budget.py
+++ b/tests/unit/test_token_budget.py
@@ -1,0 +1,23 @@
+from hypothesis import given, strategies as st
+
+from autoresearch.config import ConfigModel
+from autoresearch.orchestration.orchestrator import Orchestrator
+
+
+@given(
+    st.integers(min_value=1, max_value=4000),
+    st.text(min_size=1, max_size=200)
+)
+def test_budget_within_bounds(initial_budget, query):
+    cfg = ConfigModel(token_budget=initial_budget)
+    Orchestrator._apply_adaptive_token_budget(cfg, query)
+    q_tokens = len(query.split())
+    assert cfg.token_budget >= q_tokens
+    assert cfg.token_budget <= max(initial_budget, q_tokens * 20)
+
+
+@given(st.text(min_size=1))
+def test_budget_none_unmodified(query):
+    cfg = ConfigModel(token_budget=None)
+    Orchestrator._apply_adaptive_token_budget(cfg, query)
+    assert cfg.token_budget is None


### PR DESCRIPTION
## Summary
- add prompt compression helpers
- implement context pruning in QueryState
- use adaptive token budgeting in Orchestrator
- prune context after each cycle
- add property-based tests for token budget heuristics
- document new behaviour and update progress notes

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError and type issues)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: 'streamlit.testing' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860590b5b008333bce6c623ac388a1f