### PR TITLE
Regenerate API docs

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -231,4 +231,5 @@ Current benchmark metrics for a single dummy query:
 - Duration: ~0.003s
 - Memory delta: ~0 MB
 - Tokens: {"Dummy": {"in": 2, "out": 7}}
+- Regenerated API docs and verified architecture diagrams against current code.
 

--- a/docs/api_reference/agents.md
+++ b/docs/api_reference/agents.md
@@ -78,6 +78,25 @@ The `Planner` agent structures complex research tasks into manageable steps.
 
 ::: autoresearch.agents.specialized.planner.PlannerAgent
 
+### Moderator
+
+The `Moderator` agent oversees complex dialogues and ensures smooth agent
+interactions.
+
+::: autoresearch.agents.specialized.moderator.ModeratorAgent
+
+### Domain Specialist
+
+The `DomainSpecialist` agent focuses on specialized subject matter expertise.
+
+::: autoresearch.agents.specialized.domain_specialist.DomainSpecialistAgent
+
+### User Agent
+
+The `UserAgent` represents user preferences and acts on the user's behalf.
+
+::: autoresearch.agents.specialized.user_agent.UserAgent
+
 ## Agent Mixins
 
 The agent mixins provide common functionality that can be shared across different agent types.

--- a/docs/api_reference/distributed.md
+++ b/docs/api_reference/distributed.md
@@ -1,0 +1,22 @@
+# Distributed Execution API
+
+This page documents the utilities for running agents in distributed mode using either Ray or standard multiprocessing.
+
+## Executors
+
+::: autoresearch.distributed.RayExecutor
+
+::: autoresearch.distributed.ProcessExecutor
+
+## Brokers
+
+::: autoresearch.distributed.InMemoryBroker
+::: autoresearch.distributed.RedisQueue
+
+## Coordination Helpers
+
+::: autoresearch.distributed.StorageCoordinator
+::: autoresearch.distributed.ResultAggregator
+::: autoresearch.distributed.start_storage_coordinator
+::: autoresearch.distributed.start_result_aggregator
+::: autoresearch.distributed.publish_claim

--- a/docs/api_reference/index.md
+++ b/docs/api_reference/index.md
@@ -54,4 +54,5 @@ For detailed documentation of each module, see the corresponding pages in this s
 - [LLM](llm.md): LLM adapters, registry, and token counting
 - [Search](search.md): Search functionality and backends
 - [Config](config.md): Configuration loading and management
+- [Distributed](distributed.md): Executors and helper utilities for distributed execution
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ if "docx" not in sys.modules:
 if "streamlit" not in sys.modules:
     st_stub = types.ModuleType("streamlit")
     st_stub.markdown = lambda *a, **k: None
+
     class SessionState(dict):
         __getattr__ = dict.get
         __setattr__ = dict.__setitem__
@@ -43,9 +44,18 @@ if "streamlit" not in sys.modules:
     st_stub.selectbox = lambda *a, **k: None
     st_stub.slider = lambda *a, **k: 0
     st_stub.button = lambda *a, **k: False
-    st_stub.columns = lambda *a, **k: (types.SimpleNamespace(), types.SimpleNamespace())
-    st_stub.container = lambda: types.SimpleNamespace(__enter__=lambda s: None, __exit__=lambda s,e,t,b: None)
-    st_stub.modal = lambda *a, **k: types.SimpleNamespace(__enter__=lambda s: None, __exit__=lambda s,e,t,b: None)
+    st_stub.columns = lambda *a, **k: (
+        types.SimpleNamespace(),
+        types.SimpleNamespace(),
+    )
+    st_stub.container = lambda: types.SimpleNamespace(
+        __enter__=lambda s: None,
+        __exit__=lambda s, e, t, b: None,
+    )
+    st_stub.modal = lambda *a, **k: types.SimpleNamespace(
+        __enter__=lambda s: None,
+        __exit__=lambda s, e, t, b: None,
+    )
     sys.modules["streamlit"] = st_stub
 
 if "matplotlib" not in sys.modules:
@@ -81,9 +91,11 @@ from autoresearch.api import app as api_app
 import typer
 _orig_option = typer.Option
 
+
 def _compat_option(*args, **kwargs):
     kwargs.pop("multiple", None)
     return _orig_option(*args, **kwargs)
+
 
 typer.Option = _compat_option
 

--- a/tests/targeted/test_metrics_edgecases2.py
+++ b/tests/targeted/test_metrics_edgecases2.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 from autoresearch.orchestration import metrics
 
 

--- a/tests/targeted/test_orchestrator_edgecases2.py
+++ b/tests/targeted/test_orchestrator_edgecases2.py
@@ -1,5 +1,3 @@
-import types
-import pytest
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.orchestration.reasoning import ReasoningMode
 from autoresearch.orchestration.state import QueryState


### PR DESCRIPTION
## Summary
- regenerate API docs with mkdocstrings
- add missing specialized agents to API reference
- document distributed execution utilities
- track documentation refresh in TASK_PROGRESS

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: incompatible types and missing attributes)*
- `poetry run pytest -q` *(interrupted)*
- `poetry run pytest tests/behavior` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6867049530108333bbd4af8d739491ce