### PR TITLE
Update release timeline in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ CLI utilities are provided via Typer and the HTTP API is powered by FastAPI.
 Autoresearch is currently in the **Development** phase preparing for the
 upcoming **0.1.0** release. The codebase already reports version
 `0.1.0` in `pyproject.toml`, but that version has **not** been published yet.
-The first official release is targeted for **July 20, 2025** once the
-documentation and packaging checks complete. See
+The first official release was previously targeted for **July 20, 2025**.
+Development has slipped past that date, so the release is now expected
+to arrive sometime after **July 20, 2025**. See
 [docs/release_plan.md](docs/release_plan.md) for the full milestone schedule.
 
 ## Installation

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -3,18 +3,22 @@
 This document outlines the upcoming release milestones for **Autoresearch**. Dates are aspirational and may shift as development progresses. The publishing workflow follows the steps in [deployment.md](deployment.md).
 
 The project kicked off in **May 2025** (see the initial commit dated `2025-05-18`).
-This schedule was last updated on **July 16, 2025** and reflects the fact that
+This schedule was last updated on **July 21, 2025** and reflects the fact that
 the codebase currently sits at an **unreleased 0.1.0** version.
 
 ## Milestones
 
 | Version | Target Date | Key Goals |
 | ------- | ----------- | --------- |
-| **0.1.0** | 2025-07-20 | Finalize packaging, docs and CI checks |
+| **0.1.0** | After 2025-07-20 | Finalize packaging, docs and CI checks |
 | **0.1.1** | 2025-07-31 | Bug fixes and documentation updates |
 | **0.2.0** | 2025-09-15 | API stabilization, configuration hot-reload, improved search backends |
 | **0.3.0** | 2025-11-15 | Distributed execution support, monitoring utilities |
 | **1.0.0** | 2026-01-31 | Full feature set, performance tuning and stable interfaces |
+
+The **0.1.0** release was originally aimed for **July 20, 2025**. Ongoing work has
+shifted the timeline, so that milestone is now expected sometime **after
+July 20, 2025**.
 
 The following tasks remain before publishing **0.1.0**:
 


### PR DESCRIPTION
## Summary
- revise README timeline language
- document updated 0.1.0 schedule in release plan

## Testing
- `poetry run flake8 src tests` *(fails: E302 expected 2 blank lines, etc.)*
- `poetry run mypy src` *(fails: Interrupted)*
- `poetry run pytest -q` *(fails: test_config_watcher_cleanup)*
- `poetry run pytest tests/behavior` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68802ce2221083338ffaa46808dd4cf9