### PR TITLE
Add CLI visualization helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ table, use:
 ```bash
 autoresearch search "Explain AI ethics" --visualize
 ```
+This command prints a small table of the knowledge graph and an ASCII chart of
+metrics collected during the search.
 
 Load an ontology and infer relations during a query:
 

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -286,6 +286,8 @@ Display a condensed view of the knowledge graph built during a search:
 ```bash
 autoresearch search "Explain AI ethics" --visualize
 ```
+The `--visualize` option now prints an ASCII summary of query metrics along with
+the knowledge graph table.
 
 ## API Integration
 

--- a/docs/quickstart_guides.md
+++ b/docs/quickstart_guides.md
@@ -63,6 +63,12 @@ autoresearch query "What is the capital of France?" --output markdown > result.m
 autoresearch visualize "What is the capital of France?" graph.png
 ```
 
+7. **Show an inline graph after searching:**
+
+```bash
+autoresearch search "Explain AI ethics" --visualize
+```
+
 ### Configuration
 
 1. **View current configuration:**

--- a/src/autoresearch/cli_utils.py
+++ b/src/autoresearch/cli_utils.py
@@ -8,8 +8,9 @@ with both color and text-based alternatives, as well as symbolic indicators.
 import os
 import sys
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Mapping
 from rich.console import Console
+from rich.table import Table
 
 
 # Verbosity levels
@@ -286,3 +287,37 @@ def visualize_graph_cli() -> None:
 
     data = _collect_graph_data()
     console.print(_render_graph(data))
+
+
+def ascii_bar_graph(data: Mapping[str, float], width: int = 30) -> str:
+    """Render a simple ASCII bar chart for numeric data."""
+    if not data:
+        return "(no data)"
+
+    max_val = max(abs(v) for v in data.values()) or 1
+    lines: list[str] = []
+    for k, v in data.items():
+        bar_len = int(abs(v) / max_val * width)
+        bar = "#" * bar_len
+        lines.append(f"{k:>10} | {bar} {v}")
+    return "\n".join(lines)
+
+
+def summary_table(data: Mapping[str, Any]) -> Table:
+    """Create a table summarizing key/value pairs."""
+    table = Table(title="Metrics Summary")
+    table.add_column("Metric")
+    table.add_column("Value")
+    for k, v in data.items():
+        table.add_row(str(k), str(v))
+    if not data:
+        table.add_row("(empty)", "")
+    return table
+
+
+def visualize_metrics_cli(metrics: Mapping[str, Any]) -> None:
+    """Display metrics using a table and ASCII chart."""
+    console.print(summary_table(metrics))
+    numeric = {k: float(v) for k, v in metrics.items() if isinstance(v, (int, float))}
+    if numeric:
+        console.print(ascii_bar_graph(numeric))

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -41,6 +41,7 @@ from .cli_utils import (
     visualize_rdf_cli as _cli_visualize,
     visualize_query_cli as _cli_visualize_query,
     visualize_graph_cli,
+    visualize_metrics_cli,
     sparql_query_cli as _cli_sparql,
 )
 from .error_utils import get_error_info, format_error_for_cli
@@ -342,6 +343,7 @@ def search(
         OutputFormatter.format(result, fmt)
         if visualize:
             visualize_graph_cli()
+            visualize_metrics_cli(result.metrics)
     except Exception as e:
         # Create a valid QueryResponse object with error information
         from .models import QueryResponse

--- a/tests/unit/test_cli_visualize.py
+++ b/tests/unit/test_cli_visualize.py
@@ -1,0 +1,39 @@
+import importlib
+from typer.testing import CliRunner
+
+from autoresearch.cli_utils import ascii_bar_graph, summary_table
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.models import QueryResponse
+
+
+def test_ascii_bar_graph_basic():
+    graph = ascii_bar_graph({'a': 1, 'b': 2}, width=10)
+    lines = graph.splitlines()
+    assert len(lines) == 2
+    assert lines[0].count('#') < lines[1].count('#')
+
+
+def test_summary_table_render():
+    table = summary_table({'x': 1})
+    from rich.console import Console
+    console = Console(record=True, color_system=None)
+    console.print(table)
+    output = console.export_text()
+    assert 'x' in output
+    assert '1' in output
+
+
+def test_search_visualize_option(monkeypatch):
+    runner = CliRunner()
+
+    def _mock_run(query, config, callbacks=None):
+        return QueryResponse(answer='a', citations=[], reasoning=[], metrics={'m': 1})
+
+    monkeypatch.setattr(Orchestrator, 'run_query', _mock_run)
+    from autoresearch.config import ConfigLoader, ConfigModel
+    monkeypatch.setattr(ConfigLoader, 'load_config', lambda self: ConfigModel(loops=1))
+    main = importlib.import_module('autoresearch.main')
+    result = runner.invoke(main.app, ['search', 'q', '--visualize'])
+    assert result.exit_code == 0
+    assert 'Knowledge Graph' in result.stdout
+    assert 'm' in result.stdout


### PR DESCRIPTION
## Summary
- implement ASCII graph helpers and metrics table in `cli_utils`
- integrate new metrics visualization with the `search` CLI
- document inline graph output
- add tests for the visualization utilities

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Interrupted)*
- `poetry run pytest -q tests/unit/test_cli_visualize.py`
- `poetry run pytest tests/behavior` *(fails: NameError in agent orchestration test)*

------
https://chatgpt.com/codex/tasks/task_e_6861c2e156b883339e7f2c99b6da22eb