### PR TITLE
Enable mypy check_untyped_defs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ markers = [
 python_version = "3.12"
 ignore_missing_imports = true
 plugins = ["pydantic.mypy"]
+check_untyped_defs = true
 
 [tool.flake8]
 max-line-length = 100

--- a/src/autoresearch/streamlit_app.py
+++ b/src/autoresearch/streamlit_app.py
@@ -8,7 +8,7 @@ import streamlit as st
 import networkx as nx
 import matplotlib.pyplot as plt
 import matplotlib
-from typing import Dict, Any
+from typing import Dict, Any, List
 import random
 import io
 import time
@@ -899,7 +899,11 @@ def display_agent_performance():
         st.markdown("### Agent Performance Comparison")
 
         # Create a DataFrame for the comparison
-        comparison_data = {"Agent": [], "Metric": [], "Value": []}
+        comparison_data: Dict[str, List[Any]] = {
+            "Agent": [],
+            "Metric": [],
+            "Value": [],
+        }
 
         for agent_name, metrics in agent_performance.items():
             avg_duration = (


### PR DESCRIPTION
## Summary
- enable `check_untyped_defs` in mypy config
- type annotate a local variable in `streamlit_app.py`

## Testing
- `poetry run mypy src`
- `poetry run flake8 src tests`
- `poetry run pytest tests/behavior -q` *(fails: test_invalid_api_key)*

------
https://chatgpt.com/codex/tasks/task_e_6873d331a61c83339496fb4f6c44382f