### PR TITLE
Update search docs and diagrams

### DIFF
--- a/docs/api_reference/search.md
+++ b/docs/api_reference/search.md
@@ -8,12 +8,14 @@ The search module provides functions for searching external sources for informat
 `Search.external_lookup` now also performs an embedding-based lookup using the
 local storage index so that results from all backends benefit from semantic search.
 
-### Weight Tuning
+### Weight Tuning and Optimization
 
-The `tune_weights` utility finds optimal relevance weights based on evaluation
-data.
+The `tune_weights` utility performs a grid search to find relevance weights that
+maximize NDCG on labelled data. `optimize_weights` returns the best weights
+together with the achieved score.
 
 ::: autoresearch.search.Search.tune_weights
+::: autoresearch.search.Search.optimize_weights
 
 ::: autoresearch.search.Search.external_lookup
 

--- a/docs/diagrams/agents.puml
+++ b/docs/diagrams/agents.puml
@@ -150,6 +150,8 @@ package "Orchestration" {
 package "Search" {
   class Search {
     + {static} external_lookup(query, max_results): List[Dict]
+    + {static} tune_weights(data, step): Tuple[float,float,float]
+    + {static} optimize_weights(data, step): Tuple[Tuple[float,float,float], float]
   }
 }
 

--- a/docs/diagrams/storage.puml
+++ b/docs/diagrams/storage.puml
@@ -55,6 +55,8 @@ package "Storage & Search" {
 
   class Search {
     + external_lookup(query, max_results): List[Dict]
+    + tune_weights(data, step): Tuple[float,float,float]
+    + optimize_weights(data, step): Tuple[Tuple[float,float,float], float]
   }
 
   class "Global Storage State" as GlobalState {


### PR DESCRIPTION
## Summary
- document optimize_weights in Search API docs
- update diagrams to show search weight tuning methods

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: incompatible types)*
- `poetry run pytest -q` *(interrupted)*
- `poetry run pytest tests/behavior` *(1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_68689fc0add88333962ad3d7f73dfd98