### PR TITLE
Add installer tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,6 +16,11 @@ tasks:
       - pytest -q tests/behavior
     desc: "Run BDD (behavior) tests"
 
+  installer-tests:
+    cmds:
+      - pytest -q tests/integration/test_installer.py tests/behavior/steps/installer_steps.py
+    desc: "Run installer integration and behavior tests"
+
   test:
     deps: [unit, integration, behavior]
     desc: "Run all tests"

--- a/tests/behavior/features/installer.feature
+++ b/tests/behavior/features/installer.feature
@@ -1,0 +1,15 @@
+Feature: Installer optional dependencies
+  The installer script should handle extras groups correctly
+
+  Scenario: Minimal installation
+    When I run the installer with "--minimal"
+    Then only the minimal extra should be installed
+
+  Scenario: Automatic dependency resolution
+    When I run the installer without arguments
+    Then all extras except minimal should be installed
+
+  Scenario: Upgrade from minimal to full installation
+    Given the installer was run with "--minimal" previously
+    When I run the installer without arguments
+    Then all extras except minimal should be installed

--- a/tests/behavior/steps/installer_steps.py
+++ b/tests/behavior/steps/installer_steps.py
@@ -1,0 +1,73 @@
+"""Step definitions for the installer feature."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import tomllib
+
+from pytest_bdd import scenario, given, when, then
+
+import importlib.util
+
+INSTALLER_PATH = Path(__file__).resolve().parents[3] / "scripts" / "installer.py"
+spec = importlib.util.spec_from_file_location("installer", INSTALLER_PATH)
+installer = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(installer)  # type: ignore
+
+
+def _run_installer(monkeypatch, args):
+    cmds = []
+    monkeypatch.setattr(installer, "run", lambda cmd: cmds.append(cmd))
+    monkeypatch.setattr(sys, "argv", ["installer.py"] + args)
+    monkeypatch.chdir(Path(__file__).resolve().parents[3])
+    installer.main()
+    return cmds
+
+
+@given('the installer was run with "--minimal" previously')
+def installer_run_minimal_first(monkeypatch, bdd_context):
+    _run_installer(monkeypatch, ["--minimal"])
+
+
+@when('I run the installer with "--minimal"')
+def run_installer_minimal(monkeypatch, bdd_context):
+    bdd_context["cmds"] = _run_installer(monkeypatch, ["--minimal"])
+
+
+@when('I run the installer without arguments')
+def run_installer_default(monkeypatch, bdd_context):
+    bdd_context["cmds"] = _run_installer(monkeypatch, [])
+
+
+@then('only the minimal extra should be installed')
+def check_minimal(bdd_context):
+    cmd = bdd_context["cmds"][-1]
+    assert cmd[:5] == ["poetry", "install", "--with", "dev", "--extras"]
+    assert cmd[5:] == ["minimal"]
+
+
+@then('all extras except minimal should be installed')
+def check_all_extras(bdd_context):
+    data = tomllib.loads(Path("pyproject.toml").read_text())
+    extras = list(data.get("project", {}).get("optional-dependencies", {}).keys())
+    expected = [e for e in extras if e != "minimal"]
+    cmd = bdd_context["cmds"][-1]
+    assert cmd[:5] == ["poetry", "install", "--with", "dev", "--extras"]
+    assert cmd[5:] == expected
+
+
+@scenario("../features/installer.feature", "Minimal installation")
+def test_minimal_install():
+    pass
+
+
+@scenario("../features/installer.feature", "Automatic dependency resolution")
+def test_auto_resolution():
+    pass
+
+
+@scenario("../features/installer.feature", "Upgrade from minimal to full installation")
+def test_upgrade_install():
+    pass

--- a/tests/integration/test_installer.py
+++ b/tests/integration/test_installer.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import sys
+import tomllib
+
+import importlib.util
+
+INSTALLER_PATH = Path(__file__).resolve().parents[2] / "scripts" / "installer.py"
+spec = importlib.util.spec_from_file_location("installer", INSTALLER_PATH)
+installer = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(installer)  # type: ignore
+
+
+def _run(monkeypatch, args):
+    cmds = []
+    monkeypatch.setattr(installer, "run", lambda cmd: cmds.append(cmd))
+    monkeypatch.setattr(sys, "argv", ["installer.py"] + args)
+    monkeypatch.chdir(Path(__file__).resolve().parents[2])
+    installer.main()
+    return cmds
+
+
+def test_installer_extras(monkeypatch):
+    cmds = _run(monkeypatch, ["--minimal"])
+    assert cmds[-1] == [
+        "poetry",
+        "install",
+        "--with",
+        "dev",
+        "--extras",
+        "minimal",
+    ]
+
+    data = tomllib.loads(Path("pyproject.toml").read_text())
+    extras = list(data.get("project", {}).get("optional-dependencies", {}).keys())
+    expected = [e for e in extras if e != "minimal"]
+
+    cmds = _run(monkeypatch, [])
+    assert cmds[-1] == [
+        "poetry",
+        "install",
+        "--with",
+        "dev",
+        "--extras",
+        *expected,
+    ]


### PR DESCRIPTION
## Summary
- cover installer in behavior tests
- add integration test for installer extras
- provide task for running installer tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: incompatible types)*
- `poetry run pytest -q tests/integration/test_installer.py tests/behavior/steps/installer_steps.py` *(fails: coverage under threshold)*
- `poetry run pytest tests/behavior/steps/installer_steps.py -q` *(fails: coverage under threshold)*


------
https://chatgpt.com/codex/tasks/task_e_6869911cb13c833384beb9b62f8d5bcb