### PR TITLE
Fix rate limit check

### DIFF
--- a/src/autoresearch/api.py
+++ b/src/autoresearch/api.py
@@ -130,7 +130,7 @@ class FallbackRateLimitMiddleware(BaseHTTPMiddleware):
         if cfg_limit:
             ip = get_remote_address(request)
             REQUEST_LOG[ip] = REQUEST_LOG.get(ip, 0) + 1
-            if SLOWAPI_STUB and REQUEST_LOG[ip] > cfg_limit:
+            if REQUEST_LOG[ip] > cfg_limit:
                 raise RateLimitExceeded(cast("Limit", None))
         return await call_next(request)
 


### PR DESCRIPTION
## Summary
- remove SLOWAPI_STUB guard from fallback rate limit middleware so tests pass

## Testing
- `poetry run pytest tests/behavior` *(fails: environment limits)*
- `poetry run pytest -q` *(fails: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687d8d17d55083338666fc8227deb855