### PR TITLE
Ensure SlowAPI limiter reset between tests

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 from autoresearch.api import reset_request_log
+from tests.conftest import reset_limiter_state
 
 
 @pytest.fixture
@@ -21,6 +22,7 @@ def enable_real_vss(monkeypatch):
 def reset_api_request_log():
     """Clear API request log before each scenario."""
     reset_request_log()
+    reset_limiter_state()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -277,7 +277,7 @@ sys.modules.setdefault("sentence_transformers", dummy_st_module)
 sys.modules.setdefault("bertopic", MagicMock())
 sys.modules.setdefault("transformers", MagicMock())
 
-from autoresearch.api import app as api_app  # noqa: E402
+from autoresearch.api import app as api_app, SLOWAPI_STUB  # noqa: E402
 
 # Older Typer versions used in tests may not support the ``multiple`` parameter.
 import typer  # noqa: E402
@@ -294,6 +294,17 @@ typer.Option = _compat_option
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow")
+
+
+def reset_limiter_state() -> None:
+    """Reset SlowAPI limiter state when using the real implementation."""
+    if not SLOWAPI_STUB:
+        limiter = getattr(api_app.state, "limiter", None)
+        if limiter is not None:
+            try:
+                limiter.reset()
+            except Exception:
+                pass
 
 
 # Ensure package can be imported without installation


### PR DESCRIPTION
## Summary
- add helper to reset SlowAPI limiter state
- use helper in behaviour tests to reset limiter between scenarios

## Testing
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: Error importing plugin)*
- `poetry run pytest -k rate_limit` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687fe135f8548333a72486c53f200ba5