### PR TITLE
Fix API auth config reload

### DIFF
--- a/src/autoresearch/api.py
+++ b/src/autoresearch/api.py
@@ -65,7 +65,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         if request.url.path in {"/docs", "/openapi.json"}:
             return await call_next(request)
-        cfg = get_config().api
+        loader = ConfigLoader()
+        loader._config = loader.load_config()
+        cfg = loader._config.api
         role, error = self._resolve_role(request.headers.get("X-API-Key"), cfg)
         if error:
             return error


### PR DESCRIPTION
## Summary
- reload API config every request

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*
- `poetry run pytest tests/behavior -k api_auth -q` *(fails: assertion 200 == 429)*

------
https://chatgpt.com/codex/tasks/task_e_68746ee161d883339265b05368930268