### PR TITLE
Add GPU metrics to monitoring

### DIFF
--- a/src/autoresearch/monitor/__init__.py
+++ b/src/autoresearch/monitor/__init__.py
@@ -154,7 +154,7 @@ def metrics(watch: bool = typer.Option(False, "--watch", "-w", help="Refresh con
 def resources(
     duration: int = typer.Option(5, "--duration", "-d", help="Seconds to monitor")
 ) -> None:
-    """Record CPU and memory usage over time."""
+    """Record CPU, memory and GPU usage over time."""
     console = Console()
     tracker = orch_metrics.OrchestrationMetrics()
     end_time = time.time() + duration
@@ -169,9 +169,17 @@ def resources(
     table.add_column("Time")
     table.add_column("CPU %")
     table.add_column("Memory MB")
+    table.add_column("GPU %")
+    table.add_column("GPU MB")
     for rec in tracker.get_summary()["resource_usage"]:
         t = time.strftime("%H:%M:%S", time.localtime(rec["timestamp"]))
-        table.add_row(t, f"{rec['cpu_percent']:.2f}", f"{rec['memory_mb']:.2f}")
+        table.add_row(
+            t,
+            f"{rec['cpu_percent']:.2f}",
+            f"{rec['memory_mb']:.2f}",
+            f"{rec.get('gpu_percent', 0.0):.2f}",
+            f"{rec.get('gpu_memory_mb', 0.0):.2f}",
+        )
     console.print(table)
 
 

--- a/src/autoresearch/storage_backends.py
+++ b/src/autoresearch/storage_backends.py
@@ -89,7 +89,11 @@ class DuckDBStorageBackend:
                 raise StorageError("Failed to connect to DuckDB database", cause=e)
 
             # Create connection pool
-            self._max_connections = getattr(cfg, "max_connections", 1)
+            max_conn = getattr(cfg, "max_connections", 1)
+            try:
+                self._max_connections = int(max_conn)
+            except Exception:
+                self._max_connections = 1
             self._pool = Queue(maxsize=self._max_connections)
             self._pool.put(self._conn)
             for _ in range(self._max_connections - 1):

--- a/tests/integration/test_monitor_metrics.py
+++ b/tests/integration/test_monitor_metrics.py
@@ -51,6 +51,8 @@ def test_resource_monitor_collects_metrics():
     data = generate_latest(registry).decode()
     assert "autoresearch_cpu_percent" in data
     assert "autoresearch_memory_mb" in data
+    assert "autoresearch_gpu_percent" in data
+    assert "autoresearch_gpu_memory_mb" in data
 
 
 def test_system_monitor_metrics_exposed(monkeypatch):
@@ -96,3 +98,17 @@ def test_monitor_start_cli(monkeypatch):
     assert calls["stop"]
     assert calls["sys_start"]
     assert calls["sys_stop"]
+
+
+def test_monitor_resources_cli(monkeypatch):
+    monkeypatch.setattr(
+        metrics,
+        "_get_system_usage",
+        lambda: (10.0, 20.0, 30.0, 40.0),
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["monitor", "resources", "--duration", "1"])
+    assert result.exit_code == 0
+    out = result.stdout
+    assert "GPU %" in out
+    assert "GPU MB" in out

--- a/tests/targeted/test_metrics_extra.py
+++ b/tests/targeted/test_metrics_extra.py
@@ -23,10 +23,12 @@ def test_resource_tracking(monkeypatch):
     monkeypatch.setattr(
         metrics,
         "_get_system_usage",
-        lambda: (50.0, 100.0),
+        lambda: (50.0, 100.0, 25.0, 512.0),
     )
     m = metrics.OrchestrationMetrics()
     m.record_system_resources()
     rec = m.get_summary()["resource_usage"][0]
     assert rec["cpu_percent"] == 50.0
     assert rec["memory_mb"] == 100.0
+    assert rec["gpu_percent"] == 25.0
+    assert rec["gpu_memory_mb"] == 512.0


### PR DESCRIPTION
## Summary
- extend resource monitor to detect GPU stats via NVML
- include GPU memory and utilization in metrics and CLI display
- adjust orchestrator metrics to track GPU usage
- update storage backend connection handling for tests
- update tests for GPU metrics

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 47 errors)*
- `poetry run pytest tests/integration/test_monitor_metrics.py tests/targeted/test_metrics_extra.py -q` *(fails: Authorization error)*

------
https://chatgpt.com/codex/tasks/task_e_68646e04be8c83339c79722d748a2c8b