### PR TITLE
Enable multiprocessing executor with broker support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,9 +248,10 @@ To run agents across multiple processes or machines, configure the `[distributed
 enabled = true
 address = "auto"
 num_cpus = 2
+message_broker = "memory"
 ```
 
-When enabled, `RayExecutor` dispatches agents to Ray workers for each cycle.
+When enabled, agents are dispatched to worker processes using Ray or the fallback `ProcessExecutor`. The optional `message_broker` setting selects a coordination backend for storage and result aggregation. The default `memory` broker uses an in-process queue.
 
 ## API Keys
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -57,3 +57,4 @@ enabled, agents within a cycle are dispatched to Ray workers and combined back
 into a single `QueryState`. See `autoresearch.distributed.RayExecutor` for the
 implementation details.
 
+Two executors are available for distributed mode: `RayExecutor` uses Ray while `ProcessExecutor` relies on Python's multiprocessing. Both can coordinate storage and results via a message broker.

--- a/src/autoresearch/__init__.py
+++ b/src/autoresearch/__init__.py
@@ -5,6 +5,7 @@ interfaces and a modular architecture.
 """
 
 from .distributed import (
+    ProcessExecutor,
     RayExecutor,
     StorageCoordinator,
     ResultAggregator,
@@ -16,6 +17,7 @@ from .distributed import (
 
 __all__ = [
     "RayExecutor",
+    "ProcessExecutor",
     "StorageCoordinator",
     "ResultAggregator",
     "InMemoryBroker",

--- a/tests/integration/test_process_executor.py
+++ b/tests/integration/test_process_executor.py
@@ -1,0 +1,54 @@
+import os
+from autoresearch.distributed import ProcessExecutor
+from autoresearch.config import ConfigModel, DistributedConfig
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import AgentFactory
+from autoresearch.orchestration.state import QueryState
+
+
+class DummyAgent:
+    def __init__(self, name: str, pids: list[int]):
+        self.name = name
+        self._pids = pids
+
+    def can_execute(self, state: QueryState, config: ConfigModel) -> bool:  # pragma: no cover - dummy
+        return True
+
+    def execute(self, state: QueryState, config: ConfigModel, **_: object) -> dict:
+        self._pids.append(os.getpid())
+        state.update({"results": {self.name: "ok"}})
+        return {"results": {self.name: "ok"}}
+
+
+def test_process_executor_multi_process(monkeypatch):
+    pids: list[int] = []
+    monkeypatch.setattr(AgentFactory, "get", lambda name: DummyAgent(name, pids))
+    cfg = ConfigModel(
+        agents=["A", "B"],
+        loops=1,
+        distributed=True,
+        distributed_config=DistributedConfig(enabled=True, num_cpus=2),
+    )
+    executor = ProcessExecutor(cfg)
+    resp = executor.run_query("q")
+    assert isinstance(resp, QueryResponse)
+    assert len(set(pids)) > 1
+    executor.shutdown()
+
+
+def test_process_result_aggregation(monkeypatch):
+    pids: list[int] = []
+    monkeypatch.setattr(AgentFactory, "get", lambda name: DummyAgent(name, pids))
+    cfg = ConfigModel(
+        agents=["A", "B"],
+        loops=1,
+        distributed=True,
+        distributed_config=DistributedConfig(enabled=True, num_cpus=2),
+    )
+    executor = ProcessExecutor(cfg)
+    resp = executor.run_query("q")
+    assert isinstance(resp, QueryResponse)
+    assert len(set(pids)) > 1
+    assert executor.result_aggregator is not None
+    assert len(executor.result_aggregator.results) == len(cfg.agents)
+    executor.shutdown()


### PR DESCRIPTION
## Summary
- support Python multiprocessing executor alongside Ray
- coordinate results via optional message broker
- document new distributed settings
- test process executor in integration suite

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 47 errors)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `poetry run pytest tests/behavior` *(fails: FileNotFoundError: release_tokens.json)*

------
https://chatgpt.com/codex/tasks/task_e_68646ddbf50883339d488c2baff2c86c