### PR TITLE
Fix direct mode agent groups recomputation

### DIFF
--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -85,6 +85,11 @@ class Orchestrator:
             AgentRegistry.create_coalition(cname, members)
         enable_feedback = getattr(config, "enable_feedback", False)
 
+        # Adjust parameters based on reasoning mode
+        if mode == ReasoningMode.DIRECT:
+            agents = ["Synthesizer"]
+            loops = 1
+
         agent_groups: List[List[str]] = []
         for a in agents:
             coalition = AgentRegistry.get_coalition_obj(a)
@@ -92,11 +97,6 @@ class Orchestrator:
                 agent_groups.append(coalition.members)
             else:
                 agent_groups.append([a])
-
-        # Adjust parameters based on reasoning mode
-        if mode == ReasoningMode.DIRECT:
-            agents = ["Synthesizer"]
-            loops = 1
 
         return {
             "agents": agents,

--- a/tests/unit/test_orchestrator_order.py
+++ b/tests/unit/test_orchestrator_order.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 import asyncio
 
 from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration import ReasoningMode
 from autoresearch.config import ConfigModel
 
 
@@ -48,3 +49,10 @@ def test_async_custom_agents_concurrent():
         asyncio.run(Orchestrator.run_query_async("q", cfg, concurrent=True))
 
     assert sorted(record) == ["A1", "A2", "A3"]
+
+
+def test_parse_config_direct_mode_groups():
+    cfg = ConfigModel(reasoning_mode=ReasoningMode.DIRECT, loops=5)
+    params = Orchestrator._parse_config(cfg)
+    assert params["agent_groups"] == [["Synthesizer"]]
+    assert params["loops"] == 1


### PR DESCRIPTION
## Summary
- rebuild agent groups after applying reasoning mode changes
- ensure direct mode sets loops to 1 and agent groups to [`Synthesizer`]
- test direct mode agent group parsing

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Module has no attribute 'modal', incompatible types, etc.)*
- `poetry run pytest -q` *(failed to complete in environment)*
- `poetry run pytest tests/behavior -k reasoning_mode` *(fails due to coverage check)*

------
https://chatgpt.com/codex/tasks/task_e_687b3678a8008333b89a33ee3c340cdf