### PR TITLE
Add httpx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pydantic-settings (>=2.9.1,<3.0.0)",
     "requests (>=2.32.3,<3.0.0)",
     "responses (>=0.25.7,<0.26.0)",
+    "httpx (>=0.28.1,<0.29.0)",
     "networkx (>=3.4.2,<4.0.0)",
     "duckdb (>=1.2.2,<2.0.0)",
     "rdflib (>=7.1.4,<8.0.0)",


### PR DESCRIPTION
## Summary
- include `httpx` in the main dependencies

## Testing
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: No module named 'pydantic')*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: 'typer')*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError: 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_6877ec59eee08333adf16e552ce36864