### PR TITLE
Add search weight tuning script

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,6 +147,18 @@ while increasing `bm25_weight` prioritizes traditional keyword matching.
 When `hybrid_query` is enabled the system automatically mixes keyword
 and vector search for each query.
 
+You can automatically discover effective values for these weights using the
+`scripts/optimize_search_weights.py` helper. Provide a labelled evaluation CSV
+and the configuration file to update:
+
+```bash
+poetry run python scripts/optimize_search_weights.py \
+  examples/search_evaluation.csv autoresearch.toml
+```
+
+The script runs a simple grid search and writes the best-performing weights back
+to the `[search]` section of the given TOML file.
+
 ### Search Backends
 
 | Backend | Description | Required Keys |

--- a/scripts/optimize_search_weights.py
+++ b/scripts/optimize_search_weights.py
@@ -2,85 +2,43 @@
 """Optimize search ranking weights using evaluation data."""
 
 import argparse
-import csv
-import math
-from collections import defaultdict
 from pathlib import Path
 
 import tomllib
 import tomli_w
 
-
-def load_data(path: Path):
-    """Load evaluation data from CSV."""
-    data = defaultdict(list)
-    with path.open("r", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            q = row["query"]
-            data[q].append(
-                {
-                    "bm25": float(row["bm25"]),
-                    "semantic": float(row["semantic"]),
-                    "credibility": float(row["credibility"]),
-                    "relevance": float(row["relevance"]),
-                }
-            )
-    return data
+from autoresearch.search import Search
 
 
-def ndcg(scores):
-    """Compute normalized discounted cumulative gain."""
-    dcg = sum((2 ** s - 1) / math.log2(i + 2) for i, s in enumerate(scores))
-    ideal = sorted(scores, reverse=True)
-    idcg = sum((2 ** s - 1) / math.log2(i + 2) for i, s in enumerate(ideal))
-    return dcg / idcg if idcg else 0.0
-
-
-def evaluate(weights, data):
-    w_sem, w_bm, w_cred = weights
-    total = 0.0
-    for docs in data.values():
-        preds = [w_sem * d["semantic"] + w_bm * d["bm25"] + w_cred * d["credibility"] for d in docs]
-        # order predicted scores
-        ranked = [docs[i]["relevance"] for i in sorted(range(len(docs)), key=lambda i: preds[i], reverse=True)]
-        total += ndcg(ranked)
-    return total / len(data)
-
-
-def grid_search(data):
-    best = 0.0
-    best_w = (0.5, 0.3, 0.2)
-    steps = [i / 10 for i in range(11)]
-    for w_sem in steps:
-        for w_bm in steps:
-            w_cred = 1.0 - w_sem - w_bm
-            if w_cred < 0 or w_cred > 1:
-                continue
-            score = evaluate((w_sem, w_bm, w_cred), data)
-            if score > best:
-                best = score
-                best_w = (w_sem, w_bm, w_cred)
-    return best_w, best
-
-
-def update_config(cfg_path: Path, weights):
+def update_config(cfg_path: Path, weights: tuple[float, float, float]) -> None:
+    """Write tuned weights back to a TOML configuration file."""
     data = tomllib.loads(cfg_path.read_text())
-    data["search"]["semantic_similarity_weight"] = round(weights[0], 2)
-    data["search"]["bm25_weight"] = round(weights[1], 2)
-    data["search"]["source_credibility_weight"] = round(weights[2], 2)
+    search_cfg = data.setdefault("search", {})
+    search_cfg["semantic_similarity_weight"] = round(weights[0], 2)
+    search_cfg["bm25_weight"] = round(weights[1], 2)
+    search_cfg["source_credibility_weight"] = round(weights[2], 2)
     cfg_path.write_text(tomli_w.dumps(data))
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Tune search ranking weights")
     parser.add_argument("dataset", type=Path, help="Path to evaluation CSV")
     parser.add_argument("config", type=Path, help="Path to config TOML to update")
+    parser.add_argument(
+        "--step",
+        type=float,
+        default=0.1,
+        help="Grid search step size between 0 and 1",
+    )
     args = parser.parse_args()
 
-    data = load_data(args.dataset)
-    weights, score = grid_search(data)
-    print(f"Best weights: semantic={weights[0]:.2f}, bm25={weights[1]:.2f}, cred={weights[2]:.2f} (NDCG={score:.3f})")
+    data = Search.load_evaluation_data(args.dataset)
+    weights = Search.tune_weights(data, step=args.step)
+    score = Search.evaluate_weights(weights, data)
+    print(
+        f"Best weights: semantic={weights[0]:.2f}, bm25={weights[1]:.2f}, "
+        f"cred={weights[2]:.2f} (NDCG={score:.3f})"
+    )
     update_config(args.config, weights)
 
 

--- a/tests/integration/test_search_weights.py
+++ b/tests/integration/test_search_weights.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import tomllib
+from autoresearch.search import Search
+
+
+def test_optimize_script_updates_weights(tmp_path):
+    dataset = Path(__file__).resolve().parents[1] / "data" / "eval" / "sample_eval.csv"
+    cfg = tmp_path / "cfg.toml"
+    cfg.write_text(
+        """[search]\nsemantic_similarity_weight = 0.5\nbm25_weight = 0.3\nsource_credibility_weight = 0.2\n"""
+    )
+
+    baseline_data = Search.load_evaluation_data(dataset)
+    baseline = Search.evaluate_weights((0.5, 0.3, 0.2), baseline_data)
+
+    script = Path(__file__).resolve().parents[2] / "scripts" / "optimize_search_weights.py"
+    subprocess.run(
+        [sys.executable, str(script), str(dataset), str(cfg)],
+        check=True,
+    )
+
+    tuned = tomllib.loads(cfg.read_text())["search"]
+    tuned_weights = (
+        tuned["semantic_similarity_weight"],
+        tuned["bm25_weight"],
+        tuned["source_credibility_weight"],
+    )
+    tuned_score = Search.evaluate_weights(tuned_weights, baseline_data)
+
+    assert tuned_score >= baseline
+    assert abs(sum(tuned_weights) - 1.0) < 0.01


### PR DESCRIPTION
## Summary
- add optimize_search_weights tuning utility
- show how to run weight tuning in `[search]` docs
- test that tuned weights improve accuracy

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Module has no attribute, incompatible types)*
- `poetry run pytest tests/integration/test_search_weights.py -q`
- `poetry run pytest tests/behavior` *(fails: StorageError: owlrl reasoning)*

------
https://chatgpt.com/codex/tasks/task_e_6861b180bfd883338a23908d638493b2