### PR TITLE
Improve environment docs and CI checks

### DIFF
--- a/.github/workflows.disabled/ci.yml
+++ b/.github/workflows.disabled/ci.yml
@@ -29,6 +29,13 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Verify Python version
+      run: |
+        python - <<'EOF'
+        import sys
+        major, minor = sys.version_info[:2]
+        assert (major == 3 and minor >= 12), f"Python 3.12 or newer required, got {major}.{minor}"
+        EOF
     - name: Install dependencies
       run: |
         ./scripts/setup.sh
@@ -74,15 +81,22 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.12'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install poetry
-        poetry build
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Verify Python version
+        run: |
+          python - <<'EOF'
+          import sys
+          major, minor = sys.version_info[:2]
+          assert (major == 3 and minor >= 12), f"Python 3.12 or newer required, got {major}.{minor}"
+          EOF
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry build
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows.disabled/simple_ci.yml
+++ b/.github/workflows.disabled/simple_ci.yml
@@ -11,6 +11,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Verify Python version
+        run: |
+          python - <<'EOF'
+          import sys
+          major, minor = sys.version_info[:2]
+          assert (major == 3 and minor >= 12), f"Python 3.12 or newer required, got {major}.{minor}"
+          EOF
       - name: Install Poetry
         run: python -m pip install poetry
       - name: Install dependencies

--- a/.github/workflows.disabled/wheels.yml
+++ b/.github/workflows.disabled/wheels.yml
@@ -17,6 +17,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Verify Python version
+        run: |
+          python - <<'EOF'
+          import sys
+          major, minor = sys.version_info[:2]
+          assert (major == 3 and minor >= 12), f"Python 3.12 or newer required, got {major}.{minor}"
+          EOF
       - name: Install Poetry
         run: python -m pip install poetry
       - name: Build wheels

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ for testing.
 
 ### Using Poetry
 Python 3.12 or newer is required. When several Python versions are installed,
-select version 3.12 (or 3.13 when available) **before** running `poetry install`:
+select the interpreter **before** running `poetry install`:
 ```bash
-poetry env use $(which python3.12)
-# or: poetry env use $(which python3.13)
+# Use the `python3` executable from your PATH
+poetry env use $(which python3)
 poetry install --with dev --all-extras
 ```
 If Python 3.11 is selected, Poetry will fail with a message similar to:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,8 +12,8 @@ This guide explains how to install Autoresearch and manage optional features.
 Use Poetry to manage the environment when working from a clone:
 
 ```bash
-poetry env use $(which python3.12)
-# or: poetry env use $(which python3.13)
+# Select Python 3.12 or newer
+poetry env use $(which python3)
 poetry lock --check || poetry lock
 poetry install --with dev --all-extras
 ```

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 #python -m pip install --upgrade pip
 #pip install poetry
 poetry env use $(which python3)
-poetry install --no-root --no-interaction
-poetry install --with dev --all-extras
+poetry install --no-root --no-interaction --with dev --all-extras
 poetry run pip install -e .
 
 # Create extensions directory if it doesn't exist


### PR DESCRIPTION
## Summary
- explain how to choose the Poetry interpreter via `python3`
- clarify Python selection in installation docs
- install dev deps in setup script with a single Poetry call
- verify Python version in CI workflows

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(failed: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_687ebd6adbd88333aa661e81efa99e77