### PR TITLE
Update UI testing docs for Python 3.12

### DIFF
--- a/docs/ui_testing_procedures.md
+++ b/docs/ui_testing_procedures.md
@@ -16,7 +16,7 @@ Autoresearch uses a multi-layered testing approach for UI components:
 
 ### Prerequisites
 
-- Python 3.9+
+- Python 3.12+
 - Poetry (for dependency management)
 - pytest and pytest-bdd
 
@@ -444,7 +444,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.12
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- bump prereq Python version in UI testing guide
- set GitHub Actions workflow to use Python 3.12

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(failed: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(failed: 1 failed, 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686a0f5eb418833387e92e8604d44174