### PR TITLE
Improve token budgeting heuristics

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -170,7 +170,7 @@ This document tracks the progress of tasks for the Autoresearch project, organiz
   - [x] Implement prompt compression techniques
   - [x] Add context pruning for long conversations
   - [x] Create adaptive token budget management
-  - [x] Use historical averages for budget adjustment
+  - [x] Use per-agent historical averages for budget adjustment
 - [x] Enhance memory management
   - [x] Implement efficient caching strategies
   - [x] Add support for memory-constrained environments

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -29,11 +29,13 @@ Running `autoresearch monitor resources` will therefore include ``GPU %`` and
 The orchestration metrics module provides helpers to automatically compress
 prompts and adjust token budgets. After each cycle the orchestrator uses
 `suggest_token_budget` to expand or shrink the configured budget. The heuristic
-keeps a rolling average of token usage across cycles so the budget gradually
-converges toward typical usage. `compress_prompt_if_needed` likewise tracks
-prompt lengths and lowers its compression threshold when the average length
-exceeds the available budget. This adaptive behaviour helps prevent runaway
-token consumption.
+tracks both the overall token usage and per-agent historical averages so the
+budget gradually converges toward typical usage without starving any agent.
+`compress_prompt_if_needed` likewise tracks prompt lengths and lowers its
+compression threshold when the average length exceeds the available budget. If
+a prompt still exceeds the budget after compression, a summarization step can be
+supplied to ``compress_prompt`` to further reduce the text. This adaptive
+behaviour helps prevent runaway token consumption.
 
 When a token budget is set, the orchestrator applies this compression step
 inside ``_capture_token_usage`` before passing prompts to the LLM adapter.


### PR DESCRIPTION
## Summary
- enhance `suggest_token_budget` with per-agent tracking
- allow optional summarization when compressing prompts
- cover new behaviours with unit tests
- document heuristic improvements and update progress log

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: multiple typing errors)*
- `poetry run pytest tests/unit/test_token_usage.py -q`
- `poetry run pytest tests/behavior` *(interrupted due to KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6868c22b9ad48333b947a8942bd2c70d