### PR TITLE
Fix CLI serve command patch target

### DIFF
--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -98,7 +98,7 @@ def test_config_command(monkeypatch):
     assert '"loops"' in result.stdout
 
 
-@patch("autoresearch.mcp_interface.create_server")
+@patch("autoresearch.main.create_server")
 def test_serve_command(mock_create_server, monkeypatch):
     """Test the serve command that starts an MCP server."""
     runner = CliRunner()


### PR DESCRIPTION
## Summary
- patch `autoresearch.main.create_server` in CLI tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest tests/unit/test_main_cli.py::test_serve_command -q`
- `poetry run pytest tests/behavior -q` *(fails: test_rate_limit_exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_687ee72181788333bae653a6dde065f9