### PR TITLE
Fix workflow path in UI testing docs

### DIFF
--- a/docs/ui_testing_procedures.md
+++ b/docs/ui_testing_procedures.md
@@ -425,10 +425,10 @@ Autoresearch uses GitHub Actions for continuous integration. The CI pipeline run
 
 ### CI Configuration
 
-The CI configuration is defined in `.github/workflows/test.yml`:
+The CI configuration is defined in `.github/workflows/ci.yml`:
 
 ```yaml
-name: Test
+name: CI
 
 on:
   push:
@@ -440,9 +440,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.12
     - name: Install dependencies
@@ -454,7 +454,7 @@ jobs:
       run: |
         poetry run pytest --cov=autoresearch
     - name: Upload coverage report
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
 ```
 
 ## Best Practices for UI Testing


### PR DESCRIPTION
## Summary
- update CI workflow path in `ui_testing_procedures.md`
- match example snippet with `ci.yml`

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(failed: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(failed: tests/behavior/steps/api_auth_steps.py::test_invalid_api_key)*

------
https://chatgpt.com/codex/tasks/task_e_686ef27cf8f0833380423ee42e29b7ed