### PR TITLE
Enhance Streamlit accessibility

### DIFF
--- a/src/autoresearch/streamlit_app.py
+++ b/src/autoresearch/streamlit_app.py
@@ -84,6 +84,17 @@ st.markdown(
     .responsive-item {
         flex: 1 1 300px;
     }
+    .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
     .skip-link {
         position: absolute;
         left: -1000px;
@@ -100,6 +111,17 @@ st.markdown(
         background: #fff;
         padding: 0.5rem;
         z-index: 1000;
+    }
+    @media (max-width: 600px) {
+        .responsive-container, .metrics-container {
+            flex-direction: column;
+        }
+        .main-header {
+            font-size: 2rem;
+        }
+        .subheader {
+            font-size: 1.2rem;
+        }
     }
 </style>
 """,
@@ -1289,7 +1311,16 @@ def initialize_session_state():
 def display_query_input() -> None:
     """Render the query input controls."""
     st.markdown("<h2 class='subheader'>Query Input</h2>", unsafe_allow_html=True)
+    st.markdown(
+        (
+            "<p id='keyboard-nav' class='sr-only'>"
+            "Use Tab to navigate fields and press Enter on 'Run Query' to submit."
+            "</p>"
+        ),
+        unsafe_allow_html=True,
+    )
     with st.container():
+        st.markdown("<div role='region' aria-label='Query input area'>", unsafe_allow_html=True)
         col_query, col_actions = st.columns([3, 1])
         with col_query:
             st.session_state.current_query = st.text_area(
@@ -1297,6 +1328,7 @@ def display_query_input() -> None:
                 height=100,
                 placeholder="What would you like to research?",
                 key="query_input",
+                help="After typing, press Tab to reach the Run button",
             )
         with col_actions:
             st.session_state.reasoning_mode = st.selectbox(
@@ -1314,7 +1346,13 @@ def display_query_input() -> None:
                 value=st.session_state.config.loops,
                 key="loops_slider",
             )
-            st.session_state.run_button = st.button("Run Query", type="primary")
+            st.session_state.run_button = st.button(
+                "Run Query",
+                type="primary",
+                help="Activate to run your query",
+                key="run_query_button",
+            )
+        st.markdown("</div>", unsafe_allow_html=True)
 
 
 def main():

--- a/tests/targeted/test_streamlit_extra.py
+++ b/tests/targeted/test_streamlit_extra.py
@@ -10,3 +10,29 @@ def test_apply_accessibility(monkeypatch):
     monkeypatch.setattr(streamlit_app, 'st', fake_st)
     streamlit_app.apply_accessibility_settings()
     assert len(calls) == 2
+
+
+def test_display_query_input_has_accessibility(monkeypatch):
+    calls = {"markdown": [], "button": []}
+
+    class Dummy:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    fake_st = types.SimpleNamespace(
+        markdown=lambda *a, **k: calls["markdown"].append((a, k)),
+        text_area=lambda *a, **k: "",
+        selectbox=lambda *a, **k: None,
+        slider=lambda *a, **k: 0,
+        button=lambda *a, **k: calls["button"].append(k) or False,
+        columns=lambda *a, **k: (Dummy(), Dummy()),
+        container=lambda: Dummy(),
+        session_state={"config": types.SimpleNamespace(reasoning_mode=streamlit_app.ReasoningMode.DIALECTICAL, loops=2)}
+    )
+    monkeypatch.setattr(streamlit_app, "st", fake_st)
+    streamlit_app.display_query_input()
+    assert any("aria-label='Query input area'" in args[0] for args, _ in calls["markdown"])
+    assert any("run your query" in kw.get("help", "") for kw in calls["button"])


### PR DESCRIPTION
## Summary
- expose ARIA labelled query form and keyboard navigation cue
- add responsive CSS for mobile layout
- test that query widgets include accessibility attributes

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: attr-defined and union-attr errors)*
- `poetry run pytest -q` *(fails: test_batch_query_invalid_page)*
- `poetry run pytest tests/behavior` *(fails: NameError: runner is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6861d915cb7883338f1d66c3b95c97ef