### PR TITLE
Add search weight tuning defaults and test

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -45,3 +45,17 @@ The diagram below shows the relationships between these classes and their intera
 2. Register the adapter via `LLMFactory.register("mybackend", MyAdapter)` (for example in `src/autoresearch/llm/__init__.py`).
 3. Select it by setting `llm_backend = "mybackend"` in your configuration.
 
+## Tuning search ranking weights
+
+Autoresearch ships with a small evaluation dataset at
+`examples/search_evaluation.csv`.  You can tune the relative weights of the
+semantic similarity, BM25 and credibility signals by running the helper script:
+
+```bash
+python scripts/optimize_search_weights.py
+```
+
+The script performs a grid search to maximize NDCG and writes the optimized
+values back to a configuration file (defaults to `examples/autoresearch.toml`).
+Provide custom file paths if you want to use your own data or configuration.
+

--- a/scripts/optimize_search_weights.py
+++ b/scripts/optimize_search_weights.py
@@ -22,8 +22,21 @@ def update_config(cfg_path: Path, weights: tuple[float, float, float]) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Tune search ranking weights")
-    parser.add_argument("dataset", type=Path, help="Path to evaluation CSV")
-    parser.add_argument("config", type=Path, help="Path to config TOML to update")
+    examples_dir = Path(__file__).resolve().parents[1] / "examples"
+    parser.add_argument(
+        "dataset",
+        type=Path,
+        nargs="?",
+        default=examples_dir / "search_evaluation.csv",
+        help="Path to evaluation CSV",
+    )
+    parser.add_argument(
+        "config",
+        type=Path,
+        nargs="?",
+        default=examples_dir / "autoresearch.toml",
+        help="Path to config TOML to update",
+    )
     parser.add_argument(
         "--step",
         type=float,

--- a/tests/integration/test_search_weights.py
+++ b/tests/integration/test_search_weights.py
@@ -7,7 +7,7 @@ from autoresearch.search import Search
 
 
 def test_optimize_script_updates_weights(tmp_path):
-    dataset = Path(__file__).resolve().parents[1] / "data" / "eval" / "sample_eval.csv"
+    dataset = Path(__file__).resolve().parents[2] / "examples" / "search_evaluation.csv"
     cfg = tmp_path / "cfg.toml"
     cfg.write_text(
         """[search]\nsemantic_similarity_weight = 0.5\nbm25_weight = 0.3\nsource_credibility_weight = 0.2\n"""


### PR DESCRIPTION
## Summary
- default search weight optimizer script to examples paths
- use sample evaluation dataset in integration test
- document tuning workflow in agents guide

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Interrupted)*
- `poetry run pytest tests/integration/test_search_weights.py -q`
- `poetry run pytest tests/behavior` *(fails: test_invalid_api_key)*

------
https://chatgpt.com/codex/tasks/task_e_6862b8c2f0c4833394a2a72be4be9d0f