### PR TITLE
Implement search HTTP session teardown

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -187,6 +187,7 @@ This document tracks the progress of tasks for the Autoresearch project, organiz
   - [x] Implement asynchronous agent execution
   - [x] Add support for parallel search
   - [x] Create efficient resource pooling
+  - [x] Add teardown hooks for search connection pool
   - [x] Research message brokers for distributed mode
 
 ### 6.1 Packaging

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -40,3 +40,11 @@ inside ``_capture_token_usage`` before passing prompts to the LLM adapter.
 Any remaining excess is trimmed by the adapter so prompts never exceed the
 configured budget.
 
+## Connection Pooling
+
+HTTP requests to LLM and search backends reuse shared `requests.Session`
+instances. The pool size for LLMs is controlled by `llm_pool_size` while search
+backends use `http_pool_size`. When a session is created an `atexit` hook is
+registered to close it automatically on program exit. Reusing sessions reduces
+connection overhead during heavy query loads.
+


### PR DESCRIPTION
## Summary
- add atexit hook so search pool closes on exit
- test registration of the atexit hook and for injected sessions
- document connection pooling behavior
- mark progress on teardown hooks
- revert lockfile extras change

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Found 20 errors in 6 files)*
- `poetry run pytest -q` *(interrupted: KeyboardInterrupt)*
- `poetry run pytest tests/unit/test_search.py::test_http_session_atexit_hook -q` *(fails coverage requirement)*
- `poetry run pytest tests/behavior` *(fails: FileNotFoundError in agent_orchestration_steps)*

------
https://chatgpt.com/codex/tasks/task_e_6868bb4fc89c83339c25284a2d0b673f