### PR TITLE
Implement search weight optimization

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -237,8 +237,10 @@ truth relevance labels.
 poetry run python scripts/evaluate_ranking.py examples/search_evaluation.csv
 ```
 
-To search for the best combination of weights, use `optimize_search_weights.py`
-which performs a simple grid search and updates `examples/autoresearch.toml`:
+To automatically search for the best combination of weights, use
+`optimize_search_weights.py`. The script reads a labelled evaluation CSV,
+performs a simple grid search and writes the tuned values back to the provided
+configuration file (defaults to `examples/autoresearch.toml`):
 
 ```bash
 poetry run python scripts/optimize_search_weights.py \

--- a/src/autoresearch/__init__.py
+++ b/src/autoresearch/__init__.py
@@ -4,17 +4,31 @@ This package provides a local-first research assistant with multiple
 interfaces and a modular architecture.
 """
 
-from .distributed import (
-    ProcessExecutor,
-    RayExecutor,
-    StorageCoordinator,
-    ResultAggregator,
-    InMemoryBroker,
-    RedisBroker,
-    start_storage_coordinator,
-    start_result_aggregator,
-    publish_claim,
-)
+try:  # pragma: no cover - optional distributed extras
+    from .distributed import (
+        ProcessExecutor,
+        RayExecutor,
+        StorageCoordinator,
+        ResultAggregator,
+        InMemoryBroker,
+        RedisBroker,
+        start_storage_coordinator,
+        start_result_aggregator,
+        publish_claim,
+    )
+except Exception as exc:  # pragma: no cover - missing optional deps
+    ProcessExecutor = None  # type: ignore
+    RayExecutor = None  # type: ignore
+    StorageCoordinator = None  # type: ignore
+    ResultAggregator = None  # type: ignore
+    InMemoryBroker = None  # type: ignore
+    RedisBroker = None  # type: ignore
+    start_storage_coordinator = None  # type: ignore
+    start_result_aggregator = None  # type: ignore
+    publish_claim = None  # type: ignore
+    import warnings
+
+    warnings.warn(f"Distributed features unavailable: {exc}")
 
 __all__ = [
     "RayExecutor",


### PR DESCRIPTION
## Summary
- allow importing `Search` without optional distributed deps
- document `optimize_search_weights.py`

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: several type errors)*
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*
- `poetry run pytest tests/behavior -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6867361872dc83339ab0139d01e19cb4