### PR TITLE
Add loops CLI option

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -55,6 +55,18 @@ autoresearch query "What is the average lifespan of a blue whale?" \
 
 This uses only the Synthesizer agent to provide a direct answer without the dialectical process.
 
+### Starting with a Specific Agent
+
+You can control which agent begins the dialectical cycle using `--primus-start`:
+
+```bash
+autoresearch search "Compare JPEG and PNG compression" \
+  --reasoning-mode dialectical \
+  --primus-start 1
+```
+
+This example starts with the Contrarian agent (index `1`) before rotating through the others.
+
 ## Agent Configuration
 
 ### Using Different Models for Different Agents

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -234,6 +234,11 @@ def search(
         "--mode",
         help="Override reasoning mode for this run (direct, dialectical, chain-of-thought)",
     ),
+    loops: Optional[int] = typer.Option(
+        None,
+        "--loops",
+        help="Number of reasoning cycles to run",
+    ),
     ontology: Optional[str] = typer.Option(
         None,
         "--ontology",
@@ -253,7 +258,7 @@ def search(
     primus_start: Optional[int] = typer.Option(
         None,
         "--primus-start",
-        help="Starting agent index for dialectical reasoning",
+        help="Index of the agent to begin the dialectical cycle",
     ),
     visualize: bool = typer.Option(
         False,
@@ -284,6 +289,8 @@ def search(
     updates: dict[str, Any] = {}
     if reasoning_mode is not None:
         updates["reasoning_mode"] = reasoning_mode
+    if loops is not None:
+        updates["loops"] = loops
     if primus_start is not None:
         updates["primus_start"] = primus_start
     storage_updates: dict[str, Any] = {}

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -59,6 +59,7 @@ def test_search_help_includes_interactive(monkeypatch):
     result = runner.invoke(main.app, ["search", "--help"])
     assert result.exit_code == 0
     assert "--interactive" in result.stdout
+    assert "--loops" in result.stdout
 
 
 def test_search_help_includes_visualize(monkeypatch):
@@ -87,3 +88,40 @@ def test_search_help_includes_visualize(monkeypatch):
     result = runner.invoke(main.app, ["search", "--help"])
     assert result.exit_code == 0
     assert "--visualize" in result.stdout
+
+
+def test_search_loops_option(monkeypatch):
+    dummy_storage = types.ModuleType("autoresearch.storage")
+
+    class StorageManager:
+        @staticmethod
+        def persist_claim(claim):
+            pass
+
+        @staticmethod
+        def setup(*a, **k):
+            pass
+
+    dummy_storage.StorageManager = StorageManager
+    dummy_storage.setup = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+    from autoresearch.config import ConfigLoader, ConfigModel
+    from autoresearch.models import QueryResponse
+    from autoresearch.orchestration.orchestrator import Orchestrator
+
+    def _load(self):
+        return ConfigModel()
+
+    captured = {}
+
+    def _run(query, config, callbacks=None):
+        captured["loops"] = config.loops
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+
+    monkeypatch.setattr(ConfigLoader, "load_config", _load)
+    monkeypatch.setattr(Orchestrator, "run_query", _run)
+    main = importlib.import_module("autoresearch.main")
+    runner = CliRunner()
+    result = runner.invoke(main.app, ["search", "q", "--loops", "4"])
+    assert result.exit_code == 0
+    assert captured["loops"] == 4


### PR DESCRIPTION
## Summary
- add `--loops` flag and adjust help text
- update advanced usage docs with `--primus-start` example
- extend CLI tests to cover `--loops`

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 46 errors)*
- `poetry run pytest -q tests/unit/test_cli_help.py`
- `poetry run pytest tests/behavior` *(fails: 1 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6862b8b3c03c8333be2b28614f458a75