### PR TITLE
Add release notes for version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,19 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Update release plan to align milestones with the 2025 development timeline.
 
+## [0.1.0] - Unreleased
+Planned first public release bringing the core research workflow to life.
+
+### Highlights
+- CLI, HTTP API and Streamlit interfaces for local-first research.
+- Dialectical orchestrator coordinating multiple agents with hot-reloadable configuration.
+- Hybrid DuckDB/RDF knowledge graph persistence and plugin-based search backends (files, Git and web).
+- Prometheus metrics, interactive mode and graph visualization utilities.
+
+### Improvements
+- Refined token budget heuristics and asynchronous cancellation handling.
+- Cleaned up CLI commands and installer scripts.
+- Numerous bug fixes and reliability tweaks since the initial prototype was created in May 2025.
+
+See the [release plan](docs/release_plan.md) for upcoming milestones.
+


### PR DESCRIPTION
## Summary
- document planned 0.1.0 release features in `CHANGELOG.md`

## Testing
- `poetry run flake8 src tests` *(fails: Command not found: flake8)*
- `poetry run mypy src` *(fails: Error importing plugin "pydantic.mypy")*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_6877dbd6c28c8333a0378bfe7bdbe3b4