### PR TITLE
Update setup.sh to verify stub installation

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -81,4 +81,15 @@ chmod +x scripts/smoke_test.py
 echo "Running smoke test to verify environment..."
 poetry run python scripts/smoke_test.py
 
+# Verify that types-requests is installed so mypy can find request stubs
+echo "Verifying types-requests installation..."
+if ! poetry run pip show types-requests >/dev/null 2>&1; then
+    echo "types-requests not found, installing now..."
+    poetry run pip install types-requests
+fi
+
+# Run mypy to ensure type hints are valid and request stubs are picked up
+echo "Running mypy..."
+poetry run mypy src
+
 echo "Setup complete! VSS extension downloaded and configured."


### PR DESCRIPTION
## Summary
- check for `types-requests` in `scripts/setup.sh`
- install it if missing and run `mypy` to validate type stubs

## Testing
- `poetry run flake8 src tests`
- `timeout 90s poetry run mypy src` *(fails: some redefinition errors)*
- `timeout 60s poetry run pytest -q` *(fails: timed out)*
- `timeout 60s poetry run pytest tests/behavior` *(fails: rate limit test failure)*

------
https://chatgpt.com/codex/tasks/task_e_68823b2688b8833396c72e5446f71af0