### PR TITLE
Implement A2A message types

### DIFF
--- a/docs/a2a_mcp_integration.md
+++ b/docs/a2a_mcp_integration.md
@@ -196,6 +196,27 @@ result = client.query("What is the capital of France?")
 print(f"Answer: {result['answer']}")
 ```
 
+### A2A Query/Response Flow Example
+
+This example shows how to start the built-in A2A server and send a query using
+the :class:`A2AClient` helper.
+
+```python
+from autoresearch.a2a_interface import A2AInterface, A2AClient
+
+# Start the server
+interface = A2AInterface(host="127.0.0.1", port=8765)
+interface.start()
+
+# Query the agent
+client = A2AClient()
+response = client.query_agent("http://127.0.0.1:8765", "What is the capital of France?")
+print(response["answer"])
+
+# Shut down when done
+interface.stop()
+```
+
 ## MCP Integration
 
 The Multi-Agent Communication Protocol (MCP) is designed for more complex integration scenarios where agents need to communicate with each other in a structured way.

--- a/src/autoresearch/a2a_interface.py
+++ b/src/autoresearch/a2a_interface.py
@@ -11,6 +11,8 @@ import os
 import asyncio
 from functools import wraps
 from typing import Any, Callable, Dict
+from enum import Enum
+from pydantic import BaseModel
 from uuid import uuid4
 from threading import Thread
 
@@ -29,7 +31,7 @@ try:
     )
     A2A_AVAILABLE = True
 
-    class A2AMessageType(str):
+    class A2AMessageType(str, Enum):
         """Supported message types."""
 
         QUERY = "query"
@@ -38,6 +40,12 @@ try:
         RESULT = "result"
         ERROR = "error"
         ACK = "ack"
+
+    class A2AMessage(BaseModel):
+        """Message wrapper used by the A2A interface."""
+
+        type: A2AMessageType
+        message: Message
 
     class A2AServer:
         """Minimal A2A server based on FastAPI and uvicorn."""
@@ -262,10 +270,7 @@ class A2AInterface:
         """Handle a get_capabilities command.
 
         Returns:
-            The response A2A message with capabilities information
-
-        Raises:
-            NotImplementedError: A2AMessage and A2AMessageType are not implemented
+            The capabilities information as a dictionary.
         """
         capabilities = capabilities_endpoint()
         return capabilities
@@ -274,10 +279,7 @@ class A2AInterface:
         """Handle a get_config command.
 
         Returns:
-            The response A2A message with configuration information
-
-        Raises:
-            NotImplementedError: A2AMessage and A2AMessageType are not implemented
+            The current configuration as a dictionary.
         """
         config = get_config()
         return config.model_dump(mode="json")
@@ -289,10 +291,7 @@ class A2AInterface:
             args: The command arguments containing configuration updates
 
         Returns:
-            The response A2A message
-
-        Raises:
-            NotImplementedError: A2AMessage and A2AMessageType are not implemented
+            The updated configuration as a dictionary or an error object.
         """
         loader = ConfigLoader()
         current = loader.config.model_dump(mode="python")
@@ -323,9 +322,7 @@ class A2AClientWrapper:
                 "Install it with: pip install a2a-sdk"
             )
 
-        logger.warning(
-            "A2AMessage and A2AMessageType are not implemented. Client functionality is limited."
-        )
+        logger.info("A2A client initialized")
 
     def _send_request(self, agent_url: str, params: MessageSendParams) -> Dict[str, Any]:
         """Send a message request and return the raw response as a dict."""
@@ -464,7 +461,6 @@ def get_a2a_client() -> A2AClientWrapper:
 
     Raises:
         ImportError: If the a2a-sdk package is not installed
-        NotImplementedError: A2AMessage and A2AMessageType are not implemented
     """
     # Use the A2AClient class directly to ensure mocking works in tests
     return A2AClient()

--- a/tests/unit/test_a2a_interface.py
+++ b/tests/unit/test_a2a_interface.py
@@ -78,11 +78,13 @@ class TestA2AInterface:
 
         # Check that handlers were registered
         assert mock_a2a_server.register_handler.call_count == 3
+        from autoresearch.a2a_interface import A2AMessageType
+
         mock_a2a_server.register_handler.assert_has_calls(
             [
-                call("query", interface._handle_query),
-                call("command", interface._handle_command),
-                call("info", interface._handle_info),
+                call(A2AMessageType.QUERY, interface._handle_query),
+                call(A2AMessageType.COMMAND, interface._handle_command),
+                call(A2AMessageType.INFO, interface._handle_info),
             ]
         )
 


### PR DESCRIPTION
## Summary
- define `A2AMessage` and `A2AMessageType` with pydantic and Enum
- log initialization in `A2AClientWrapper`
- adjust unit tests for enum handlers
- document a complete A2A query/response example

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest tests/unit/test_a2a_interface.py -q` *(fails: coverage < 90)*

------
https://chatgpt.com/codex/tasks/task_e_686f0537aff8833387173fb79e532c9a