### PR TITLE
Ensure release metric dirs exist

### DIFF
--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -146,6 +146,7 @@ class OrchestrationMetrics:
             except Exception:
                 data = {}
         data[self.release] = self.token_counts
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(data, indent=2))
         self._release_logged = True
 

--- a/tests/targeted/test_metrics_extra.py
+++ b/tests/targeted/test_metrics_extra.py
@@ -2,9 +2,11 @@ import types
 from autoresearch.orchestration import metrics
 
 
-def test_cycle_and_agent_metrics(monkeypatch):
+def test_cycle_and_agent_metrics(monkeypatch, tmp_path):
     fake_time = types.SimpleNamespace(time=lambda: 1.0)
     monkeypatch.setattr(metrics, "time", fake_time)
+    path = tmp_path / "dir" / "release.json"
+    monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", str(path))
     m = metrics.OrchestrationMetrics()
     m.start_cycle()
     m.record_agent_timing("agent", 0.5)
@@ -17,6 +19,8 @@ def test_cycle_and_agent_metrics(monkeypatch):
     assert summary["agent_tokens"]["agent"]["in"] == 2
     assert summary["agent_tokens"]["agent"]["out"] == 3
     assert summary["errors"]["total"] == 1
+    if path.exists():
+        path.unlink()
 
 
 def test_resource_tracking(monkeypatch):


### PR DESCRIPTION
## Summary
- create parent directories before writing release metrics
- isolate cycle metrics test output with temporary path and remove file after

## Testing
- `poetry run flake8 src tests`
- `timeout 120 poetry run mypy src` *(fails: Interrupted)*
- `poetry run pytest -q` *(stopped)*
- `poetry run pytest tests/behavior` *(fails: test_rate_limit_exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_687fcb6289c0833382983b60a3c907c1