### PR TITLE
Implement inter-agent messaging

### DIFF
--- a/src/autoresearch/agents/__init__.py
+++ b/src/autoresearch/agents/__init__.py
@@ -1,6 +1,8 @@
 """Dialectical agent infrastructure."""
 
 from .base import Agent, AgentRole
+from .messaging import AgentMessage, MessageBus
+from .mixins import MessageHandlerMixin
 from .registry import AgentRegistry, AgentFactory
 from .dialectical import SynthesizerAgent, ContrarianAgent, FactChecker
 from .specialized import ResearcherAgent, CriticAgent, SummarizerAgent, PlannerAgent
@@ -28,4 +30,7 @@ __all__ = [
     "CriticAgent",
     "SummarizerAgent",
     "PlannerAgent",
+    "AgentMessage",
+    "MessageBus",
+    "MessageHandlerMixin",
 ]

--- a/src/autoresearch/agents/messaging.py
+++ b/src/autoresearch/agents/messaging.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""Utilities for inter-agent messaging."""
+
+from typing import Any, Dict, List
+import time
+from pydantic import BaseModel, Field
+
+from ..orchestration.state import QueryState
+
+
+class AgentMessage(BaseModel):
+    """Representation of a message exchanged between agents."""
+
+    sender: str = Field(..., alias="from")
+    recipient: str | None = Field(None, alias="to")
+    coalition: str | None = None
+    type: str = "message"
+    content: str
+    cycle: int = 0
+    timestamp: float = Field(default_factory=time.time)
+
+    model_config = {
+        "populate_by_name": True,
+        "extra": "ignore",
+    }
+
+
+class MessageBus:
+    """Simple message bus storing messages in :class:`QueryState`."""
+
+    @staticmethod
+    def send(state: QueryState, message: AgentMessage) -> None:
+        """Add a message to the state's message list."""
+
+        state.add_message(message.model_dump(by_alias=True))
+
+    @staticmethod
+    def broadcast(state: QueryState, message: AgentMessage, coalition: str) -> None:
+        """Broadcast a message to all members of a coalition."""
+
+        members = state.coalitions.get(coalition, [])
+        for member in members:
+            msg = message.model_copy(update={"recipient": member, "coalition": coalition})
+            MessageBus.send(state, msg)
+
+    @staticmethod
+    def inbox(state: QueryState, agent_name: str) -> List[Dict[str, Any]]:
+        """Retrieve new messages for ``agent_name``."""
+
+        delivered = state.metadata.setdefault("_delivered", {}).setdefault(agent_name, 0)
+        messages = state.get_messages(recipient=agent_name)
+        new = messages[delivered:]
+        state.metadata["_delivered"][agent_name] = delivered + len(new)
+        return new

--- a/src/autoresearch/agents/mixins.py
+++ b/src/autoresearch/agents/mixins.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from ..config import ConfigModel
 from ..logging_utils import get_logger
 from .prompts import render_prompt
+from ..orchestration.state import QueryState
 
 log = get_logger(__name__)
 
@@ -104,3 +105,14 @@ class ResultGeneratorMixin:
         if sources:
             result["sources"] = sources
         return result
+
+class MessageHandlerMixin:
+    """Mixin for agents that handle incoming messages."""
+
+    def receive_messages(self, messages: List[Dict[str, Any]], state: QueryState) -> None:
+        """Handle incoming messages before execution.
+
+        Subclasses can override this method to process messages directed at them.
+        The default implementation does nothing.
+        """
+        return

--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -335,6 +335,11 @@ class ConfigModel(BaseSettings):
         default=False,
         description="Enable cross-agent feedback messages",
     )
+    message_retention: int = Field(
+        default=50,
+        ge=1,
+        description="Maximum number of messages retained in state",
+    )
     coalitions: Dict[str, List[str]] = Field(
         default_factory=dict,
         description="Named coalitions of agents for message broadcasting",

--- a/tests/behavior/features/agent_messages.feature
+++ b/tests/behavior/features/agent_messages.feature
@@ -1,0 +1,9 @@
+Feature: Agent messaging
+  As a developer
+  I want agents to exchange data via orchestrator
+  So that they can collaborate during a cycle
+
+  Scenario: Messages are delivered between agents
+    Given agent messaging is enabled
+    When the orchestrator runs a messaging query
+    Then the receiver agent should process the message

--- a/tests/behavior/steps/agent_messages_steps.py
+++ b/tests/behavior/steps/agent_messages_steps.py
@@ -1,0 +1,65 @@
+from pytest_bdd import given, when, then, scenario
+
+from autoresearch.agents import Agent, MessageHandlerMixin
+from pydantic import PrivateAttr
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.config import ConfigModel
+
+
+class SenderAgent(Agent):
+    name: str = "Sender"
+
+    def execute(self, state, config):
+        self.send_message(state, "ping", to="Receiver")
+        return {}
+
+
+class ReceiverAgent(Agent, MessageHandlerMixin):
+    name: str = "Receiver"
+    _received: list[str] = PrivateAttr(default_factory=list)
+
+    def receive_messages(self, messages, state):
+        for m in messages:
+            self._received.append(m["content"])
+
+    def execute(self, state, config):
+        return {}
+
+
+@given("agent messaging is enabled", target_fixture="agent_messaging_is_enabled")
+def agent_messaging_is_enabled(monkeypatch, tmp_path):
+    cfg = ConfigModel(
+        agents=["Sender", "Receiver"],
+        loops=1,
+        enable_agent_messages=True,
+    )
+
+    sender = SenderAgent()
+    receiver = ReceiverAgent()
+
+    def get_agent(name):
+        return sender if name == "Sender" else receiver
+
+    monkeypatch.setattr(
+        "autoresearch.orchestration.orchestrator.AgentFactory.get", get_agent
+    )
+    monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", str(tmp_path / "rel.json"))
+    monkeypatch.setenv("AUTORESEARCH_QUERY_TOKENS", str(tmp_path / "query.json"))
+    return {"config": cfg, "receiver": receiver}
+
+
+@when("the orchestrator runs a messaging query", target_fixture="run_orchestrator")
+def run_orchestrator(agent_messaging_is_enabled):
+    Orchestrator.run_query("test", agent_messaging_is_enabled["config"])
+    return agent_messaging_is_enabled
+
+
+@then("the receiver agent should process the message")
+def check_receiver(run_orchestrator):
+    receiver = run_orchestrator["receiver"]
+    assert receiver._received == ["ping"]
+
+
+@scenario("../features/agent_messages.feature", "Messages are delivered between agents")
+def test_agent_messages():
+    pass

--- a/tests/unit/test_message_routing.py
+++ b/tests/unit/test_message_routing.py
@@ -1,0 +1,54 @@
+import pytest
+from unittest.mock import patch
+
+from autoresearch.agents import Agent, MessageHandlerMixin
+from pydantic import PrivateAttr
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.state import QueryState
+from autoresearch.config import ConfigModel
+
+
+class SenderAgent(Agent):
+    name: str = "Sender"
+
+    def execute(self, state, config):
+        self.send_message(state, "hi", to="Receiver")
+        return {"results": {"sent": True}}
+
+
+class ReceiverAgent(Agent, MessageHandlerMixin):
+    name: str = "Receiver"
+
+    _received: list[str] = PrivateAttr(default_factory=list)
+
+    def receive_messages(self, messages, state):
+        for m in messages:
+            self._received.append(m["content"])
+
+    def execute(self, state, config):
+        return {"results": {"received": self._received}}
+
+
+def test_orchestrator_routes_messages(monkeypatch, tmp_path):
+    cfg = ConfigModel(
+        agents=["Sender", "Receiver"],
+        loops=1,
+        enable_agent_messages=True,
+    )
+
+    sender = SenderAgent()
+    receiver = ReceiverAgent()
+
+    def get_agent(name):
+        return sender if name == "Sender" else receiver
+
+    monkeypatch.setattr(
+        "autoresearch.orchestration.orchestrator.AgentFactory.get", get_agent
+    )
+
+    monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", str(tmp_path / "rel.json"))
+    monkeypatch.setenv("AUTORESEARCH_QUERY_TOKENS", str(tmp_path / "query.json"))
+
+    Orchestrator.run_query("q", cfg)
+
+    assert receiver._received == ["hi"]


### PR DESCRIPTION
## Summary
- add `MessageBus` utility for storing and delivering agent messages
- extend Orchestrator to deliver messages to agents
- expose message handling mixin and bus in agent package
- allow message retention to be configured
- add behaviour scenario and unit test for agent messaging

## Testing
- `flake8 src tests`
- `mypy src`
- `pytest --no-cov -q tests/unit/test_message_routing.py`
- `pytest --no-cov tests/behavior/steps/agent_messages_steps.py`

------
https://chatgpt.com/codex/tasks/task_e_68752301c6488333b04ebe58dc4112e7