### PR TITLE
Update README Python version instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,17 @@ project has not yet been published outside of this repository. See
 
 ## Installation
 
-You can install the project dependencies with either **Poetry** or **pip**.
-See [docs/installation.md](docs/installation.md) for details on optional features
-and upgrade instructions.
+Autoresearch requires **Python 3.12 or newer**. You can install the project
+dependencies with either **Poetry** or **pip**. See
+[docs/installation.md](docs/installation.md) for details on optional features and
+upgrade instructions.
 The `scripts/setup.sh` helper runs `poetry install --with dev` so all
 development and runtime dependencies are available for testing.
 
 ### Using Poetry
-Select the interpreter and install the development dependencies:
+Python 3.12 or newer is required. If multiple Python interpreters exist,
+explicitly select version 3.12 with `poetry env use $(which python3.12)`.
+Install the development dependencies:
 ```bash
 poetry env use $(which python3)
 poetry install --with dev


### PR DESCRIPTION
## Summary
- document that Python 3.12 or newer is required
- note how to select the interpreter when multiple versions exist

## Testing
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: Error importing plugin)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6877f3af525c833391bf9cef0d70a707