### PR TITLE
Add distributed result aggregation

### DIFF
--- a/src/autoresearch/__init__.py
+++ b/src/autoresearch/__init__.py
@@ -7,15 +7,19 @@ interfaces and a modular architecture.
 from .distributed import (
     RayExecutor,
     StorageCoordinator,
+    ResultAggregator,
     InMemoryBroker,
     start_storage_coordinator,
+    start_result_aggregator,
     publish_claim,
 )
 
 __all__ = [
     "RayExecutor",
     "StorageCoordinator",
+    "ResultAggregator",
     "InMemoryBroker",
     "start_storage_coordinator",
+    "start_result_aggregator",
     "publish_claim",
 ]

--- a/src/autoresearch/distributed.py
+++ b/src/autoresearch/distributed.py
@@ -61,6 +61,24 @@ class StorageCoordinator(multiprocessing.Process):
         storage.teardown()
 
 
+class ResultAggregator(multiprocessing.Process):
+    """Collect results from agents running in other processes."""
+
+    def __init__(self, queue: Queue) -> None:
+        super().__init__(daemon=True)
+        self._queue = queue
+        self._manager = multiprocessing.Manager()
+        self.results: list[dict[str, Any]] = self._manager.list()
+
+    def run(self) -> None:  # pragma: no cover - runs in separate process
+        while True:
+            msg = self._queue.get()
+            if msg.get("action") == "stop":
+                break
+            if msg.get("action") == "agent_result":
+                self.results.append(msg)
+
+
 def start_storage_coordinator(config: ConfigModel) -> tuple[StorageCoordinator, InMemoryBroker]:
     """Start a storage coordinator according to the distributed config."""
 
@@ -77,12 +95,29 @@ def publish_claim(broker: InMemoryBroker, claim: dict[str, Any], partial_update:
     broker.publish({"action": "persist_claim", "claim": claim, "partial_update": partial_update})
 
 
+def start_result_aggregator(config: ConfigModel) -> tuple[ResultAggregator, InMemoryBroker]:
+    """Start a background aggregator process for agent results."""
+
+    broker = get_message_broker(getattr(config.distributed_config, "message_broker", None))
+    aggregator = ResultAggregator(broker.queue)
+    aggregator.start()
+    return aggregator, broker
+
+
 @ray.remote
-def _execute_agent_remote(agent_name: str, state: QueryState, config: ConfigModel) -> Dict[str, Any]:
+def _execute_agent_remote(
+    agent_name: str,
+    state: QueryState,
+    config: ConfigModel,
+    queue: Queue | None = None,
+) -> Dict[str, Any]:
     """Execute a single agent in a Ray worker."""
     agent = AgentFactory.get(agent_name)
     result = agent.execute(state, config)
-    return {"agent": agent_name, "result": result, "pid": os.getpid()}
+    msg = {"action": "agent_result", "agent": agent_name, "result": result, "pid": os.getpid()}
+    if queue is not None:
+        queue.put(msg)
+    return msg
 
 
 class RayExecutor:
@@ -100,19 +135,34 @@ class RayExecutor:
 
         self.storage_coordinator: Optional[StorageCoordinator] = None
         self.broker: Optional[InMemoryBroker] = None
+        self.result_aggregator: Optional[ResultAggregator] = None
+        self.result_broker: Optional[InMemoryBroker] = None
         if getattr(config, "distributed", False):
             self.storage_coordinator, self.broker = start_storage_coordinator(config)
+            self.result_aggregator, self.result_broker = start_result_aggregator(config)
 
     def run_query(self, query: str, callbacks: Dict[str, Callable[..., None]] | None = None) -> QueryResponse:
         """Run agents in parallel across processes."""
         callbacks = callbacks or {}
         state = QueryState(query=query, primus_index=getattr(self.config, "primus_start", 0))
         for loop in range(self.config.loops):
+            if self.result_aggregator:
+                self.result_aggregator.results[:] = []
             futures = [
-                _execute_agent_remote.remote(name, state, self.config)
+                _execute_agent_remote.remote(
+                    name,
+                    state,
+                    self.config,
+                    self.result_broker.queue if self.result_broker else None,
+                )
                 for name in self.config.agents
             ]
-            results = ray.get(futures)
+            remote_results = ray.get(futures)
+            results = (
+                list(self.result_aggregator.results) if self.result_aggregator else remote_results
+            )
+            if self.result_aggregator:
+                self.result_aggregator.results[:] = []
             for res in results:
                 state.update(res["result"])
             if callbacks.get("on_cycle_end"):
@@ -127,4 +177,8 @@ class RayExecutor:
             self.broker.publish({"action": "stop"})
             self.storage_coordinator.join()
             self.broker.shutdown()
+        if self.result_broker and self.result_aggregator:
+            self.result_broker.publish({"action": "stop"})
+            self.result_aggregator.join()
+            self.result_broker.shutdown()
         ray.shutdown()

--- a/tests/integration/test_distributed_results.py
+++ b/tests/integration/test_distributed_results.py
@@ -1,0 +1,39 @@
+import os
+import ray
+from autoresearch.distributed import RayExecutor
+from autoresearch.config import ConfigModel, DistributedConfig
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import AgentFactory
+from autoresearch.orchestration.state import QueryState
+
+
+class DummyAgent:
+    def __init__(self, name: str, pid_list: list[int]):
+        self.name = name
+        self._pids = pid_list
+
+    def can_execute(self, state: QueryState, config: ConfigModel) -> bool:  # pragma: no cover - dummy
+        return True
+
+    def execute(self, state: QueryState, config: ConfigModel, **_: object) -> dict:
+        self._pids.append(os.getpid())
+        state.update({"results": {self.name: "ok"}})
+        return {"results": {self.name: "ok"}}
+
+
+def test_result_aggregation_multi_process(monkeypatch):
+    pids: list[int] = []
+    monkeypatch.setattr(AgentFactory, "get", lambda name: DummyAgent(name, pids))
+    cfg = ConfigModel(
+        agents=["A", "B"],
+        loops=1,
+        distributed=True,
+        distributed_config=DistributedConfig(enabled=True, num_cpus=2),
+    )
+    executor = RayExecutor(cfg)
+    resp = executor.run_query("q")
+    assert isinstance(resp, QueryResponse)
+    assert len(set(pids)) > 1
+    assert len(executor.result_aggregator.results) == len(cfg.agents)
+    executor.shutdown()
+    ray.shutdown()


### PR DESCRIPTION
## Summary
- implement `ResultAggregator` and coordination helpers
- extend `RayExecutor` to send results via message queues
- add integration test verifying multi-process aggregation

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError, attribute errors)*
- `poetry run pytest -q` *(fails: missing `matplotlib`)*
- `poetry run pytest tests/behavior` *(fails: API auth test)*

------
https://chatgpt.com/codex/tasks/task_e_686430b42ce083338e638897da519124