### PR TITLE
Fix duplicate call to ontology reasoner

### DIFF
--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -717,9 +717,6 @@ class StorageManager:
             obj = rdflib.Literal(v)
             _rdf_store.add((subj, pred, obj))
 
-        # Apply ontology reasoning so updates expose inferred triples
-        run_ontology_reasoner(_rdf_store)
-
         # Apply ontology reasoning so advanced queries see inferred triples
         run_ontology_reasoner(_rdf_store)
 


### PR DESCRIPTION
## Summary
- clean up `_persist_to_rdf` by removing a duplicate call to `run_ontology_reasoner`

## Testing
- `flake8 src tests`
- `mypy src`
- `pytest -q`
- `pytest tests/behavior`

------
https://chatgpt.com/codex/tasks/task_e_6877dbd1d0d88333ac0518235784e270