### PR TITLE
Add connection pools for LLM and search

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,7 @@ These options are set in the `[core]` section of the configuration file.
 | Option | Type | Default | Description | Valid Values |
 |--------|------|---------|-------------|-------------|
 | `llm_backend` | string | `"lmstudio"` | The LLM adapter to use | `"lmstudio"`, `"openai"`, `"openrouter"`, `"dummy"` |
+| `llm_pool_size` | integer | `2` | Size of the HTTP connection pool for LLM adapters | ≥ 1 |
 | `loops` | integer | `2` | Number of reasoning cycles to run | ≥ 1 |
 | `ram_budget_mb` | integer | `1024` | Memory budget in megabytes | ≥ 0 |
 | `token_budget` | integer | `null` | Maximum tokens allowed per run. When set, the orchestrator adapts this value based on query length, loop count, and parallel group size to avoid wasting tokens. | ≥ 1 or `null` |
@@ -137,6 +138,7 @@ These options are set in the `[search]` section.
 | `citation_count_factor` | float | `0.4` | Weight for citation count | 0.0 to 1.0 |
 | `use_feedback` | boolean | `false` | Use user feedback for ranking | `true`, `false` |
 | `feedback_weight` | float | `0.3` | Weight for user feedback | 0.0 to 1.0 |
+| `http_pool_size` | integer | `10` | Size of HTTP connection pool for web backends | ≥ 1 |
 
 **Note**: `semantic_similarity_weight`, `bm25_weight`, and `source_credibility_weight` must sum to 1.0.
 

--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -114,6 +114,7 @@ class SearchConfig(BaseModel):
 
     # Thread pool settings for concurrent search backends
     max_workers: int = Field(default=4, ge=1)
+    http_pool_size: int = Field(default=10, ge=1)
 
     @field_validator(
         "semantic_similarity_weight", "bm25_weight", "source_credibility_weight"
@@ -251,6 +252,7 @@ class ConfigModel(BaseSettings):
     # Core settings
     backend: str = Field(default="lmstudio")  # backward compatibility
     llm_backend: str = Field(default="lmstudio")
+    llm_pool_size: int = Field(default=2, ge=1)
     loops: int = Field(default=2, ge=1)
     ram_budget_mb: int = Field(default=1024, ge=0)
     token_budget: Optional[int] = Field(

--- a/src/autoresearch/llm/__init__.py
+++ b/src/autoresearch/llm/__init__.py
@@ -12,6 +12,7 @@ from .adapters import (
     OpenAIAdapter,
     OpenRouterAdapter,
 )
+from .pool import get_session, close_session
 
 # Register default backends
 LLMFactory.register("dummy", DummyAdapter)
@@ -28,4 +29,6 @@ __all__ = [
     "LMStudioAdapter",
     "OpenAIAdapter",
     "OpenRouterAdapter",
+    "get_session",
+    "close_session",
 ]

--- a/src/autoresearch/llm/adapters.py
+++ b/src/autoresearch/llm/adapters.py
@@ -15,6 +15,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict
 import os
 import requests
+from .pool import get_session
 
 
 class LLMAdapter(ABC):
@@ -135,7 +136,8 @@ class LMStudioAdapter(LLMAdapter):
                 "model": model,
                 "messages": [{"role": "user", "content": prompt}],
             }
-            resp = requests.post(self.endpoint, json=payload, timeout=30)
+            session = get_session()
+            resp = session.post(self.endpoint, json=payload, timeout=30)
             resp.raise_for_status()
             data: Dict[str, Any] = resp.json()
             return str(
@@ -199,7 +201,8 @@ class OpenAIAdapter(LLMAdapter):
                 "messages": [{"role": "user", "content": prompt}],
             }
             headers = {"Authorization": f"Bearer {self.api_key}"}
-            resp = requests.post(
+            session = get_session()
+            resp = session.post(
                 self.endpoint, json=payload, headers=headers, timeout=30
             )
             resp.raise_for_status()
@@ -280,7 +283,8 @@ class OpenRouterAdapter(LLMAdapter):
                 "HTTP-Referer": "https://github.com/ravenoak/autoresearch",
                 "X-Title": "Autoresearch",
             }
-            resp = requests.post(
+            session = get_session()
+            resp = session.post(
                 self.endpoint, json=payload, headers=headers, timeout=60
             )
             resp.raise_for_status()

--- a/src/autoresearch/llm/pool.py
+++ b/src/autoresearch/llm/pool.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Optional
+from threading import Lock
+import requests
+
+from ..config import get_config
+
+_session: Optional[requests.Session] = None
+_lock = Lock()
+
+
+def get_session() -> requests.Session:
+    """Return a pooled HTTP session for LLM adapters."""
+    global _session
+    with _lock:
+        if _session is None:
+            cfg = get_config()
+            size = getattr(cfg, "llm_pool_size", 2)
+            session = requests.Session()
+            adapter = requests.adapters.HTTPAdapter(
+                pool_connections=size,
+                pool_maxsize=size,
+            )
+            session.mount("http://", adapter)
+            session.mount("https://", adapter)
+            _session = session
+        return _session
+
+
+def close_session() -> None:
+    """Close the pooled HTTP session."""
+    global _session
+    with _lock:
+        if _session is not None:
+            _session.close()
+            _session = None

--- a/tests/integration/test_connection_pool.py
+++ b/tests/integration/test_connection_pool.py
@@ -1,0 +1,54 @@
+import autoresearch.search as search
+from autoresearch.llm.adapters import LMStudioAdapter
+from autoresearch.config import ConfigModel
+from autoresearch.llm import pool as llm_pool
+
+
+def test_search_session_reuse_and_cleanup(monkeypatch):
+    cfg = ConfigModel(loops=1)
+    cfg.search.backends = ["dummy"]
+    cfg.search.context_aware.enabled = False
+    session_ids = []
+
+    def dummy_backend(q, max_results=5):
+        session_ids.append(id(search.get_http_session()))
+        return []
+
+    monkeypatch.setitem(search.Search.backends, "dummy", dummy_backend)
+    monkeypatch.setattr("autoresearch.search.get_config", lambda: cfg)
+
+    search.Search.external_lookup("a")
+    search.Search.external_lookup("b")
+    assert len(set(session_ids)) == 1
+
+    first = session_ids[0]
+    search.close_http_session()
+    search.Search.external_lookup("c")
+    assert session_ids[-1] != first
+
+
+def test_llm_session_reuse_and_cleanup(monkeypatch):
+    session_ids = []
+
+    def mock_post(self, url, json=None, timeout=30, headers=None):
+        session_ids.append(id(self))
+        class R:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"choices": [{"message": {"content": "ok"}}]}
+        return R()
+
+    session = llm_pool.get_session()
+    monkeypatch.setattr(session, "post", mock_post)
+
+    adapter = LMStudioAdapter()
+    adapter.generate("hi")
+    adapter.generate("there")
+    assert len(set(session_ids)) == 1
+
+    first = session_ids[0]
+    llm_pool.close_session()
+    session2 = llm_pool.get_session()
+    assert id(session2) != first
+


### PR DESCRIPTION
## Summary
- allow tuning pool sizes in configuration
- share HTTP sessions for web search backends
- reuse HTTP session for LLM adapters
- document new options
- test that pooled resources are reused and can be reset

## Testing
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: Error importing plugin 'pydantic')*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_6866cb7068408333b2ea0000b31bd01b