### PR TITLE
Improve CLI reasoning-mode options

### DIFF
--- a/docs/quickstart_guides.md
+++ b/docs/quickstart_guides.md
@@ -25,7 +25,7 @@ autoresearch query "What is the capital of France?"
 2. **Specify reasoning mode:**
 
 ```bash
-autoresearch query "What is the capital of France?" --reasoning-mode dialectical
+autoresearch query "What is the capital of France?" --mode dialectical
 ```
 
 Available reasoning modes:
@@ -33,7 +33,13 @@ Available reasoning modes:
 - `dialectical` (default): Rotates through agents in a thesis→antithesis→synthesis cycle
 - `chain-of-thought`: Loops the Synthesizer agent
 
-3. **Export results to a file:**
+3. **Specify Primus start index (dialectical mode):**
+
+```bash
+autoresearch query "What is the capital of France?" --mode dialectical --primus-start 1
+```
+
+4. **Export results to a file:**
 
 ```bash
 # Export as JSON
@@ -43,7 +49,7 @@ autoresearch query "What is the capital of France?" --output json > result.json
 autoresearch query "What is the capital of France?" --output markdown > result.md
 ```
 
-4. **Visualize query results:**
+5. **Visualize query results:**
 
 ```bash
 autoresearch visualize "What is the capital of France?" graph.png

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -102,9 +102,10 @@ def handle_command_not_found(ctx: typer.Context, command: str) -> None:
 app = typer.Typer(
     help=(
         "Autoresearch CLI entry point.\n\n"
-        "Set the reasoning mode in autoresearch.toml under "
+        "Set the reasoning mode using --mode or in autoresearch.toml under "
         "[core.reasoning_mode]. Valid values: direct, dialectical, "
-        "chain-of-thought."
+        "chain-of-thought. Use --primus-start to choose the starting agent "
+        "for dialectical reasoning."
     ),
     name="autoresearch",
     no_args_is_help=True,  # Show help when no arguments are provided
@@ -229,7 +230,8 @@ def search(
     reasoning_mode: Optional[str] = typer.Option(
         None,
         "--reasoning-mode",
-        help="Override reasoning mode for this run",
+        "--mode",
+        help="Override reasoning mode for this run (direct, dialectical, chain-of-thought)",
     ),
     primus_start: Optional[int] = typer.Option(
         None,

--- a/tests/behavior/features/reasoning_mode.feature
+++ b/tests/behavior/features/reasoning_mode.feature
@@ -15,3 +15,10 @@ Feature: Reasoning Mode Selection
     Given reasoning mode is "chain-of-thought"
     When I run the orchestrator on query "mode test"
     Then the agents executed should be "Synthesizer, Synthesizer"
+
+  Scenario: Dialectical mode with custom Primus start
+    Given loops is set to 1 in configuration
+    And reasoning mode is "dialectical"
+    And primus start is 1
+    When I run the orchestrator on query "mode test"
+    Then the agents executed should be "Contrarian, FactChecker, Synthesizer"

--- a/tests/behavior/steps/agent_orchestration_steps.py
+++ b/tests/behavior/steps/agent_orchestration_steps.py
@@ -38,6 +38,12 @@ def set_reasoning_mode(mode, set_loops):
     return set_loops
 
 
+@given(parsers.parse('primus start is {index:d}'))
+def set_primus_start(index: int, set_loops):
+    set_loops.primus_start = index
+    return set_loops
+
+
 @when(
     parsers.parse('I run the orchestrator on query "{query}"'),
     target_fixture="run_orchestrator_on_query",


### PR DESCRIPTION
## Summary
- describe reasoning options in CLI help
- alias `--mode` flag in `search` command
- document new flag usage in quickstart guide
- extend reasoning mode BDD tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: attribute/type errors)*
- `poetry run pytest -q` *(interrupted: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: StorageError in `dkg_persistence_steps`)*

------
https://chatgpt.com/codex/tasks/task_e_686167e80584833386cc5782c37b570c