### PR TITLE
Add graph layout option and update help tests

### DIFF
--- a/src/autoresearch/cli_utils.py
+++ b/src/autoresearch/cli_utils.py
@@ -243,8 +243,18 @@ def sparql_query_cli(query: str, engine: str | None = None, apply_reasoning: boo
     console.print(tabulate(rows, headers=headers, tablefmt="github"))
 
 
-def visualize_query_cli(query: str, output_path: str) -> None:
-    """Run a query and save a knowledge graph visualization."""
+def visualize_query_cli(query: str, output_path: str, *, layout: str = "spring") -> None:
+    """Run a query and save a knowledge graph visualization.
+
+    Parameters
+    ----------
+    query:
+        Natural language query to run.
+    output_path:
+        Where to save the rendered PNG image.
+    layout:
+        Layout algorithm for the graph visualization.
+    """
     from rich.progress import Progress
 
     from .config import ConfigLoader
@@ -269,7 +279,7 @@ def visualize_query_cli(query: str, output_path: str) -> None:
     OutputFormatter.format(result, fmt)
 
     try:
-        save_knowledge_graph(result, output_path)
+        save_knowledge_graph(result, output_path, layout=layout)
         print_success(f"Graph written to {output_path}")
     except Exception as e:  # pragma: no cover - optional dependency
         print_error(

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -1436,10 +1436,15 @@ def visualize(
     output: str = typer.Argument(
         "query_graph.png", help="Output PNG path for the visualization"
     ),
+    layout: str = typer.Option(
+        "spring",
+        "--layout",
+        help="Graph layout algorithm (spring or circular)",
+    ),
 ) -> None:
     """Run a query and render a knowledge graph."""
     try:
-        _cli_visualize_query(query, output)
+        _cli_visualize_query(query, output, layout=layout)
     except Exception:
         raise typer.Exit(1)
 

--- a/src/autoresearch/visualization.py
+++ b/src/autoresearch/visualization.py
@@ -13,7 +13,12 @@ from .models import QueryResponse
 matplotlib.use("Agg")
 
 
-def save_knowledge_graph(result: QueryResponse, output_path: str) -> None:
+def save_knowledge_graph(
+    result: QueryResponse,
+    output_path: str,
+    *,
+    layout: str = "spring",
+) -> None:
     """Save a simple knowledge graph visualization to ``output_path``.
 
     Parameters
@@ -22,6 +27,14 @@ def save_knowledge_graph(result: QueryResponse, output_path: str) -> None:
         The query response to visualize.
     output_path:
         Path to the PNG file to create.
+    Parameters
+    ----------
+    result:
+        The query response to visualize.
+    output_path:
+        Path to the PNG file to create.
+    layout:
+        Layout algorithm to use ("spring" or "circular").
     """
     G: nx.DiGraph[Any] = nx.DiGraph()
     main_query = "Query"
@@ -46,7 +59,10 @@ def save_knowledge_graph(result: QueryResponse, output_path: str) -> None:
             G.add_edge(rid, answer)
 
     plt.figure(figsize=(10, 8))
-    pos = nx.spring_layout(G, seed=42)
+    if layout == "circular":
+        pos = nx.circular_layout(G)
+    else:
+        pos = nx.spring_layout(G, seed=42)
     nx.draw(G, pos, with_labels=True, node_color="lightblue", font_size=8)
     plt.tight_layout()
     plt.savefig(output_path)

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -125,3 +125,60 @@ def test_search_loops_option(monkeypatch):
     result = runner.invoke(main.app, ["search", "q", "--loops", "4"])
     assert result.exit_code == 0
     assert captured["loops"] == 4
+
+
+def test_search_help_includes_ontology_flags(monkeypatch):
+    dummy_storage = types.ModuleType("autoresearch.storage")
+
+    class StorageManager:
+        @staticmethod
+        def persist_claim(claim):
+            pass
+
+        @staticmethod
+        def setup(*a, **k):
+            pass
+
+    dummy_storage.StorageManager = StorageManager
+    dummy_storage.setup = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+    from autoresearch.config import ConfigLoader, ConfigModel
+
+    def _load(self):
+        return ConfigModel(loops=1)
+
+    monkeypatch.setattr(ConfigLoader, "load_config", _load)
+    main = importlib.import_module("autoresearch.main")
+    runner = CliRunner()
+    result = runner.invoke(main.app, ["search", "--help"])
+    assert result.exit_code == 0
+    assert "--ontology-reasoner" in result.stdout
+    assert "--infer-relations" in result.stdout
+
+
+def test_visualize_help_includes_layout(monkeypatch):
+    dummy_storage = types.ModuleType("autoresearch.storage")
+
+    class StorageManager:
+        @staticmethod
+        def persist_claim(claim):
+            pass
+
+        @staticmethod
+        def setup(*a, **k):
+            pass
+
+    dummy_storage.StorageManager = StorageManager
+    dummy_storage.setup = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+    from autoresearch.config import ConfigLoader, ConfigModel
+
+    def _load(self):
+        return ConfigModel(loops=1)
+
+    monkeypatch.setattr(ConfigLoader, "load_config", _load)
+    main = importlib.import_module("autoresearch.main")
+    runner = CliRunner()
+    result = runner.invoke(main.app, ["visualize", "--help"])
+    assert result.exit_code == 0
+    assert "--layout" in result.stdout


### PR DESCRIPTION
## Summary
- allow custom layout algorithm when saving knowledge graphs
- expose `--layout` option in `visualize` command
- document layout option in CLI utils
- test ontology flags and layout option appear in CLI help

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: various type errors)*
- `poetry run pytest tests/unit/test_cli_help.py::test_visualize_help_includes_layout -q` *(fails: Coverage failure)*

------
https://chatgpt.com/codex/tasks/task_e_686439e222c48333a446f438d8a13a97