### PR TITLE
Refactor validators to pydantic v2 style

### DIFF
--- a/src/autoresearch/agents/base.py
+++ b/src/autoresearch/agents/base.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, Any, Optional, List
 from enum import Enum
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 from ..config import ConfigModel
 from ..orchestration.state import QueryState
@@ -39,8 +39,9 @@ class AgentConfig(BaseModel):
     enabled: bool = True
     prompt_templates: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
 
-    @validator("prompt_templates")
-    def validate_prompt_templates(cls, v):
+    @field_validator("prompt_templates")
+    @classmethod
+    def validate_prompt_templates(cls, v: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
         """Validate prompt templates."""
         for name, template in v.items():
             if "template" not in template:
@@ -64,10 +65,9 @@ class Agent(
     enabled: bool = True
     llm_adapter: Optional[LLMAdapter] = None
 
-    class Config:
-        """Pydantic configuration for the agent model."""
-
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     def execute(self, state: QueryState, config: ConfigModel) -> Dict[str, Any]:
         """Execute agent's task on the given state."""

--- a/src/autoresearch/agents/messages.py
+++ b/src/autoresearch/agents/messages.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 import time
 from typing import Optional
 from enum import Enum
@@ -25,9 +25,10 @@ class AgentMessage(BaseModel):
     cycle: int
     timestamp: float = Field(default_factory=lambda: time.time())
 
-    class Config:
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+    )
 
     def to_dict(self) -> dict:
         """Return message as plain dictionary."""


### PR DESCRIPTION
## Summary
- update deprecated `@validator` to `@field_validator`
- use `ConfigDict` for pydantic model configuration

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `timeout 120 poetry run pytest -q` *(fails: Catalog Error: Setting with name "hnsw_enable_experimental_persistence" is not in the catalog)*
- `timeout 60 poetry run pytest tests/behavior` *(fails: Failed to create HNSW index)*

------
https://chatgpt.com/codex/tasks/task_e_687c6a58e34483338fb9cbc8872bd9e8