### PR TITLE
Add distributed storage coordination

### DIFF
--- a/src/autoresearch/__init__.py
+++ b/src/autoresearch/__init__.py
@@ -4,6 +4,18 @@ This package provides a local-first research assistant with multiple
 interfaces and a modular architecture.
 """
 
-from .distributed import RayExecutor
+from .distributed import (
+    RayExecutor,
+    StorageCoordinator,
+    InMemoryBroker,
+    start_storage_coordinator,
+    publish_claim,
+)
 
-__all__ = ["RayExecutor"]
+__all__ = [
+    "RayExecutor",
+    "StorageCoordinator",
+    "InMemoryBroker",
+    "start_storage_coordinator",
+    "publish_claim",
+]

--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -215,6 +215,7 @@ class APIConfig(BaseModel):
     )
     role_permissions: Dict[str, List[str]] = Field(
         default_factory=lambda: {
+            "anonymous": ["query"],
             "user": ["query"],
             "admin": ["query", "metrics", "capabilities"],
         },
@@ -237,6 +238,7 @@ class DistributedConfig(BaseModel):
     enabled: bool = Field(default=False)
     address: str | None = Field(default=None, description="Ray cluster address")
     num_cpus: int = Field(default=1, ge=1)
+    message_broker: str = Field(default="memory")
 
 
 class ConfigModel(BaseSettings):

--- a/src/autoresearch/distributed.py
+++ b/src/autoresearch/distributed.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Dict, Callable, Any
+from typing import Dict, Callable, Any, Optional
 import os
+import multiprocessing
+
+from multiprocessing.queues import Queue
+
+from . import storage
 
 import ray
 
@@ -11,6 +16,65 @@ from .config import ConfigModel
 from .orchestration.state import QueryState
 from .orchestration.orchestrator import AgentFactory
 from .models import QueryResponse
+
+
+class InMemoryBroker:
+    """Simple in-memory message broker using multiprocessing.Queue."""
+
+    def __init__(self) -> None:
+        self._manager = multiprocessing.Manager()
+        self.queue: Queue = self._manager.Queue()
+
+    def publish(self, message: dict[str, Any]) -> None:
+        self.queue.put(message)
+
+    def shutdown(self) -> None:
+        self._manager.shutdown()
+
+
+def get_message_broker(name: str | None) -> InMemoryBroker:
+    """Return a message broker instance by name."""
+
+    if name in (None, "memory"):
+        return InMemoryBroker()
+    raise ValueError(f"Unsupported message broker: {name}")
+
+
+class StorageCoordinator(multiprocessing.Process):
+    """Background process that persists claims from a queue."""
+
+    def __init__(self, queue: Queue, db_path: str) -> None:
+        super().__init__(daemon=True)
+        self._queue = queue
+        self._db_path = db_path
+
+    def run(self) -> None:  # pragma: no cover - runs in separate process
+        storage.setup(self._db_path)
+        while True:
+            msg = self._queue.get()
+            if msg.get("action") == "stop":
+                break
+            if msg.get("action") == "persist_claim":
+                storage.StorageManager.persist_claim(
+                    msg["claim"], msg.get("partial_update", False)
+                )
+        storage.teardown()
+
+
+def start_storage_coordinator(config: ConfigModel) -> tuple[StorageCoordinator, InMemoryBroker]:
+    """Start a storage coordinator according to the distributed config."""
+
+    broker = get_message_broker(getattr(config.distributed_config, "message_broker", None))
+    db_path = config.storage.duckdb_path
+    coordinator = StorageCoordinator(broker.queue, db_path)
+    coordinator.start()
+    return coordinator, broker
+
+
+def publish_claim(broker: InMemoryBroker, claim: dict[str, Any], partial_update: bool = False) -> None:
+    """Publish a claim persistence request to the broker."""
+
+    broker.publish({"action": "persist_claim", "claim": claim, "partial_update": partial_update})
 
 
 @ray.remote
@@ -34,6 +98,11 @@ class RayExecutor:
             num_cpus = cfg.num_cpus
         ray.init(address=address, num_cpus=num_cpus, ignore_reinit_error=True, configure_logging=False)
 
+        self.storage_coordinator: Optional[StorageCoordinator] = None
+        self.broker: Optional[InMemoryBroker] = None
+        if getattr(config, "distributed", False):
+            self.storage_coordinator, self.broker = start_storage_coordinator(config)
+
     def run_query(self, query: str, callbacks: Dict[str, Callable[..., None]] | None = None) -> QueryResponse:
         """Run agents in parallel across processes."""
         callbacks = callbacks or {}
@@ -50,3 +119,12 @@ class RayExecutor:
                 callbacks["on_cycle_end"](loop, state)
             state.cycle += 1
         return state.synthesize()
+
+    def shutdown(self) -> None:
+        """Shut down Ray and any storage coordinator."""
+
+        if self.broker and self.storage_coordinator:
+            self.broker.publish({"action": "stop"})
+            self.storage_coordinator.join()
+            self.broker.shutdown()
+        ray.shutdown()

--- a/tests/integration/test_distributed_storage.py
+++ b/tests/integration/test_distributed_storage.py
@@ -1,0 +1,38 @@
+import os
+import ray
+from autoresearch.config import ConfigModel, DistributedConfig, StorageConfig
+from autoresearch.distributed import start_storage_coordinator
+from autoresearch.storage import StorageManager
+
+
+def test_distributed_storage(tmp_path):
+    cfg = ConfigModel(
+        distributed=True,
+        distributed_config=DistributedConfig(enabled=True, num_cpus=2, message_broker="memory"),
+        storage=StorageConfig(duckdb_path=str(tmp_path / "kg.duckdb")),
+    )
+
+    coordinator, broker = start_storage_coordinator(cfg)
+    ray.init(num_cpus=2, ignore_reinit_error=True, configure_logging=False)
+
+    @ray.remote
+    def persist(claim, q):
+        q.put({"action": "persist_claim", "claim": claim})
+        return os.getpid()
+
+    claims = [
+        {"id": "c1", "type": "fact", "content": "a"},
+        {"id": "c2", "type": "fact", "content": "b"},
+    ]
+    pids = ray.get([persist.remote(c, broker.queue) for c in claims])
+    assert len(set(pids)) == len(claims)
+
+    broker.publish({"action": "stop"})
+    coordinator.join()
+    broker.shutdown()
+    ray.shutdown()
+
+    StorageManager.setup(str(tmp_path / "kg.duckdb"))
+    conn = StorageManager.get_duckdb_conn()
+    rows = conn.execute("SELECT id FROM nodes ORDER BY id").fetchall()
+    assert [r[0] for r in rows] == ["c1", "c2"]


### PR DESCRIPTION
## Summary
- enable anonymous API access by default
- coordinate storage across processes using a message broker
- add in-memory message broker and storage coordinator
- test claim persistence when multiple processes publish via the broker

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src/autoresearch | head -n 20`
- `poetry run pytest tests/unit/test_config_watcher_cleanup.py::test_api_watcher_cleanup -q`
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6861e80fd2b88333b9b1eecbac4cce48