### PR TITLE
Add installer script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Use Go Task to create platform-specific wheels:
 ```bash
 task wheels
 ```
+The CI release workflow also runs this command before publishing the
+generated wheels to PyPI with:
+
+```bash
+poetry publish --build
+```
 ### Upgrading
 To upgrade Autoresearch run:
 ```bash
@@ -45,7 +51,8 @@ If installed via pip:
 ```bash
 pip install -U autoresearch
 ```
-Run the installer to resolve optional dependencies automatically:
+Run the installer to resolve optional dependencies automatically
+(pass ``--extras nlp,parsers`` to specify additional extras):
 ```bash
 python scripts/installer.py --minimal
 ```

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -191,14 +191,14 @@ This document tracks the progress of tasks for the Autoresearch project, organiz
 
 ### 6.1 Packaging
 
-- [ ] Complete package distribution
+- [x] Complete package distribution
   - [x] Ensure all dependencies are properly specified
   - [x] Create platform-specific packages
   - [x] Add support for containerization
-- [ ] Enhance installation process
-  - [ ] Implement automatic dependency resolution
-  - [ ] Add support for minimal installations
-  - [ ] Create upgrade paths for existing installations
+- [x] Enhance installation process
+  - [x] Implement automatic dependency resolution
+  - [x] Add support for minimal installations
+  - [x] Create upgrade paths for existing installations
   - [x] Publish dev build to PyPI test repository
 
 ### 6.2 Deployment

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -116,23 +116,28 @@ For pip based installs use:
 ```bash
 pip install -U autoresearch
 ```
-You can also run the installer script which resolves optional dependencies automatically:
+You can also run the installer script to resolve optional dependencies automatically:
 ```bash
 python scripts/installer.py --minimal
 ```
-Omit `--minimal` to install all extras.
+Omit `--minimal` or pass additional extras with `--extras nlp,parsers` to install more features.
 
 ## Release workflow
 
 1. Bump the version in `pyproject.toml`.
 2. Run the unit and behavior test suites.
-3. Publish a development build to TestPyPI:
+3. Build wheels for all platforms:
+
+```bash
+task wheels
+```
+4. Publish a development build to TestPyPI:
 
 ```bash
 ./scripts/publish_dev.py
 ```
 
-4. If everything looks good, publish to the main PyPI repository:
+5. If everything looks good, publish to the main PyPI repository:
 
 ```bash
 poetry publish --build

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,6 +34,15 @@ Install multiple extras separated by commas:
 pip install "autoresearch[minimal,nlp,parsers]"
 ```
 
+### Using the installer
+
+For a repository clone you can also run the helper installer to resolve
+optional dependencies automatically:
+
+```bash
+python scripts/installer.py --minimal --extras nlp
+```
+
 ## Upgrading
 
 To upgrade an existing installation run:

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 """Platform aware installer for Autoresearch.
 
-This script checks basic platform requirements and installs optional
-dependencies using Poetry. Pass ``--minimal`` to install only the
-minimal optional dependencies. Without flags, all optional extras will
-be installed.
+This utility simplifies installation by resolving optional dependencies
+based on the arguments provided.  By default all extras are installed.
+Use ``--minimal`` to only install the minimal extra or ``--extras`` to
+specify a comma separated list as documented in ``docs/installation.md``.
+The script ensures Poetry uses the running interpreter before invoking
+``poetry install``.
 """
 
 from __future__ import annotations
 
 import argparse
-import os
 import platform
 import subprocess
 import sys
@@ -39,14 +40,25 @@ def main() -> None:
     parser.add_argument(
         "--minimal",
         action="store_true",
-        help="Install only minimal optional dependencies",
+        help="Install only the minimal extra",
+    )
+    parser.add_argument(
+        "--extras",
+        help="Comma separated extras to install (e.g. nlp,parsers)",
+        default="",
     )
     args = parser.parse_args()
 
     check_python()
 
-    # Select extras set
-    extras = ["minimal"] if args.minimal else ["full"]
+    # Determine extras set
+    extras: List[str] = []
+    if args.minimal:
+        extras.append("minimal")
+    if args.extras:
+        extras.extend([e.strip() for e in args.extras.split(",") if e.strip()])
+    if not extras:
+        extras = ["full"]
 
     # Ensure Poetry uses the current interpreter
     run(["poetry", "env", "use", sys.executable])


### PR DESCRIPTION
## Summary
- expand installer script to handle optional extras
- document wheel publishing in README and deployment guide
- mention installer script in installation docs
- tick off packaging tasks in progress doc

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Incompatible types in assignment)*
- `poetry run pytest tests/behavior` *(fails: 1 failed, 2 passed)*
- `poetry run pytest -q` *(interrupted after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_6868bb5740948333a526a8aae6dec0fe