### PR TITLE
Add setuptools to dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6505,7 +6505,6 @@ description = "Embeddings, Retrieval, and Reranking"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"minimal\" or extra == \"full\" or extra == \"nlp\""
 files = [
     {file = "sentence_transformers-5.0.0-py3-none-any.whl", hash = "sha256:346240f9cc6b01af387393f03e103998190dfb0826a399d0c38a81a05c7a5d76"},
     {file = "sentence_transformers-5.0.0.tar.gz", hash = "sha256:e5a411845910275fd166bacb01d28b7f79537d3550628ae42309dbdd3d5670d1"},
@@ -6532,10 +6531,9 @@ train = ["accelerate (>=0.20.3)", "datasets"]
 name = "setuptools"
 version = "80.9.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"minimal\" or extra == \"full\" or extra == \"nlp\""
 files = [
     {file = "setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"},
     {file = "setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"},
@@ -8901,4 +8899,4 @@ vss = ["duckdb-extension-vss"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "74fb863fda0168024b8a7eefe22e4762d8b2278c3fa4c2dbe59f245e7aeed44a"
+content-hash = "a9a293267a12ff5d3b03296290a825f13fcd11091d75ed7c6c92d8fd009439c3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
     "tabulate >=0.9.0",
     "tinydb >=4.8.0",
     "typer >=0.16.0",
-    "watchfiles >=0.21"
+    "watchfiles >=0.21",
+    "setuptools"
 ]
 [project.optional-dependencies]
 # Minimal install: only core embedding model support


### PR DESCRIPTION
## Summary
- add `setuptools` dependency so `pkg_resources` is available
- update lock file accordingly

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `timeout 120s poetry run pytest -q` *(fails: tests hang, truncated output)*

------
https://chatgpt.com/codex/tasks/task_e_688059f1de6483338eaaf84b3b818cba