### PR TITLE
Update roadmap and docs on fully implemented modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,11 @@ extension. These extras are installed when running
 All testing commands are wrapped by `task`, which uses `poetry run` internally
 to ensure the correct virtual environment is active.
 
+Integration tests can leverage the helper classes in `autoresearch.test_tools`.
+`MCPTestClient` and `A2ATestClient` provide simple interfaces for exercising
+the CLI and API endpoints while capturing formatted results. They are fully
+tested and ship with the package for external use.
+
 Maintain at least 90% test coverage and remove temporary files before submitting a pull request. Use `task coverage` to run the entire suite with coverage enabled. If you run suites separately, prefix each invocation with `coverage run -p` to create partial results, then merge them with `coverage combine` before generating the final report with `coverage html` or `coverage xml`.
 
 ### Troubleshooting

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,6 +20,8 @@ Before publishing 0.1.0 the release plan lists several checks:
 - Ensure packaging metadata and publish scripts work correctly.
 
 Any remaining issues from these tasks will be addressed in 0.1.1.
+- CLI backup commands, testing utilities and all specialized agents now have
+  full implementations and comprehensive unit tests.
 
 ## 0.2.0 – API stabilization and improved search
 


### PR DESCRIPTION
## Summary
- clarify test utilities in README
- note completion of backup CLI and agents in roadmap

## Testing
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: No module named 'pydantic')*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68810aae742483338bbfe519b2785aea