### PR TITLE
Add agent communication docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,21 @@ and `.env` for changes. Updates to these files are picked up automatically and
 the configuration is reloaded on the fly. The watcher shuts down gracefully when
 the process exits.
 
+### Agent Communication Features
+
+Enable message passing and feedback by adding these options to `autoresearch.toml`:
+
+```toml
+[coalitions]
+research_team = ["Synthesizer", "Contrarian", "FactChecker"]
+
+enable_agent_messages = true
+enable_feedback = true
+```
+
+Agents can then share short notes with `send_message()` and read them using
+`get_messages()` in the next cycle.
+
 ## Usage Examples
 
 ### Different Reasoning Modes

--- a/docs/agent_communication.md
+++ b/docs/agent_communication.md
@@ -1,0 +1,31 @@
+# Agent Communication
+
+Autoresearch can optionally let agents exchange short messages during each reasoning cycle.
+When `enable_agent_messages` is `true`, any agent may call `send_message()` to
+share information with its peers. These messages are stored on the shared
+`QueryState` and can be retrieved with `get_messages()` in later steps.
+
+## Coalitions
+
+Agents can be grouped into named coalitions for message broadcasting. Define
+them in a `[coalitions]` section. Messages sent by one member are delivered to
+all other agents in the same coalition.
+
+```toml
+[coalitions]
+research_team = ["Synthesizer", "Contrarian", "FactChecker"]
+
+enable_agent_messages = true
+```
+
+## Feedback Mechanism
+
+Enabling `enable_feedback` lets agents such as the Critic or UserAgent provide
+feedback about other agents' outputs. Feedback messages are stored like normal
+agent messages and can influence subsequent reasoning.
+
+```toml
+enable_feedback = true
+```
+
+For a brief overview of available agents see [Agents](agents.md).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -25,6 +25,8 @@ defined in the `[coalitions]` section of the config to broadcast messages among
 groups of agents. Enabling `enable_feedback` allows agents such as the Critic or
 User agent to send feedback messages to their peers during a cycle.
 
+See [Agent Communication](agent_communication.md) for configuration examples.
+
 ## Architecture
 
 The agents component consists of several key classes:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,6 +241,26 @@ tracing_enabled = true
 
 The same option can be set via the environment variable `CORE__TRACING_ENABLED=true`.
 
+## Agent Communication Settings
+
+Enable cross-agent messaging and feedback with the following options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enable_agent_messages` | boolean | `false` | Allow agents to exchange messages during a cycle |
+| `enable_feedback` | boolean | `false` | Enable dedicated feedback messages between agents |
+| `coalitions` | table | `{}` | Named groups of agents for message broadcasting |
+
+Example:
+
+```toml
+[coalitions]
+research_team = ["Synthesizer", "Contrarian", "FactChecker"]
+
+enable_agent_messages = true
+enable_feedback = true
+```
+
 ## Distributed Execution
 
 To run agents across multiple processes or machines, configure the `[distributed]` section:

--- a/docs/examples/autoresearch.toml
+++ b/docs/examples/autoresearch.toml
@@ -1,3 +1,9 @@
+[coalitions]
+research_team = ["Synthesizer", "Contrarian", "FactChecker"]
+
+enable_agent_messages = true
+enable_feedback = true
+
 [core]
 llm_backend = "lmstudio"
 loops = 3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ nav:
   - Getting Started: getting_started.md
   - Configuration: configuration.md
   - Agents: agents.md
+  - Agent Communication: agent_communication.md
   - Storage: storage.md
   - Orchestration: orchestration.md
   - API Usage: api.md


### PR DESCRIPTION
## Summary
- document agent-to-agent messaging and feedback
- add config guide for coalitions
- include communication snippet in README
- provide example settings in `autoresearch.toml`
- link new page in MkDocs navigation

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: rate_limit_exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_6874873e5d9c833389d1b4ee51e8731b