### PR TITLE
Update docs and Codex setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines
 
-> Special note: the environment that ChatGPT Codex operates in executes `scripts/codex_setup.sh` as the setup setup. If it fails, a CODEX_ENVIRONMENT_SETUP_FAILED file will be created.
+> Special note: the environment that ChatGPT Codex operates in executes `scripts/codex_setup.sh` for setup. If it fails, a `CODEX_ENVIRONMENT_SETUP_FAILED` file will be created.
 
 Adopt a multi-disciplinary, dialectical approach: propose solutions, critically evaluate them, and refine based on evidence. Combine best practices from software engineering, documentation, and research methodology.
 
@@ -10,6 +10,7 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   - Install dependencies with `poetry install --with dev`.
   - Activate the environment using `poetry shell` or prefix commands with `poetry run`.
   - Avoid system-level Python or `pip`. Run `pip install -e .` only inside the Poetry virtual environment using `poetry shell` or `poetry run pip`.
+  - Codex environments run `scripts/codex_setup.sh`, which delegates to `scripts/setup.sh` to ensure optional extras and tooling are installed.
 
 ## Verification steps
 - Check code style with `poetry run flake8 src tests`.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ The `scripts/setup.sh` helper now calls the installer so optional dependencies
 are resolved automatically during development setup.
 
 ### Using Poetry
+Install the development dependencies:
 ```bash
-poetry install
+poetry install --with dev
 ```
 
 ### Minimal installation

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -16,10 +16,10 @@ Autoresearch uses a modular architecture with several key components. The PlantU
 
 ## Installation
 
-Use `poetry install` to set up a development environment:
+Use `poetry install --with dev` to set up a development environment:
 
 ```bash
-poetry install
+poetry install --with dev
 ```
 
 `hdbscan` is built from source and needs compilation tools. Install `gcc`, `g++`,

--- a/docs/quickstart_guides.md
+++ b/docs/quickstart_guides.md
@@ -8,7 +8,7 @@ This document provides quickstart guides for each interface type of the Autorese
 
 ```bash
 # Install with Poetry (recommended)
-poetry install
+poetry install --with dev
 
 # Alternatively, use pip
 pip install autoresearch

--- a/docs/ui_testing_procedures.md
+++ b/docs/ui_testing_procedures.md
@@ -425,7 +425,7 @@ Autoresearch uses GitHub Actions for continuous integration. The CI pipeline run
 
 ### CI Configuration
 
-The CI configuration is defined in `.github/workflows/ci.yml`:
+The CI configuration is defined in `.github/workflows.disabled/ci.yml`:
 
 ```yaml
 name: CI

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -7,7 +7,6 @@ apt-get install -y \
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 
-poetry env use $(which python3)
-poetry install --with dev
+./scripts/setup.sh
 poetry run pip install -e .
 poetry run python -m spacy download en_core_web_sm


### PR DESCRIPTION
## Summary
- refresh docs and instructions with `poetry install --with dev`
- clarify Codex setup procedure
- reference the disabled CI config location
- delegate `scripts/codex_setup.sh` to the standard setup script

## Testing
- `poetry install --with dev` *(fails: pyproject.toml changed significantly)*

------
https://chatgpt.com/codex/tasks/task_e_687553e633f08333a9dbc7415f47b658