### PR TITLE
Update mypy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ markers = [
 [tool.mypy]
 python_version = "3.12"
 ignore_missing_imports = true
+plugins = ["pydantic.mypy"]
 
 [tool.flake8]
 max-line-length = 100


### PR DESCRIPTION
## Summary
- configure mypy to load the pydantic plugin

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: `StorageManager._last_adaptive_policy` etc.)*
- `poetry run pytest -q` *(fails: KeyboardInterrupt during test discovery)*
- `poetry run pytest tests/behavior` *(fails: KeyboardInterrupt during import)*

------
https://chatgpt.com/codex/tasks/task_e_686435d808908333bee39953f2e43fc6