### PR TITLE
Add rich graph visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,13 @@ autoresearch search "Explain AI ethics" --interactive
 ```
 Press `q` at the feedback prompt to abort early.
 
-To visualize the resulting knowledge graph directly in the terminal as a small
-table, use:
+To visualize the resulting knowledge graph directly in the terminal, use:
 
 ```bash
 autoresearch search "Explain AI ethics" --visualize
 ```
-This command prints a small table of the knowledge graph and an ASCII chart of
-metrics collected during the search.
+This command prints a Rich tree showing the knowledge graph followed by an
+ASCII chart of metrics collected during the search.
 
 To save the knowledge graph as an image after running a search, use the
 `visualize` subcommand:

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -40,7 +40,6 @@ from .cli_utils import (
     Verbosity,
     visualize_rdf_cli as _cli_visualize,
     visualize_query_cli as _cli_visualize_query,
-    visualize_graph_cli,
     visualize_metrics_cli,
     sparql_query_cli as _cli_sparql,
 )
@@ -349,7 +348,7 @@ def search(
 
         OutputFormatter.format(result, fmt)
         if visualize:
-            visualize_graph_cli()
+            OutputFormatter.format(result, "graph")
             visualize_metrics_cli(result.metrics)
     except Exception as e:
         # Create a valid QueryResponse object with error information

--- a/src/autoresearch/output_format.py
+++ b/src/autoresearch/output_format.py
@@ -317,6 +317,27 @@ class OutputFormatter:
 
         if fmt == "json":
             sys.stdout.write(response.model_dump_json(indent=2) + "\n")
+        elif fmt == "graph":
+            from rich.tree import Tree
+            from rich.console import Console
+
+            tree = Tree("Knowledge Graph")
+            ans_node = tree.add("Answer")
+            ans_node.add(response.answer)
+
+            citations_node = ans_node.add("Citations")
+            for c in response.citations:
+                citations_node.add(str(c))
+
+            reasoning_node = tree.add("Reasoning")
+            for r in response.reasoning:
+                reasoning_node.add(str(r))
+
+            metrics_node = tree.add("Metrics")
+            for k, v in response.metrics.items():
+                metrics_node.add(f"{k}: {v}")
+
+            Console(file=sys.stdout, force_terminal=False, color_system=None).print(tree)
         elif fmt.startswith("template:"):
             # Custom template format
             template_name = fmt.split(":", 1)[1]

--- a/tests/behavior/steps/interactive_monitor_steps.py
+++ b/tests/behavior/steps/interactive_monitor_steps.py
@@ -81,7 +81,7 @@ def search_exit_successfully(bdd_context):
 def search_output_contains_graph(bdd_context):
     output = bdd_context["visual_result"].stdout
     assert "Knowledge Graph" in output
-    assert "A" in output
+    assert "Answer" in output
 
 
 @scenario("../features/interactive_monitor.feature", "Interactive monitoring")

--- a/tests/unit/test_cli_visualize.py
+++ b/tests/unit/test_cli_visualize.py
@@ -37,3 +37,4 @@ def test_search_visualize_option(monkeypatch):
     assert result.exit_code == 0
     assert 'Knowledge Graph' in result.stdout
     assert 'm' in result.stdout
+    assert 'Answer' in result.stdout


### PR DESCRIPTION
## Summary
- render Rich tree graphs in the output formatter
- show graph tree when using `--visualize`
- document visualization behaviour
- adjust tests for new graph output

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: process interrupted)*
- `poetry run pytest -q` *(fails: process interrupted due to heavy deps)*
- `poetry run pytest tests/behavior` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6862d06a37688333a7a1ae9376f9c061