### PR TITLE
Update setup instructions

### DIFF
--- a/.github/workflows.disabled/simple_ci.yml
+++ b/.github/workflows.disabled/simple_ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           poetry env use $(which python)
-          poetry install --with dev
+          poetry install --with dev --all-extras
       - name: Lint
         run: poetry run flake8 src tests
       - name: Type check

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.12-slim
 WORKDIR /app
 COPY . /app
 RUN pip install --no-cache-dir poetry \
-    && poetry install --with dev --no-interaction
+    && poetry install --with dev --all-extras --no-interaction
 EXPOSE 8000
 CMD ["poetry", "run", "uvicorn", "autoresearch.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ explicitly select version 3.12 with `poetry env use $(which python3.12)`.
 Install the development dependencies:
 ```bash
 poetry env use $(which python3)
-poetry install --with dev
+poetry install --with dev --all-extras
 ```
 
 Once installed, verify the environment by running the checks listed under [Running tests](#running-tests).
@@ -421,7 +421,7 @@ For a detailed breakdown of the requirements and architecture, see
 Install the development dependencies and link the package in editable mode:
 
 ```bash
-poetry install --with dev
+poetry install --with dev --all-extras
 poetry run pip install -e .
 ```
 
@@ -431,7 +431,7 @@ Alternatively you can run the helper script:
 ./scripts/setup.sh
 ```
 
-The helper installs all dependencies with `poetry install --with dev` and links
+The helper installs all dependencies with `poetry install --with dev --all-extras` and links
 the package in editable mode. Tools such as `flake8`, `mypy`, `pytest` and
 `tomli_w` are therefore available for development and testing.
 
@@ -453,6 +453,10 @@ task test:behavior     # behavior-driven tests
 task test:all          # run all suites including slow tests
 ```
 
+Several unit and integration tests rely on `gitpython` and the DuckDB VSS
+extension. These extras are installed when running
+`poetry install --with dev --all-extras`.
+
 All testing commands are wrapped by `task`, which uses `poetry run` internally
 to ensure the correct virtual environment is active.
 
@@ -460,7 +464,7 @@ Maintain at least 90% test coverage and remove temporary files before submitting
 
 ### Troubleshooting
 
-- If tests fail with `ModuleNotFoundError`, ensure all dependencies are installed inside the Poetry environment using `poetry install --with dev` or `poetry run pip install -e .`.
+- If tests fail with `ModuleNotFoundError`, ensure all dependencies are installed inside the Poetry environment using `poetry install --with dev --all-extras` or `poetry run pip install -e .`.
 - When starting the API with `uvicorn autoresearch.api:app --reload`, install `uvicorn` if the command is not found and verify that port `8000` is free.
 
 ## Building the documentation

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -9,11 +9,15 @@ This guide describes how to set up a development environment and the expected wo
    ```bash
    poetry env use $(which python3)
    ```
-3. Install dependencies including development tools:
+3. Install dependencies including development tools and all optional extras:
    ```bash
-   poetry install --with dev
+   poetry install --with dev --all-extras
    ```
 4. Activate the environment with `poetry shell` or prefix commands with `poetry run`.
+
+Several unit and integration tests require `gitpython` and the DuckDB VSS
+extension. Both are installed when you set up the environment with
+`poetry install --with dev --all-extras`.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary
- advise using Poetry with `--all-extras`
- note GitPython and VSS extension requirement in docs
- run CI with all extras
- build Docker image with optional extras

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: interrupted)*
- `poetry run pytest -q` *(fails: timed out)*
- `poetry run pytest tests/behavior` *(fails: 1 failed)*

------
https://chatgpt.com/codex/tasks/task_e_687dbff253f08333a524852cf0a4a1d6