### PR TITLE
Implement role-based permissions for API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -145,6 +145,20 @@ api_keys = {admin = "secret1", user = "secret2"}
 Include the desired key in the `X-API-Key` header. The associated role will be
 available as `request.state.role` inside the application.
 
+### Role permissions
+
+Use `[api].role_permissions` to restrict which endpoints each role can call.
+Permissions are `query`, `metrics` and `capabilities`.
+
+```toml
+[api.role_permissions]
+admin = ["query", "metrics", "capabilities"]
+user = ["query"]
+```
+
+By default `user` can only submit queries while `admin` has access to all
+endpoints.
+
 ## Throttling
 
 Rate limiting is configured via `[api].rate_limit` or the environment variable

--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -213,6 +213,13 @@ class APIConfig(BaseModel):
         default_factory=dict,
         description="Optional mapping of API keys to roles",
     )
+    role_permissions: Dict[str, List[str]] = Field(
+        default_factory=lambda: {
+            "user": ["query"],
+            "admin": ["query", "metrics", "capabilities"],
+        },
+        description="Mapping of roles to allowed actions",
+    )
     bearer_token: str | None = Field(
         default=None,
         description="Token required in the Authorization header when set",


### PR DESCRIPTION
## Summary
- extend `AuthMiddleware` with role permissions and expose them via `request.state`
- add `require_permission` dependency and apply it to API endpoints
- document role permissions in `docs/api.md`
- ensure dynamic rate limits and role checks in integration tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: "_last_adaptive_policy" not defined, etc.)*
- `poetry run pytest -q` *(fails to complete due to KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails to complete due to KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6861c2e6408c83339d81ad0992d6e9f0