### PR TITLE
Fix setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ CLI utilities are provided via Typer and the HTTP API is powered by FastAPI.
 You can install the project dependencies with either **Poetry** or **pip**.
 See [docs/installation.md](docs/installation.md) for details on optional features,
 upgrade instructions and the new installer.
-The `scripts/setup.sh` helper now calls the installer so optional dependencies
-are resolved automatically during development setup.
+The `scripts/setup.sh` helper now calls the installer and runs
+`poetry install --with dev` so all development and runtime dependencies are
+available for testing.
 
 ### Using Poetry
 Select the interpreter and install the development dependencies:
@@ -423,10 +424,10 @@ Alternatively you can run the helper script:
 ./scripts/setup.sh
 ```
 
-The script now invokes `installer.py` so any optional dependencies required by
-your configuration are installed automatically. It also installs tools such as
-`flake8`, `mypy`, `pytest` and `tomli_w` which are used to write TOML files
-during testing.
+The script invokes `installer.py`, installs all dependencies with
+`poetry install --with dev` and links the package in editable mode. Tools such
+as `flake8`, `mypy`, `pytest` and `tomli_w` are therefore available for
+development and testing.
 
 ## Running tests
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,7 +6,8 @@ We welcome contributions via pull requests. Install the development dependencies
 poetry install --with dev
 ```
 
-You can alternatively run the helper script to install all dependencies:
+You can alternatively run the helper script, which installs all dependencies
+with `poetry install --with dev` and links the package in editable mode:
 
 ```bash
 ./scripts/setup.sh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,6 +5,8 @@ python -m pip install --upgrade pip
 pip install poetry
 poetry env use $(which python3)
 python scripts/installer.py
+poetry install --with dev
+poetry run pip install -e .
 
 # Create extensions directory if it doesn't exist
 mkdir -p extensions


### PR DESCRIPTION
## Summary
- ensure `scripts/setup.sh` installs dev dependencies
- clarify script's behaviour in README and contributing guide

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest tests/unit/test_api.py -q` *(fails: Coverage failure)*

------
https://chatgpt.com/codex/tasks/task_e_6875a15dd4888333b4ed4d75e9d38eac