### PR TITLE
Improve shutdown logging for ProcessExecutor

### DIFF
--- a/src/autoresearch/distributed.py
+++ b/src/autoresearch/distributed.py
@@ -369,21 +369,23 @@ class ProcessExecutor:
         if self.broker and self.storage_coordinator:
             try:
                 self.broker.publish({"action": "stop"})
-            except Exception:
-                pass
+            except Exception as e:
+                log.warning("Failed to publish stop message", exc_info=e)
             self.storage_coordinator.join()
             try:
                 self.broker.shutdown()
-            except Exception:
-                pass
+            except Exception as e:
+                log.warning("Failed to shutdown broker", exc_info=e)
             storage.set_message_queue(None)
         if self.result_broker and self.result_aggregator:
             try:
                 self.result_broker.publish({"action": "stop"})
-            except Exception:
-                pass
+            except Exception as e:
+                log.warning(
+                    "Failed to publish stop to result broker", exc_info=e
+                )
             self.result_aggregator.join()
             try:
                 self.result_broker.shutdown()
-            except Exception:
-                pass
+            except Exception as e:
+                log.warning("Failed to shutdown result broker", exc_info=e)


### PR DESCRIPTION
## Summary
- log exceptions during ProcessExecutor shutdown

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: test_invalid_api_key)*

------
https://chatgpt.com/codex/tasks/task_e_687413005e5c8333ac7b5c741f5e0d03