### PR TITLE
Improve failure logging in monitoring and distributed modules

### DIFF
--- a/src/autoresearch/monitor/__init__.py
+++ b/src/autoresearch/monitor/__init__.py
@@ -21,11 +21,13 @@ from ..config import ConfigLoader
 from ..orchestration.orchestrator import Orchestrator
 from ..orchestration.state import QueryState
 from ..output_format import OutputFormatter
+from ..logging_utils import get_logger
 
 monitor_app = typer.Typer(help="Monitoring utilities", invoke_without_command=True)
 
 _loader = ConfigLoader()
 _system_monitor: SystemMonitor | None = None
+log = get_logger(__name__)
 
 
 @monitor_app.callback(invoke_without_command=True)
@@ -68,8 +70,8 @@ def _collect_system_metrics() -> Dict[str, Any]:
         metrics.setdefault("memory_percent", mem.percent)
         metrics["memory_used_mb"] = mem.used / (1024 * 1024)
         metrics["process_memory_mb"] = proc.memory_info().rss / (1024 * 1024)
-    except Exception:
-        pass
+    except Exception as e:
+        log.warning("Failed to collect system metrics", exc_info=e)
 
     metrics["tokens_in_total"] = int(orch_metrics.TOKENS_IN_COUNTER._value.get())
     metrics["tokens_out_total"] = int(orch_metrics.TOKENS_OUT_COUNTER._value.get())

--- a/src/autoresearch/resource_monitor.py
+++ b/src/autoresearch/resource_monitor.py
@@ -10,6 +10,8 @@ import structlog
 from prometheus_client import Gauge, start_http_server, CollectorRegistry, REGISTRY
 from .orchestration import metrics as orch_metrics
 
+log = structlog.get_logger(__name__)
+
 
 _DEF_REGISTRY = REGISTRY
 
@@ -33,8 +35,8 @@ def _get_gpu_stats() -> tuple[float, float]:
         if count:
             util_total /= count
         return util_total, mem_total
-    except Exception:
-        pass
+    except Exception as e:
+        log.warning("Failed to get GPU stats via pynvml", exc_info=e)
 
     try:  # pragma: no cover - may not be present
         import subprocess
@@ -78,8 +80,8 @@ def _get_gpu_stats() -> tuple[float, float]:
             avg_util = sum(utils) / len(utils)
             total_mem = sum(mems)
             return avg_util, total_mem
-    except Exception:
-        pass
+    except Exception as e:
+        log.warning("Failed to get GPU stats via nvidia-smi", exc_info=e)
 
     return 0.0, 0.0
 


### PR DESCRIPTION
## Summary
- log GPU stats failures in `resource_monitor.py`
- report session handling errors in `_execute_agent_remote`
- surface broker shutdown issues in `RayExecutor.shutdown`
- log metric collection errors in monitor utilities

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `timeout 60 poetry run pytest -q` *(failed: KeyboardInterrupt)*
- `timeout 60 poetry run pytest tests/behavior` *(failed: 1 failed, 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6873e6345c58833389edfdbfa91aee75