### PR TITLE
Mark slow tests and add doc for fast subset

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -31,10 +31,20 @@ This guide describes how to set up a development environment and the expected wo
 2. Run the full test suite:
    ```bash
    poetry run pytest -q
-   poetry run pytest tests/behavior
-   ```
-   All testing commands should be executed with `poetry run` to use the
-   project's virtual environment.
+    poetry run pytest tests/behavior
+    ```
+    All testing commands should be executed with `poetry run` to use the
+    project's virtual environment.
+
+### Running only fast tests
+
+For quick feedback, you can skip heavy integration tests marked with
+`@pytest.mark.slow`:
+
+```bash
+poetry run pytest -m "not slow" -q
+poetry run pytest -m "not slow" tests/behavior
+```
 3. Update or add documentation when needed.
 4. Open a pull request explaining the rationale for the change.
 

--- a/tests/integration/test_distributed_agent_storage.py
+++ b/tests/integration/test_distributed_agent_storage.py
@@ -1,5 +1,6 @@
 import os
 import ray
+import pytest
 from autoresearch.distributed import RayExecutor
 from autoresearch.config import ConfigModel, DistributedConfig, StorageConfig
 from autoresearch.storage import StorageManager
@@ -22,6 +23,7 @@ class ClaimAgent:
         return {"results": {self.name: "ok"}}
 
 
+@pytest.mark.slow
 def test_distributed_storage_with_executor(tmp_path, monkeypatch):
     pids: list[int] = []
     monkeypatch.setattr(AgentFactory, "get", lambda name: ClaimAgent(name, pids))

--- a/tests/integration/test_distributed_orchestration.py
+++ b/tests/integration/test_distributed_orchestration.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from autoresearch.distributed import ProcessExecutor
 from autoresearch.config import ConfigModel, DistributedConfig, StorageConfig
 from autoresearch.models import QueryResponse
@@ -22,6 +23,7 @@ class ClaimAgent:
         return {"results": {self.name: "ok"}, "claims": [claim]}
 
 
+@pytest.mark.slow
 def test_distributed_orchestration_persistence(tmp_path, monkeypatch):
     pids: list[int] = []
     monkeypatch.setattr(AgentFactory, "get", lambda name: ClaimAgent(name, pids))

--- a/tests/integration/test_distributed_process_storage.py
+++ b/tests/integration/test_distributed_process_storage.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from autoresearch.distributed import ProcessExecutor
 from autoresearch.config import ConfigModel, DistributedConfig, StorageConfig
 from autoresearch.storage import StorageManager
@@ -21,6 +22,7 @@ class ClaimAgent:
         return {"results": {self.name: "ok"}}
 
 
+@pytest.mark.slow
 def test_process_storage_with_executor(tmp_path, monkeypatch):
     pids: list[int] = []
     monkeypatch.setattr(AgentFactory, "get", lambda name: ClaimAgent(name, pids))

--- a/tests/integration/test_distributed_results.py
+++ b/tests/integration/test_distributed_results.py
@@ -1,5 +1,6 @@
 import os
 import ray
+import pytest
 from autoresearch.distributed import RayExecutor
 from autoresearch.config import ConfigModel, DistributedConfig
 from autoresearch.models import QueryResponse
@@ -21,6 +22,7 @@ class DummyAgent:
         return {"results": {self.name: "ok"}}
 
 
+@pytest.mark.slow
 def test_result_aggregation_multi_process(monkeypatch):
     pids: list[int] = []
     monkeypatch.setattr(AgentFactory, "get", lambda name: DummyAgent(name, pids))

--- a/tests/integration/test_distributed_storage.py
+++ b/tests/integration/test_distributed_storage.py
@@ -1,10 +1,12 @@
 import os
 import ray
+import pytest
 from autoresearch.config import ConfigModel, DistributedConfig, StorageConfig
 from autoresearch.distributed import start_storage_coordinator
 from autoresearch.storage import StorageManager
 
 
+@pytest.mark.slow
 def test_distributed_storage(tmp_path):
     cfg = ConfigModel(
         distributed=True,

--- a/tests/integration/test_knn_benchmark.py
+++ b/tests/integration/test_knn_benchmark.py
@@ -1,3 +1,4 @@
+import os
 import time
 import numpy as np
 import pytest
@@ -5,6 +6,7 @@ from autoresearch.storage import StorageManager
 from autoresearch.config import ConfigModel, StorageConfig, ConfigLoader
 
 
+@pytest.mark.slow
 def test_knn_latency_benchmark(tmp_path, monkeypatch):
     cfg = ConfigModel(
         storage=StorageConfig(
@@ -28,7 +30,7 @@ def test_knn_latency_benchmark(tmp_path, monkeypatch):
         pytest.skip("Vector extension not available")
 
     dim = 384
-    n = 10000
+    n = int(os.environ.get("KNN_BENCHMARK_N", "1000"))
     nodes = [(f"n{i}", "", "", 0.0) for i in range(n)]
     vectors = [(f"n{i}", np.random.rand(dim).astype(float).tolist()) for i in range(n)]
 

--- a/tests/integration/test_process_executor.py
+++ b/tests/integration/test_process_executor.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from autoresearch.distributed import ProcessExecutor
 from autoresearch.config import ConfigModel, DistributedConfig
 from autoresearch.models import QueryResponse
@@ -20,6 +21,7 @@ class DummyAgent:
         return {"results": {self.name: "ok"}}
 
 
+@pytest.mark.slow
 def test_process_executor_multi_process(monkeypatch):
     pids: list[int] = []
     monkeypatch.setattr(AgentFactory, "get", lambda name: DummyAgent(name, pids))
@@ -36,6 +38,7 @@ def test_process_executor_multi_process(monkeypatch):
     executor.shutdown()
 
 
+@pytest.mark.slow
 def test_process_result_aggregation(monkeypatch):
     pids: list[int] = []
     monkeypatch.setattr(AgentFactory, "get", lambda name: DummyAgent(name, pids))


### PR DESCRIPTION
## Summary
- mark integration tests that spawn multiple processes as `slow`
- reduce dataset size in KNN benchmark and allow env override
- update developer guide with instructions for running fast tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest tests/behavior -q` *(fails: test_invalid_api_key)*

------
https://chatgpt.com/codex/tasks/task_e_6874132c5c148333bfe2c0bc46fbdc35