### PR TITLE
Fix integration task path

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,7 +8,7 @@ tasks:
 
   integration:
     cmds:
-      - pytest -q integration
+      - pytest -q tests/integration
     desc: "Run integration tests"
 
   behavior:


### PR DESCRIPTION
## Summary
- run integration tests from `tests/integration`

## Testing
- `poetry run flake8 src tests` *(fails: command not found)*
- `poetry run mypy src` *(fails: pydantic missing)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: typer)*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError: typer)*

------
https://chatgpt.com/codex/tasks/task_e_6875d3958d488333bef331772d730167