### PR TITLE
Add API edge case tests

### DIFF
--- a/tests/behavior/features/api_edge_cases.feature
+++ b/tests/behavior/features/api_edge_cases.feature
@@ -1,0 +1,15 @@
+Feature: API Edge Cases
+  As a developer
+  I want the API to handle invalid input and permission errors
+  So that clients receive proper error responses
+
+  Background:
+    Given the API server is running
+
+  Scenario: Invalid JSON returns 422
+    When I send invalid JSON to the API
+    Then the response status should be 422
+
+  Scenario: Permission denied for metrics endpoint
+    When I request the metrics endpoint
+    Then the response status should be 403

--- a/tests/behavior/steps/api_edge_case_steps.py
+++ b/tests/behavior/steps/api_edge_case_steps.py
@@ -1,0 +1,50 @@
+from pytest_bdd import scenario, given, when, then
+from autoresearch.config import ConfigModel, APIConfig, ConfigLoader
+
+
+@given("the API server is running")
+def api_server_running(test_context, api_client):
+    test_context["client"] = api_client
+
+
+@when("I send invalid JSON to the API")
+def send_invalid_json(test_context):
+    client = test_context["client"]
+    resp = client.post(
+        "/query",
+        data="{invalid",
+        headers={"Content-Type": "application/json"},
+    )
+    test_context["response"] = resp
+
+
+@when("I request the metrics endpoint")
+def request_metrics(test_context, monkeypatch):
+    cfg = ConfigModel(api=APIConfig())
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    client = test_context["client"]
+    resp = client.get("/metrics")
+    test_context["response"] = resp
+
+
+@then("the response status should be 422")
+def assert_status_422(test_context):
+    assert test_context["response"].status_code == 422
+
+
+@then("the response status should be 403")
+def assert_status_403(test_context):
+    assert test_context["response"].status_code == 403
+
+
+@scenario("../features/api_edge_cases.feature", "Invalid JSON returns 422")
+def test_invalid_json():
+    pass
+
+
+@scenario(
+    "../features/api_edge_cases.feature",
+    "Permission denied for metrics endpoint",
+)
+def test_permission_denied_metrics():
+    pass


### PR DESCRIPTION
## Summary
- test API edge cases for invalid JSON and permission errors

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Incompatible types in assignment)*
- `poetry run pytest -k "api_edge_case" -q`
- `poetry run pytest tests/behavior` *(fails: 1 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6868b471913c8333a45d689e7102c3ca