### PR TITLE
Add agent messaging and coalition support

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -18,6 +18,13 @@ Additional specialized agents extend these roles:
 
 Agents communicate via a shared state object and can be customized in `autoresearch.toml`.
 
+When `enable_agent_messages` is set to `true` in the configuration, agents may
+exchange short messages using the `Agent.send_message()` API. Messages are stored
+on the `QueryState` and retrieved with `Agent.get_messages()`. Coalitions can be
+defined in the `[coalitions]` section of the config to broadcast messages among
+groups of agents. Enabling `enable_feedback` allows agents such as the Critic or
+User agent to send feedback messages to their peers during a cycle.
+
 ## Architecture
 
 The agents component consists of several key classes:

--- a/docs/component_interactions.md
+++ b/docs/component_interactions.md
@@ -102,6 +102,16 @@ Key interactions:
 - Agents execute queries using LLM adapters
 - Agents return structured results to the Orchestrator
 
+#### Agent Communication and Coalitions
+
+When `enable_agent_messages` is enabled the Orchestrator records messages sent
+between agents on the shared ``QueryState``.  Agents call ``send_message`` and
+``get_messages`` from the base class to coordinate their work.  Coalitions
+declared in the configuration allow groups of agents to broadcast messages to
+each other.  With ``enable_feedback`` active, agents such as the Critic and User
+agents publish feedback about their peers' outputs which subsequent agents can
+consume in the same cycle.
+
 ### Storage System
 
 The storage system persists research findings and enables knowledge retrieval:

--- a/src/autoresearch/agents/specialized/domain_specialist.py
+++ b/src/autoresearch/agents/specialized/domain_specialist.py
@@ -71,7 +71,7 @@ class DomainSpecialistAgent(Agent):
         analysis_claim = self.create_claim(analysis, "domain_analysis")
         recommendations_claim = self.create_claim(recommendations, "domain_recommendations")
 
-        return self.create_result(
+        result = self.create_result(
             claims=[analysis_claim, recommendations_claim],
             metadata={
                 "phase": DialoguePhase.ANALYSIS,
@@ -84,6 +84,20 @@ class DomainSpecialistAgent(Agent):
                 "domain": self.domain
             },
         )
+
+        if getattr(config, "enable_agent_messages", False):
+            if state.coalitions:
+                for c, m in state.coalitions.items():
+                    if self.name in m:
+                        self.broadcast(
+                            state,
+                            f"Domain analysis ready in cycle {state.cycle}",
+                            coalition=c,
+                        )
+            else:
+                self.send_message(state, "Domain analysis ready")
+
+        return result
 
     def can_execute(self, state: QueryState, config: ConfigModel) -> bool:
         """Determine if this specialist should execute based on the query domain."""

--- a/src/autoresearch/agents/specialized/moderator.py
+++ b/src/autoresearch/agents/specialized/moderator.py
@@ -65,7 +65,7 @@ class ModeratorAgent(Agent):
         moderation_claim = self.create_claim(moderation, "moderation")
         guidance_claim = self.create_claim(guidance, "guidance")
 
-        return self.create_result(
+        result = self.create_result(
             claims=[moderation_claim, guidance_claim],
             metadata={
                 "phase": DialoguePhase.MODERATION,
@@ -78,6 +78,20 @@ class ModeratorAgent(Agent):
                 "conflicts": conflicts
             },
         )
+
+        if getattr(config, "enable_agent_messages", False):
+            if state.coalitions:
+                for c, m in state.coalitions.items():
+                    if self.name in m:
+                        self.broadcast(
+                            state,
+                            f"Moderation guidance ready in cycle {state.cycle}",
+                            coalition=c,
+                        )
+            else:
+                self.send_message(state, "Moderation guidance ready")
+
+        return result
 
     def can_execute(self, state: QueryState, config: ConfigModel) -> bool:
         """Only execute when there are multiple claims from different agents."""

--- a/src/autoresearch/agents/specialized/planner.py
+++ b/src/autoresearch/agents/specialized/planner.py
@@ -36,13 +36,27 @@ class PlannerAgent(Agent):
 
         # Create and return the result
         claim = self.create_claim(research_plan, "research_plan")
-        return self.create_result(
+        result = self.create_result(
             claims=[claim],
             metadata={
                 "phase": DialoguePhase.PLANNING,
             },
             results={"research_plan": research_plan},
         )
+
+        if getattr(config, "enable_agent_messages", False):
+            if state.coalitions:
+                for c, m in state.coalitions.items():
+                    if self.name in m:
+                        self.broadcast(
+                            state,
+                            f"Planning complete in cycle {state.cycle}",
+                            coalition=c,
+                        )
+            else:
+                self.send_message(state, "Planning complete")
+
+        return result
 
     def can_execute(self, state: QueryState, config: ConfigModel) -> bool:
         """Best executed at the beginning of the research process."""

--- a/src/autoresearch/agents/specialized/researcher.py
+++ b/src/autoresearch/agents/specialized/researcher.py
@@ -56,7 +56,7 @@ class ResearcherAgent(Agent):
 
         # Create and return the result
         claim = self.create_claim(research_findings, "research_findings")
-        return self.create_result(
+        result = self.create_result(
             claims=[claim],
             metadata={
                 "phase": DialoguePhase.RESEARCH,
@@ -65,6 +65,20 @@ class ResearcherAgent(Agent):
             results={"research_findings": research_findings},
             sources=sources,
         )
+
+        if getattr(config, "enable_agent_messages", False):
+            if state.coalitions:
+                for c, m in state.coalitions.items():
+                    if self.name in m:
+                        self.broadcast(
+                            state,
+                            f"Research complete in cycle {state.cycle}",
+                            coalition=c,
+                        )
+            else:
+                self.send_message(state, "Research complete")
+
+        return result
 
     def can_execute(self, state: QueryState, config: ConfigModel) -> bool:
         """Determine if this agent should execute in the current state."""

--- a/src/autoresearch/agents/specialized/summarizer.py
+++ b/src/autoresearch/agents/specialized/summarizer.py
@@ -58,7 +58,7 @@ class SummarizerAgent(Agent):
 
         # Create and return the result
         claim = self.create_claim(summary, "summary")
-        return self.create_result(
+        result = self.create_result(
             claims=[claim],
             metadata={
                 "phase": DialoguePhase.SUMMARY,
@@ -66,6 +66,20 @@ class SummarizerAgent(Agent):
             },
             results={"summary": summary},
         )
+
+        if getattr(config, "enable_agent_messages", False):
+            if state.coalitions:
+                for c, m in state.coalitions.items():
+                    if self.name in m:
+                        self.broadcast(
+                            state,
+                            f"Summary ready in cycle {state.cycle}",
+                            coalition=c,
+                        )
+            else:
+                self.send_message(state, "Summary ready")
+
+        return result
 
     def can_execute(self, state: QueryState, config: ConfigModel) -> bool:
         """Only execute when there is content to summarize."""

--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -315,6 +315,20 @@ class ConfigModel(BaseSettings):
     # User preference settings
     user_preferences: Dict[str, Any] = Field(default_factory=dict)
 
+    # Agent communication settings
+    enable_agent_messages: bool = Field(
+        default=False,
+        description="Allow agents to exchange messages during cycles",
+    )
+    enable_feedback: bool = Field(
+        default=False,
+        description="Enable cross-agent feedback messages",
+    )
+    coalitions: Dict[str, List[str]] = Field(
+        default_factory=dict,
+        description="Named coalitions of agents for message broadcasting",
+    )
+
     # Dynamic knowledge graph settings
     graph_eviction_policy: str = Field(default="LRU")
 

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -79,6 +79,9 @@ class Orchestrator:
         max_errors = config.max_errors if hasattr(config, "max_errors") else 3
         cb_threshold = getattr(config, "circuit_breaker_threshold", 3)
         cb_cooldown = getattr(config, "circuit_breaker_cooldown", 30)
+        enable_messages = getattr(config, "enable_agent_messages", False)
+        coalitions = getattr(config, "coalitions", {})
+        enable_feedback = getattr(config, "enable_feedback", False)
 
         # Adjust parameters based on reasoning mode
         if mode == ReasoningMode.DIRECT:
@@ -93,6 +96,9 @@ class Orchestrator:
             "max_errors": max_errors,
             "circuit_breaker_threshold": cb_threshold,
             "circuit_breaker_cooldown": cb_cooldown,
+            "enable_agent_messages": enable_messages,
+            "enable_feedback": enable_feedback,
+            "coalitions": coalitions,
         }
 
     @staticmethod
@@ -992,7 +998,11 @@ class Orchestrator:
             )
 
         # Initialize query state
-        state = QueryState(query=query, primus_index=primus_index)
+        state = QueryState(
+            query=query,
+            primus_index=primus_index,
+            coalitions=config_params.get("coalitions", {}),
+        )
 
         # Execute dialectical cycles with detailed logging
         log.info(
@@ -1131,7 +1141,11 @@ class Orchestrator:
                 agent_factory=agent_factory,
             )
 
-        state = QueryState(query=query, primus_index=primus_index)
+        state = QueryState(
+            query=query,
+            primus_index=primus_index,
+            coalitions=config_params.get("coalitions", {}),
+        )
 
         log.info(
             f"Starting dialectical process with {len(agents)} agents and {loops} loops",
@@ -1226,7 +1240,10 @@ class Orchestrator:
         log = get_logger(__name__)
 
         # Create a state for the final synthesis
-        final_state = QueryState(query=query)
+        final_state = QueryState(
+            query=query,
+            coalitions=getattr(config, "coalitions", {}),
+        )
 
         # Calculate optimal number of workers based on system resources and group count
         cpu_count = os.cpu_count() or 4


### PR DESCRIPTION
## Summary
- implement message-passing API in base Agent
- extend QueryState and ConfigModel with messaging fields
- allow orchestrator to pass coalition config to states
- update specialized agents to broadcast messages and send feedback when enabled
- document new agent communication features

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(failed: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(failed: 1 failed, 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687436c2f7fc833386a1c56cc7549d90