### PR TITLE
Improve dark mode and add TUI graph option

### DIFF
--- a/src/autoresearch/monitor/__init__.py
+++ b/src/autoresearch/monitor/__init__.py
@@ -186,11 +186,17 @@ def resources(
 @monitor_app.command("graph")
 def graph(
     tree: bool = typer.Option(False, "--tree", help="Show graph as a tree"),
+    tui: bool = typer.Option(False, "--tui", help="Display graph in TUI panel"),
 ) -> None:
     """Display a simple textual view of the knowledge graph."""
     console = Console()
     data = _collect_graph_data()
-    console.print(_render_graph(data, tree=tree))
+    if tui:
+        from rich.panel import Panel
+
+        console.print(Panel(_render_graph(data, tree=True), title="Graph View"))
+    else:
+        console.print(_render_graph(data, tree=tree))
 
 
 @monitor_app.command("run")

--- a/src/autoresearch/streamlit_app.py
+++ b/src/autoresearch/streamlit_app.py
@@ -158,7 +158,13 @@ def apply_accessibility_settings() -> None:
             """
             <style>
             body, .stApp {background-color:#000 !important; color:#fff !important;}
-            .stButton>button {background-color:#fff !important; color:#000 !important;}
+            a {color:#0ff !important; text-decoration: underline !important;}
+            .stButton>button {
+                background-color:#fff !important;
+                color:#000 !important;
+                border:2px solid #fff !important;
+            }
+            .stSidebar {background-color:#000 !important;}
             </style>
             """,
             unsafe_allow_html=True,
@@ -171,7 +177,8 @@ def apply_theme_settings() -> None:
         st.markdown(
             """
             <style>
-            body, .stApp {background-color:#1e1e1e !important; color:#e0e0e0 !important;}
+            body, .stApp {background-color:#1c1c1c !important; color:#e0e0e0 !important;}
+            a {color:#93c5fd !important;}
             .stButton>button {background-color:#444 !important; color:#fff !important;}
             .stSidebar {background-color:#2c2c2c !important;}
             </style>

--- a/tests/behavior/features/interactive_monitor.feature
+++ b/tests/behavior/features/interactive_monitor.feature
@@ -24,6 +24,11 @@ Feature: Interactive Monitoring
     Then the monitor should exit successfully
     And the monitor output should display graph data
 
+  Scenario: Display TUI graph
+    When I run `autoresearch monitor graph --tui`
+    Then the monitor should exit successfully
+    And the monitor output should display graph data
+
   Scenario: Visualize search results
     When I run `autoresearch search "Test graph" --visualize`
     Then the search command should exit successfully

--- a/tests/behavior/steps/interactive_monitor_steps.py
+++ b/tests/behavior/steps/interactive_monitor_steps.py
@@ -33,6 +33,16 @@ def run_graph(monkeypatch, bdd_context, cli_runner):
     bdd_context["monitor_result"] = result
 
 
+@when('I run `autoresearch monitor graph --tui`')
+def run_graph_tui(monkeypatch, bdd_context, cli_runner):
+    monkeypatch.setattr(
+        "autoresearch.monitor._collect_graph_data",
+        lambda: {"A": ["B", "C"]},
+    )
+    result = cli_runner.invoke(cli_app, ["monitor", "graph", "--tui"])
+    bdd_context["monitor_result"] = result
+
+
 @when(parsers.parse('I run `autoresearch search "{query}" --visualize`'))
 def run_search_visualize(query, monkeypatch, bdd_context, cli_runner):
     from autoresearch.orchestration.orchestrator import Orchestrator
@@ -101,6 +111,11 @@ def test_monitor_metrics(bdd_context):
 
 @scenario("../features/interactive_monitor.feature", "Display graph")
 def test_monitor_graph(bdd_context):
+    assert bdd_context["monitor_result"].exit_code == 0
+
+
+@scenario("../features/interactive_monitor.feature", "Display TUI graph")
+def test_monitor_graph_tui(bdd_context):
     assert bdd_context["monitor_result"].exit_code == 0
 
 


### PR DESCRIPTION
## Summary
- tweak dark mode and high contrast styles in `streamlit_app.py`
- allow `autoresearch monitor graph` to show a Rich panel with `--tui`
- extend BDD tests for new TUI option

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'ray')*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError: No module named 'ray')*

------
https://chatgpt.com/codex/tasks/task_e_6866feaee68483339fe652a091b2dca0