### PR TITLE
Add A2A SDK integration

### DIFF
--- a/docs/quickstart_guides.md
+++ b/docs/quickstart_guides.md
@@ -171,53 +171,39 @@ This will start the Streamlit server and open the GUI in your default web browse
 
 ## A2A (Agent-to-Agent) Interface Quickstart Guide
 
-### Starting the API Server
+### Starting the A2A Server
 
 ```bash
-uvicorn autoresearch.api:app --host 0.0.0.0 --port 8000
-```
-
-### Starting the FastMCP Server
-
-```bash
-autoresearch serve
+autoresearch serve_a2a --host 0.0.0.0 --port 8765
 ```
 
 ### Basic Usage with Python
 
 ```python
-import requests
-import json
+import asyncio
+import httpx
+from a2a.client import A2AClient
+from a2a.utils.message import new_agent_text_message
+from a2a.types import MessageSendParams, SendMessageRequest
 
-# Define the API endpoint
-url = "http://localhost:8000/query"
 
-# Prepare the request
-headers = {"Content-Type": "application/json"}
-data = {
-    "query": "What is the capital of France?",
-    "reasoning_mode": "dialectical"
-}
+async def main() -> None:
+    async with httpx.AsyncClient() as http_client:
+        client = A2AClient(http_client, url="http://localhost:8765/")
+        params = MessageSendParams(message=new_agent_text_message("What is the capital of France?"))
+        request = SendMessageRequest(id="1", params=params)
+        response = await client.send_message(request)
+        print(response.result)
 
-# Send the request
-response = requests.post(url, headers=headers, data=json.dumps(data))
-
-# Process the response
-if response.status_code == 200:
-    result = response.json()
-    print(f"Answer: {result['answer']}")
-    print(f"Reasoning: {result['reasoning']}")
-    print(f"Citations: {', '.join(result['citations'])}")
-else:
-    print(f"Error: {response.status_code} - {response.text}")
+asyncio.run(main())
 ```
 
 ### Basic Usage with cURL
 
 ```bash
-curl -X POST http://localhost:8000/query \
+curl -X POST http://localhost:8765/ \
   -H "Content-Type: application/json" \
-  -d '{"query": "What is the capital of France?", "reasoning_mode": "dialectical"}'
+  -d '{"type": "query", "message": {"messageId": "1", "role": "agent", "parts": [{"kind": "text", "text": "What is the capital of France?"}]}}'
 ```
 
 ### Discovering Capabilities

--- a/tests/behavior/steps/cross_modal_integration_steps.py
+++ b/tests/behavior/steps/cross_modal_integration_steps.py
@@ -248,7 +248,8 @@ def check_cli_config_updated(bdd_context):
 @when("I execute a query via the A2A interface")
 def execute_query_via_a2a(bdd_context):
     """Execute a query via the A2A interface."""
-    from autoresearch.a2a_interface import A2AInterface, A2AMessage, A2AMessageType
+    from autoresearch.a2a_interface import A2AInterface
+    from a2a.utils.message import new_agent_text_message
 
     mock_response = {
         "answer": "Paris is the capital of France.",
@@ -262,9 +263,9 @@ def execute_query_via_a2a(bdd_context):
         return_value=mock_response,
     ) as mock_handle:
         interface = A2AInterface()
-        result = interface._handle_query(
-            A2AMessage(type=A2AMessageType.QUERY, content={"query": "What is the capital of France?"})
-        )
+        msg = new_agent_text_message("")
+        msg.metadata = {"query": "What is the capital of France?"}
+        result = interface._handle_query(msg)
 
         bdd_context["a2a_result"] = result
 
@@ -327,11 +328,14 @@ def check_error_handling(bdd_context):
         mock_query.side_effect = ValueError("Invalid query: Query cannot be empty")
 
         if "a2a_result" in bdd_context:
-            from autoresearch.a2a_interface import A2AInterface, A2AMessage, A2AMessageType
+            from autoresearch.a2a_interface import A2AInterface
+            from a2a.utils.message import new_agent_text_message
 
             interface = A2AInterface()
             try:
-                interface._handle_query(A2AMessage(type=A2AMessageType.QUERY, content={"query": ""}))
+                msg = new_agent_text_message("")
+                msg.metadata = {"query": ""}
+                interface._handle_query(msg)
             except ValueError as e:
                 bdd_context[error_key] = str(e)
         else:


### PR DESCRIPTION
## Summary
- implement minimal A2A server using FastAPI and uvicorn
- parse message metadata using A2A Message objects
- adjust tests for new message implementation
- document how to run the A2A server and query using the SDK

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src/autoresearch/a2a_interface.py`
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68620bc3ac88833380f8f6971e4a571e