### PR TITLE
Refactor CLI and API fixtures

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -1,20 +1,4 @@
 import pytest
-from typer.testing import CliRunner
-from fastapi.testclient import TestClient
-
-from autoresearch.api import app as api_app
-
-
-@pytest.fixture
-def cli_runner():
-    """Provide a Typer CLI runner for behavior tests."""
-    return CliRunner()
-
-
-@pytest.fixture
-def api_client():
-    """Provide a FastAPI test client for behavior tests."""
-    return TestClient(api_app)
 
 
 @pytest.fixture

--- a/tests/behavior/steps/api_orchestrator_integration_steps.py
+++ b/tests/behavior/steps/api_orchestrator_integration_steps.py
@@ -9,9 +9,6 @@ import pytest
 import concurrent.futures
 from pytest_bdd import scenario, given, when, then, parsers
 from unittest.mock import MagicMock
-from fastapi.testclient import TestClient
-
-from autoresearch.api import app
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.models import QueryResponse
 from autoresearch.errors import OrchestrationError
@@ -29,12 +26,6 @@ def test_context():
         "errors": [],
         "concurrent_responses": [],
     }
-
-
-@pytest.fixture
-def api_client():
-    """Create a test client for the API."""
-    return TestClient(app)
 
 
 @pytest.fixture

--- a/tests/behavior/steps/common_steps.py
+++ b/tests/behavior/steps/common_steps.py
@@ -1,15 +1,7 @@
 # flake8: noqa
-import os
-import json
-from typer.testing import CliRunner
-from fastapi.testclient import TestClient
 from pytest_bdd import given
 
 from autoresearch.main import app as cli_app
-from autoresearch.api import app as api_app
-
-runner = CliRunner()
-client = TestClient(api_app)
 
 
 @given("the Autoresearch application is running")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,9 @@ from uuid import uuid4
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 import importlib.util
+from typer.testing import CliRunner
+from fastapi.testclient import TestClient
+from autoresearch.api import app as api_app
 
 # Ensure package can be imported without installation
 if importlib.util.find_spec("autoresearch") is None:
@@ -366,3 +369,15 @@ def mock_llm_adapter(monkeypatch):
     monkeypatch.setattr("autoresearch.llm.get_llm_adapter", lambda name: adapter)
     yield adapter
     LLMFactory._registry.pop("mock", None)
+
+
+@pytest.fixture
+def cli_runner():
+    """Return a Typer CLI runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def api_client():
+    """Return a FastAPI test client."""
+    return TestClient(api_app)


### PR DESCRIPTION
## Summary
- create reusable `cli_runner` and `api_client` fixtures
- rely on the global fixtures from behaviour steps
- remove inline runner/client setup in step definitions

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: BrokenPipeError)*
- `poetry run pytest`
- `poetry run pytest tests/behavior -q --maxfail=1` *(fails: KeyboardInterrupt during heavy import)*

------
https://chatgpt.com/codex/tasks/task_e_6861bb72bde483338bcd9afe4f3ee1ac