### PR TITLE
Fix style issues in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,27 @@ from unittest.mock import patch, MagicMock
 import pytest
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
+
+if importlib.util.find_spec("autoresearch") is None:
+    src_path = Path(__file__).resolve().parents[1] / "src"
+    sys.path.insert(0, str(src_path))
+
+from autoresearch.api import app as api_app, SLOWAPI_STUB, reset_request_log
+import typer
+from autoresearch import cache, storage
+from autoresearch.config import ConfigLoader
+from autoresearch.agents.registry import (
+    AgentFactory,
+    AgentRegistry,
+)
+from autoresearch.llm.registry import LLMFactory
+from autoresearch.storage import (
+    set_delegate as set_storage_delegate,
+)
+from autoresearch.extensions import VSSExtensionLoader
+import duckdb
+
+_orig_option = typer.Option
 # Provide a lightweight stub for the optional ``ray`` dependency so that
 # ``autoresearch`` can be imported without the actual package installed.
 if "ray" not in sys.modules:
@@ -285,12 +306,6 @@ sys.modules.setdefault("sentence_transformers", dummy_st_module)
 sys.modules.setdefault("bertopic", MagicMock())
 sys.modules.setdefault("transformers", MagicMock())
 
-from autoresearch.api import app as api_app, SLOWAPI_STUB, reset_request_log  # noqa: E402
-
-# Older Typer versions used in tests may not support the ``multiple`` parameter.
-import typer  # noqa: E402
-_orig_option = typer.Option
-
 
 def _compat_option(*args, **kwargs):
     kwargs.pop("multiple", None)
@@ -316,22 +331,6 @@ def reset_limiter_state() -> None:
 
 
 # Ensure package can be imported without installation
-if importlib.util.find_spec("autoresearch") is None:
-    src_path = Path(__file__).resolve().parents[1] / "src"
-    sys.path.insert(0, str(src_path))  # noqa: E402
-
-from autoresearch import cache, storage  # noqa: E402
-from autoresearch.config import ConfigLoader  # noqa: E402
-from autoresearch.agents.registry import (  # noqa: E402
-    AgentFactory,
-    AgentRegistry,
-)
-from autoresearch.llm.registry import LLMFactory  # noqa: E402
-from autoresearch.storage import (  # noqa: E402
-    set_delegate as set_storage_delegate,
-)
-from autoresearch.extensions import VSSExtensionLoader  # noqa: E402
-import duckdb  # noqa: E402
 
 
 def _module_available(name: str) -> bool:


### PR DESCRIPTION
## Summary
- move module imports in `tests/conftest.py` to the file top
- tidy blank lines around `_compat_option`

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Interrupted)*
- `poetry run pytest -q` *(fails: test_api)*
- `poetry run pytest tests/behavior` *(fails: rate limit test)*

------
https://chatgpt.com/codex/tasks/task_e_6881597bc748833390e67aa908cb7ac3