### PR TITLE
Compress prompts before LLM call

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -35,3 +35,8 @@ prompt lengths and lowers its compression threshold when the average length
 exceeds the available budget. This adaptive behaviour helps prevent runaway
 token consumption.
 
+When a token budget is set, the orchestrator applies this compression step
+inside ``_capture_token_usage`` before passing prompts to the LLM adapter.
+Any remaining excess is trimmed by the adapter so prompts never exceed the
+configured budget.
+


### PR DESCRIPTION
## Summary
- compress prompts before calling into LLM adapter
- test compression behaviour
- mention prompt compression in performance docs

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Incompatible types in orchestrator and other modules)*
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: 1 failed)*
- `poetry run pytest -q tests/unit/test_token_usage.py`

------
https://chatgpt.com/codex/tasks/task_e_6868b44c15b8833396e13237850d18e7