### PR TITLE
Remove obsolete extras section from pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,15 +101,6 @@ full = [
     "polars >=1.31.0",
     "gitpython >=3.1"
 ]
-
-[tool.poetry.extras]
-minimal = [
-    "sentence-transformers"
-]
-analysis = ["polars"]
-kuzu = ["kuzu"]
-
-
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"
 pytest-bdd = "^8.1.0"


### PR DESCRIPTION
## Summary
- drop `[tool.poetry.extras]` from pyproject
- run `poetry check` (fails due to lockfile mismatch)

## Testing
- `poetry check` *(fails: pyproject.toml changed significantly since poetry.lock was last generated)*

------
https://chatgpt.com/codex/tasks/task_e_687fcb3a61a4833389309c27a21f6455