### PR TITLE
Fix orchestrator test path issues

### DIFF
--- a/tests/behavior/steps/agent_orchestration_steps.py
+++ b/tests/behavior/steps/agent_orchestration_steps.py
@@ -48,10 +48,19 @@ def set_primus_start(index: int, set_loops):
     parsers.parse('I run the orchestrator on query "{query}"'),
     target_fixture="run_orchestrator_on_query",
 )
-def run_orchestrator_on_query(query):
+def run_orchestrator_on_query(query, monkeypatch, tmp_path):
     loader = ConfigLoader()
     loader._config = None
     cfg = loader.load_config()
+
+    monkeypatch.setenv(
+        "AUTORESEARCH_RELEASE_METRICS",
+        str(tmp_path / "release_tokens.json"),
+    )
+    monkeypatch.setenv(
+        "AUTORESEARCH_QUERY_TOKENS",
+        str(tmp_path / "query_tokens.json"),
+    )
 
     from autoresearch.orchestration.reasoning import ReasoningMode
 

--- a/tests/behavior/steps/api_auth_steps.py
+++ b/tests/behavior/steps/api_auth_steps.py
@@ -3,6 +3,7 @@
 from pytest_bdd import scenario, given, when, then, parsers
 from . import api_orchestrator_integration_steps  # noqa: F401
 from autoresearch.config import ConfigModel, ConfigLoader, APIConfig
+from autoresearch.api import config_loader
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.models import QueryResponse
 
@@ -17,6 +18,8 @@ def api_server_running():
 def require_api_key(monkeypatch, key):
     cfg = ConfigModel(api=APIConfig(api_key=key))
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setenv("AUTORESEARCH_API_KEY", key)
+    config_loader._config = None
     monkeypatch.setattr(
         Orchestrator,
         "run_query",
@@ -30,6 +33,8 @@ def require_api_key(monkeypatch, key):
 def require_bearer_token(monkeypatch, token):
     cfg = ConfigModel(api=APIConfig(bearer_token=token))
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setenv("AUTORESEARCH_BEARER_TOKEN", token)
+    config_loader._config = None
     monkeypatch.setattr(
         Orchestrator,
         "run_query",


### PR DESCRIPTION
## Summary
- ensure release and query metric files writeable in tests
- reset API config during auth setup for proper key handling

## Testing
- `poetry run pytest tests/behavior -k agent_orchestration -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a121d74c8333b5a485ee17565782