### PR TITLE
Add minimal extras and installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ Use Go Task to create platform-specific wheels:
 ```bash
 task wheels
 ```
+### Upgrading
+To upgrade Autoresearch run:
+```bash
+poetry update
+```
+If installed via pip:
+```bash
+pip install -U autoresearch
+```
+Run the installer to resolve optional dependencies automatically:
+```bash
+python scripts/installer.py --minimal
+```
+
 
 ## Quick start
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -86,3 +86,14 @@ To publish a development build to the TestPyPI repository run:
 ```bash
 ./scripts/publish_dev.py
 ```
+## Upgrading
+Run `poetry update` to refresh an existing installation.
+For pip based installs use:
+```bash
+pip install -U autoresearch
+```
+You can also run the installer script which detects the platform and installs optional extras:
+```bash
+python scripts/installer.py
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,20 @@ dependencies = [
     "tabulate (>=0.9.0,<0.10.0)",
     "ray (>=2.10.0,<3.0.0)"
 ]
+[project.optional-dependencies]
+minimal = [
+    "sentence-transformers"
+]
+full = [
+    "sentence-transformers",
+    "spacy",
+    "bertopic",
+    "pynndescent",
+    "scipy",
+    "transformers",
+    "ray"
+]
+
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Platform aware installer for Autoresearch.
+
+This script checks basic platform requirements and installs optional
+dependencies using Poetry. Pass ``--minimal`` to install only the
+minimal optional dependencies. Without flags, all optional extras will
+be installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import subprocess
+import sys
+from typing import List
+
+MIN_VERSION = (3, 12)
+
+
+def check_python() -> None:
+    """Ensure the running Python meets the minimum version."""
+    if sys.version_info < MIN_VERSION:
+        sys.exit(
+            f"Python {MIN_VERSION[0]}.{MIN_VERSION[1]}+ is required, "
+            f"found {sys.version.split()[0]}"
+        )
+
+
+def run(cmd: List[str]) -> None:
+    """Execute a command and exit on failure."""
+    print(" ".join(cmd))
+    subprocess.check_call(cmd)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Install Autoresearch")
+    parser.add_argument(
+        "--minimal",
+        action="store_true",
+        help="Install only minimal optional dependencies",
+    )
+    args = parser.parse_args()
+
+    check_python()
+
+    # Select extras set
+    extras = ["minimal"] if args.minimal else ["full"]
+
+    # Ensure Poetry uses the current interpreter
+    run(["poetry", "env", "use", sys.executable])
+
+    cmd = ["poetry", "install", "--with", "dev", "--extras"] + extras
+    run(cmd)
+
+    print("Installation complete on", platform.platform())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- define optional `minimal` and `full` extras in **pyproject.toml**
- add a platform-aware installer helper
- document upgrade workflow in README and deployment guide

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: StorageManager attributes missing)*
- `poetry run pytest -q` *(fails: heavy dependency compilation)*
- `poetry run pytest tests/behavior -q` *(fails: heavy dependency compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68646e11ec988333ab5000b563979fce