### PR TITLE
Fix docs to reflect modular layout

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -4,7 +4,8 @@
 
 - `src/autoresearch/`
   - `__init__.py`
-  - `agentic_serper_search_v2.py` (core logic, to be modularized)
+  - `orchestration/orchestrator.py` (core agent coordination)
+  - `agents/` (individual agent implementations)
   - `config.py` (configuration system)
   - `main.py` (new entry point)
   - `output_format.py` (adaptive output formatting for CLI)
@@ -23,7 +24,7 @@
 
 ## 2. Modularization
 
-- Refactor `agentic_serper_search_v2.py`:
+- Refactor the monolithic `agentic_serper_search_v2.py` into the modular `orchestration` and `agents` packages:
   - Move configuration, logging, output formatting, and utility functions to separate modules.
   - Isolate agent logic, search logic, and synthesis logic.
 - Create `main.py` as the new CLI entry point.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -5,7 +5,7 @@
 - Modular Python package under `src/autoresearch/`.
 - Entry point: `main.py` (CLI, primary interface for all user and automation workflows).
 - Configuration: `config.py` (loads from `.env`, environment, or config file).
-- Core logic: Modularized from `agentic_serper_search_v2.py`.
+- Core logic: Provided by `orchestration/orchestrator.py` coordinating the `agents` modules.
 - Output formatting: `output_format.py` for adaptive, context-aware output.
 - Logging: Centralized, structured, and secure (no secrets).
 


### PR DESCRIPTION
## Summary
- update docs to mention orchestrator and agent modules instead of the old monolithic script

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest tests/behavior -q` *(fails: test_invalid_api_key)*

------
https://chatgpt.com/codex/tasks/task_e_686f0532001c83338ca4131e244cbbdb