### PR TITLE
Improve setup to refresh lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Autoresearch requires **Python 3.12 or newer**. You can install the project
 dependencies with either **Poetry** or **pip**. See
 [docs/installation.md](docs/installation.md) for details on optional features and
 upgrade instructions.
-The `scripts/setup.sh` helper runs `poetry install --with dev` so all
-development and runtime dependencies are available for testing.
+The `scripts/setup.sh` helper ensures the lock file is current and installs
+all optional extras so development and runtime dependencies are available
+for testing.
 
 ### Using Poetry
 Python 3.12 or newer is required. If multiple Python interpreters exist,
@@ -41,7 +42,7 @@ Install only the minimal optional dependencies using pip:
 pip install autoresearch[minimal]
 ```
 When working from a clone, run `scripts/setup.sh` which installs all
-development dependencies via Poetry.
+development dependencies and optional extras via Poetry.
 Use extras to enable additional features, e.g. `pip install "autoresearch[minimal,nlp]"`.
 To upgrade a cloned environment run `python scripts/upgrade.py`.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,8 +6,9 @@ We welcome contributions via pull requests. Install the development dependencies
 poetry install --with dev
 ```
 
-You can alternatively run the helper script, which installs all dependencies
-with `poetry install --with dev` and links the package in editable mode:
+You can alternatively run the helper script. It refreshes the lock file when
+needed, installs all extras with `poetry install --with dev --all-extras` and
+links the package in editable mode:
 
 ```bash
 ./scripts/setup.sh

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,7 +13,8 @@ Use Poetry to manage the environment when working from a clone:
 
 ```bash
 poetry env use $(which python3)
-poetry install --with dev
+poetry lock --check || poetry lock
+poetry install --with dev --all-extras
 ```
 
 Verify the environment by running:
@@ -39,10 +40,10 @@ If you cloned the repository, run the setup helper instead:
 ./scripts/setup.sh
 ```
 
-This provides the CLI, API and knowledge graph without heavy NLP or UI packages.
-Optional features will be disabled when their dependencies are missing.
-Specify extras explicitly with pip to enable additional features, e.g.
-``pip install "autoresearch[minimal,nlp]"``.
+The helper ensures the lock file is refreshed and installs every optional
+extra needed for the test suite. Optional features are disabled when their
+dependencies are missing. Specify extras explicitly with pip to enable
+additional features, e.g. ``pip install "autoresearch[minimal,nlp]"``.
 
 ## Optional extras
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 python -m pip install --upgrade pip
 pip install poetry
 poetry env use $(which python3)
+if ! poetry lock --check >/dev/null 2>&1; then
+  echo "Lock file outdated, regenerating..."
+  poetry lock
+fi
 poetry install --with dev --all-extras
 poetry run pip install -e .
 


### PR DESCRIPTION
## Summary
- update setup.sh to check the Poetry lock file and install all extras
- document full setup in README
- update installation docs with lock step and extras
- note extras in the contributing guide

## Testing
- `poetry lock` *(fails: Resolving dependencies...)*
- `poetry run flake8 src tests` *(fails: Command not found: flake8)*

------
https://chatgpt.com/codex/tasks/task_e_6878485c455883339877bd4d7704bf9d