### PR TITLE
Update diagrams with RayExecutor

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -98,6 +98,7 @@ This document tracks the progress of tasks for the Autoresearch project, organiz
   - [x] Document design decisions
   - [x] Add references to relevant research
   - _Next:_ review modules for consistency with sphinx docs
+  - _Next:_ verify docs/api_reference pages match source docstrings
 
 ### 4.2 User Documentation
 

--- a/docs/diagrams/orchestration.puml
+++ b/docs/diagrams/orchestration.puml
@@ -52,6 +52,9 @@ package "Orchestration" {
   class ChainOfThoughtStrategy {
     + run_query(query, config, agent_factory): QueryResponse
   }
+  class RayExecutor {
+    + run_query(query, callbacks): QueryResponse
+  }
 }
 
 package "Agents" {
@@ -118,6 +121,9 @@ Orchestrator --> OrchestrationError: throws
 Orchestrator --> AgentError: throws
 Orchestrator --> NotFoundError: throws
 Orchestrator --> TimeoutError: throws
+RayExecutor --> QueryState: maintains state
+RayExecutor --> AgentFactory: gets agents from
+RayExecutor --> Agent: executes
 
 QueryState --> QueryResponse: synthesizes
 

--- a/docs/diagrams/system_architecture.puml
+++ b/docs/diagrams/system_architecture.puml
@@ -18,6 +18,7 @@ node "Core Components" {
   component "Tracing" as Tracing
   component "KG Reasoning" as KGReasoning
   component "Visualization" as Visualization
+  component "Ray Executor" as RayExecutor
 }
 
 package "Agents" {
@@ -127,4 +128,5 @@ VectorSearch -> DuckDB : query
 Orchestrator -> OutputFormatter : format_result()
 OutputFormatter -> Synthesis : build_answer()/build_rationale()
 Orchestrator -> Visualization : visualize_results()
+Orchestrator --> RayExecutor : delegate distributed cycles
 @enduml


### PR DESCRIPTION
## Summary
- add RayExecutor to system and orchestration diagrams
- record docstring review reminder in task progress

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: many type errors)*
- `poetry run pytest -q` *(interrupted)*
- `poetry run pytest tests/behavior` *(fails: 1 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6861888a4a208333b46dcff6c9a721ef