### PR TITLE
Implement distributed storage coordinator

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -73,6 +73,23 @@ task wheels  # builds wheels for Linux, Windows and macOS
 
 The wheels will be placed under the `dist/` directory.
 
+## Distributed Deployment
+
+For large-scale workloads you can run Autoresearch on a Ray cluster.  Set
+`distributed=true` in your configuration and provide the Ray address in the
+`[distributed]` section:
+
+```toml
+[distributed]
+enabled = true
+address = "ray://head-node:10001"
+num_cpus = 4
+message_broker = "memory"
+```
+
+When started with this configuration, agents are dispatched to remote workers and all
+claim persistence is coordinated through a background `StorageCoordinator`.
+
 ## Deployment Checks
 
 After starting the service, run the deployment script to validate configuration and perform a health check:

--- a/src/autoresearch/distributed.py
+++ b/src/autoresearch/distributed.py
@@ -149,6 +149,7 @@ class RayExecutor:
         self.result_broker: Optional[InMemoryBroker] = None
         if getattr(config, "distributed", False):
             self.storage_coordinator, self.broker = start_storage_coordinator(config)
+            storage.set_message_queue(self.broker.queue)
             self.result_aggregator, self.result_broker = start_result_aggregator(config)
 
     def run_query(self, query: str, callbacks: Dict[str, Callable[..., None]] | None = None) -> QueryResponse:
@@ -187,6 +188,7 @@ class RayExecutor:
             self.broker.publish({"action": "stop"})
             self.storage_coordinator.join()
             self.broker.shutdown()
+            storage.set_message_queue(None)
         if self.result_broker and self.result_aggregator:
             self.result_broker.publish({"action": "stop"})
             self.result_aggregator.join()
@@ -205,6 +207,7 @@ class ProcessExecutor:
         self.result_broker: Optional[InMemoryBroker] = None
         if getattr(config, "distributed", False):
             self.storage_coordinator, self.broker = start_storage_coordinator(config)
+            storage.set_message_queue(self.broker.queue)
             self.result_aggregator, self.result_broker = start_result_aggregator(config)
 
     def run_query(self, query: str, callbacks: Dict[str, Callable[..., None]] | None = None) -> QueryResponse:
@@ -234,6 +237,7 @@ class ProcessExecutor:
             self.broker.publish({"action": "stop"})
             self.storage_coordinator.join()
             self.broker.shutdown()
+            storage.set_message_queue(None)
         if self.result_broker and self.result_aggregator:
             self.result_broker.publish({"action": "stop"})
             self.result_aggregator.join()

--- a/tests/integration/test_distributed_agent_storage.py
+++ b/tests/integration/test_distributed_agent_storage.py
@@ -1,0 +1,43 @@
+import os
+import ray
+from autoresearch.distributed import RayExecutor
+from autoresearch.config import ConfigModel, DistributedConfig, StorageConfig
+from autoresearch.storage import StorageManager
+from autoresearch.orchestration.orchestrator import AgentFactory
+from autoresearch.orchestration.state import QueryState
+
+
+class ClaimAgent:
+    def __init__(self, name: str, pids: list[int]):
+        self.name = name
+        self._pids = pids
+
+    def can_execute(self, state: QueryState, config: ConfigModel) -> bool:  # pragma: no cover - dummy
+        return True
+
+    def execute(self, state: QueryState, config: ConfigModel, **_: object) -> dict:
+        self._pids.append(os.getpid())
+        StorageManager.persist_claim({"id": self.name, "type": "fact", "content": "x"})
+        state.update({"results": {self.name: "ok"}})
+        return {"results": {self.name: "ok"}}
+
+
+def test_distributed_storage_with_executor(tmp_path, monkeypatch):
+    pids: list[int] = []
+    monkeypatch.setattr(AgentFactory, "get", lambda name: ClaimAgent(name, pids))
+    cfg = ConfigModel(
+        agents=["A", "B"],
+        loops=1,
+        distributed=True,
+        distributed_config=DistributedConfig(enabled=True, num_cpus=2),
+        storage=StorageConfig(duckdb_path=str(tmp_path / "kg.duckdb")),
+    )
+    executor = RayExecutor(cfg)
+    executor.run_query("q")
+    assert len(set(pids)) > 1
+    executor.shutdown()
+    StorageManager.setup(str(tmp_path / "kg.duckdb"))
+    conn = StorageManager.get_duckdb_conn()
+    rows = conn.execute("SELECT id FROM nodes ORDER BY id").fetchall()
+    assert [r[0] for r in rows] == ["A", "B"]
+    ray.shutdown()


### PR DESCRIPTION
## Summary
- enable distributed persistence via message queues
- hook RayExecutor and ProcessExecutor into the StorageCoordinator
- test distributed storage through RayExecutor
- document distributed cluster usage

## Testing
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: missing dependencies)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError)*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6866cb6afb8c833383893a5a41667cbf