### PR TITLE
Expose reasoning parameter flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ loops = 3
 # Maximum token budget per run
 token_budget = 4000
 
+# Adaptive token budgeting parameters
+adaptive_max_factor = 20
+adaptive_min_buffer = 10
+
+# Circuit breaker configuration
+circuit_breaker_threshold = 3
+circuit_breaker_cooldown = 30
+
 # Enable distributed tracing
 tracing_enabled = false
 
@@ -298,6 +306,13 @@ Set a custom token budget and number of reasoning loops:
 
 ```bash
 autoresearch search --loops 3 --token-budget 2000 "Explain AI ethics"
+```
+
+Customize circuit breaker settings and adaptive budgeting:
+
+```bash
+autoresearch search "Resilient run" --circuit-breaker-threshold 5 --circuit-breaker-cooldown 60 \
+  --adaptive-max-factor 25 --adaptive-min-buffer 20
 ```
 
 ### Using Different LLM Backends

--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -271,6 +271,16 @@ class ConfigModel(BaseSettings):
         ge=0,
         description="Minimum token buffer added when using adaptive budgeting",
     )
+    circuit_breaker_threshold: int = Field(
+        default=3,
+        ge=1,
+        description="Failure count before a circuit opens",
+    )
+    circuit_breaker_cooldown: int = Field(
+        default=30,
+        ge=1,
+        description="Cooldown in seconds before attempting recovery",
+    )
     max_errors: int = Field(
         default=3,
         ge=1,

--- a/src/autoresearch/main.py
+++ b/src/autoresearch/main.py
@@ -270,6 +270,16 @@ def search(
         "--adaptive-min-buffer",
         help="Adaptive budgeting minimum extra tokens",
     ),
+    circuit_breaker_threshold: Optional[int] = typer.Option(
+        None,
+        "--circuit-breaker-threshold",
+        help="Failures before an agent circuit opens",
+    ),
+    circuit_breaker_cooldown: Optional[int] = typer.Option(
+        None,
+        "--circuit-breaker-cooldown",
+        help="Circuit breaker cooldown period in seconds",
+    ),
     agents: Optional[str] = typer.Option(
         None,
         "--agents",
@@ -318,6 +328,12 @@ def search(
         # Limit tokens and run multiple loops
         autoresearch search --loops 3 --token-budget 2000 "Explain AI ethics"
 
+        # Adjust circuit breaker thresholds
+        autoresearch search "Test" --circuit-breaker-threshold 5 --circuit-breaker-cooldown 60
+
+        # Tune adaptive token budgeting
+        autoresearch search "Long query" --adaptive-max-factor 25 --adaptive-min-buffer 20
+
         # Choose specific agents
         autoresearch search --agents Synthesizer,Contrarian "What is quantum computing?"
 
@@ -337,6 +353,10 @@ def search(
         updates["adaptive_max_factor"] = adaptive_max_factor
     if adaptive_min_buffer is not None:
         updates["adaptive_min_buffer"] = adaptive_min_buffer
+    if circuit_breaker_threshold is not None:
+        updates["circuit_breaker_threshold"] = circuit_breaker_threshold
+    if circuit_breaker_cooldown is not None:
+        updates["circuit_breaker_cooldown"] = circuit_breaker_cooldown
     if primus_start is not None:
         updates["primus_start"] = primus_start
     if agents is not None:

--- a/tests/behavior/features/reasoning_parameters.feature
+++ b/tests/behavior/features/reasoning_parameters.feature
@@ -1,0 +1,10 @@
+Feature: Reasoning parameter overrides
+  Scenarios demonstrating CLI flags for circuit breaker and adaptive budgeting
+
+  Scenario: Override circuit breaker settings via CLI
+    When I run `autoresearch search "breaker" --circuit-breaker-threshold 5 --circuit-breaker-cooldown 60 --no-ontology-reasoning`
+    Then the search config should set circuit breaker threshold 5 and cooldown 60
+
+  Scenario: Tune adaptive token budgeting via CLI
+    When I run `autoresearch search "adapt" --adaptive-max-factor 25 --adaptive-min-buffer 20 --no-ontology-reasoning`
+    Then the search config should have adaptive factor 25 and buffer 20

--- a/tests/behavior/steps/reasoning_parameters_steps.py
+++ b/tests/behavior/steps/reasoning_parameters_steps.py
@@ -1,0 +1,77 @@
+from pytest_bdd import scenario, when, then, parsers
+from autoresearch.main import app as cli_app
+from autoresearch.config import ConfigModel, ConfigLoader
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.models import QueryResponse
+
+
+@scenario("../features/reasoning_parameters.feature", "Override circuit breaker settings via CLI")
+def test_circuit_breaker_flags(bdd_context):
+    pass
+
+
+@scenario("../features/reasoning_parameters.feature", "Tune adaptive token budgeting via CLI")
+def test_adaptive_budget_flags(bdd_context):
+    pass
+
+
+@when(parsers.parse('I run `autoresearch search "{query}" --circuit-breaker-threshold {threshold:d} --circuit-breaker-cooldown {cooldown:d} --no-ontology-reasoning'))
+def run_breaker_cli(query, threshold, cooldown, monkeypatch, cli_runner, bdd_context):
+    def mock_run_query(q, cfg, callbacks=None):
+        bdd_context["cfg"] = cfg
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+
+    monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: ConfigModel())
+    result = cli_runner.invoke(
+        cli_app,
+        [
+            "search",
+            query,
+            "--circuit-breaker-threshold",
+            str(threshold),
+            "--circuit-breaker-cooldown",
+            str(cooldown),
+            "--no-ontology-reasoning",
+        ],
+    )
+    bdd_context["result"] = result
+
+
+@then(parsers.parse("the search config should set circuit breaker threshold {threshold:d} and cooldown {cooldown:d}"))
+def check_breaker_config(bdd_context, threshold, cooldown):
+    cfg = bdd_context.get("cfg")
+    assert cfg.circuit_breaker_threshold == threshold
+    assert cfg.circuit_breaker_cooldown == cooldown
+    assert bdd_context["result"].exit_code == 0
+
+
+@when(parsers.parse('I run `autoresearch search "{query}" --adaptive-max-factor {factor:d} --adaptive-min-buffer {buffer:d} --no-ontology-reasoning'))
+def run_adaptive_cli(query, factor, buffer, monkeypatch, cli_runner, bdd_context):
+    def mock_run_query(q, cfg, callbacks=None):
+        bdd_context["cfg"] = cfg
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+
+    monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: ConfigModel())
+    result = cli_runner.invoke(
+        cli_app,
+        [
+            "search",
+            query,
+            "--adaptive-max-factor",
+            str(factor),
+            "--adaptive-min-buffer",
+            str(buffer),
+            "--no-ontology-reasoning",
+        ],
+    )
+    bdd_context["result"] = result
+
+
+@then(parsers.parse("the search config should have adaptive factor {factor:d} and buffer {buffer:d}"))
+def check_adaptive_config(bdd_context, factor, buffer):
+    cfg = bdd_context.get("cfg")
+    assert cfg.adaptive_max_factor == factor
+    assert cfg.adaptive_min_buffer == buffer
+    assert bdd_context["result"].exit_code == 0


### PR DESCRIPTION
## Summary
- add circuit breaker threshold & cooldown fields
- expose tuning flags in the search command
- document new options and config keys
- demonstrate new options with BDD scenarios

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Incompatible types in several files)*
- `poetry run pytest -q` *(interrupted after 12%)*
- `poetry run pytest tests/behavior` *(fails: FileNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6867361343a483339d6173324a982d30