### PR TITLE
Gracefully handle missing optional packages

### DIFF
--- a/src/autoresearch/search.py
+++ b/src/autoresearch/search.py
@@ -28,13 +28,18 @@ from collections import defaultdict
 import requests
 try:
     from git import Repo
+
     GITPYTHON_AVAILABLE = True
-except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    Repo = None  # type: ignore[assignment]
     GITPYTHON_AVAILABLE = False
-    raise ImportError(
-        "Local Git search requires the 'gitpython' package. "
-        "Install with `pip install \"autoresearch[git]\"`."
-    ) from exc
+    import warnings
+
+    warnings.warn(
+        "Local Git search backend disabled: 'gitpython' is not installed. "
+        "Install with `pip install \"autoresearch[git]\"` to enable it.",
+        stacklevel=2,
+    )
 import numpy as np
 import csv
 import math

--- a/tests/unit/test_search_import.py
+++ b/tests/unit/test_search_import.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 
-def test_search_import_error_without_gitpython(monkeypatch):
+def test_search_import_without_gitpython(monkeypatch):
     orig_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
@@ -15,9 +15,9 @@ def test_search_import_error_without_gitpython(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
     monkeypatch.delitem(sys.modules, "autoresearch.search", raising=False)
-    with pytest.raises(ImportError) as excinfo:
-        importlib.import_module("autoresearch.search")
-    assert "gitpython" in str(excinfo.value).lower()
+    with pytest.warns(UserWarning):
+        module = importlib.import_module("autoresearch.search")
+    assert not module.GITPYTHON_AVAILABLE
 
 
 def test_search_import_with_gitpython():


### PR DESCRIPTION
## Summary
- skip ImportError on optional `gitpython` extra and warn instead
- update search import test for new warning behavior

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(failed: timeout)*
- `poetry run pytest tests/behavior` *(failed: 1 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f9ab5db008333a97e7e2a5822220c