### PR TITLE
Fix CLI output for RDF visualization

### DIFF
--- a/src/autoresearch/streamlit_app.py
+++ b/src/autoresearch/streamlit_app.py
@@ -27,6 +27,7 @@ from .orchestration.orchestrator import Orchestrator
 from .models import QueryResponse
 from .orchestration import ReasoningMode
 from .error_utils import get_error_info, format_error_for_gui
+from .cli_utils import print_success
 
 # Configure matplotlib to use a non-interactive backend
 matplotlib.use("Agg")
@@ -1993,7 +1994,7 @@ def visualize_rdf(output_path: str = "rdf_graph.png") -> None:
 
     StorageManager.setup()
     StorageManager.visualize_rdf(output_path)
-    print(f"Graph written to {output_path}")
+    print_success(f"Graph written to {output_path}")
 
 
 def display_results(result: QueryResponse):


### PR DESCRIPTION
## Summary
- use `print_success` in `visualize_rdf`

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Found 20 errors)*
- `poetry run pytest -q` *(interrupted: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: 1 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686990dfb7288333ab7537e00604702c