### PR TITLE
Update testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ task test:unit         # unit tests
 task test:integration  # integration tests excluding slow tests
 task test:behavior     # behavior-driven tests
 task test:all          # run all suites including slow tests
+task test:slow         # run only tests marked as slow
 ```
 
 Several unit and integration tests rely on `gitpython` and the DuckDB VSS
@@ -465,7 +466,7 @@ extension. These extras are installed when running
 All testing commands are wrapped by `task`, which uses `poetry run` internally
 to ensure the correct virtual environment is active.
 
-Maintain at least 90% test coverage and remove temporary files before submitting a pull request.
+Maintain at least 90% test coverage and remove temporary files before submitting a pull request. Use `task coverage` to run the entire suite with coverage enabled. If you run suites separately, prefix each invocation with `coverage run -p` to create partial results, then merge them with `coverage combine` before generating the final report with `coverage html` or `coverage xml`.
 
 ### Troubleshooting
 

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -10,6 +10,19 @@ Tests are organized into three categories:
 2. **Integration Tests** (`tests/integration/`): Test interactions between components
 3. **Behavior Tests** (`tests/behavior/`): BDD-style tests using Gherkin syntax
 
+## Running tests
+
+Use [Go Task](https://taskfile.dev/#/) to run specific suites inside the Poetry environment:
+
+```bash
+task test:unit         # unit tests
+task test:integration  # integration tests excluding slow tests
+task test:behavior     # behavior-driven tests
+task test:slow         # only tests marked as slow
+```
+
+`task test:all` executes every suite. Maintain at least **90% coverage**. When running suites separately, prefix each command with `coverage run -p` and merge the results using `coverage combine` before generating a report with `coverage html` or `coverage xml`.
+
 ## Naming Conventions
 
 ### Test Files


### PR DESCRIPTION
## Summary
- document extra test command `task test:slow`
- explain coverage aggregation
- add short running tests section in docs

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest tests/unit/test_a2a_interface.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6893bcac8333a0ba6ec5fdb9a41a