### PR TITLE
Add shared clients fixtures

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -58,7 +58,7 @@ This document tracks the progress of tasks for the Autoresearch project, organiz
   - [ ] Ensure at least 90% code coverage
   - [ ] Add tests for edge cases and error conditions
   - [x] Implement property-based testing for complex components
-- [ ] Enhance test fixtures
+- [x] Enhance test fixtures
   - [x] Create more realistic test data
   - [x] Implement comprehensive mock LLM adapters
   - [x] Add parameterized tests for configuration variations
@@ -81,11 +81,10 @@ This document tracks the progress of tasks for the Autoresearch project, organiz
   - [x] Add scenarios for all user-facing features
   - [x] Test all reasoning modes with realistic queries
   - [x] Verify error handling and recovery
-- [ ] Enhance test step definitions
+- [x] Enhance test step definitions
   - [x] Add more detailed assertions
   - [x] Implement better test isolation
   - [x] Create more comprehensive test contexts
-  - _Next:_ introduce reusable fixtures for CLI and API clients
 
 ### 4.1 Code Documentation
 

--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -1,8 +1,4 @@
 import pytest
-from fastapi.testclient import TestClient
-from typer.testing import CliRunner
-
-from autoresearch.api import app as api_app
 
 
 @pytest.fixture
@@ -245,28 +241,3 @@ def claim_factory():
             return len(results) > 0
 
     return ClaimFactory()
-
-
-@pytest.fixture
-def api_client_factory():
-    """Return a factory for TestClient with preset headers."""
-
-    def _make(headers: dict[str, str] | None = None) -> TestClient:
-        client = TestClient(api_app)
-        if headers:
-            client.headers.update(headers)
-        return client
-
-    return _make
-
-
-@pytest.fixture
-def cli_client() -> CliRunner:
-    """Return a Typer CLI runner for behavior tests."""
-    return CliRunner()
-
-
-@pytest.fixture
-def api_client() -> TestClient:
-    """Return a FastAPI test client for behavior tests."""
-    return TestClient(api_app)

--- a/tests/behavior/steps/api_auth_steps.py
+++ b/tests/behavior/steps/api_auth_steps.py
@@ -1,9 +1,16 @@
 """Step definitions for API authentication and rate limiting."""
 
 from pytest_bdd import scenario, given, when, then, parsers
+from . import api_orchestrator_integration_steps  # noqa: F401
 from autoresearch.config import ConfigModel, ConfigLoader, APIConfig
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.models import QueryResponse
+
+
+@given("the API server is running")
+def api_server_running():
+    """Placeholder step to signify the API is available."""
+    pass
 
 
 @given(parsers.parse('the API requires an API key "{key}"'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, MagicMock
 import importlib.util
 from typer.testing import CliRunner
 from fastapi.testclient import TestClient
+from typing import Callable
 from autoresearch.api import app as api_app
 
 # Ensure package can be imported without installation
@@ -378,6 +379,25 @@ def cli_runner():
 
 
 @pytest.fixture
+def cli_client(cli_runner: CliRunner) -> CliRunner:
+    """Alias fixture for a Typer CLI runner used in behavior tests."""
+    return cli_runner
+
+
+@pytest.fixture
 def api_client():
     """Return a FastAPI test client."""
     return TestClient(api_app)
+
+
+@pytest.fixture
+def api_client_factory() -> Callable[[dict[str, str] | None], TestClient]:
+    """Return a factory for creating TestClient instances with optional headers."""
+
+    def _make(headers: dict[str, str] | None = None) -> TestClient:
+        client = TestClient(api_app)
+        if headers:
+            client.headers.update(headers)
+        return client
+
+    return _make

--- a/tests/unit/test_orchestrator_edgecases.py
+++ b/tests/unit/test_orchestrator_edgecases.py
@@ -1,17 +1,19 @@
-import types
 import pytest
 from autoresearch.orchestration.orchestrator import Orchestrator, ReasoningMode
 from autoresearch.config import ConfigModel
 from autoresearch.errors import NotFoundError
+
 
 class DummyFactory:
     @staticmethod
     def get(name):
         raise RuntimeError("missing")
 
+
 def test_get_agent_not_found():
     with pytest.raises(NotFoundError):
         Orchestrator._get_agent("X", DummyFactory)
+
 
 def test_parse_config_direct_mode():
     cfg = ConfigModel(reasoning_mode=ReasoningMode.DIRECT, loops=5)

--- a/tests/unit/test_output_format_edgecases.py
+++ b/tests/unit/test_output_format_edgecases.py
@@ -1,4 +1,3 @@
-import pytest
 from autoresearch.output_format import OutputFormatter, TemplateRegistry
 from autoresearch.models import QueryResponse
 

--- a/tests/unit/test_streamlit_app_edgecases.py
+++ b/tests/unit/test_streamlit_app_edgecases.py
@@ -3,10 +3,12 @@ from pathlib import Path
 
 from autoresearch import streamlit_app
 
+
 class DummySt(types.SimpleNamespace):
     def __init__(self):
         super().__init__(markdown=lambda *a, **k: None, error=lambda *a, **k: None)
         self.session_state = {}
+
 
 def test_apply_theme_settings(monkeypatch):
     st = DummySt()
@@ -16,10 +18,12 @@ def test_apply_theme_settings(monkeypatch):
     st.session_state['dark_mode'] = False
     streamlit_app.apply_theme_settings()
 
+
 def test_save_config_to_toml_error(tmp_path, monkeypatch):
     st = DummySt()
     monkeypatch.setattr(streamlit_app, 'st', st)
     monkeypatch.setattr(Path, 'cwd', lambda: tmp_path)
+
     def boom(*a, **k):
         raise OSError('fail')
     monkeypatch.setattr('tomli_w.dump', boom)


### PR DESCRIPTION
## Summary
- define `cli_client` and `api_client_factory` in `tests/conftest.py`
- remove duplicate fixtures from behaviour config
- adjust API auth steps to register common steps
- fix flake8 errors in edge case tests
- mark progress on test fixtures and step definitions

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 46 errors)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `poetry run pytest tests/behavior` *(fails: assert 200 == 401)*

------
https://chatgpt.com/codex/tasks/task_e_6862a0be98e8833390a699be3f31a029