### PR TITLE
Mark slow tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,12 @@ task test:all          # run all suites including slow tests
 task test:slow         # run only tests marked as slow
 ```
 
+To execute the long-running tests directly without Go Task, run:
+
+```bash
+poetry run pytest -m slow
+```
+
 Several unit and integration tests rely on `gitpython` and the DuckDB VSS
 extension. These extras are installed when running
 `poetry install --with dev --all-extras`.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -49,6 +49,11 @@ For quick feedback, you can skip heavy integration tests marked with
 poetry run pytest -m "not slow" -q
 poetry run pytest -m "not slow" tests/behavior
 ```
+To run the heavier tests separately:
+
+```bash
+poetry run pytest -m slow
+```
 3. Update or add documentation when needed.
 4. Open a pull request explaining the rationale for the change.
 

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -22,6 +22,11 @@ task test:fast         # unit, integration, and behavior tests (no slow)
 task test:slow         # only tests marked as slow
 task test:all          # entire suite including slow tests
 ```
+You can also invoke the slow suite directly with:
+
+```bash
+poetry run pytest -m slow
+```
 
 `task test:fast` usually finishes in about **3 minutes**. The slow tests add roughly **7 minutes**, so `task test:all` takes around **10 minutes** total and is used by CI. Maintain at least **90% coverage**. When running suites separately, prefix each command with `coverage run -p` and merge the results using `coverage combine` before generating a report with `coverage html` or `coverage xml`.
 

--- a/tests/integration/test_performance.py
+++ b/tests/integration/test_performance.py
@@ -4,6 +4,9 @@ from pathlib import Path
 from autoresearch.storage import StorageManager
 from autoresearch.search import Search
 import importlib.util
+import pytest
+
+pytestmark = pytest.mark.slow
 
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "benchmark_token_memory.py"
 spec = importlib.util.spec_from_file_location("benchmark_token_memory", SCRIPT_PATH)

--- a/tests/integration/test_search_weights.py
+++ b/tests/integration/test_search_weights.py
@@ -4,6 +4,9 @@ from pathlib import Path
 
 import tomllib
 from autoresearch.search import Search
+import pytest
+
+pytestmark = pytest.mark.slow
 
 
 def test_optimize_script_updates_weights(tmp_path):

--- a/tests/integration/test_streamlit_gui.py
+++ b/tests/integration/test_streamlit_gui.py
@@ -1,6 +1,8 @@
 import os
 import pytest
 
+pytestmark = pytest.mark.slow
+
 AppTest = pytest.importorskip("streamlit.testing.v1", reason="streamlit testing module not available").AppTest
 
 APP_FILE = os.path.join("src", "autoresearch", "streamlit_app.py")

--- a/tests/integration/test_token_regression.py
+++ b/tests/integration/test_token_regression.py
@@ -1,7 +1,11 @@
 import subprocess
 from pathlib import Path
 
+import pytest
+
 SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_token_regression.py"
+
+pytestmark = pytest.mark.slow
 
 
 def test_token_regression_script():

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -244,6 +244,7 @@ def test_local_file_backend(monkeypatch, tmp_path):
     assert any("hello" in r["snippet"].lower() for r in results)
 
 
+@pytest.mark.slow
 def test_local_git_backend(monkeypatch, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/unit/test_storage_backup.py
+++ b/tests/unit/test_storage_backup.py
@@ -8,7 +8,6 @@ import os
 import shutil
 import tempfile
 from unittest.mock import patch
-
 import pytest
 import duckdb
 import rdflib
@@ -22,6 +21,8 @@ from autoresearch.storage_backup import (
     BackupConfig,
 )
 from autoresearch.errors import BackupError
+
+pytestmark = pytest.mark.slow
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- mark heavy integration and unit tests with `pytest.mark.slow`
- update README and docs with instructions to run slow tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q`
- `poetry run pytest tests/behavior` *(fails: test_api_batch_pagination)*

------
https://chatgpt.com/codex/tasks/task_e_687f92245d8c8333b5f611757df36bde