### PR TITLE
Add heuristics for token compression and budget

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -14,3 +14,11 @@ This collects metrics for ten seconds and displays them in a table. The duration
 
 You can also run `autoresearch monitor` to view a live stream of basic metrics.
 
+## Token Usage Heuristics
+
+The orchestration metrics module provides helpers to automatically compress
+prompts and adjust token budgets. After each cycle the orchestrator uses
+`suggest_token_budget` to expand or shrink the configured budget based on
+actual usage. `compress_prompt_if_needed` can shorten prompts when they exceed
+a given budget, helping prevent runaway token consumption.
+

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -773,6 +773,9 @@ class Orchestrator:
             metrics.end_cycle()
             state.metadata["execution_metrics"] = metrics.get_summary()
             metrics.record_query_tokens(state.query)
+            token_budget = getattr(config, "token_budget", None)
+            if token_budget is not None:
+                config.token_budget = metrics.suggest_token_budget(token_budget)
 
             # Prune context to keep state size manageable
             state.prune_context()
@@ -860,6 +863,9 @@ class Orchestrator:
 
             metrics.end_cycle()
             state.metadata["execution_metrics"] = metrics.get_summary()
+            token_budget = getattr(config, "token_budget", None)
+            if token_budget is not None:
+                config.token_budget = metrics.suggest_token_budget(token_budget)
 
             # Prune context to keep state size manageable
             state.prune_context()

--- a/tests/unit/test_metrics_heuristics.py
+++ b/tests/unit/test_metrics_heuristics.py
@@ -1,0 +1,16 @@
+from autoresearch.orchestration.metrics import OrchestrationMetrics
+
+
+def test_compress_prompt_if_needed():
+    m = OrchestrationMetrics()
+    prompt = "one two three four five"
+    compressed = m.compress_prompt_if_needed(prompt, 3)
+    assert len(compressed.split()) <= 3
+    assert m.compress_prompt_if_needed(prompt, 6) == prompt
+
+
+def test_suggest_token_budget():
+    m = OrchestrationMetrics()
+    m.record_tokens("A", 5, 5)
+    assert m.suggest_token_budget(8) == 11
+    assert m.suggest_token_budget(20) == 18


### PR DESCRIPTION
## Summary
- add prompt compression and dynamic budget helpers to `OrchestrationMetrics`
- adjust orchestrator cycles to adapt token budget using collected metrics
- document heuristics in `performance.md`
- add unit tests for new helpers

## Testing
- `poetry run flake8 src tests` *(fails: E231, F401, etc.)*
- `poetry run mypy src` *(fails: Found 20 errors)*
- `poetry run pytest -q` *(interrupted due to long runtime)*
- `poetry run pytest tests/behavior -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686704ab3c5c83338bb587087cb162bc