### PR TITLE
Fix direct reasoning mode execution

### DIFF
--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -86,17 +86,18 @@ class Orchestrator:
         enable_feedback = getattr(config, "enable_feedback", False)
 
         # Adjust parameters based on reasoning mode
+        agent_groups: List[List[str]] = []
         if mode == ReasoningMode.DIRECT:
             agents = ["Synthesizer"]
             loops = 1
-
-        agent_groups: List[List[str]] = []
-        for a in agents:
-            coalition = AgentRegistry.get_coalition_obj(a)
-            if coalition:
-                agent_groups.append(coalition.members)
-            else:
-                agent_groups.append([a])
+            agent_groups = [["Synthesizer"]]
+        else:
+            for a in agents:
+                coalition = AgentRegistry.get_coalition_obj(a)
+                if coalition:
+                    agent_groups.append(coalition.members)
+                else:
+                    agent_groups.append([a])
 
         return {
             "agents": agents,

--- a/tests/unit/test_orchestrator_edgecases.py
+++ b/tests/unit/test_orchestrator_edgecases.py
@@ -21,3 +21,10 @@ def test_parse_config_direct_mode():
     assert params["agents"] == ["Synthesizer"]
     assert params["loops"] == 1
     assert params["max_errors"] == 3
+
+
+def test_parse_config_direct_mode_agent_groups():
+    """Ensure direct mode uses only the Synthesizer group."""
+    cfg = ConfigModel(reasoning_mode=ReasoningMode.DIRECT, loops=5)
+    params = Orchestrator._parse_config(cfg)
+    assert params["agent_groups"] == [["Synthesizer"]]


### PR DESCRIPTION
## Summary
- fix config parsing to set Synthesizer group when using direct reasoning mode
- extend unit test coverage for direct reasoning config

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Interrupted)*
- `poetry run pytest -q` *(fails: Coverage failure)*
- `poetry run pytest tests/behavior/steps/agent_orchestration_steps.py::test_reasoning_direct -q` *(fails: Coverage failure)*

------
https://chatgpt.com/codex/tasks/task_e_687bddd76f448333acf7175e3b2eeb89