### PR TITLE
Clarify extras usage in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ dependencies with either **Poetry** or **pip**. See
 upgrade instructions.
 The `scripts/setup.sh` helper ensures the lock file is current and installs
 all optional extras so development and runtime dependencies are available
-for testing.
+for testing. The unit suite relies on stub implementations of several optional
+packages (for example `slowapi`), so running tests without extras installed is
+recommended. Extras may enable real functionality such as rate limiting which
+can alter test behaviour. Reinstall with `poetry install --with dev` if you
+need to disable extras after running the setup script.
 
 ### Using Poetry
 Python 3.12 or newer is required. When several Python versions are installed,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,9 +47,13 @@ If you cloned the repository, run the setup helper instead:
 ```
 
 The helper ensures the lock file is refreshed and installs every optional
-extra needed for the test suite. Optional features are disabled when their
-dependencies are missing. Specify extras explicitly with pip to enable
-additional features, e.g. ``pip install "autoresearch[minimal,nlp]"``.
+extra needed for the test suite. Tests normally rely on stubbed versions of
+these extras, so running the suite without them is recommended. Extras such as
+`slowapi` may enable real behaviour (like rate limiting) that changes how
+assertions are evaluated. If you wish to revert to stub-only testing after
+running the helper, reinstall using `poetry install --with dev`. Optional
+features are disabled when their dependencies are missing. Specify extras
+explicitly with pip to enable additional features, e.g. ``pip install "autoresearch[minimal,nlp]"``.
 
 ## Optional extras
 


### PR DESCRIPTION
## Summary
- document stub-based testing and extras in README and installation guide

## Testing
- `poetry run flake8 src tests | head -n 20`
- `poetry run mypy src | tail -n 20`
- `PYTHONPATH=. poetry run pytest -q tests/unit/test_api_imports.py >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`
- `PYTHONPATH=. poetry run pytest tests/behavior/test_minimal.feature -k 'nonexistent' >/tmp/pytest_bdd.log && tail -n 20 /tmp/pytest_bdd.log`

------
https://chatgpt.com/codex/tasks/task_e_688006eeeb108333ba9b0f614ca75f5f