### PR TITLE
Implement LLM and storage connection pooling

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -185,7 +185,7 @@ This document tracks the progress of tasks for the Autoresearch project, organiz
 - [x] Enhance concurrency
   - [x] Implement asynchronous agent execution
   - [x] Add support for parallel search
-  - [ ] Create efficient resource pooling
+  - [x] Create efficient resource pooling
   - [x] Research message brokers for distributed mode
 
 ### 6.1 Packaging

--- a/src/autoresearch/agents/base.py
+++ b/src/autoresearch/agents/base.py
@@ -82,9 +82,9 @@ class Agent(
         if self.llm_adapter:
             return self.llm_adapter
 
-        from ..llm import get_llm_adapter
+        from ..llm import get_pooled_adapter
 
-        return get_llm_adapter(config.llm_backend)
+        return get_pooled_adapter(config.llm_backend)
 
     def get_model(self, config: ConfigModel) -> str:
         """Get the model to use for this agent.

--- a/src/autoresearch/llm/__init__.py
+++ b/src/autoresearch/llm/__init__.py
@@ -12,7 +12,12 @@ from .adapters import (
     OpenAIAdapter,
     OpenRouterAdapter,
 )
-from .pool import get_session, close_session
+from .pool import (
+    get_session,
+    close_session,
+    get_adapter as get_pooled_adapter,
+    close_adapters,
+)
 
 # Register default backends
 LLMFactory.register("dummy", DummyAdapter)
@@ -31,4 +36,6 @@ __all__ = [
     "OpenRouterAdapter",
     "get_session",
     "close_session",
+    "get_pooled_adapter",
+    "close_adapters",
 ]

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -1600,7 +1600,7 @@ class Orchestrator:
 
         # Get the adapter for the agent using the configured backend
         backend = config.llm_backend
-        adapter = llm.get_llm_adapter(backend)
+        adapter = llm.get_pooled_adapter(backend)
         token_budget = getattr(config, "token_budget", None)
 
         # Use the count_tokens context manager to count tokens

--- a/tests/integration/test_connection_pool.py
+++ b/tests/integration/test_connection_pool.py
@@ -1,7 +1,11 @@
 import autoresearch.search as search
-from autoresearch.llm.adapters import LMStudioAdapter
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
 from autoresearch.config import ConfigModel
 from autoresearch.llm import pool as llm_pool
+from autoresearch.storage import StorageManager
+from autoresearch.config import ConfigLoader
 
 
 def test_search_session_reuse_and_cleanup(monkeypatch):
@@ -46,7 +50,7 @@ def test_llm_session_reuse_and_cleanup(monkeypatch):
     session = llm_pool.get_session()
     monkeypatch.setattr(session, "post", mock_post)
 
-    adapter = LMStudioAdapter()
+    adapter = llm_pool.get_adapter("lmstudio")
     adapter.generate("hi")
     adapter.generate("there")
     assert len(set(session_ids)) == 1
@@ -55,3 +59,64 @@ def test_llm_session_reuse_and_cleanup(monkeypatch):
     llm_pool.close_session()
     session2 = llm_pool.get_session()
     assert id(session2) != first
+
+
+def test_llm_adapter_pool_concurrency(monkeypatch):
+    """Adapters should be reused across threads."""
+    session = llm_pool.get_session()
+
+    def mock_post(self, url, json=None, timeout=30, headers=None):
+        class R:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"message": {"content": "ok"}}]}
+
+        return R()
+
+    monkeypatch.setattr(session, "post", mock_post)
+
+    ids = []
+
+    def call():
+        adapter = llm_pool.get_adapter("lmstudio")
+        adapter.generate("x")
+        ids.append(id(adapter))
+
+    with ThreadPoolExecutor(max_workers=5) as ex:
+        for _ in range(20):
+            ex.submit(call)
+
+    assert len(set(ids)) == 1
+    first = ids[0]
+    llm_pool.close_adapters()
+    assert id(llm_pool.get_adapter("lmstudio")) != first
+
+
+def test_duckdb_connection_pool_concurrency(tmp_path):
+    cfg = ConfigModel(
+        loops=1,
+        storage=dict(max_connections=2, duckdb_path=str(tmp_path / "kg.duckdb")),
+    )
+    llm_pool.close_adapters()
+    search.close_http_session()
+    StorageManager.teardown(remove_db=True)
+    with patch("autoresearch.config.ConfigLoader.load_config", lambda self: cfg):
+        ConfigLoader.reset_instance()
+        StorageManager.setup(cfg.storage.duckdb_path)
+    ids = []
+
+    def use_conn():
+        with StorageManager.connection() as conn:
+            conn.execute("SELECT 1").fetchall()
+            ids.append(id(conn))
+
+    with ThreadPoolExecutor(max_workers=4) as ex:
+        for _ in range(10):
+            ex.submit(use_conn)
+
+    backend = StorageManager._db_backend
+    assert backend is not None
+    assert len(set(ids)) <= backend._max_connections
+    StorageManager.teardown(remove_db=True)


### PR DESCRIPTION
## Summary
- reuse LLM adapter instances through a simple pool
- update orchestrator and agents to fetch pooled adapters
- expose adapter pooling helpers in `llm.__init__`
- add concurrency tests for HTTP/LLM adapter and DuckDB pools
- mark resource pooling task complete

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src/autoresearch` *(fails: several type errors)*
- `poetry run pytest -q` *(interrupted after long runtime)*
- `poetry run pytest tests/behavior` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6868afd189848333b61167b64315bb88