### PR TITLE
Switch Docker and CI to uv

### DIFF
--- a/.github/workflows.disabled/ci.yml
+++ b/.github/workflows.disabled/ci.yml
@@ -36,18 +36,18 @@ jobs:
         major, minor = sys.version_info[:2]
         assert (major == 3 and minor >= 12), f"Python 3.12 or newer required, got {major}.{minor}"
         EOF
+      - name: Install uv
+        run: python -m pip install uv
       - name: Install dependencies
-        run: |
-          poetry env use $(which python)
-          poetry install --with dev --all-extras
+        run: uv pip sync uv.lock
     - name: Lint with flake8
       if: matrix.os == 'ubuntu-latest' && matrix.test-mode == 'offline'
       run: |
-        poetry run flake8 src tests
+        uv run flake8 src tests
     - name: Type check with mypy
       if: matrix.os == 'ubuntu-latest' && matrix.test-mode == 'offline'
       run: |
-        poetry run mypy --strict src
+        uv run mypy --strict src
     - name: Set up offline environment for tests
       if: matrix.test-mode == 'offline'
       run: |
@@ -61,10 +61,10 @@ jobs:
         echo "AUTORESEARCH_STRICT_EXTENSIONS=false" > .env
       - name: Test with pytest
         run: |
-          poetry run pytest tests/
+          uv run pytest tests/
     - name: Deployment checks
       run: |
-        poetry run python scripts/deploy.py
+        uv run python scripts/deploy.py
     - name: Upload coverage report
       if: matrix.os == 'ubuntu-latest' && matrix.test-mode == 'offline'
       uses: codecov/codecov-action@v3
@@ -90,11 +90,12 @@ jobs:
           major, minor = sys.version_info[:2]
           assert (major == 3 and minor >= 12), f"Python 3.12 or newer required, got {major}.{minor}"
           EOF
-      - name: Install dependencies
+      - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install poetry
-          poetry build
+          pip install uv build
+          uv pip sync uv.lock
+          python -m build
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows.disabled/simple_ci.yml
+++ b/.github/workflows.disabled/simple_ci.yml
@@ -18,18 +18,16 @@ jobs:
           major, minor = sys.version_info[:2]
           assert (major == 3 and minor >= 12), f"Python 3.12 or newer required, got {major}.{minor}"
           EOF
-      - name: Install Poetry
-        run: python -m pip install poetry
+      - name: Install uv
+        run: python -m pip install uv
       - name: Install dependencies
-        run: |
-          poetry env use $(which python)
-          poetry install --with dev --all-extras
+        run: uv pip sync uv.lock
       - name: Lint
-        run: poetry run flake8 src tests
+        run: uv run flake8 src tests
       - name: Type check
-        run: poetry run mypy src
+        run: uv run mypy src
       - name: Test
-        run: poetry run pytest -q
+        run: uv run pytest -q
       - name: Upload coverage
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows.disabled/wheels.yml
+++ b/.github/workflows.disabled/wheels.yml
@@ -24,8 +24,8 @@ jobs:
           major, minor = sys.version_info[:2]
           assert (major == 3 and minor >= 12), f"Python 3.12 or newer required, got {major}.{minor}"
           EOF
-      - name: Install Poetry
-        run: python -m pip install poetry
+      - name: Install uv
+        run: python -m pip install uv
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
       - uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.12-slim
 WORKDIR /app
+COPY uv.lock pyproject.toml /app/
+RUN pip install --no-cache-dir uv \
+    && uv pip sync uv.lock
 COPY . /app
-RUN pip install --no-cache-dir poetry \
-    && poetry install --with dev --all-extras --no-interaction
 EXPOSE 8000
-CMD ["poetry", "run", "uvicorn", "autoresearch.api:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uv", "run", "uvicorn", "autoresearch.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,4 @@ services:
       - "8000:8000"
     env_file:
       - .env
-    command: poetry run uvicorn autoresearch.api:app --host 0.0.0.0 --port 8000
+    command: uv run uvicorn autoresearch.api:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- install `uv` in Dockerfile and sync dependencies from `uv.lock`
- run uvicorn with `uv run` in docker-compose
- update CI workflows to install `uv` and use `uv` for lint, type check, tests, and builds

## Testing
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: missing module pydantic)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: fastapi)*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6882c986843483339cac98d6654e3e56