### PR TITLE
Fix outdated CLI docs

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -9,7 +9,7 @@ This document provides advanced usage examples for the Autoresearch system, demo
 For complex research questions that benefit from extensive dialectical analysis:
 
 ```bash
-autoresearch query "What are the environmental impacts of lithium mining for EV batteries?" \
+autoresearch search "What are the environmental impacts of lithium mining for EV batteries?" \
   --reasoning-mode dialectical \
   --loops 3
 ```
@@ -37,7 +37,7 @@ Enter an updated query string to guide the next cycle or `q` to abort.
 For problems that benefit from incremental reasoning:
 
 ```bash
-autoresearch query "Explain the implications of quantum computing for cryptography" \
+autoresearch search "Explain the implications of quantum computing for cryptography" \
   --reasoning-mode chain-of-thought \
   --loops 5
 ```
@@ -49,7 +49,7 @@ This runs the Synthesizer agent five times, with each iteration building on the 
 For straightforward questions that don't require dialectical analysis:
 
 ```bash
-autoresearch query "What is the average lifespan of a blue whale?" \
+autoresearch search "What is the average lifespan of a blue whale?" \
   --reasoning-mode direct
 ```
 
@@ -469,7 +469,7 @@ The command applies the configured reasoner before executing the query, returnin
 Use the custom template:
 
 ```bash
-autoresearch query "What are the neurological effects of meditation?" --output-template academic
+autoresearch search "What are the neurological effects of meditation?" --output-template academic
 ```
 
 ## Monitoring and Debugging
@@ -497,7 +497,7 @@ autoresearch monitor
 autoresearch monitor -w
 
 # In another terminal, run a query while watching
-autoresearch query "What are the implications of AI on labor markets?"
+autoresearch search "What are the implications of AI on labor markets?"
 ```
 
 The monitor shows real-time information about agent execution, token usage, and system state.

--- a/docs/quickstart_guides.md
+++ b/docs/quickstart_guides.md
@@ -19,13 +19,13 @@ pip install autoresearch
 1. **Run a simple query:**
 
 ```bash
-autoresearch query "What is the capital of France?"
+autoresearch search "What is the capital of France?"
 ```
 
 2. **Specify reasoning mode:**
 
 ```bash
-autoresearch query "What is the capital of France?" --mode dialectical
+autoresearch search "What is the capital of France?" --mode dialectical
 ```
 
 Available reasoning modes:
@@ -36,13 +36,13 @@ Available reasoning modes:
 3. **Specify Primus start index (dialectical mode):**
 
 ```bash
-autoresearch query "What is the capital of France?" --mode dialectical --primus-start 1
+autoresearch search "What is the capital of France?" --mode dialectical --primus-start 1
 ```
 
 4. **Enable ontology reasoning:**
 
 ```bash
-autoresearch query "What is the capital of France?" --ontology schema.ttl --infer-relations
+autoresearch search "What is the capital of France?" --ontology schema.ttl --infer-relations
 ```
 
 Use `--ontology-reasoner` to specify a custom reasoning engine.
@@ -51,10 +51,10 @@ Use `--ontology-reasoner` to specify a custom reasoning engine.
 
 ```bash
 # Export as JSON
-autoresearch query "What is the capital of France?" --output json > result.json
+autoresearch search "What is the capital of France?" --output json > result.json
 
 # Export as Markdown
-autoresearch query "What is the capital of France?" --output markdown > result.md
+autoresearch search "What is the capital of France?" --output markdown > result.md
 ```
 
 6. **Visualize query results:**
@@ -77,16 +77,16 @@ autoresearch search "Explain AI ethics" --visualize
 autoresearch config
 ```
 
-2. **Set a configuration value:**
+2. **Update reasoning configuration:**
 
 ```bash
-autoresearch config set core.loops 3
+autoresearch config reasoning --loops 3
 ```
 
-3. **Get a specific configuration value:**
+3. **Show current reasoning settings:**
 
 ```bash
-autoresearch config get core.loops
+autoresearch config reasoning --show
 ```
 
 ### Monitoring

--- a/docs/user_flows.md
+++ b/docs/user_flows.md
@@ -8,7 +8,7 @@ This document describes the typical user flows for all interface modalities of t
 
 1. **Start the CLI**
    ```bash
-   autoresearch query "What is the capital of France?"
+   autoresearch search "What is the capital of France?"
    ```
 
 2. **View Progress**
@@ -21,7 +21,7 @@ This document describes the typical user flows for all interface modalities of t
 
 4. **Export Results (Optional)**
    ```bash
-   autoresearch query "What is the capital of France?" --output json > results.json
+   autoresearch search "What is the capital of France?" --output json > results.json
    ```
 
 ### Configuration Flow
@@ -33,12 +33,12 @@ This document describes the typical user flows for all interface modalities of t
 
 2. **Update Configuration**
    ```bash
-   autoresearch config set core.loops 3
+   autoresearch config reasoning --loops 3
    ```
 
 3. **Verify Configuration**
    ```bash
-   autoresearch config get core.loops
+   autoresearch config reasoning --show
    ```
 
 ### Monitoring Flow
@@ -77,12 +77,7 @@ This document describes the typical user flows for all interface modalities of t
    branches = ["main"]
    history_depth = 50
    ```
-   Or set the same values via CLI commands:
-   ```bash
-   autoresearch config set search.backends "['serper','local_file','local_git']"
-   autoresearch config set search.local_file.path /path/to/docs
-   autoresearch config set search.local_git.repo_path /path/to/repo
-   ```
+   Then run `autoresearch config reasoning --show` to verify the settings were loaded.
 
 2. **Run a Query**
    - Execute a search that includes your local files and repository history:
@@ -234,7 +229,7 @@ This document describes the typical user flows for all interface modalities of t
 
 1. **Start with CLI Query**
    ```bash
-   autoresearch query "What is the capital of France?"
+   autoresearch search "What is the capital of France?"
    ```
 
 2. **Switch to GUI**
@@ -254,7 +249,7 @@ This document describes the typical user flows for all interface modalities of t
 
 1. **Update Configuration via CLI**
    ```bash
-   autoresearch config set core.loops 3
+   autoresearch config reasoning --loops 3
    ```
 
 2. **Open GUI**
@@ -272,7 +267,7 @@ This document describes the typical user flows for all interface modalities of t
 
 5. **Verify in CLI**
    ```bash
-   autoresearch config get core.loops
+   autoresearch config reasoning --show
    ```
    - The CLI shows the value updated from the GUI
 


### PR DESCRIPTION
## Summary
- update docs to reference `autoresearch search`
- update configuration instructions to use `config reasoning`

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*
- `poetry run pytest tests/behavior` *(fails: 1 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6877dbeeb4f08333ac83c687667fce45