### PR TITLE
Add BDD scenarios for API auth errors

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+from fastapi.testclient import TestClient
+from autoresearch.api import app as api_app
 
 
 @pytest.fixture
@@ -241,3 +243,16 @@ def claim_factory():
             return len(results) > 0
 
     return ClaimFactory()
+
+
+@pytest.fixture
+def api_client_factory():
+    """Return a factory for TestClient with preset headers."""
+
+    def _make(headers: dict[str, str] | None = None) -> TestClient:
+        client = TestClient(api_app)
+        if headers:
+            client.headers.update(headers)
+        return client
+
+    return _make

--- a/tests/behavior/features/api_auth.feature
+++ b/tests/behavior/features/api_auth.feature
@@ -1,0 +1,23 @@
+Feature: API Authentication and Rate Limiting
+  As a user of the Autoresearch API
+  I want authentication and throttling enforced
+  So that unauthorized or excessive usage is prevented
+
+  Background:
+    Given the API server is running
+
+  Scenario: Invalid API key
+    Given the API requires an API key "secret"
+    When I send a query "test" with header "X-API-Key" set to "bad"
+    Then the response status should be 401
+
+  Scenario: Invalid bearer token
+    Given the API requires a bearer token "token"
+    When I send a query "test" with header "Authorization" set to "Bearer bad"
+    Then the response status should be 401
+
+  Scenario: Rate limit exceeded
+    Given the API rate limit is 1 request per minute
+    When I send two queries to the API
+    Then the first response status should be 200
+    And the second response status should be 429

--- a/tests/behavior/steps/api_auth_steps.py
+++ b/tests/behavior/steps/api_auth_steps.py
@@ -1,0 +1,89 @@
+"""Step definitions for API authentication and rate limiting."""
+
+from pytest_bdd import scenario, given, when, then, parsers
+from autoresearch.config import ConfigModel, ConfigLoader, APIConfig
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.models import QueryResponse
+
+
+@given(parsers.parse('the API requires an API key "{key}"'))
+def require_api_key(monkeypatch, key):
+    cfg = ConfigModel(api=APIConfig(api_key=key))
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setattr(
+        Orchestrator,
+        "run_query",
+        lambda q, c, callbacks=None, **k: QueryResponse(
+            answer="ok", citations=[], reasoning=[], metrics={}
+        ),
+    )
+
+
+@given(parsers.parse('the API requires a bearer token "{token}"'))
+def require_bearer_token(monkeypatch, token):
+    cfg = ConfigModel(api=APIConfig(bearer_token=token))
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setattr(
+        Orchestrator,
+        "run_query",
+        lambda q, c, callbacks=None, **k: QueryResponse(
+            answer="ok", citations=[], reasoning=[], metrics={}
+        ),
+    )
+
+
+@given(parsers.parse('the API rate limit is {limit:d} request per minute'))
+def set_rate_limit(monkeypatch, limit):
+    cfg = ConfigModel(api=APIConfig(rate_limit=limit))
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setattr(
+        Orchestrator,
+        "run_query",
+        lambda q, c, callbacks=None, **k: QueryResponse(
+            answer="ok", citations=[], reasoning=[], metrics={}
+        ),
+    )
+
+
+@when(parsers.parse('I send a query "{query}" with header "{header}" set to "{value}"'))
+def send_query_with_header(api_client_factory, test_context, query, header, value):
+    client = api_client_factory({header: value})
+    resp = client.post("/query", json={"query": query})
+    test_context["response"] = resp
+
+
+@when("I send two queries to the API")
+def send_two_queries(api_client_factory, test_context):
+    client = api_client_factory()
+    test_context["resp1"] = client.post("/query", json={"query": "q"})
+    test_context["resp2"] = client.post("/query", json={"query": "q"})
+
+
+@then(parsers.parse('the response status should be {status:d}'))
+def check_status(test_context, status):
+    assert test_context["response"].status_code == status
+
+
+@then(parsers.parse('the first response status should be {status:d}'))
+def check_first_status(test_context, status):
+    assert test_context["resp1"].status_code == status
+
+
+@then(parsers.parse('the second response status should be {status:d}'))
+def check_second_status(test_context, status):
+    assert test_context["resp2"].status_code == status
+
+
+@scenario("../features/api_auth.feature", "Invalid API key")
+def test_invalid_api_key():
+    pass
+
+
+@scenario("../features/api_auth.feature", "Invalid bearer token")
+def test_invalid_bearer_token():
+    pass
+
+
+@scenario("../features/api_auth.feature", "Rate limit exceeded")
+def test_rate_limit_exceeded():
+    pass


### PR DESCRIPTION
## Summary
- add feature file covering API key, bearer token and rate‑limit failures
- implement `api_auth_steps.py` to exercise `/query` via `TestClient`
- provide `api_client_factory` fixture for custom headers

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Item "None" of "str | Any | None" has no attribute "split" etc.)*
- `poetry run pytest -q` *(interrupted: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: NameError: name 'runner' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6861fad91ef08333b9ccad1ef527dc3b