### PR TITLE
Improve installer automation

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,13 +127,14 @@ You can also run the installer script which resolves optional dependencies autom
 ```bash
 python scripts/installer.py --minimal
 ```
-Omit `--minimal` to install all extras.
+Omit `--minimal` to install all extras. Add `--upgrade` to update existing
+packages.
 
 ### Minimal installation
 For lightweight deployments run the installer with the `--minimal` flag. This
 installs only the dependencies from the `minimal` extras group. Running the
-installer again without flags will upgrade the environment with all optional
-packages.
+installer again without flags will install any missing extras. Use the
+`--upgrade` flag to update already installed packages.
 
 ## Release workflow
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,6 +15,12 @@ The project can be installed with only the minimal optional dependencies:
 pip install autoresearch[minimal]
 ```
 
+If you cloned the repository, run the installer script instead:
+
+```bash
+python scripts/installer.py --minimal
+```
+
 This provides the CLI, API and knowledge graph without heavy NLP or UI packages. Optional features will be disabled when their dependencies are missing.
 
 ## Optional extras
@@ -46,6 +52,12 @@ For Poetry based setups use:
 
 ```bash
 poetry update autoresearch
+```
+
+When using the installer script you can upgrade all packages with:
+
+```bash
+python scripts/installer.py --upgrade
 ```
 
 The project follows semantic versioning. Minor releases within the same major version are backwards compatible. Check the [duckdb_compatibility.md](duckdb_compatibility.md) document for extension version notes.

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -3,8 +3,10 @@
 
 This script checks basic platform requirements and installs optional
 dependencies using Poetry. Pass ``--minimal`` to install only the
-minimal optional dependencies. Without flags, all optional extras will
-be installed.
+minimal optional dependencies. Without flags, optional extras are
+resolved automatically and missing groups are installed. Use
+``--upgrade`` to run ``poetry update`` on the environment after
+installation.
 """
 
 from __future__ import annotations
@@ -15,7 +17,8 @@ import platform
 import subprocess
 import sys
 from pathlib import Path
-from typing import List
+from typing import Dict, List, Set
+from importlib import metadata
 import tomllib
 
 MIN_VERSION = (3, 12)
@@ -36,6 +39,23 @@ def run(cmd: List[str]) -> None:
     subprocess.check_call(cmd)
 
 
+def get_optional_dependencies() -> Dict[str, List[str]]:
+    """Return the optional dependency groups from ``pyproject.toml``."""
+    data = tomllib.loads(Path("pyproject.toml").read_text())
+    return data.get("project", {}).get("optional-dependencies", {})
+
+
+def get_installed_packages() -> Set[str]:
+    """Return the names of packages installed in the current environment."""
+    return {dist.metadata["Name"] for dist in metadata.distributions()}
+
+
+def extract_name(requirement: str) -> str:
+    """Extract the package name from a Poetry requirement string."""
+    name = requirement.split()[0]
+    return name.split("[")[0]
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Install Autoresearch")
     parser.add_argument(
@@ -43,23 +63,40 @@ def main() -> None:
         action="store_true",
         help="Install only minimal optional dependencies",
     )
+    parser.add_argument(
+        "--upgrade",
+        action="store_true",
+        help="Run 'poetry update' after installation",
+    )
     args = parser.parse_args()
 
     check_python()
 
-    def get_all_extras() -> List[str]:
-        data = tomllib.loads(Path("pyproject.toml").read_text())
-        deps = data.get("project", {}).get("optional-dependencies", {})
-        return list(deps.keys())
+    optional = get_optional_dependencies()
+    installed = get_installed_packages()
 
-    # Select extras set
-    extras = ["minimal"] if args.minimal else [e for e in get_all_extras() if e != "minimal"]
+    extras: List[str]
+    if args.minimal:
+        extras = ["minimal"]
+    else:
+        extras = []
+        for name, pkgs in optional.items():
+            if name == "minimal":
+                continue
+            pkg_names = [extract_name(p) for p in pkgs]
+            if any(p not in installed for p in pkg_names):
+                extras.append(name)
 
     # Ensure Poetry uses the current interpreter
     run(["poetry", "env", "use", sys.executable])
 
-    cmd = ["poetry", "install", "--with", "dev", "--extras"] + extras
+    cmd = ["poetry", "install", "--with", "dev"]
+    if extras:
+        cmd += ["--extras"] + extras
     run(cmd)
+
+    if args.upgrade:
+        run(["poetry", "update"])
 
     print("Installation complete on", platform.platform())
 

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -1,0 +1,69 @@
+"""Tests for the :mod:`scripts.installer` module."""
+
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "installer", Path(__file__).resolve().parents[2] / "scripts" / "installer.py"
+)
+installer = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(installer)
+
+
+def _run_installer(monkeypatch, argv, optional, installed):
+    calls = []
+
+    monkeypatch.setattr(installer, "get_optional_dependencies", lambda: optional)
+    monkeypatch.setattr(installer, "get_installed_packages", lambda: installed)
+
+    def fake_check_call(cmd):
+        calls.append(cmd)
+
+    monkeypatch.setattr(installer.subprocess, "check_call", fake_check_call)
+    monkeypatch.setattr(installer.sys, "argv", ["installer.py", *argv])
+    installer.main()
+    return calls
+
+
+def test_minimal_install(monkeypatch):
+    calls = _run_installer(
+        monkeypatch,
+        ["--minimal"],
+        {"minimal": ["a"], "extra": ["b"]},
+        set(),
+    )
+
+    assert ["poetry", "env", "use", installer.sys.executable] in calls
+    assert [
+        "poetry",
+        "install",
+        "--with",
+        "dev",
+        "--extras",
+        "minimal",
+    ] in calls
+    assert all("update" not in c for c in calls)
+
+
+def test_full_auto_resolution(monkeypatch):
+    calls = _run_installer(
+        monkeypatch,
+        [],
+        {"minimal": ["a"], "extra": ["b"]},
+        {"a"},
+    )
+
+    assert any("--extras" in c for c in calls)
+    assert ["poetry", "update"] not in calls
+
+
+def test_upgrade(monkeypatch):
+    calls = _run_installer(
+        monkeypatch,
+        ["--upgrade"],
+        {"minimal": ["a"], "extra": ["b"]},
+        {"a", "b"},
+    )
+
+    assert calls[-1] == ["poetry", "update"]


### PR DESCRIPTION
## Summary
- auto-detect extras from `pyproject.toml` in installer
- add `--upgrade` flag to run `poetry update`
- cover installer logic with unit tests
- document new flags in deployment and installation guides

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: storage and orchestrator type errors)*
- `poetry run pytest -q` *(fails: interrupted due to long runtime)*
- `poetry run pytest tests/behavior` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_686990c44d2c8333a85b2dcd2eaf9dd6