### PR TITLE
Update env setup instructions to use uv

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,10 @@
 Adopt a multi-disciplinary, dialectical approach: propose solutions, critically evaluate them, and refine based on evidence. Combine best practices from software engineering, documentation, and research methodology.
 
 ## Environment setup
-- Use **Poetry** for all project interactions.
-  - Select the Python interpreter with `poetry env use $(which python3)` (Python 3.12 or newer).
-  - Install dependencies with `poetry install --with dev --all-extras` to enable optional packages. Tests run without these extras using bundled stubs, but installing them activates real components such as SlowAPI's rate limiting.
-  - Activate the environment using `poetry shell` or prefix commands with `poetry run`.
-  - Avoid system-level Python or `pip`. Run `pip install -e .` only inside the Poetry virtual environment using `poetry shell` or `poetry run pip`.
+- Use **uv** for dependency management and project interactions.
+  - Create a virtual environment with `uv venv`.
+  - Install dependencies with `uv pip install --all-extras`.
+  - Activate the environment using `source .venv/bin/activate` or prefix commands with `uv pip`.
   - Codex environments run `scripts/codex_setup.sh`, which delegates to `scripts/setup.sh` and installs all dev dependencies and extras so tools like `flake8`, `mypy`, and `pytest` are available and real rate limits are enforced.
 
 ## Verification steps
@@ -21,3 +20,10 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 ## Commit etiquette
 - Keep commits focused and write clear messages detailing your reasoning.
 - Remove temporary files and keep the repository tidy.
+
+## Legacy workflow
+- The project previously used **Poetry** for virtual environment management.
+  - Select the Python interpreter with `poetry env use $(which python3)` (Python 3.12 or newer).
+  - Install dependencies with `poetry install --with dev --all-extras`.
+  - Activate the environment using `poetry shell` or prefix commands with `poetry run`.
+  - Avoid system-level Python or `pip`. Run `pip install -e .` only inside the Poetry virtual environment using `poetry shell` or `poetry run pip`.


### PR DESCRIPTION
## Summary
- switch contribution guidelines to use uv for dependency management
- keep old Poetry workflow in a new Legacy workflow section

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Found 4 errors)*
- `poetry run pytest -q` *(interrupted)*
- `poetry run pytest tests/behavior` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68824dbdfba08333b7256348c20f29de