### PR TITLE
Implement query token monitoring

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -500,6 +500,15 @@ autoresearch query "What are the implications of AI on labor markets?"
 
 The monitor shows real-time information about agent execution, token usage, and system state.
 
+## Adaptive Token Budgeting
+
+Autoresearch automatically scales the available token budget based on the
+complexity of each query. The orchestrator considers query length and the number
+of loops, capping excessive budgets while ensuring enough tokens are available.
+When agents run in parallel groups each group receives a fair share of the
+budget. Usage per query is stored in `tests/integration/baselines/query_tokens.json`
+so the `check_token_regression.py` script can detect regressions.
+
 ## Prompt Compression
 
 When prompts grow too long they may exceed the available token budget. The `autoresearch.synthesis` module provides utilities that shorten prompts by truncating the middle section and inserting an ellipsis. This keeps essential context while staying under the limit.

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -772,6 +772,7 @@ class Orchestrator:
             # End cycle and update metrics
             metrics.end_cycle()
             state.metadata["execution_metrics"] = metrics.get_summary()
+            metrics.record_query_tokens(state.query)
 
             # Prune context to keep state size manageable
             state.prune_context()
@@ -1039,6 +1040,7 @@ class Orchestrator:
 
         # Add final metrics to state
         state.metadata["execution_metrics"] = metrics.get_summary()
+        metrics.record_query_tokens(query)
 
         # Raise error if process aborted or if there were any errors
         if "error" in state.results or state.error_count > 0:

--- a/tests/unit/test_token_monitoring.py
+++ b/tests/unit/test_token_monitoring.py
@@ -1,0 +1,22 @@
+import json
+
+from autoresearch.orchestration.metrics import OrchestrationMetrics
+
+
+def test_record_and_regression(tmp_path):
+    metrics = OrchestrationMetrics()
+    metrics.record_tokens("A", 2, 3)
+    metrics.record_tokens("B", 1, 1)
+
+    metrics_path = tmp_path / "metrics.json"
+    baseline_path = tmp_path / "baseline.json"
+
+    # baseline lower than current total (7)
+    baseline_path.write_text(json.dumps({"q": 5}))
+
+    metrics.record_query_tokens("q", metrics_path)
+    saved = json.loads(metrics_path.read_text())
+    assert saved["q"] == 7
+
+    assert metrics.check_query_regression("q", baseline_path) is True
+    assert metrics.check_query_regression("q", baseline_path, threshold=2) is False


### PR DESCRIPTION
## Summary
- monitor total tokens for each query
- expose helper to check token regression
- log token totals when executing a query
- document adaptive budgets
- test query token monitoring logic

## Testing
- `flake8 src tests`
- `mypy src` *(fails: Library stubs not installed for "requests")*
- `pytest tests/unit/test_token_monitoring.py::test_record_and_regression --cov=src --cov=tests/unit/test_token_monitoring.py --cov-report=term --cov-fail-under=0 -q`
- `pytest tests/behavior -q` *(fails: FileNotFoundError: release_tokens.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866cb5c60b48333a3ca02cdaea82d3b