### PR TITLE
Fix auth role

### DIFF
--- a/src/autoresearch/api.py
+++ b/src/autoresearch/api.py
@@ -59,7 +59,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if cfg.api_key:
             if key != cfg.api_key:
                 return "anonymous", JSONResponse({"detail": "Invalid API key"}, status_code=401)
-            return "default", None
+            return "user", None
         return "anonymous", None
 
     async def dispatch(self, request: Request, call_next):


### PR DESCRIPTION
## Summary
- assign `user` role when a single API key is configured

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest tests/integration/test_api_auth.py tests/integration/test_api_auth_failure.py tests/behavior/steps/api_auth_steps.py::test_invalid_api_key -q` *(fails: response status 200 != 401)*

------
https://chatgpt.com/codex/tasks/task_e_68720b5bf4548333a7a5aa1a67d3fd4b