### PR TITLE
Add GPU fallback and token snapshot metrics

### DIFF
--- a/tests/integration/test_monitor_metrics.py
+++ b/tests/integration/test_monitor_metrics.py
@@ -53,6 +53,9 @@ def test_resource_monitor_collects_metrics():
     assert "autoresearch_memory_mb" in data
     assert "autoresearch_gpu_percent" in data
     assert "autoresearch_gpu_memory_mb" in data
+    assert "autoresearch_tokens_in_snapshot_total" in data
+    assert "autoresearch_tokens_out_snapshot_total" in data
+    assert monitor.token_snapshots
 
 
 def test_system_monitor_metrics_exposed(monkeypatch):


### PR DESCRIPTION
## Summary
- extend `_get_gpu_stats` to use `nvidia-smi` when pynvml is unavailable
- track token usage snapshots in `ResourceMonitor` and expose them via Prometheus
- update monitor metrics integration test

## Testing
- `poetry run flake8 src/autoresearch/resource_monitor.py tests/integration/test_monitor_metrics.py`
- `poetry run mypy src/autoresearch/resource_monitor.py tests/integration/test_monitor_metrics.py`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'ray')*


------
https://chatgpt.com/codex/tasks/task_e_6866fea7f5888333884069e0f0ff0af2