### PR TITLE
Add GPU metrics fallback and tests

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -14,6 +14,16 @@ This collects metrics for ten seconds and displays them in a table. The duration
 
 You can also run `autoresearch monitor` to view a live stream of basic metrics.
 
+## GPU Monitoring
+
+If your system has NVIDIA GPUs, Autoresearch will attempt to collect GPU
+utilization and memory usage. Metrics are gathered using `pynvml` when
+available or by invoking `nvidia-smi`. When neither is present the GPU values
+remain zero.
+
+Running `autoresearch monitor resources` will therefore include ``GPU %`` and
+``GPU MB`` columns when supported.
+
 ## Token Usage Heuristics
 
 The orchestration metrics module provides helpers to automatically compress

--- a/src/autoresearch/resource_monitor.py
+++ b/src/autoresearch/resource_monitor.py
@@ -37,20 +37,34 @@ def _get_gpu_stats() -> tuple[float, float]:
         pass
 
     try:  # pragma: no cover - may not be present
-        import psutil  # type: ignore
         import subprocess
+        try:
+            import psutil  # type: ignore
 
-        proc = psutil.Popen(
-            [
-                "nvidia-smi",
-                "--query-gpu=utilization.gpu,memory.used",
-                "--format=csv,noheader,nounits",
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-        out, _ = proc.communicate(timeout=1)
+            proc = psutil.Popen(
+                [
+                    "nvidia-smi",
+                    "--query-gpu=utilization.gpu,memory.used",
+                    "--format=csv,noheader,nounits",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            out, _ = proc.communicate(timeout=1)
+        except Exception:
+            proc = subprocess.run(
+                [
+                    "nvidia-smi",
+                    "--query-gpu=utilization.gpu,memory.used",
+                    "--format=csv,noheader,nounits",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=1,
+            )
+            out = proc.stdout
         utils = []
         mems = []
         for line in out.strip().splitlines():

--- a/tests/unit/test_resource_monitor_gpu.py
+++ b/tests/unit/test_resource_monitor_gpu.py
@@ -1,0 +1,50 @@
+import builtins
+import sys
+import types
+
+from autoresearch import resource_monitor
+
+
+def test_get_gpu_stats_pynvml(monkeypatch):
+    fake_pynvml = types.SimpleNamespace(
+        nvmlInit=lambda: None,
+        nvmlShutdown=lambda: None,
+        nvmlDeviceGetCount=lambda: 2,
+        nvmlDeviceGetHandleByIndex=lambda i: i,
+        nvmlDeviceGetUtilizationRates=lambda h: types.SimpleNamespace(gpu=10.0 * (h + 1)),
+        nvmlDeviceGetMemoryInfo=lambda h: types.SimpleNamespace(used=(h + 1) * 1024 * 1024),
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", fake_pynvml)
+    util, mem = resource_monitor._get_gpu_stats()
+    assert util == 15.0
+    assert mem == 3.0
+
+
+def test_get_gpu_stats_cli_psutil(monkeypatch):
+    class FakeProc:
+        def communicate(self, timeout=None):
+            return "25, 512", ""
+
+    fake_psutil = types.SimpleNamespace(Popen=lambda *a, **k: FakeProc())
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    monkeypatch.setattr(builtins, "__import__", lambda name, *a, **k: (_ for _ in ()).throw(ImportError()) if name == "pynvml" else builtins.__import__(name, *a, **k))
+    util, mem = resource_monitor._get_gpu_stats()
+    assert util == 25.0
+    assert mem == 512.0
+
+
+def test_get_gpu_stats_cli_subprocess(monkeypatch):
+    def fake_run(*args, **kwargs):
+        class FakeRes:
+            stdout = "30, 1024"
+        return FakeRes()
+
+    monkeypatch.setattr(
+        builtins,
+        "__import__",
+        lambda name, *a, **k: (_ for _ in ()).throw(ImportError()) if name in {"pynvml", "psutil"} else builtins.__import__(name, *a, **k),
+    )
+    monkeypatch.setitem(sys.modules, "subprocess", types.SimpleNamespace(run=fake_run, PIPE=None, DEVNULL=None))
+    util, mem = resource_monitor._get_gpu_stats()
+    assert util == 30.0
+    assert mem == 1024.0


### PR DESCRIPTION
## Summary
- support GPU monitoring when `nvidia-smi` is available even if `psutil` isn't
- add unit tests mocking GPU metric collection
- document GPU monitoring capability

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: found errors)*
- `poetry run pytest -q` *(failed: interrupted after partial run)*
- `poetry run pytest tests/behavior` *(failed: 1 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68673620e5288333b48772d6367843cd