### PR TITLE
Improve docs and add CI task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Poetry and Task
+        run: |
+          python -m pip install poetry
+          curl -sL https://taskfile.dev/install.sh | sh -s -- -d -b /usr/local/bin
+      - name: Install dependencies
+        run: |
+          poetry env use $(which python)
+          poetry install --with dev --all-extras
+      - name: Run full test suite
+        run: task test:all
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ documentation and packaging checks complete. See
 
 ## Installation
 
-Autoresearch requires **Python 3.12 or newer**. You can install the project
+Autoresearch requires **Python 3.12 or newer**. Before installing, ask yourself: "Is my `python` interpreter at least version 3.12?" You can install the project
 dependencies with either **Poetry** or **pip**. See
 [docs/installation.md](docs/installation.md) for details on optional features and
 upgrade instructions.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -6,6 +6,7 @@ This guide describes how to set up a development environment and the expected wo
 
 1. Install [Poetry](https://python-poetry.org/docs/#installation).
 2. Select the Python interpreter:
+   Confirm with `python --version` that it is 3.12 or newer.
    ```bash
    poetry env use $(which python3)
    ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,3 +5,6 @@ Set `Dark Mode` in the sidebar of the Streamlit interface.
 
 ## Why do my token counts change after upgrading?
 Token counts may vary slightly with model updates. Run `Taskfile check-baselines` to ensure usage is within expected limits.
+
+## Why does the CI run `task test:all`?
+Running the entire suite, including slow tests, helps catch edge cases before release.


### PR DESCRIPTION
## Summary
- add GitHub workflow to run `task test:all` on Python 3.12 and 3.13
- clarify Python requirement in README and developer guide
- note why CI runs the full test suite in the FAQ

## Testing
- `flake8 src tests`
- `mypy src`
- ❌ `pytest -q` *(failed to run due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687eb4b9a50883338aae8dcb48c9f26b