### PR TITLE
Add minimal extras and improve installer integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ CLI utilities are provided via Typer and the HTTP API is powered by FastAPI.
 ## Installation
 
 You can install the project dependencies with either **Poetry** or **pip**.
-See [docs/installation.md](docs/installation.md) for details on optional features and upgrade instructions.
+See [docs/installation.md](docs/installation.md) for details on optional features,
+upgrade instructions and the new installer.
+The `scripts/setup.sh` helper now calls the installer so optional dependencies
+are resolved automatically during development setup.
 
 ### Using Poetry
 ```bash
@@ -24,6 +27,10 @@ python scripts/installer.py --minimal
 Running the installer without ``--minimal`` reads ``autoresearch.toml`` and
 installs any extras required by your configuration. Extras can also be specified
 manually with ``--extras nlp,ui``.
+You can also install the minimal group from PyPI:
+```bash
+pip install autoresearch[minimal]
+```
 
 ### Using pip
 Install the latest release from PyPI:
@@ -54,7 +61,8 @@ The script runs `poetry update autoresearch` when a `pyproject.toml` is
 present, otherwise it falls back to `pip install -U autoresearch`.
 Run the installer to resolve optional dependencies automatically. Omit
 `--minimal` to upgrade with all extras and pass `--upgrade` to update
-existing packages:
+existing packages. The installer detects which extras are missing and
+installs them for you:
 ```bash
 python scripts/installer.py --minimal
 ```
@@ -388,8 +396,10 @@ Alternatively you can run the helper script:
 ./scripts/setup.sh
 ```
 
-This installs tools such as `flake8`, `mypy`, `pytest` and `tomli_w` which is
-used to write TOML files during testing.
+The script now invokes `installer.py` so any optional dependencies required by
+your configuration are installed automatically. It also installs tools such as
+`flake8`, `mypy`, `pytest` and `tomli_w` which are used to write TOML files
+during testing.
 
 ## Running tests
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,3 +69,14 @@ backwards compatible. Check the
 [duckdb_compatibility.md](duckdb_compatibility.md) document for extension
 version notes.
 
+### Migrating from older releases
+
+If you installed Autoresearch before ``0.1.0`` you may not have the
+installer script available. Upgrade the base package and then run the
+installer to pull in any new optional dependencies:
+
+```bash
+pip install -U autoresearch
+python scripts/installer.py --upgrade
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,11 @@ full = [
     "redis (>=6.2,<7.0)"
 ]
 
+[tool.poetry.extras]
+minimal = [
+    "sentence-transformers"
+]
+
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 python -m pip install --upgrade pip
 pip install poetry
-poetry install --with dev
+poetry env use $(which python3)
+python scripts/installer.py
 
 # Create extensions directory if it doesn't exist
 mkdir -p extensions


### PR DESCRIPTION
## Summary
- call `installer.py` from `setup.sh` to automatically install extras
- expose minimal extras via `[tool.poetry.extras]`
- document the new installer in README and installation guide

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q tests/unit/test_cli_help.py` *(fails: coverage < 90%)*
- `poetry run pytest tests/behavior -q` *(fails: FileNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68699da70cb48333af3116a4bd685370