### PR TITLE
Add shared CLI and API client fixtures

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -249,6 +249,11 @@ that validate this context. When writing scenario functions:
 * Capture CLI or GUI logs with `caplog` to verify accessibility or
   logging output.
 
+Behavior step files can access preconfigured clients using two fixtures:
+`cli_client` provides a `CliRunner` for invoking the Typer CLI and
+`api_client` yields a `TestClient` connected to the FastAPI app. Use
+these fixtures instead of instantiating new clients within step functions.
+
 This pattern keeps the feature files expressive while ensuring the
 Python tests make concrete assertions about CLI behaviour, GUI
 accessibility, and log messages.

--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
+from typer.testing import CliRunner
+
 from autoresearch.api import app as api_app
 
 
@@ -256,3 +258,15 @@ def api_client_factory():
         return client
 
     return _make
+
+
+@pytest.fixture
+def cli_client() -> CliRunner:
+    """Return a Typer CLI runner for behavior tests."""
+    return CliRunner()
+
+
+@pytest.fixture
+def api_client() -> TestClient:
+    """Return a FastAPI test client for behavior tests."""
+    return TestClient(api_app)

--- a/tests/behavior/steps/agent_orchestration_steps.py
+++ b/tests/behavior/steps/agent_orchestration_steps.py
@@ -95,7 +95,7 @@ def check_agents_executed(run_orchestrator_on_query, order):
     parsers.parse('I submit a query via CLI `autoresearch search "{query}"`'),
     target_fixture="submit_query_via_cli",
 )
-def submit_query_via_cli(query, monkeypatch):
+def submit_query_via_cli(query, monkeypatch, cli_client):
     from autoresearch.models import QueryResponse
 
     original_run_query = Orchestrator.run_query
@@ -121,7 +121,7 @@ def submit_query_via_cli(query, monkeypatch):
     main_mod._config_loader = ConfigLoader()
     main_mod._config_loader._config = cfg
 
-    result = runner.invoke(cli_app, ["search", query])
+    result = cli_client.invoke(cli_app, ["search", query])
 
     monkeypatch.setattr(Orchestrator, "run_query", original_run_query)
 

--- a/tests/behavior/steps/output_formatting_steps.py
+++ b/tests/behavior/steps/output_formatting_steps.py
@@ -6,9 +6,9 @@ from .common_steps import *  # noqa: F401,F403
 
 
 @when(parsers.parse('I run `autoresearch search "{query}"` in TTY mode'))
-def run_in_terminal(query, monkeypatch, bdd_context):
+def run_in_terminal(query, monkeypatch, bdd_context, cli_client):
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    result = runner.invoke(cli_app, ["search", query])
+    result = cli_client.invoke(cli_app, ["search", query])
     bdd_context["terminal_result"] = result
 
 
@@ -24,10 +24,10 @@ def check_markdown_output(bdd_context):
 
 
 @when(parsers.parse('I run `autoresearch search "{query}" | cat`'))
-def run_piped(query, monkeypatch, bdd_context):
+def run_piped(query, monkeypatch, bdd_context, cli_client):
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
-    result = runner.invoke(cli_app, ["search", query])
+    result = cli_client.invoke(cli_app, ["search", query])
     bdd_context["piped_result"] = result
 
 
@@ -44,8 +44,8 @@ def check_json_output(bdd_context):
 
 
 @when(parsers.re(r'I run `autoresearch search "(?P<query>.+)" --output json`'))
-def run_with_json_flag(query, monkeypatch, bdd_context):
-    result = runner.invoke(cli_app, ["search", query, "--output", "json"])
+def run_with_json_flag(query, monkeypatch, bdd_context, cli_client):
+    result = cli_client.invoke(cli_app, ["search", query, "--output", "json"])
     bdd_context["json_flag_result"] = result
 
 
@@ -60,8 +60,8 @@ def check_json_output_with_flag(bdd_context):
 
 
 @when(parsers.re(r'I run `autoresearch search "(?P<query>.+)" --output markdown`'))
-def run_with_markdown_flag(query, monkeypatch, bdd_context):
-    result = runner.invoke(cli_app, ["search", query, "--output", "markdown"])
+def run_with_markdown_flag(query, monkeypatch, bdd_context, cli_client):
+    result = cli_client.invoke(cli_app, ["search", query, "--output", "markdown"])
     bdd_context["markdown_flag_result"] = result
 
 

--- a/tests/behavior/steps/query_interface_steps.py
+++ b/tests/behavior/steps/query_interface_steps.py
@@ -6,9 +6,9 @@ from .common_steps import *  # noqa: F401,F403
 
 
 @when(parsers.parse('I run `autoresearch search "{query}"` in a terminal'))
-def run_cli_query(query, monkeypatch, bdd_context):
+def run_cli_query(query, monkeypatch, bdd_context, cli_client):
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    result = runner.invoke(cli_app, ["search", query])
+    result = cli_client.invoke(cli_app, ["search", query])
     bdd_context["cli_result"] = result
 
 
@@ -31,8 +31,8 @@ def check_cli_output(bdd_context):
         'I send a POST request to `/query` with JSON `{ "query": "{query}" }`'
     )
 )
-def send_http_query(query, bdd_context):
-    response = client.post("/query", json={"query": query})
+def send_http_query(query, bdd_context, api_client):
+    response = api_client.post("/query", json={"query": query})
     bdd_context["http_response"] = response
 
 
@@ -48,10 +48,10 @@ def check_http_response(bdd_context):
 
 
 @when(parsers.re(r'I run `autoresearch\.search\("(?P<query>.+)"\)` via the MCP CLI'))
-def run_mcp_cli_query(query, monkeypatch, bdd_context):
+def run_mcp_cli_query(query, monkeypatch, bdd_context, cli_client):
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
-    result = runner.invoke(cli_app, ["search", query])
+    result = cli_client.invoke(cli_app, ["search", query])
     bdd_context["mcp_result"] = result
 
 
@@ -60,7 +60,7 @@ def run_mcp_cli_query(query, monkeypatch, bdd_context):
         'I run `autoresearch search "{query}" -i` and refine to "{refined}" then exit'
     )
 )
-def run_interactive_query(query, refined, monkeypatch, bdd_context):
+def run_interactive_query(query, refined, monkeypatch, bdd_context, cli_client):
     from autoresearch.config import ConfigModel, ConfigLoader
 
     monkeypatch.setattr(
@@ -71,14 +71,14 @@ def run_interactive_query(query, refined, monkeypatch, bdd_context):
     responses = iter([refined, "q"])
     monkeypatch.setattr("autoresearch.main.Prompt.ask", lambda *a, **k: next(responses))
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    result = runner.invoke(cli_app, ["search", query, "--interactive"])
+    result = cli_client.invoke(cli_app, ["search", query, "--interactive"])
     bdd_context["cli_result"] = result
 
 
 @when(parsers.re(r'I run `autoresearch visualize "(?P<query>.+)" (?P<file>.+)`'))
-def run_visualize_cli(query, file, tmp_path, bdd_context):
+def run_visualize_cli(query, file, tmp_path, bdd_context, cli_client):
     out = tmp_path / file
-    result = runner.invoke(cli_app, ["visualize", query, str(out)])
+    result = cli_client.invoke(cli_app, ["visualize", query, str(out)])
     bdd_context["viz_result"] = result
     bdd_context["viz_path"] = out
 


### PR DESCRIPTION
## Summary
- add `cli_client` and `api_client` fixtures for BDD tests
- use new fixtures in CLI and API step definitions
- document the fixtures in testing guidelines

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Item "None" of "str | Any | None" has no attribute "split")*
- `poetry run pytest -q` *(interrupted)*
- `poetry run pytest tests/behavior -q` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686203545b4c8333bb8ca4f8e56b6286