### PR TITLE
Improve Streamlit accessibility

### DIFF
--- a/src/autoresearch/streamlit_app.py
+++ b/src/autoresearch/streamlit_app.py
@@ -116,6 +116,9 @@ st.markdown(
         .responsive-container, .metrics-container {
             flex-direction: column;
         }
+        .stForm button[type="submit"] {
+            width: 100%;
+        }
         .main-header {
             font-size: 2rem;
         }
@@ -207,6 +210,28 @@ def display_guided_tour() -> None:
             )
             if st.button("Got it", key="tour_done", help="Close the guided tour"):
                 st.session_state.show_tour = False
+
+
+def display_help_sidebar() -> None:
+    """Show a persistent help/tutorial sidebar."""
+    if "first_visit" not in st.session_state:
+        st.session_state.first_visit = True
+
+    expanded = st.session_state.first_visit
+    with st.sidebar.expander("Tutorial", expanded=expanded):
+        st.markdown(
+            """
+            **Getting Started**
+
+            1. Enter a question in the main panel.
+            2. Choose the reasoning mode and loops.
+            3. Press **Run Query** to launch the agents.
+            """
+        )
+
+        if expanded:
+            if st.button("Dismiss tutorial", key="dismiss_tutorial"):
+                st.session_state.first_visit = False
 
 
 def save_config_to_toml(config_dict):
@@ -1328,8 +1353,11 @@ def display_query_input() -> None:
         ),
         unsafe_allow_html=True,
     )
-    with st.container():
-        st.markdown("<div role='region' aria-label='Query input area'>", unsafe_allow_html=True)
+    with st.form("query_form"):
+        st.markdown(
+            "<div role='region' aria-label='Query input area' tabindex='0'>",
+            unsafe_allow_html=True,
+        )
         col_query, col_actions = st.columns([3, 1])
         with col_query:
             st.session_state.current_query = st.text_area(
@@ -1355,12 +1383,13 @@ def display_query_input() -> None:
                 value=st.session_state.config.loops,
                 key="loops_slider",
             )
-            st.session_state.run_button = st.button(
+            submitted = st.form_submit_button(
                 "Run Query",
                 type="primary",
                 help="Activate to run your query",
-                key="run_query_button",
+                use_container_width=True,
             )
+            st.session_state.run_button = submitted
         st.markdown("</div>", unsafe_allow_html=True)
 
 
@@ -1446,6 +1475,9 @@ def main():
         # Add an expander for the configuration editor
         with st.expander("Edit Configuration"):
             display_config_editor()
+
+        # Tutorial/help sidebar
+        display_help_sidebar()
 
     # Apply theme and accessibility styles based on sidebar settings
     apply_theme_settings()

--- a/tests/behavior/steps/ui_accessibility_steps.py
+++ b/tests/behavior/steps/ui_accessibility_steps.py
@@ -59,6 +59,18 @@ def test_high_contrast_mode(bdd_context):
     assert "mock_markdown" in bdd_context
 
 
+@scenario("../features/ui_accessibility.feature", "Responsive Layout on Mobile")
+def test_responsive_layout(bdd_context):
+    """Test responsive layout on small screens."""
+    assert "css" in bdd_context
+
+
+@scenario("../features/ui_accessibility.feature", "Guided Tour Availability")
+def test_guided_tour_availability(bdd_context):
+    """Test guided tour availability."""
+    assert bdd_context.get("tour_modal", False) is True
+
+
 @when("I use the CLI with color output disabled")
 def use_cli_without_color(bdd_context):
     """Simulate using the CLI with color output disabled."""
@@ -277,4 +289,60 @@ def check_color_independence(bdd_context):
     """Check that information is not conveyed by color alone."""
     # This would typically check that information is conveyed by multiple means
     # For now, we'll just assert True as a placeholder
+    assert True
+
+
+@given("the Streamlit application is running on a small screen")
+def streamlit_small_screen(monkeypatch, bdd_context, tmp_path):
+    """Set up the Streamlit app and capture CSS for mobile layout."""
+    autoresearch_system_running(tmp_path, monkeypatch)
+    with (
+        patch("streamlit.session_state", {}),
+        patch("streamlit.markdown") as mock_markdown,
+    ):
+        import importlib
+        import autoresearch.streamlit_app as app
+
+        importlib.reload(app)
+        css_blocks = [call.args[0] for call in mock_markdown.call_args_list if "<style>" in call.args[0]]
+        bdd_context["css"] = "".join(css_blocks)
+
+
+@when("I view the page")
+def view_page():
+    """Placeholder for viewing the page."""
+    pass
+
+
+@then("columns should stack vertically")
+def columns_stack_vertically(bdd_context):
+    """Ensure CSS contains rules for vertical stacking."""
+    assert "flex-direction: column" in bdd_context.get("css", "")
+
+
+@then("controls should remain usable without horizontal scrolling")
+def controls_no_horizontal_scroll(bdd_context):
+    """Check controls adapt to small widths."""
+    assert "width: 100%" in bdd_context.get("css", "")
+
+
+@when("I open the page for the first time")
+def open_page_first_time(monkeypatch, bdd_context):
+    """Simulate opening the page for the first time."""
+    with patch("streamlit.modal") as mock_modal:
+        import autoresearch.streamlit_app as app
+
+        app.display_guided_tour()
+        bdd_context["tour_modal"] = mock_modal.called
+
+
+@then("a guided tour modal should describe the main features")
+def check_guided_tour_modal(bdd_context):
+    """Verify the modal was displayed."""
+    assert bdd_context.get("tour_modal", False) is True
+
+
+@then("I should be able to dismiss the tour")
+def dismiss_tour():
+    """Placeholder for dismissing the tour."""
     assert True


### PR DESCRIPTION
## Summary
- adapt Streamlit forms for small screens and responsive layout
- add persistent tutorial sidebar for first‑time users
- include ARIA labels and keyboard navigation helpers
- test mobile layout CSS and guided tour hooks

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(failed: ModuleNotFoundError and interrupted)*
- `poetry run pytest -q` *(failed: ModuleNotFoundError: No module named 'matplotlib')*
- `poetry run pytest tests/behavior` *(failed: API auth assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68631a04f254833387dae3e9d75c2c39