### PR TITLE
Finalize wheel build and minimal extras

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -42,16 +42,16 @@ tasks:
 
   wheel-linux:
     cmds:
-      - poetry run pip wheel . --wheel-dir dist/linux --no-deps --platform manylinux2014_x86_64 --abi cp312 --python-version 3.12
+      - poetry run cibuildwheel --platform linux --output-dir dist/linux
     desc: "Build Linux wheel"
 
   wheel-windows:
     cmds:
-      - poetry run pip wheel . --wheel-dir dist/windows --no-deps --platform win_amd64 --abi cp312 --python-version 3.12
+      - poetry run cibuildwheel --platform windows --output-dir dist/windows
     desc: "Build Windows wheel"
 
   wheel-macos:
     cmds:
-      - poetry run pip wheel . --wheel-dir dist/macos --no-deps --platform macosx_11_0_x86_64 --abi cp312 --python-version 3.12
+      - poetry run cibuildwheel --platform macos --output-dir dist/macos
     desc: "Build macOS wheel"
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -110,10 +110,11 @@ For pip based installs use:
 ```bash
 pip install -U autoresearch
 ```
-You can also run the installer script which detects the platform and installs optional extras:
+You can also run the installer script which resolves optional dependencies automatically:
 ```bash
-python scripts/installer.py
+python scripts/installer.py --minimal
 ```
+Omit `--minimal` to install all extras.
 
 ## Release workflow
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,10 +9,10 @@ This guide explains how to install Autoresearch and manage optional features.
 
 ## Minimal installation
 
-The project can be installed with only the core dependencies:
+The project can be installed with only the minimal optional dependencies:
 
 ```bash
-pip install autoresearch[core]
+pip install autoresearch[minimal]
 ```
 
 This provides the CLI, API and knowledge graph without heavy NLP or UI packages. Optional features will be disabled when their dependencies are missing.
@@ -31,7 +31,7 @@ Additional functionality is grouped into Poetry extras:
 Install multiple extras separated by commas:
 
 ```bash
-pip install "autoresearch[core,nlp,parsers]"
+pip install "autoresearch[minimal,nlp,parsers]"
 ```
 
 ## Upgrading

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ dependencies = [
     "tabulate (>=0.9.0,<0.10.0)"
 ]
 [project.optional-dependencies]
+minimal = [
+    "sentence-transformers (>=2.7.0,<3.0.0)"
+]
 core = [
     "sentence-transformers (>=2.7.0,<3.0.0)"
 ]
@@ -134,3 +137,6 @@ target-version = ["py312"]
 profile = "black"
 line_length = 100
 known_first_party = ["autoresearch", "tests"]
+
+[tool.cibuildwheel]
+build = "cp312-*"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ if "docx" not in sys.modules:
 if "streamlit" not in sys.modules:
     st_stub = types.ModuleType("streamlit")
     st_stub.markdown = lambda *a, **k: None
+
     class SessionState(dict):
         __getattr__ = dict.get
         __setattr__ = dict.__setitem__
@@ -43,9 +44,18 @@ if "streamlit" not in sys.modules:
     st_stub.selectbox = lambda *a, **k: None
     st_stub.slider = lambda *a, **k: 0
     st_stub.button = lambda *a, **k: False
-    st_stub.columns = lambda *a, **k: (types.SimpleNamespace(), types.SimpleNamespace())
-    st_stub.container = lambda: types.SimpleNamespace(__enter__=lambda s: None, __exit__=lambda s,e,t,b: None)
-    st_stub.modal = lambda *a, **k: types.SimpleNamespace(__enter__=lambda s: None, __exit__=lambda s,e,t,b: None)
+    st_stub.columns = lambda *a, **k: (
+        types.SimpleNamespace(),
+        types.SimpleNamespace(),
+    )
+    st_stub.container = lambda: types.SimpleNamespace(
+        __enter__=lambda s: None,
+        __exit__=lambda s, e, t, b: None,
+    )
+    st_stub.modal = lambda *a, **k: types.SimpleNamespace(
+        __enter__=lambda s: None,
+        __exit__=lambda s, e, t, b: None,
+    )
     sys.modules["streamlit"] = st_stub
 
 if "matplotlib" not in sys.modules:
@@ -81,9 +91,11 @@ from autoresearch.api import app as api_app
 import typer
 _orig_option = typer.Option
 
+
 def _compat_option(*args, **kwargs):
     kwargs.pop("multiple", None)
     return _orig_option(*args, **kwargs)
+
 
 typer.Option = _compat_option
 

--- a/tests/targeted/test_metrics_edgecases2.py
+++ b/tests/targeted/test_metrics_edgecases2.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 from autoresearch.orchestration import metrics
 
 

--- a/tests/targeted/test_orchestrator_edgecases2.py
+++ b/tests/targeted/test_orchestrator_edgecases2.py
@@ -1,5 +1,3 @@
-import types
-import pytest
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.orchestration.reasoning import ReasoningMode
 from autoresearch.orchestration.state import QueryState


### PR DESCRIPTION
## Summary
- add optional `minimal` install extras and pyproject build config
- update wheel build tasks to use `cibuildwheel`
- document minimal install in installation and deployment guides
- fix flake8 issues in tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Incompatible types in assignment)*
- `poetry run pytest -q` *(interrupted: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: FileNotFoundError)*
- `./scripts/publish_dev.py` *(fails: Repository testpypi is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686704cbc3488333b10a8b3ecf04955c