### PR TITLE
Fix adaptive token budget duplication

### DIFF
--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -961,9 +961,6 @@ class Orchestrator:
                 )
                 config.token_budget = group_tokens
 
-        # Adapt token budget based on query complexity
-        Orchestrator._apply_adaptive_token_budget(config, query)
-
         # Heuristically adjust token budget when running within parallel agent
         # groups. ``run_parallel_query`` passes ``group_size`` and
         # ``total_groups`` to ``run_query`` using ``model_copy`` so we can


### PR DESCRIPTION
## Summary
- remove redundant call to `_apply_adaptive_token_budget` in `run_query`

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: Command terminated after several minutes)*
- `poetry run pytest tests/behavior` *(fails: 1 failed, 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686bf1a3af3883339b91e01da1b8eae9