### PR TITLE
Add example weights docs and fix tests

### DIFF
--- a/src/autoresearch/search.py
+++ b/src/autoresearch/search.py
@@ -98,6 +98,7 @@ def close_http_session() -> None:
             _http_session.close()
             _http_session = None
 
+
 log = get_logger(__name__)
 
 

--- a/tests/integration/test_connection_pool.py
+++ b/tests/integration/test_connection_pool.py
@@ -32,11 +32,15 @@ def test_llm_session_reuse_and_cleanup(monkeypatch):
 
     def mock_post(self, url, json=None, timeout=30, headers=None):
         session_ids.append(id(self))
+
         class R:
+
             def raise_for_status(self):
                 pass
+
             def json(self):
                 return {"choices": [{"message": {"content": "ok"}}]}
+
         return R()
 
     session = llm_pool.get_session()
@@ -51,4 +55,3 @@ def test_llm_session_reuse_and_cleanup(monkeypatch):
     llm_pool.close_session()
     session2 = llm_pool.get_session()
     assert id(session2) != first
-

--- a/tests/unit/test_additional_coverage.py
+++ b/tests/unit/test_additional_coverage.py
@@ -1,9 +1,7 @@
 import types
 import json
-import time
 from collections import OrderedDict
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -44,8 +42,11 @@ def test_circuit_breaker_transitions(monkeypatch):
 
 
 def test_http_session_reuse_and_close(monkeypatch):
-    class Cfg: pass
-    cfg = Cfg(); cfg.search = types.SimpleNamespace(http_pool_size=1)
+    class Cfg:
+        pass
+
+    cfg = Cfg()
+    cfg.search = types.SimpleNamespace(http_pool_size=1)
     monkeypatch.setattr(search, "get_config", lambda: cfg)
     search.close_http_session()
     s1 = search.get_http_session()
@@ -58,6 +59,7 @@ def test_http_session_reuse_and_close(monkeypatch):
 def test_set_get_delegate():
     class Dummy(StorageManager):
         called = False
+
         @classmethod
         def setup(cls, db_path=None):
             cls.called = True
@@ -103,4 +105,3 @@ def test_streamlit_metrics(monkeypatch):
     assert metrics_data["cpu_percent"] == 10.0
     assert metrics_data["tokens_in_total"] == 1
     assert metrics_data["tokens_out_total"] == 2
-


### PR DESCRIPTION
## Summary
- fix whitespace for HTTP session closing and update tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError: 'ray', etc.)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: 'ray')*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError: 'ray')*

------
https://chatgpt.com/codex/tasks/task_e_6866fea42dc08333b86d2c75ec2ca8ce