### PR TITLE
Clarify Python selection for Poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,17 @@ all optional extras so development and runtime dependencies are available
 for testing.
 
 ### Using Poetry
-Python 3.12 or newer is required. If multiple Python interpreters exist,
-explicitly select version 3.12 with `poetry env use $(which python3.12)`.
-Install the development dependencies:
+Python 3.12 or newer is required. When several Python versions are installed,
+select version 3.12 (or 3.13 when available) **before** running `poetry install`:
 ```bash
-poetry env use $(which python3)
+poetry env use $(which python3.12)
+# or: poetry env use $(which python3.13)
 poetry install --with dev --all-extras
+```
+If Python 3.11 is selected, Poetry will fail with a message similar to:
+```
+Because autoresearch requires Python >=3.12,<4.0 and the current Python is
+3.11.*, no compatible version could be found.
 ```
 
 Once installed, verify the environment by running the checks listed under [Running tests](#running-tests).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,9 +12,15 @@ This guide explains how to install Autoresearch and manage optional features.
 Use Poetry to manage the environment when working from a clone:
 
 ```bash
-poetry env use $(which python3)
+poetry env use $(which python3.12)
+# or: poetry env use $(which python3.13)
 poetry lock --check || poetry lock
 poetry install --with dev --all-extras
+```
+Selecting Python 3.11 results in an error similar to:
+```
+Because autoresearch requires Python >=3.12,<4.0 and the current Python is
+3.11.*, no compatible version could be found.
 ```
 
 Verify the environment by running:

--- a/tests/unit/test_main_backup_commands.py
+++ b/tests/unit/test_main_backup_commands.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from autoresearch.main import app
 from autoresearch.storage_backup import BackupInfo
 
+
 @patch("autoresearch.cli_backup.BackupManager")
 def test_backup_create_command(mock_manager):
     """Test the backup create command."""


### PR DESCRIPTION
## Summary
- explicitly select Python 3.12 or newer before installing with Poetry
- document error message when Python 3.11 is selected
- fix flake8 issue in unit tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687e5e1a7c588333a3f6580e2667c5b9