### PR TITLE
Improve reasoning mode test coverage

### DIFF
--- a/tests/behavior/features/reasoning_mode.feature
+++ b/tests/behavior/features/reasoning_mode.feature
@@ -9,11 +9,15 @@ Feature: Reasoning Mode Selection
   Scenario: Direct mode runs Synthesizer only
     Given reasoning mode is "direct"
     When I run the orchestrator on query "mode test"
+    Then the loops used should be 1
+    And the agent groups should be "Synthesizer"
     Then the agents executed should be "Synthesizer"
 
   Scenario: Chain-of-thought mode loops Synthesizer
     Given reasoning mode is "chain-of-thought"
     When I run the orchestrator on query "mode test"
+    Then the loops used should be 2
+    And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     Then the agents executed should be "Synthesizer, Synthesizer"
 
   Scenario: Dialectical mode with custom Primus start
@@ -21,4 +25,6 @@ Feature: Reasoning Mode Selection
     And reasoning mode is "dialectical"
     And primus start is 1
     When I run the orchestrator on query "mode test"
+    Then the loops used should be 1
+    And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     Then the agents executed should be "Contrarian, FactChecker, Synthesizer"


### PR DESCRIPTION
## Summary
- assert loops and agent groups when running orchestrator
- track config params in the spy fixture
- exercise dialectical reasoning scenario

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(failed: KeyboardInterrupt)*
- `poetry run pytest tests/behavior -k reasoning_mode -q` *(failed: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_687c0707a9f0833386d0859ff4ecbf79