### PR TITLE
Expose runtime config endpoints and async query status

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -112,6 +112,40 @@ Return information about available agents, LLM backends and current settings.
 curl http://localhost:8000/capabilities
 ```
 
+### `GET /config`
+
+Return the current configuration as JSON.
+
+```bash
+curl http://localhost:8000/config
+```
+
+### `PUT /config`
+
+Update configuration values at runtime. Only fields present in the JSON body are
+modified.
+
+```bash
+curl -X PUT http://localhost:8000/config -H "Content-Type: application/json" \
+     -d '{"loops": 3}'
+```
+
+### `POST /query/async`
+
+Run a query in the background and return an identifier.
+
+```bash
+curl -X POST http://localhost:8000/query/async \
+  -H "Content-Type: application/json" \
+  -d '{"query": "Explain AI"}'
+```
+
+Check the result with `GET /query/<id>`:
+
+```bash
+curl http://localhost:8000/query/<id>
+```
+
 ## Authentication
 
 Enable API key authentication by setting `[api].api_key` in `autoresearch.toml`

--- a/tests/integration/test_api_additional.py
+++ b/tests/integration/test_api_additional.py
@@ -1,0 +1,71 @@
+from autoresearch.api import app as api_app
+from autoresearch.config import ConfigModel, ConfigLoader, APIConfig
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.models import QueryResponse
+from fastapi.testclient import TestClient
+import asyncio
+import time
+
+
+def _setup(monkeypatch):
+    cfg = ConfigModel(api=APIConfig())
+    # allow all permissions for anonymous for simplicity
+    cfg.api.role_permissions["anonymous"] = ["query", "metrics", "capabilities"]
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    return cfg
+
+
+def test_config_endpoints(monkeypatch):
+    cfg = _setup(monkeypatch)
+    client = TestClient(api_app)
+
+    resp = client.get("/config")
+    assert resp.status_code == 200
+    assert resp.json()["loops"] == cfg.loops
+
+    resp = client.put("/config", json={"loops": 3})
+    assert resp.status_code == 200
+    assert resp.json()["loops"] == 3
+
+
+def test_async_query_status(monkeypatch):
+    _setup(monkeypatch)
+
+    async def dummy_async(query, config, callbacks=None, **k):
+        await asyncio.sleep(0.01)
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+
+    monkeypatch.setattr(Orchestrator, "run_query_async", dummy_async)
+    client = TestClient(api_app)
+
+    resp = client.post("/query/async", json={"query": "hi"})
+    assert resp.status_code == 200
+    qid = resp.json()["query_id"]
+
+    running = client.get(f"/query/{qid}")
+    assert running.status_code == 200
+    assert running.json()["status"] == "running"
+
+    time.sleep(0.05)
+    done = client.get(f"/query/{qid}")
+    assert done.status_code == 200
+    assert done.json()["answer"] == "ok"
+
+
+def test_metrics_and_capabilities(monkeypatch):
+    _setup(monkeypatch)
+    client = TestClient(api_app)
+
+    assert client.get("/metrics").status_code == 200
+    cap = client.get("/capabilities")
+    assert cap.status_code == 200
+    assert "llm_backends" in cap.json()
+
+
+def test_openapi_lists_new_routes(monkeypatch):
+    _setup(monkeypatch)
+    client = TestClient(api_app)
+    schema = client.get("/openapi.json").json()
+    assert "/config" in schema["paths"]
+    assert "/query/async" in schema["paths"]
+    assert "/query/{query_id}" in schema["paths"]


### PR DESCRIPTION
## Summary
- add `/config` endpoints for runtime configuration management
- support asynchronous queries with status polling
- document new routes in the API docs
- extend OpenAPI docs with full endpoint list
- integration tests for the additional endpoints

## Testing
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: No module named 'pydantic')*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_6866cb613944833385f30057e3203eee