### PR TITLE
Mark integration tests as slow

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -1,7 +1,16 @@
-import pytest
+import sys
+from pathlib import Path
 
-from autoresearch.api import reset_request_log
-from tests.conftest import reset_limiter_state
+# Ensure the repository root is on the import path so ``tests.conftest`` can be
+# imported reliably when running behavior tests directly.
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))  # noqa: E402
+
+import pytest  # noqa: E402
+
+from autoresearch.api import reset_request_log  # noqa: E402
+from tests.conftest import reset_limiter_state  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.slow


### PR DESCRIPTION
## Summary
- mark the entire integration suite with `pytest.mark.slow`
- ensure behavior tests can import project fixtures when run directly

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run pytest tests/behavior --maxfail=1 -k distributed -q`

------
https://chatgpt.com/codex/tasks/task_e_68801b59f1ac83339cc2bb6af6368dbf