### PR TITLE
Add extra coverage tests

### DIFF
--- a/tests/integration/test_streamlit_gui.py
+++ b/tests/integration/test_streamlit_gui.py
@@ -37,3 +37,12 @@ def test_dark_mode_injects_styles():
     at.run()
     styles = [m.proto.body for m in at.markdown if "<style>" in m.proto.body]
     assert any("background-color:#222" in css for css in styles)
+
+
+def test_high_contrast_injects_styles():
+    at = AppTest.from_file(APP_FILE)
+    at.session_state["show_tour"] = False
+    at.session_state["high_contrast"] = True
+    at.run()
+    styles = [m.proto.body for m in at.markdown if "<style>" in m.proto.body]
+    assert any("background-color:#000" in css for css in styles)

--- a/tests/unit/test_metrics_extra2.py
+++ b/tests/unit/test_metrics_extra2.py
@@ -1,0 +1,26 @@
+import sys
+import builtins
+import types
+from autoresearch.orchestration import metrics
+
+
+def test_get_system_usage_success(monkeypatch):
+    fake_psutil = types.SimpleNamespace(
+        cpu_percent=lambda interval=None: 42.0,
+        Process=lambda: types.SimpleNamespace(memory_info=lambda: types.SimpleNamespace(rss=1024 * 1024))
+    )
+    monkeypatch.setitem(sys.modules, 'psutil', fake_psutil)
+    cpu, mem = metrics._get_system_usage()
+    assert cpu == 42.0 and mem == 1.0
+
+
+def test_get_system_usage_failure(monkeypatch):
+    def fake_import(name, *args, **kwargs):
+        if name == 'psutil':
+            raise ImportError
+        return orig_import(name, *args, **kwargs)
+
+    orig_import = builtins.__import__
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+    cpu, mem = metrics._get_system_usage()
+    assert cpu == 0.0 and mem == 0.0

--- a/tests/unit/test_output_format_extra2.py
+++ b/tests/unit/test_output_format_extra2.py
@@ -1,0 +1,20 @@
+import logging
+from autoresearch.output_format import FormatTemplate, OutputFormatter, TemplateRegistry
+from autoresearch.models import QueryResponse
+
+logging.getLogger("autoresearch.output_format").setLevel(logging.CRITICAL)
+
+
+def test_metric_variable_rendering():
+    template = FormatTemplate(name="metrics", template="Tokens: ${metric_tokens}")
+    resp = QueryResponse(answer="a", citations=[], reasoning=[], metrics={"tokens": 5})
+    assert template.render(resp) == "Tokens: 5"
+
+
+def test_format_missing_variable_fallback(capsys):
+    TemplateRegistry._templates = {}
+    TemplateRegistry.register(FormatTemplate(name="bad", template="${missing}"))
+    resp = QueryResponse(answer="a", citations=[], reasoning=[], metrics={})
+    OutputFormatter.format(resp, "template:bad")
+    out = capsys.readouterr().out
+    assert "# Answer" in out  # fell back to markdown

--- a/tests/unit/test_storage_backend_extra.py
+++ b/tests/unit/test_storage_backend_extra.py
@@ -1,0 +1,68 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from autoresearch.storage_backends import DuckDBStorageBackend
+from autoresearch.errors import StorageError
+
+
+@patch("autoresearch.storage_backends.duckdb.connect")
+def test_persist_claim_calls_execute(mock_connect):
+    conn = MagicMock()
+    mock_connect.return_value = conn
+    backend = DuckDBStorageBackend()
+    backend.setup(db_path=":memory:")
+    conn.execute.reset_mock()
+    claim = {
+        "id": "c1",
+        "type": "fact",
+        "content": "text",
+        "confidence": 0.5,
+        "relations": [{"src": "c1", "dst": "c2", "rel": "r", "weight": 0.1}],
+        "embedding": [0.0] * 384,
+    }
+    backend.persist_claim(claim)
+    conn.execute.assert_any_call(
+        "INSERT INTO nodes VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
+        ["c1", "fact", "text", 0.5],
+    )
+    conn.execute.assert_any_call(
+        "INSERT INTO edges VALUES (?, ?, ?, ?)",
+        ["c1", "c2", "r", 0.1],
+    )
+    conn.execute.assert_any_call(
+        "INSERT INTO embeddings VALUES (?, ?)",
+        ["c1", claim["embedding"]],
+    )
+
+
+@patch("autoresearch.storage_backends.duckdb.connect")
+def test_persist_claim_failure(mock_connect):
+    conn = MagicMock()
+    conn.execute.side_effect = Exception("fail")
+    mock_connect.return_value = conn
+    backend = DuckDBStorageBackend()
+    backend.setup(db_path=":memory:")
+    with pytest.raises(StorageError):
+        backend.persist_claim({"id": "c1"})
+
+
+@patch("autoresearch.storage_backends.duckdb.connect")
+def test_vector_search_no_vss(mock_connect):
+    conn = MagicMock()
+    mock_connect.return_value = conn
+    backend = DuckDBStorageBackend()
+    backend.setup(db_path=":memory:")
+    backend._has_vss = False
+    with pytest.raises(StorageError):
+        backend.vector_search([0.1, 0.2, 0.3])
+
+
+@patch("autoresearch.storage_backends.duckdb.connect")
+def test_vector_search_failure(mock_connect):
+    conn = MagicMock()
+    conn.execute.side_effect = Exception("boom")
+    mock_connect.return_value = conn
+    backend = DuckDBStorageBackend()
+    backend.setup(db_path=":memory:")
+    backend._has_vss = True
+    with pytest.raises(StorageError):
+        backend.vector_search([0.1, 0.2, 0.3])


### PR DESCRIPTION
## Summary
- add tests for template error handling and metrics
- add tests for DuckDB backend vector search and persistence
- add high contrast Streamlit test

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Interrupted)*
- `poetry run pytest tests/unit/test_output_format_extra2.py tests/unit/test_storage_backend_extra.py tests/unit/test_metrics_extra2.py tests/integration/test_streamlit_gui.py::test_high_contrast_injects_styles -q --cov=src` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6861fac8f2d08333bce803ca55a38f6a