### PR TITLE
Add optional dependency guards

### DIFF
--- a/tests/behavior/steps/local_sources_steps.py
+++ b/tests/behavior/steps/local_sources_steps.py
@@ -7,6 +7,17 @@ from autoresearch.config import ConfigModel
 from autoresearch.search import Search
 from pdfminer.high_level import extract_text
 from docx import Document
+import pytest
+import importlib.util
+
+try:
+    _spec = importlib.util.find_spec("git")
+    _git_available = bool(_spec and _spec.origin)
+except Exception:
+    _git_available = False
+
+if not _git_available:
+    pytest.skip("GitPython not installed", allow_module_level=True)
 
 
 @given("a directory with text files")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,6 +231,36 @@ from autoresearch.storage import (  # noqa: E402
     set_delegate as set_storage_delegate,
 )
 from autoresearch.extensions import VSSExtensionLoader  # noqa: E402
+import duckdb  # noqa: E402
+
+
+def _module_available(name: str) -> bool:
+    """Return True if a module can be imported from the real environment."""
+    try:
+        spec = importlib.util.find_spec(name)
+    except Exception:
+        return False
+    return bool(spec and spec.origin)
+
+
+GITPYTHON_INSTALLED = _module_available("git")
+POLARS_INSTALLED = _module_available("polars")
+
+
+def _check_vss() -> bool:
+    try:
+        conn = duckdb.connect(database=":memory:")
+        return VSSExtensionLoader.verify_extension(conn, verbose=False)
+    except Exception:
+        return False
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+VSS_AVAILABLE = _check_vss()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_search_backends.py
+++ b/tests/integration/test_search_backends.py
@@ -7,9 +7,21 @@ backends and the main search functionality.
 import subprocess
 
 import pytest
+import importlib.util
+
+try:
+    _spec = importlib.util.find_spec("git")
+    GITPYTHON_INSTALLED = bool(_spec and _spec.origin)
+except Exception:
+    GITPYTHON_INSTALLED = False
+
 from autoresearch.search import Search
 from autoresearch import cache
 from autoresearch.config import ConfigModel
+
+pytestmark = pytest.mark.skipif(
+    not GITPYTHON_INSTALLED, reason="GitPython not installed"
+)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_kuzu_polars.py
+++ b/tests/unit/test_kuzu_polars.py
@@ -2,12 +2,7 @@ import pytest
 
 from autoresearch.storage_backends import KuzuStorageBackend
 from autoresearch.data_analysis import metrics_dataframe
-
-polars_available = True
-try:
-    import polars  # noqa: F401
-except Exception:  # pragma: no cover - optional dependency
-    polars_available = False
+pytest.importorskip("polars")
 
 
 def test_kuzu_backend_roundtrip(tmp_path):
@@ -21,8 +16,6 @@ def test_kuzu_backend_roundtrip(tmp_path):
 
 
 def test_metrics_dataframe():
-    if not polars_available:
-        pytest.skip("polars not installed")
     metrics = {"agent_timings": {"A": [1.0, 2.0], "B": [3.0]}}
     df = metrics_dataframe(metrics, polars_enabled=True)
     assert df.shape[0] == 2

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -4,12 +4,22 @@ from responses import matchers
 import pytest
 import requests
 import subprocess
+import importlib.util
+
+try:
+    _spec = importlib.util.find_spec("git")
+    GITPYTHON_INSTALLED = bool(_spec and _spec.origin)
+except Exception:
+    GITPYTHON_INSTALLED = False
 from autoresearch.config import ConfigModel
 from autoresearch.errors import SearchError, TimeoutError
 from unittest.mock import patch
-
 import autoresearch.search as search
 from autoresearch.search import Search
+
+pytestmark = pytest.mark.skipif(
+    not GITPYTHON_INSTALLED, reason="GitPython not installed"
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- skip tests requiring optional dependencies when not installed
- compute extension availability checks in `conftest`

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_687dc529e2d08333b19346b087129c22