### PR TITLE
Clarify extras impact on tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,10 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 ## Environment setup
 - Use **Poetry** for all project interactions.
   - Select the Python interpreter with `poetry env use $(which python3)` (Python 3.12 or newer).
-  - Install dependencies with `poetry install --with dev --all-extras` to ensure optional
-    packages used by the tests are available.
+  - Install dependencies with `poetry install --with dev --all-extras` to enable optional packages. Tests run without these extras using bundled stubs, but installing them activates real components such as SlowAPI's rate limiting.
   - Activate the environment using `poetry shell` or prefix commands with `poetry run`.
   - Avoid system-level Python or `pip`. Run `pip install -e .` only inside the Poetry virtual environment using `poetry shell` or `poetry run pip`.
-  - Codex environments run `scripts/codex_setup.sh`, which delegates to `scripts/setup.sh` and installs all dev dependencies so tools like `flake8`, `mypy`, and `pytest` are available.
+  - Codex environments run `scripts/codex_setup.sh`, which delegates to `scripts/setup.sh` and installs all dev dependencies and extras so tools like `flake8`, `mypy`, and `pytest` are available and real rate limits are enforced.
 
 ## Verification steps
 - Check code style with `poetry run flake8 src tests`.

--- a/README.md
+++ b/README.md
@@ -24,12 +24,18 @@ dependencies with either **Poetry** or **pip**. See
 [docs/installation.md](docs/installation.md) for details on optional features and
 upgrade instructions.
 The `scripts/setup.sh` helper ensures the lock file is current and installs
-all optional extras so development and runtime dependencies are available
-for testing. The unit suite relies on stub implementations of several optional
-packages (for example `slowapi`), so running tests without extras installed is
-recommended. Extras may enable real functionality such as rate limiting which
-can alter test behaviour. Reinstall with `poetry install --with dev` if you
-need to disable extras after running the setup script.
+all optional extras so development and runtime dependencies are available for
+testing. The test suite works both with and without extras:
+
+- **Without extras** – stub implementations of optional packages like
+  `slowapi` are used. Rate limiting middleware is disabled and tests run
+  quickly with predictable behaviour.
+- **With extras** – real packages are installed, activating features such as
+  SlowAPI's rate‑limiting middleware. This may change how certain tests
+  behave and can make them slower.
+
+Reinstall with `poetry install --with dev` if you need to disable extras after
+running the setup script.
 
 ### Using Poetry
 Python 3.12 or newer is required. When several Python versions are installed,
@@ -467,13 +473,17 @@ Alternatively you can run the helper script:
 
 The helper installs all dependencies with `poetry install --with dev --all-extras` and
 links the package in editable mode. Tools such as `flake8`, `mypy`, `pytest` and `tomli_w`
-are therefore available for development and testing. Running the full test suite requires
-these extras; a minimal installation may raise `ModuleNotFoundError` errors.
+are therefore available for development and testing. Tests will run even without
+extras because stub versions of optional packages are bundled, but coverage is
+limited. Installing extras enables the real implementations—for example
+SlowAPI’s middleware, which enforces rate limits during integration tests.
 
 ## Running tests
 
 The full suite, including behavior-driven tests, relies on optional extras such as
-`pdfminer` and `gitpython`. Ensure they are installed with:
+`pdfminer` and `gitpython`. Tests can run without them using bundled stubs, but
+real behaviour – including SlowAPI rate limiting – is only exercised when the
+extras are installed. Install them with:
 
 ```bash
 poetry install --with dev --all-extras


### PR DESCRIPTION
## Summary
- document running tests with and without extras in README
- call out SlowAPI middleware activation when extras are installed
- align AGENTS.md with README about extras and Codex setup

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: RateLimitExceeded, Limiter, Limit redefined)*
- `poetry run pytest -q` *(interrupted)*
- `poetry run pytest tests/behavior` *(1 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6881a9affac08333b695d1e3bfbfd120