### PR TITLE
Add markers for optional extras

### DIFF
--- a/.github/workflows.disabled/ci.yml
+++ b/.github/workflows.disabled/ci.yml
@@ -38,7 +38,8 @@ jobs:
         EOF
     - name: Install dependencies
       run: |
-        ./scripts/setup.sh
+        poetry env use $(which python)
+        poetry install --with dev
     - name: Lint with flake8
       if: matrix.os == 'ubuntu-latest' && matrix.test-mode == 'offline'
       run: |
@@ -60,10 +61,15 @@ jobs:
         echo "AUTORESEARCH_STRICT_EXTENSIONS=false" > .env
     - name: Test with pytest
       run: |
-        poetry run pytest tests/
-    - name: Run BDD tests
-      run: |
-        poetry run pytest tests/behavior/
+        poetry run pytest tests/ -m "not requires_ui and not requires_vss"
+    - name: Install UI extras
+      run: poetry install --with dev --extras ui
+    - name: UI tests
+      run: poetry run pytest tests/behavior -m requires_ui
+    - name: Install VSS extras
+      run: poetry install --with dev --extras vss
+    - name: VSS tests
+      run: poetry run pytest tests/behavior -m requires_vss
     - name: Deployment checks
       run: |
         poetry run python scripts/deploy.py

--- a/.github/workflows.disabled/simple_ci.yml
+++ b/.github/workflows.disabled/simple_ci.yml
@@ -23,13 +23,21 @@ jobs:
       - name: Install dependencies
         run: |
           poetry env use $(which python)
-          poetry install --with dev --all-extras
+          poetry install --with dev
       - name: Lint
         run: poetry run flake8 src tests
       - name: Type check
         run: poetry run mypy src
       - name: Test
-        run: poetry run pytest -q
+        run: poetry run pytest -q -m "not requires_ui and not requires_vss"
+      - name: Install UI extras
+        run: poetry install --with dev --extras ui
+      - name: UI tests
+        run: poetry run pytest tests/behavior -m requires_ui
+      - name: Install VSS extras
+        run: poetry install --with dev --extras vss
+      - name: VSS tests
+        run: poetry run pytest tests/behavior -m requires_vss
       - name: Upload coverage
         if: always()
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,9 @@ markers = [
     "integration: mark integration tests",
     "unit: mark unit tests",
     "real_vss: enable actual VSS extension logic",
-    "slow: tests that take a long time to run"
+    "slow: tests that take a long time to run",
+    "requires_ui: tests that depend on the ui extra",
+    "requires_vss: tests that depend on the vss extra"
 ]
 
 [tool.mypy]

--- a/tests/behavior/README.md
+++ b/tests/behavior/README.md
@@ -1,0 +1,31 @@
+# Behavior Tests
+
+This directory contains the pytest-bdd scenarios for Autoresearch. Some tests
+require optional features that are not installed during a normal development
+setup.
+
+## Installing extras
+
+To run scenarios that depend on the Streamlit UI or the DuckDB VSS extension,
+install the appropriate extras with Poetry:
+
+```bash
+poetry install --with dev --extras ui
+poetry install --with dev --extras vss
+```
+
+## Running extra tests
+
+Use pytest markers to execute these scenarios separately:
+
+```bash
+# Scenarios that need the UI extra
+poetry run pytest tests/behavior -m requires_ui
+
+# Scenarios that need the VSS extra
+poetry run pytest tests/behavior -m requires_vss
+```
+
+Scenarios with these markers are skipped when the corresponding extras are not
+installed.
+

--- a/tests/behavior/features/cross_modal_integration.feature
+++ b/tests/behavior/features/cross_modal_integration.feature
@@ -6,6 +6,7 @@ Feature: Cross-Modal Integration
   Background:
     Given the Autoresearch system is running
 
+  @requires_ui
   Scenario: Shared Query History
     When I execute a query "What is the capital of France?" via CLI
     And I open the Streamlit GUI
@@ -13,12 +14,14 @@ Feature: Cross-Modal Integration
     And I should be able to rerun the query from the GUI
     And the results should be consistent with the CLI results
 
+  @requires_ui
   Scenario: Consistent Error Handling
     When I execute an invalid query via CLI
     Then I should receive a specific error message
     When I execute the same invalid query via GUI
     Then I should receive the same error message in the GUI
 
+  @requires_ui
   Scenario: Configuration Synchronization
     When I update the configuration via CLI
     And I open the Streamlit GUI
@@ -27,12 +30,14 @@ Feature: Cross-Modal Integration
     And I check the configuration via CLI
     Then the CLI should show the updated configuration
 
+  @requires_ui
   Scenario: A2A Interface Consistency
     When I execute a query via the A2A interface
     Then the response format should match the CLI response format
     And the response should contain the same fields as the GUI response
     And the error handling should be consistent with other interfaces
 
+  @requires_ui
   Scenario: MCP Interface Consistency
     When I execute a query via the MCP interface
     Then the response format should match the CLI response format

--- a/tests/behavior/features/streamlit_gui.feature
+++ b/tests/behavior/features/streamlit_gui.feature
@@ -6,24 +6,28 @@ Feature: Streamlit GUI Features
   Background:
     Given the Streamlit application is running
 
+  @requires_ui
   Scenario: Formatted Answer Display with Markdown Rendering
     When I enter a query that returns Markdown-formatted content
     Then the answer should be displayed with proper Markdown rendering
     And formatting elements like headers, lists, and code blocks should be properly styled
     And math expressions in LaTeX format should be properly rendered
 
+  @requires_ui
   Scenario: Tabbed Interface for Results
     When I run a query in the Streamlit interface
     Then the results should be displayed in a tabbed interface
     And there should be tabs for "Citations", "Reasoning", "Metrics", and "Knowledge Graph"
     And I should be able to switch between tabs without losing information
 
+  @requires_ui
   Scenario: Knowledge Graph Visualization
     When I run a query that generates a knowledge graph
     Then the knowledge graph should be visualized in the "Knowledge Graph" tab
     And the visualization should show relationships between concepts
     And the nodes should be color-coded by type
 
+  @requires_ui
   Scenario: Configuration Editor Interface
     When I navigate to the configuration section
     Then I should see a form with configuration options
@@ -31,22 +35,26 @@ Feature: Streamlit GUI Features
     And I should be able to save changes to the configuration
     And I should see feedback when the configuration is saved
 
+  @requires_ui
   Scenario: Configuration Updates Persist
     When I update a configuration value in the GUI
     Then the configuration should be saved with the new value
     And the updated configuration should be used for the next query
 
+  @requires_ui
   Scenario: Agent Interaction Trace Visualization
     When I run a query in the Streamlit interface
     Then an interaction trace should be displayed
     And progress metrics should be visualized
 
+  @requires_ui
   Scenario: User Preferences Configuration
     When I open the configuration editor
     And I change a user preference value
     Then the preference should be saved
     And the sidebar should reflect the updated preference
 
+  @requires_ui
   Scenario: Theme Toggle Switch
     When I toggle dark mode
     Then the page background should change according to the selected mode

--- a/tests/behavior/features/ui_accessibility.feature
+++ b/tests/behavior/features/ui_accessibility.feature
@@ -19,6 +19,7 @@ Feature: UI Accessibility
     And all visual elements should have text descriptions
     And command help text should be properly structured for screen readers
 
+  @requires_ui
   Scenario: Streamlit GUI Keyboard Navigation
     Given the Streamlit application is running
     When I navigate the interface using only keyboard
@@ -26,6 +27,7 @@ Feature: UI Accessibility
     And focus indicators should be clearly visible
     And tab order should be logical and follow page structure
 
+  @requires_ui
   Scenario: Streamlit GUI Screen Reader Compatibility
     Given the Streamlit application is running
     When I use the GUI with a screen reader
@@ -33,6 +35,7 @@ Feature: UI Accessibility
     And all form controls should have proper labels
     And dynamic content updates should be announced to screen readers
 
+  @requires_ui
   Scenario: High Contrast Mode
     Given the Streamlit application is running
     When I enable high contrast mode
@@ -40,12 +43,14 @@ Feature: UI Accessibility
     And interactive elements should be clearly distinguishable
     And information should not be conveyed by color alone
 
+  @requires_ui
   Scenario: Responsive Layout on Mobile
     Given the Streamlit application is running on a small screen
     When I view the page
     Then columns should stack vertically
     And controls should remain usable without horizontal scrolling
 
+  @requires_ui
   Scenario: Guided Tour Availability
     Given the Streamlit application is running
     When I open the page for the first time

--- a/tests/behavior/features/vector_extension_handling.feature
+++ b/tests/behavior/features/vector_extension_handling.feature
@@ -6,6 +6,7 @@ Feature: DuckDB VSS Extension Handling
   Background:
     Given I have a valid configuration with VSS extension enabled
 
+  @requires_vss
   Scenario: Load VSS extension from filesystem
     Given I have a local copy of the VSS extension
     And I have configured the VSS extension path
@@ -13,6 +14,7 @@ Feature: DuckDB VSS Extension Handling
     Then the VSS extension should be loaded from the filesystem
     And vector search functionality should work
 
+  @requires_vss
   Scenario: Download VSS extension automatically
     Given I have no local copy of the VSS extension
     And I have not configured the VSS extension path
@@ -20,6 +22,7 @@ Feature: DuckDB VSS Extension Handling
     Then the VSS extension should be downloaded automatically
     And vector search functionality should work
 
+  @requires_vss
   Scenario: Fallback to download when local extension is invalid
     Given I have an invalid local copy of the VSS extension
     And I have configured the VSS extension path
@@ -27,6 +30,7 @@ Feature: DuckDB VSS Extension Handling
     Then the system should attempt to download the extension
     And vector search functionality should work
 
+  @requires_vss
   Scenario: Handle offline environment with local extension
     Given I have a local copy of the VSS extension
     And I have configured the VSS extension path
@@ -35,6 +39,7 @@ Feature: DuckDB VSS Extension Handling
     Then the VSS extension should be loaded from the filesystem
     And vector search functionality should work
 
+  @requires_vss
   Scenario: Handle offline environment without local extension
     Given I have no local copy of the VSS extension
     And I have not configured the VSS extension path
@@ -44,6 +49,7 @@ Feature: DuckDB VSS Extension Handling
     And basic storage functionality should still work
     But vector search should raise an appropriate error
 
+  @requires_vss
   Scenario: Embedding search wrapper dispatches to backend
     Given I have persisted claims with embeddings
     When I perform an embedding lookup with a query embedding

--- a/tests/behavior/features/vector_search_performance.feature
+++ b/tests/behavior/features/vector_search_performance.feature
@@ -1,4 +1,5 @@
 Feature: Vector Search Performance
+  @requires_vss
   Scenario: Vector search executes quickly
     Given I have persisted claims with embeddings
     When I measure vector search time


### PR DESCRIPTION
## Summary
- mark BDD scenarios that need optional features
- document installing extras and running their tests
- update CI workflows to install extras only for the marked tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest tests/behavior -m requires_ui --maxfail=1 -q` *(fails: environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_687ed5c3978483339b4f57404c8c507b