### PR TITLE
Adjust test deps and coverage settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ hypothesis = "^6.135.33"
 cibuildwheel = "^3.0.1"
 types-tabulate = "^0.9.0"
 pydantic = "^2.11.7"
+typer = "^0.16.0"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
@@ -126,7 +127,7 @@ autoresearch = "autoresearch.main:app"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--maxfail=1 --disable-warnings -q --cov=src --cov=tests --cov-report=xml --cov-report=term-missing --cov-fail-under=20 -m 'not slow'"
+addopts = "--maxfail=1 --disable-warnings -q --cov=src --cov=tests --cov-report=xml --cov-report=term-missing --cov-fail-under=90 -m 'not slow'"
 testpaths = ["tests/unit", "tests/integration", "tests/behavior"]
 python_files = ["test_*.py", "*_steps.py"]
 markers = [


### PR DESCRIPTION
## Summary
- add `typer` to the dev dependency group
- enforce higher coverage goal

## Testing
- `poetry run flake8 src tests` *(fails: E302, E402 in tests/conftest.py)*
- `poetry run mypy src` *(interrupted)*
- `poetry run pytest -q` *(interrupted after ~10%)*
- `poetry run pytest tests/behavior -k "" -q` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68803829232883339bb7107c20970788