### PR TITLE
Add optional Git search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ pip install autoresearch[minimal]
 When working from a clone, run `scripts/setup.sh` which installs all
 development dependencies and optional extras via Poetry.
 Use extras to enable additional features, e.g. `pip install "autoresearch[minimal,nlp]"`.
+Local Git search requires the `git` extra.
 To upgrade a cloned environment run `python scripts/upgrade.py`.
 
 ### Using pip
@@ -277,6 +278,12 @@ file_types = ["md", "pdf", "txt"]
 repo_path = "/path/to/repo"
 branches = ["main"]
 history_depth = 50
+```
+
+Install the `git` extra to enable local Git search:
+
+```bash
+pip install "autoresearch[git]"
 ```
 
 Example queries:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,12 +55,13 @@ Additional functionality is grouped into Poetry extras:
 - `vss` – DuckDB VSS extension for vector search
 - `distributed` – distributed processing with Ray
 - `analysis` – Polars-based data analysis utilities
+- `git` – local Git repository search support
 - `full` – installs all optional extras
 
 Install multiple extras separated by commas:
 
 ```bash
-pip install "autoresearch[minimal,nlp,parsers]"
+pip install "autoresearch[minimal,nlp,parsers,git]"
 ```
 
 ## Upgrading

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,10 @@ parsers = [
     "pdfminer-six >=20250506",
     "python-docx >=1.2.0"
 ]
+# Local Git repository search
+git = [
+    "gitpython >=3.1"
+]
 # Distributed computing support
 distributed = [
     "ray >=2.10.0",
@@ -94,7 +98,8 @@ full = [
     "redis >=6.2",
     "slowapi ==0.1.9",
     "lmstudio >=1.4.1",
-    "polars >=1.31.0"
+    "polars >=1.31.0",
+    "gitpython >=3.1"
 ]
 
 [tool.poetry.extras]

--- a/src/autoresearch/search.py
+++ b/src/autoresearch/search.py
@@ -26,7 +26,15 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 from collections import defaultdict
 import requests
-from git import Repo
+try:
+    from git import Repo
+    GITPYTHON_AVAILABLE = True
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+    GITPYTHON_AVAILABLE = False
+    raise ImportError(
+        "Local Git search requires the 'gitpython' package. "
+        "Install with `pip install \"autoresearch[git]\"`."
+    ) from exc
 import numpy as np
 import csv
 import math

--- a/tests/unit/test_search_import.py
+++ b/tests/unit/test_search_import.py
@@ -1,0 +1,25 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+def test_search_import_error_without_gitpython(monkeypatch):
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "git" or name.startswith("git."):
+            raise ModuleNotFoundError("No module named 'git'")
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "autoresearch.search", raising=False)
+    with pytest.raises(ImportError) as excinfo:
+        importlib.import_module("autoresearch.search")
+    assert "gitpython" in str(excinfo.value).lower()
+
+
+def test_search_import_with_gitpython():
+    module = importlib.import_module("autoresearch.search")
+    assert module.GITPYTHON_AVAILABLE


### PR DESCRIPTION
## Summary
- add `gitpython` optional dependency and include in `full`
- document extra for local Git repository search
- raise helpful error when GitPython is missing
- test search module import with and without GitPython

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(failed: environment issue)*
- `poetry run pytest -q` *(failed: environment issue)*

------
https://chatgpt.com/codex/tasks/task_e_687c6a690a8c8333b7dc9ca6554ad524