### PR TITLE
Implement adaptive token budget heuristic

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,7 @@ These options are set in the `[core]` section of the configuration file.
 | `llm_backend` | string | `"lmstudio"` | The LLM adapter to use | `"lmstudio"`, `"openai"`, `"openrouter"`, `"dummy"` |
 | `loops` | integer | `2` | Number of reasoning cycles to run | ≥ 1 |
 | `ram_budget_mb` | integer | `1024` | Memory budget in megabytes | ≥ 0 |
-| `token_budget` | integer | `null` | Maximum tokens allowed per run. When set, the orchestrator adapts this value based on query length to avoid wasting tokens. | ≥ 1 or `null` |
+| `token_budget` | integer | `null` | Maximum tokens allowed per run. When set, the orchestrator adapts this value based on query length, loop count, and parallel group size to avoid wasting tokens. | ≥ 1 or `null` |
 | `agents` | list of strings | `["Synthesizer", "Contrarian", "FactChecker"]` | Agents to use in the reasoning process | Any valid agent names |
 | `primus_start` | integer | `0` | Index of the starting agent in the agents list | ≥ 0 |
 | `reasoning_mode` | string | `"dialectical"` | The reasoning mode to use | `"dialectical"`, `"direct"`, `"chain-of-thought"` |

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -921,6 +921,27 @@ class Orchestrator:
         mode = config_params["mode"]
         max_errors = config_params["max_errors"]
 
+        # Adapt token budget based on query complexity and loops
+        Orchestrator._apply_adaptive_token_budget(config, query)
+
+        # Scale token budget for parallel agent groups if metadata is present
+        token_budget = getattr(config, "token_budget", None)
+        if (
+            token_budget is not None
+            and hasattr(config, "group_size")
+            and hasattr(config, "total_groups")
+        ):
+            total_agents = getattr(
+                config,
+                "total_agents",
+                config.group_size * config.total_groups,
+            )
+            if total_agents:
+                group_tokens = max(
+                    1, token_budget * config.group_size // total_agents
+                )
+                config.token_budget = group_tokens
+
         # Adapt token budget based on query complexity
         Orchestrator._apply_adaptive_token_budget(config, query)
 
@@ -1062,6 +1083,27 @@ class Orchestrator:
         loops = config_params["loops"]
         mode = config_params["mode"]
         max_errors = config_params["max_errors"]
+
+        # Adapt token budget based on query complexity and loops
+        Orchestrator._apply_adaptive_token_budget(config, query)
+
+        # Scale token budget for parallel agent groups if metadata is present
+        token_budget = getattr(config, "token_budget", None)
+        if (
+            token_budget is not None
+            and hasattr(config, "group_size")
+            and hasattr(config, "total_groups")
+        ):
+            total_agents = getattr(
+                config,
+                "total_agents",
+                config.group_size * config.total_groups,
+            )
+            if total_agents:
+                group_tokens = max(
+                    1, token_budget * config.group_size // total_agents
+                )
+                config.token_budget = group_tokens
 
         if mode == ReasoningMode.CHAIN_OF_THOUGHT:
             strategy = ChainOfThoughtStrategy()

--- a/tests/unit/test_token_budget.py
+++ b/tests/unit/test_token_budget.py
@@ -22,3 +22,27 @@ def test_budget_none_unmodified(query):
     cfg = ConfigModel(token_budget=None)
     Orchestrator._apply_adaptive_token_budget(cfg, query)
     assert cfg.token_budget is None
+
+
+@given(
+    st.integers(min_value=1, max_value=4000),
+    st.integers(min_value=1, max_value=10),
+    st.integers(min_value=1, max_value=20),
+)
+def test_budget_scaling_exact(initial_budget, loops, q_tokens):
+    query = " ".join("x" for _ in range(q_tokens))
+    cfg = ConfigModel(token_budget=initial_budget, loops=loops)
+    Orchestrator._apply_adaptive_token_budget(cfg, query)
+
+    budget = initial_budget
+    if loops > 1:
+        budget = max(1, budget // loops)
+    max_budget = q_tokens * 20
+    if budget > max_budget:
+        expected = max_budget
+    elif budget < q_tokens:
+        expected = q_tokens + 10
+    else:
+        expected = budget
+
+    assert cfg.token_budget == expected


### PR DESCRIPTION
## Summary
- scale token budget in `run_query_async`
- property test for adaptive token budget logic
- document adaptive scaling logic

## Testing
- `poetry run mypy src` *(fails: Module has no attribute modal, etc.)*
- `poetry run pytest -q` *(interrupted due to long runtime)*
- `poetry run pytest tests/behavior` *(fails: StorageError: owlrl reasoning)*

------
https://chatgpt.com/codex/tasks/task_e_6860c599631883339b0e17a45b852e41