### PR TITLE
Implement health endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -112,6 +112,14 @@ Return information about available agents, LLM backends and current settings.
 curl http://localhost:8000/capabilities
 ```
 
+### `GET /health`
+
+Check whether the API server is running.
+
+```bash
+curl http://localhost:8000/health
+```
+
 ### `GET /config`
 
 Return the current configuration as JSON.

--- a/src/autoresearch/api.py
+++ b/src/autoresearch/api.py
@@ -513,6 +513,17 @@ def metrics_endpoint(_: None = require_permission("metrics")) -> PlainTextRespon
     return PlainTextResponse(data, media_type=CONTENT_TYPE_LATEST)
 
 
+@app.get("/health")
+def health_endpoint() -> dict:
+    """Simple health check endpoint.
+
+    Returns a JSON object indicating the server is running. This endpoint can be
+    used by deployment tooling or load balancers to verify the service status.
+    """
+
+    return {"status": "ok"}
+
+
 @app.get("/capabilities")
 def capabilities_endpoint(_: None = require_permission("capabilities")) -> dict:
     """Discover the capabilities of the Autoresearch system.

--- a/tests/integration/test_api_additional.py
+++ b/tests/integration/test_api_additional.py
@@ -69,3 +69,14 @@ def test_openapi_lists_new_routes(monkeypatch):
     assert "/config" in schema["paths"]
     assert "/query/async" in schema["paths"]
     assert "/query/{query_id}" in schema["paths"]
+
+
+def test_health_endpoint(monkeypatch):
+    """/health should return service status."""
+
+    _setup(monkeypatch)
+    client = TestClient(api_app)
+
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"


### PR DESCRIPTION
## Summary
- add `/health` endpoint to API and document usage
- document new endpoint in API documentation
- cover health check with integration test

## Testing
- `poetry run flake8 src tests` *(fails: E301 expected 1 blank line, and more)*
- `poetry run mypy src` *(fails: item has no attribute errors)*
- `poetry run pytest -q` *(interrupted: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: 1 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686704a7b1bc8333b5c07523d1c5b82f