### PR TITLE
Fix mkdocs build and update docs

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -29,9 +29,7 @@ The agents component consists of several key classes:
 - **AgentRegistry** - Registry of available agent types
 - **AgentFactory** - Factory for creating and retrieving agent instances
 
-The diagram below shows the relationships between these classes and their interactions with other components:
-
-![Agents Component](diagrams/agents.png)
+The relationships between these classes are documented in `docs/diagrams/agents.puml`.
 
 ## Adding custom agents
 

--- a/docs/component_interactions.md
+++ b/docs/component_interactions.md
@@ -13,7 +13,7 @@ The Autoresearch system is composed of several interconnected components that wo
 5. Storage & Search
 6. Output Formatting
 
-![System Architecture](diagrams/system_architecture.png)
+The overall system architecture is defined in `docs/diagrams/system_architecture.puml`.
 
 ## Key Component Interactions
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,7 +214,7 @@ enabled = true
 
 ## Complete Example
 
-A complete example configuration is provided in [`examples/autoresearch.toml`](../examples/autoresearch.toml). You can use this as a starting point for your own configuration.
+A complete example configuration is provided in [`examples/autoresearch.toml`](examples/autoresearch.toml). You can use this as a starting point for your own configuration.
 
 ```toml
 [search]

--- a/docs/examples/autoresearch.toml
+++ b/docs/examples/autoresearch.toml
@@ -1,0 +1,73 @@
+[core]
+llm_backend = "lmstudio"
+loops = 3
+token_budget = 4000
+tracing_enabled = false
+
+[search]
+backends = [
+    "serper",
+    "local_file",
+    "local_git",
+]
+embedding_backends = [
+    "duckdb",
+]
+hybrid_query = true
+max_results_per_query = 5
+use_semantic_similarity = true
+use_bm25 = true
+use_source_credibility = true
+semantic_similarity_weight = 1.0
+bm25_weight = 0.0
+source_credibility_weight = 0.0
+domain_authority_factor = 0.6
+citation_count_factor = 0.4
+use_feedback = false
+feedback_weight = 0.3
+
+[search.context_aware]
+enabled = true
+use_query_expansion = true
+expansion_factor = 0.3
+use_entity_recognition = true
+entity_weight = 0.5
+use_topic_modeling = true
+num_topics = 5
+topic_weight = 0.3
+use_search_history = true
+history_weight = 0.2
+max_history_items = 10
+
+[search.local_file]
+path = "/path/to/research_docs"
+file_types = [
+    "md",
+    "pdf",
+    "txt",
+]
+
+[search.local_git]
+repo_path = "/path/to/repo"
+branches = [
+    "main",
+]
+history_depth = 50
+
+[storage.duckdb]
+path = "data/research.duckdb"
+vector_extension = true
+
+[agent.Synthesizer]
+model = "gpt-3.5-turbo"
+
+[agent.Contrarian]
+enabled = true
+
+[agent.FactChecker]
+enabled = true
+
+[distributed]
+enabled = false
+address = "auto"
+num_cpus = 2

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,9 +4,7 @@ This guide walks you through installing the project dependencies and running you
 
 ## System Architecture
 
-Autoresearch uses a modular architecture with several key components:
-
-![System Architecture](diagrams/system_architecture.png)
+Autoresearch uses a modular architecture with several key components. The PlantUML diagram for the overall system architecture is available at `docs/diagrams/system_architecture.puml`.
 
 - The system consists of:
 - **Client Interfaces**: CLI, API, Monitor, and FastMCP

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -27,9 +27,7 @@ The Orchestrator class provides methods for:
 - Managing token usage and metrics
 - Handling errors and timeouts
 
-The diagram below shows the relationships between these classes and their interactions with other components:
-
-![Orchestration Component](diagrams/orchestration.png)
+The orchestration workflow is illustrated by the PlantUML description in `docs/diagrams/orchestration.puml`.
 
 ## Execution Flow
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -15,9 +15,7 @@ The storage component consists of several key classes:
 - **StorageConfig** - Configuration for the storage system
 - **StorageError** - Error hierarchy for storage-related errors
 
-The diagram below shows the relationships between these classes and their interactions with external libraries:
-
-![Storage Component](diagrams/storage.png)
+The relationships between these classes and their external dependencies are documented in `docs/diagrams/storage.puml`.
 
 ## Storage Flow
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,32 +1,32 @@
 site_name: Autoresearch
 nav:
-  - Getting Started: docs/getting_started.md
-  - Configuration: docs/configuration.md
-  - Agents: docs/agents.md
-  - Storage: docs/storage.md
-  - Orchestration: docs/orchestration.md
-  - API Usage: docs/api.md
-  - Advanced Usage: docs/advanced_usage.md
-  - Deployment: docs/deployment.md
-  - FAQ: docs/faq.md
-  - Agent System: docs/agent_system.md
-  - Component Interactions: docs/component_interactions.md
-  - Message Brokers: docs/message_brokers.md
+  - Getting Started: getting_started.md
+  - Configuration: configuration.md
+  - Agents: agents.md
+  - Storage: storage.md
+  - Orchestration: orchestration.md
+  - API Usage: api.md
+  - Advanced Usage: advanced_usage.md
+  - Deployment: deployment.md
+  - FAQ: faq.md
+  - Agent System: agent_system.md
+  - Component Interactions: component_interactions.md
+  - Message Brokers: message_brokers.md
   - API Reference:
-    - Overview: docs/api_reference/index.md
-    - Agents: docs/api_reference/agents.md
-    - Orchestration: docs/api_reference/orchestration.md
-    - Storage: docs/api_reference/storage.md
-    - LLM: docs/api_reference/llm.md
-    - Search: docs/api_reference/search.md
-    - Config: docs/api_reference/config.md
-  - Contributing: docs/contributing.md
-  - Requirements: docs/requirements.md
-  - Specification: docs/specification.md
-  - Plan: docs/plan.md
-  - Pseudocode: docs/pseudocode.md
-  - Requirements Tracability Matrix: docs/requirements_tracability_matrix.md
-  - Testing Guidelines: docs/testing_guidelines.md
+    - Overview: api_reference/index.md
+    - Agents: api_reference/agents.md
+    - Orchestration: api_reference/orchestration.md
+    - Storage: api_reference/storage.md
+    - LLM: api_reference/llm.md
+    - Search: api_reference/search.md
+    - Config: api_reference/config.md
+  - Contributing: contributing.md
+  - Requirements: requirements.md
+  - Specification: specification.md
+  - Plan: plan.md
+  - Pseudocode: pseudocode.md
+  - Requirements Tracability Matrix: requirements_tracability_matrix.md
+  - Testing Guidelines: testing_guidelines.md
 markdown_extensions:
   - toc
   - admonition


### PR DESCRIPTION
## Summary
- adjust nav paths in `mkdocs.yml`
- copy example config into docs
- reference example config in documentation
- remove placeholder diagram images and link to PlantUML sources

## Testing
- `poetry run mkdocs build`
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: test_invalid_api_key)*

------
https://chatgpt.com/codex/tasks/task_e_686ef2991f7c83339a98af8f62db400a