### PR TITLE
Add periodic system monitor

### DIFF
--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -265,6 +265,13 @@ class ConfigModel(BaseSettings):
     # Defaults to None (auto-detect in CLI)
     tracing_enabled: bool = Field(default=False)
 
+    # Monitoring settings
+    monitor_interval: float = Field(default=1.0, ge=0.1)
+    cpu_warning_threshold: float = Field(default=80.0, ge=0.0, le=100.0)
+    memory_warning_threshold: float = Field(default=80.0, ge=0.0, le=100.0)
+    cpu_critical_threshold: float = Field(default=90.0, ge=0.0, le=100.0)
+    memory_critical_threshold: float = Field(default=90.0, ge=0.0, le=100.0)
+
     # Storage settings
     storage: StorageConfig = Field(default_factory=StorageConfig)
 

--- a/src/autoresearch/monitor/system_monitor.py
+++ b/src/autoresearch/monitor/system_monitor.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Dict, Optional
+
+import psutil  # type: ignore
+from prometheus_client import Gauge, CollectorRegistry, REGISTRY
+
+
+class SystemMonitor:
+    """Periodically collect system metrics using psutil."""
+
+    def __init__(
+        self,
+        interval: float = 1.0,
+        *,
+        registry: CollectorRegistry | None = None,
+    ) -> None:
+        self.interval = interval
+        self.registry = registry or REGISTRY
+        self.cpu_gauge = Gauge(
+            "autoresearch_system_cpu_percent",
+            "System wide CPU usage percent",
+            registry=self.registry,
+        )
+        self.mem_gauge = Gauge(
+            "autoresearch_system_memory_percent",
+            "System memory usage percent",
+            registry=self.registry,
+        )
+        self.metrics: Dict[str, float] = {}
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        if self._thread:
+            return
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self.metrics = self.collect()
+            self.cpu_gauge.set(self.metrics.get("cpu_percent", 0.0))
+            self.mem_gauge.set(self.metrics.get("memory_percent", 0.0))
+            time.sleep(self.interval)
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join()
+            self._thread = None
+
+    @staticmethod
+    def collect() -> Dict[str, float]:
+        cpu = psutil.cpu_percent(interval=None)
+        mem = psutil.virtual_memory()
+        return {
+            "cpu_percent": float(cpu),
+            "memory_percent": float(mem.percent),
+        }

--- a/tests/unit/test_system_monitor.py
+++ b/tests/unit/test_system_monitor.py
@@ -1,0 +1,19 @@
+import time
+from prometheus_client import CollectorRegistry
+import psutil
+from autoresearch.monitor.system_monitor import SystemMonitor
+
+
+def test_system_monitor_collects(monkeypatch):
+    monkeypatch.setattr(psutil, "cpu_percent", lambda interval=None: 12.0)
+    mem = type("mem", (), {"percent": 34.0})()
+    monkeypatch.setattr(psutil, "virtual_memory", lambda: mem)
+
+    registry = CollectorRegistry()
+    monitor = SystemMonitor(interval=0.01, registry=registry)
+    monitor.start()
+    time.sleep(0.03)
+    monitor.stop()
+
+    assert registry.get_sample_value("autoresearch_system_cpu_percent") == 12.0
+    assert registry.get_sample_value("autoresearch_system_memory_percent") == 34.0


### PR DESCRIPTION
## Summary
- convert `monitor.py` to a package and add `SystemMonitor`
- expose CPU and memory thresholds via `ConfigModel`
- integrate new system metrics into monitor CLI
- add tests for system monitor and metrics endpoint

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src/autoresearch/monitor src/autoresearch/config.py` *(fails: Interrupted)*
- `poetry run pytest tests/unit/test_system_monitor.py tests/integration/test_monitor_metrics.py::test_system_monitor_metrics_exposed -q`

------
https://chatgpt.com/codex/tasks/task_e_68631a0e88788333828330a2fb8b485c