### PR TITLE
Add search weight optimizer

### DIFF
--- a/src/autoresearch/search.py
+++ b/src/autoresearch/search.py
@@ -831,6 +831,16 @@ class Search:
         return best
 
     @classmethod
+    def optimize_weights(
+        cls, data: Dict[str, List[Dict[str, float]]], step: float = 0.1
+    ) -> Tuple[Tuple[float, float, float], float]:
+        """Return the best weights and corresponding NDCG score."""
+
+        best = cls.tune_weights(data, step=step)
+        score = cls.evaluate_weights(best, data)
+        return best, score
+
+    @classmethod
     def register_backend(
         cls, name: str
     ) -> Callable[

--- a/tests/integration/test_grid_search_optimization.py
+++ b/tests/integration/test_grid_search_optimization.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from autoresearch.search import Search
+
+
+def test_optimize_weights_returns_better_score():
+    data_path = Path(__file__).resolve().parents[1] / "data" / "eval" / "sample_eval.csv"
+    data = Search.load_evaluation_data(data_path)
+
+    baseline = Search.evaluate_weights((0.5, 0.3, 0.2), data)
+    best, score = Search.optimize_weights(data, step=0.1)
+
+    assert score >= baseline
+    assert abs(sum(best) - 1.0) < 0.01


### PR DESCRIPTION
## Summary
- add `Search.optimize_weights` helper that returns optimized weights and score
- test that the optimizer improves NDCG using sample evaluation data

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src/autoresearch/search.py` *(fails: execution interrupted)*
- `poetry run pytest tests/integration/test_grid_search_optimization.py -q` *(fails: coverage requirement not met)*
- `poetry run pytest tests/behavior -q` *(fails: KeyboardInterrupt during import)*

------
https://chatgpt.com/codex/tasks/task_e_68646e01087c8333bbccdd13f4263130