### PR TITLE
Add user preference tests

### DIFF
--- a/tests/unit/test_user_preferences.py
+++ b/tests/unit/test_user_preferences.py
@@ -1,0 +1,62 @@
+import tomli_w
+import pytest
+from unittest.mock import patch, MagicMock
+
+from autoresearch.agents.specialized.user_agent import UserAgent
+from autoresearch.config import ConfigLoader, ConfigModel
+from autoresearch.orchestration.state import QueryState
+
+
+@pytest.fixture
+def simple_state():
+    # Reset preferences between tests
+    UserAgent.preferences = {
+        "detail_level": "balanced",
+        "perspective": "neutral",
+        "format_preference": "structured",
+        "expertise_level": "intermediate",
+        "focus_areas": [],
+        "excluded_areas": [],
+    }
+    state = QueryState(query="example")
+    state.claims = [{"id": "1", "type": "thesis", "content": "c"}]
+    state.cycle = 1
+    return state
+
+
+def test_user_agent_loads_preferences(monkeypatch, simple_state):
+    mock_adapter = MagicMock()
+    mock_adapter.generate.return_value = "resp"
+    with patch("autoresearch.llm.get_pooled_adapter", return_value=mock_adapter):
+        cfg = ConfigModel(user_preferences={"detail_level": "detailed", "focus_areas": ["ai"]})
+        agent = UserAgent(name="User")
+        result = agent.execute(simple_state, cfg)
+
+    assert result["metadata"]["user_preferences"]["detail_level"] == "detailed"
+    assert result["metadata"]["user_preferences"]["focus_areas"] == ["ai"]
+
+
+def test_user_preferences_hot_reload(tmp_path, monkeypatch, simple_state):
+    monkeypatch.chdir(tmp_path)
+    ConfigLoader.reset_instance()
+    cfg_path = tmp_path / "autoresearch.toml"
+    cfg_path.write_text(tomli_w.dumps({"core": {"loops": 1}, "user_preferences": {"detail_level": "concise"}}))
+
+    loader = ConfigLoader()
+    loader._config = loader.load_config()
+    loader._update_watch_paths()
+    loader.watch_changes()
+
+    mock_adapter = MagicMock()
+    mock_adapter.generate.return_value = "resp"
+    with patch("autoresearch.llm.get_pooled_adapter", return_value=mock_adapter):
+        agent = UserAgent(name="User")
+        first = agent.execute(simple_state, loader.config)
+        first_prefs = first["metadata"]["user_preferences"].copy()
+
+        cfg_path.write_text(tomli_w.dumps({"core": {"loops": 1}, "user_preferences": {"detail_level": "detailed"}}))
+        loader._config = loader.load_config()
+        second = agent.execute(simple_state, loader.config)
+
+    assert first_prefs["detail_level"] == "concise"
+    assert second["metadata"]["user_preferences"]["detail_level"] == "detailed"


### PR DESCRIPTION
## Summary
- add tests validating that `UserAgent` uses config `user_preferences`
- ensure preferences update correctly when `ConfigLoader` reloads

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest tests/unit/test_user_preferences.py -q` *(fails coverage when running alone)*
- `time poetry run pytest -q` *(fails to complete within allowed time)*

------
https://chatgpt.com/codex/tasks/task_e_687457b986088333a19e7a46df7505ff