### PR TITLE
Enable inter-agent messaging and coalitions

### DIFF
--- a/src/autoresearch/agents/registry.py
+++ b/src/autoresearch/agents/registry.py
@@ -23,6 +23,7 @@ class AgentRegistry:
     """
 
     _registry: Dict[str, Type[Agent]] = {}
+    _coalitions: Dict[str, List[str]] = {}
 
     @classmethod
     def register(cls, name: str, agent_class: Type[Agent]) -> None:
@@ -60,6 +61,28 @@ class AgentRegistry:
             A list of names of all registered agent types
         """
         return list(cls._registry.keys())
+
+    # ------------------------------------------------------------------
+    # Coalition management
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def create_coalition(cls, name: str, members: List[str]) -> None:
+        """Register a named coalition of agents."""
+        for member in members:
+            if member not in cls._registry:
+                raise ValueError(f"Unknown agent type: {member}")
+        cls._coalitions[name] = members
+
+    @classmethod
+    def get_coalition(cls, name: str) -> List[str]:
+        """Return members of a registered coalition."""
+        return cls._coalitions.get(name, [])
+
+    @classmethod
+    def list_coalitions(cls) -> List[str]:
+        """List all registered coalitions."""
+        return list(cls._coalitions.keys())
 
 
 class AgentFactory:

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -29,7 +29,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 import asyncio
 
-from ..agents.registry import AgentFactory
+from ..agents.registry import AgentFactory, AgentRegistry
 from ..config import ConfigModel
 from .reasoning import ReasoningMode, ChainOfThoughtStrategy
 from ..models import QueryResponse
@@ -81,6 +81,8 @@ class Orchestrator:
         cb_cooldown = getattr(config, "circuit_breaker_cooldown", 30)
         enable_messages = getattr(config, "enable_agent_messages", False)
         coalitions = getattr(config, "coalitions", {})
+        for cname, members in coalitions.items():
+            AgentRegistry.create_coalition(cname, members)
         enable_feedback = getattr(config, "enable_feedback", False)
 
         # Adjust parameters based on reasoning mode

--- a/src/autoresearch/orchestration/state.py
+++ b/src/autoresearch/orchestration/state.py
@@ -48,6 +48,27 @@ class QueryState(BaseModel):
         """Store a message exchanged between agents."""
         self.messages.append(message)
 
+    # ------------------------------------------------------------------
+    # Coalition management utilities
+    # ------------------------------------------------------------------
+
+    def add_coalition(self, name: str, members: List[str]) -> None:
+        """Register a coalition of agents.
+
+        Args:
+            name: Name of the coalition
+            members: Agent names that belong to the coalition
+        """
+        self.coalitions[name] = members
+
+    def remove_coalition(self, name: str) -> None:
+        """Remove a coalition if it exists."""
+        self.coalitions.pop(name, None)
+
+    def get_coalition_members(self, name: str) -> List[str]:
+        """Return members of a coalition."""
+        return self.coalitions.get(name, [])
+
     def get_messages(
         self,
         *,

--- a/tests/unit/test_agent_communication.py
+++ b/tests/unit/test_agent_communication.py
@@ -1,0 +1,41 @@
+from autoresearch.agents.base import Agent, AgentRole
+from autoresearch.agents.registry import AgentFactory, AgentRegistry
+from autoresearch.orchestration.state import QueryState
+
+
+class SimpleAgent(Agent):
+    role: AgentRole = AgentRole.SPECIALIST
+
+    def execute(self, state, config):
+        return {}
+
+
+def test_message_exchange_and_feedback():
+    state = QueryState(query="q", coalitions={"team": ["Alice", "Bob"]})
+    alice = SimpleAgent(name="Alice")
+    bob = SimpleAgent(name="Bob")
+
+    alice.send_message(state, "hello", to="Bob")
+    bob_messages = bob.get_messages(state, from_agent="Alice")
+    assert len(bob_messages) == 1
+    assert bob_messages[0]["content"] == "hello"
+
+    bob.send_feedback(state, "Alice", "good job")
+    feedback = alice.get_messages(state, from_agent="Bob")
+    assert feedback[0]["type"] == "feedback"
+    assert feedback[0]["content"] == "good job"
+
+
+def test_coalition_management_in_state():
+    state = QueryState(query="q")
+    state.add_coalition("c1", ["A", "B"])
+    assert state.get_coalition_members("c1") == ["A", "B"]
+    state.remove_coalition("c1")
+    assert state.get_coalition_members("c1") == []
+
+
+def test_agent_registry_coalitions():
+    AgentFactory.register("Simple", SimpleAgent)
+    AgentRegistry.create_coalition("squad", ["Simple"])
+    assert "squad" in AgentRegistry.list_coalitions()
+    assert AgentRegistry.get_coalition("squad") == ["Simple"]


### PR DESCRIPTION
## Summary
- add coalition management methods to `QueryState`
- extend `AgentRegistry` with coalition helpers
- register coalitions in the orchestrator config parser
- test message passing and coalition utilities

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q tests/unit/test_agent_communication.py` *(fails: coverage < 90%)*
- `poetry run pytest tests/behavior -k "none" -q` *(fails: coverage < 90%)*

------
https://chatgpt.com/codex/tasks/task_e_68746133b26c83338c5bccc1698fdc88