### PR TITLE
Add request log helper for API rate limiting

### DIFF
--- a/tests/integration/test_cli_http.py
+++ b/tests/integration/test_cli_http.py
@@ -246,7 +246,7 @@ def test_http_throttling(monkeypatch):
 
         set_delegate(None)
         DummyStorage.persisted = []
-        api_mod.REQUEST_LOG.clear()
+        api_mod.reset_request_log()
 
 
 def test_stream_endpoint(monkeypatch):


### PR DESCRIPTION
## Summary
- record requests in `REQUEST_LOG` inside API and add `reset_request_log`
- log every request when throttling is enabled and update tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: FileNotFoundError in integration tests)*
- `poetry run pytest tests/behavior` *(fails: assertion on rate limit)*

------
https://chatgpt.com/codex/tasks/task_e_687c6a088c6c8333b01d98ac6f725d29