### PR TITLE
Update release timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ CLI utilities are provided via Typer and the HTTP API is powered by FastAPI.
 ## Roadmap
 
 Autoresearch is currently in the **Development** phase preparing for the
-upcoming **0.1.0** release. This will be the first official version and the
-project has not yet been published outside of this repository. See
+upcoming **0.1.0** release. The codebase already reports version
+`0.1.0` in `pyproject.toml`, but that version has **not** been published yet.
+The first official release is targeted for **July 20, 2025** once the
+documentation and packaging checks complete. See
 [docs/release_plan.md](docs/release_plan.md) for the full milestone schedule.
 
 ## Installation

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -2,16 +2,26 @@
 
 This document outlines the upcoming release milestones for **Autoresearch**. Dates are aspirational and may shift as development progresses. The publishing workflow follows the steps in [deployment.md](deployment.md).
 
-The project kicked off in **May 2025** (see the initial commit dated `2025-05-18`). This schedule was last updated on **July 15, 2025**.
+The project kicked off in **May 2025** (see the initial commit dated `2025-05-18`).
+This schedule was last updated on **July 16, 2025** and reflects the fact that
+the codebase currently sits at an **unreleased 0.1.0** version.
 
 ## Milestones
 
 | Version | Target Date | Key Goals |
 | ------- | ----------- | --------- |
+| **0.1.0** | 2025-07-20 | Finalize packaging, docs and CI checks |
 | **0.1.1** | 2025-07-31 | Bug fixes and documentation updates |
 | **0.2.0** | 2025-09-15 | API stabilization, configuration hot-reload, improved search backends |
 | **0.3.0** | 2025-11-15 | Distributed execution support, monitoring utilities |
 | **1.0.0** | 2026-01-31 | Full feature set, performance tuning and stable interfaces |
+
+The following tasks remain before publishing **0.1.0**:
+
+- Verify all automated tests pass in CI.
+- Review documentation for clarity using a Socratic approach—question each section's assumptions and evidence.
+- Conduct a dialectical evaluation of core workflows, addressing potential counterarguments in the docs.
+- Ensure packaging metadata is accurate and the publish scripts run without error.
 
 ## Release Phases
 


### PR DESCRIPTION
## Summary
- clarify unreleased 0.1.0 status in the README
- update release plan with 0.1.0 milestone and remaining tasks

## Testing
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: Error importing plugin pydantic.mypy)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6877f48a213883338118f192766a7021