### PR TITLE
Switch docs to uv for dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,11 +458,12 @@ For a detailed breakdown of the requirements and architecture, see
 
 ## Development setup
 
-Install the development dependencies and link the package in editable mode:
+Create a virtual environment and install all extras:
 
 ```bash
-poetry install --with dev --all-extras
-poetry run pip install -e .
+uv venv
+uv pip install --all-extras
+uv pip install -e .
 ```
 
 Alternatively you can run the helper script:
@@ -471,7 +472,7 @@ Alternatively you can run the helper script:
 ./scripts/setup.sh
 ```
 
-The helper installs all dependencies with `poetry install --with dev --all-extras` and
+The helper installs all dependencies with `uv pip install --all-extras` and
 links the package in editable mode. Tools such as `flake8`, `mypy`, `pytest` and `tomli_w`
 are therefore available for development and testing. Tests will run even without
 extras because stub versions of optional packages are bundled, but coverage is
@@ -486,14 +487,14 @@ real behaviour – including SlowAPI rate limiting – is only exercised when th
 extras are installed. Install them with:
 
 ```bash
-poetry install --with dev --all-extras
+uv pip install --all-extras
 ```
 
 Execute linting and type checks once the development environment is ready:
 
 ```bash
-poetry run flake8 src tests
-poetry run mypy src
+flake8 src tests
+mypy src
 ```
 
 Run the test suites using Go Task:
@@ -509,15 +510,14 @@ task test:slow         # run only tests marked as slow
 To execute the long-running tests directly without Go Task, run:
 
 ```bash
-poetry run pytest -m slow
+pytest -m slow
 ```
 
 Several unit and integration tests rely on `gitpython` and the DuckDB VSS
-extension. These extras are installed when running
-`poetry install --with dev --all-extras`.
+extension. These extras are installed when running `uv pip install --all-extras`.
 
-All testing commands are wrapped by `task`, which uses `poetry run` internally
-to ensure the correct virtual environment is active.
+All testing commands are wrapped by `task`, which activates the `.venv`
+environment before running each tool.
 
 Integration tests can leverage the helper classes in `autoresearch.test_tools`.
 `MCPTestClient` and `A2ATestClient` provide simple interfaces for exercising
@@ -526,9 +526,21 @@ tested and ship with the package for external use.
 
 Maintain at least 90% test coverage and remove temporary files before submitting a pull request. Use `task coverage` to run the entire suite with coverage enabled. If you run suites separately, prefix each invocation with `coverage run -p` to create partial results, then merge them with `coverage combine` before generating the final report with `coverage html` or `coverage xml`.
 
+### Migrating from Poetry
+
+Previous versions used Poetry for environment management. `uv` now handles dependency installation and virtual environment creation for faster setup. If you have an existing Poetry environment, remove the `.venv` directory and recreate it with:
+
+```bash
+uv venv
+uv pip install --all-extras
+uv pip install -e .
+```
+
+Activate the environment with `source .venv/bin/activate` before running commands.
+
 ### Troubleshooting
 
-- If tests fail with `ModuleNotFoundError`, ensure all dependencies are installed inside the Poetry environment using `poetry install --with dev --all-extras` or `poetry run pip install -e .`.
+- If tests fail with `ModuleNotFoundError`, ensure all dependencies are installed in the virtual environment using `uv pip install --all-extras` and `uv pip install -e .`.
 - When starting the API with `uvicorn autoresearch.api:app --reload`, install `uvicorn` if the command is not found and verify that port `8000` is free.
 
 ### Smoke test
@@ -536,7 +548,7 @@ Maintain at least 90% test coverage and remove temporary files before submitting
 Run the environment smoke test to verify your installation:
 
 ```bash
-poetry run python scripts/smoke_test.py
+python scripts/smoke_test.py
 ```
 
 If running without network access, copy `.env.offline` to `.env` so the script
@@ -544,7 +556,7 @@ uses the pre-downloaded VSS extension:
 
 ```bash
 cp .env.offline .env
-poetry run python scripts/smoke_test.py
+python scripts/smoke_test.py
 ```
 
 ## Building the documentation
@@ -552,7 +564,7 @@ poetry run python scripts/smoke_test.py
 Install MkDocs and generate the static site:
 
 ```bash
-poetry run pip install mkdocs
+uv pip install mkdocs
 mkdocs build
 ```
 

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -234,7 +234,7 @@ You can evaluate how different relevance weights perform by running the
 truth relevance labels.
 
 ```bash
-poetry run python scripts/evaluate_ranking.py examples/search_evaluation.csv
+python scripts/evaluate_ranking.py examples/search_evaluation.csv
 ```
 
 To automatically search for the best combination of weights, use
@@ -243,7 +243,7 @@ performs a simple grid search and writes the tuned values back to the provided
 configuration file (defaults to `examples/autoresearch.toml`):
 
 ```bash
-poetry run python scripts/optimize_search_weights.py \
+python scripts/optimize_search_weights.py \
   examples/search_evaluation.csv examples/autoresearch.toml
 ```
 
@@ -461,7 +461,7 @@ This research was conducted using dialectical reasoning with {{loops}} cycles.
 Persisted claims trigger ontology reasoning so that inferred triples are stored automatically. Use the `sparql` command to inspect the graph:
 
 ```bash
-poetry run autoresearch sparql "SELECT ?s WHERE { ?s a <http://example.com/B> }"
+autoresearch sparql "SELECT ?s WHERE { ?s a <http://example.com/B> }"
 ```
 
 The command applies the configured reasoner before executing the query, returning any inferred relationships.

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -17,7 +17,7 @@ Initial indexing happens automatically the first time these backends run.
 You can refresh the index at any time by executing:
 
 ```bash
-poetry run python scripts/smoke_test.py
+python scripts/smoke_test.py
 ```
 
 This script calls `StorageManager.create_hnsw_index()` to rebuild the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,7 +161,7 @@ You can automatically discover effective values for these weights using the
 and the configuration file to update:
 
 ```bash
-poetry run python scripts/optimize_search_weights.py \
+python scripts/optimize_search_weights.py \
   examples/search_evaluation.csv autoresearch.toml
 ```
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,12 +3,14 @@
 We welcome contributions via pull requests. Install the development dependencies first:
 
 ```bash
-poetry install --with dev
+uv venv
+uv pip install --all-extras
+uv pip install -e .
 ```
 
 You can alternatively run the helper script. It refreshes the lock file when
-needed, installs all extras with `poetry install --with dev --all-extras` and
-links the package in editable mode:
+needed, installs all extras with `uv pip install --all-extras` and links the
+package in editable mode:
 
 ```bash
 ./scripts/setup.sh
@@ -19,10 +21,10 @@ links the package in editable mode:
 Execute the commands below before opening a pull request:
 
 ```bash
-poetry run flake8 src tests
-poetry run mypy src
-poetry run pytest -q
-poetry run pytest tests/behavior
+flake8 src tests
+mypy src
+pytest -q
+pytest tests/behavior
 ```
 
 Maintain at least 90% test coverage and remove temporary files before submitting your changes.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,14 +7,16 @@ Autoresearch can be deployed in several ways depending on your needs. This guide
 For personal use, run Autoresearch directly on your machine. Install the dependencies and invoke the CLI or API:
 
 ```bash
-poetry install --with dev
-poetry run autoresearch search "example query"
+uv venv
+uv pip install --all-extras
+uv pip install -e .
+autoresearch search "example query"
 ```
 
 Start the API service with Uvicorn for HTTP access:
 
 ```bash
-poetry run uvicorn autoresearch.api:app --reload
+uvicorn autoresearch.api:app --reload
 ```
 
 ## Running as a Service
@@ -29,10 +31,11 @@ Autoresearch can also be containerized. A production `Dockerfile` is included:
 FROM python:3.12-slim
 WORKDIR /app
 COPY . /app
-RUN pip install --no-cache-dir poetry \
-    && poetry install --with dev --no-interaction
+RUN pip install uv \
+    && uv pip install --all-extras \
+    && uv pip install -e .
 EXPOSE 8000
-CMD ["poetry", "run", "uvicorn", "autoresearch.api:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "autoresearch.api:app", "--host", "0.0.0.0", "--port", "8000"]
 ```
 
 Build and run the image:
@@ -109,7 +112,7 @@ lost during shutdown.
 After starting the service, run the deployment script to validate configuration and perform a health check:
 
 ```bash
-poetry run python scripts/deploy.py
+python scripts/deploy.py
 ```
 
 To publish a development build to the TestPyPI repository run:
@@ -118,7 +121,7 @@ To publish a development build to the TestPyPI repository run:
 ./scripts/publish_dev.py
 ```
 ## Upgrading
-Run `poetry update` to refresh an existing installation.
+Run `uv pip install -U autoresearch` to refresh an existing installation.
 For pip based installs use:
 ```bash
 pip install -U autoresearch
@@ -150,6 +153,7 @@ extras.
 4. If everything looks good, publish to the main PyPI repository:
 
 ```bash
-poetry publish --build
+python -m build
+twine upload dist/*
 ```
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -4,27 +4,27 @@ This guide describes how to set up a development environment and the expected wo
 
 ## Environment Setup
 
-1. Install [Poetry](https://python-poetry.org/docs/#installation).
-2. Select the Python interpreter:
+1. Create a virtual environment:
    ```bash
-   poetry env use $(which python3)
+   uv venv
    ```
-3. Install dependencies including development tools and all optional extras:
+2. Install dependencies including development tools and all optional extras:
    ```bash
-   poetry install --with dev --all-extras
+   uv pip install --all-extras
+   uv pip install -e .
    ```
-4. Activate the environment with `poetry shell` or prefix commands with `poetry run`.
+3. Activate the environment with `source .venv/bin/activate` before running commands.
 
 Several unit and integration tests require `gitpython` and the DuckDB VSS
 extension. Both are installed when you set up the environment with
-`poetry install --with dev --all-extras`.
+`uv pip install --all-extras`.
 
 ## Code Style
 
 - Run code format and style checks before committing:
  ```bash
-  poetry run flake8 src tests
-  poetry run mypy src
+  flake8 src tests
+  mypy src
   ```
 - Public modules and functions should include concise docstrings.
 - Keep commits focused and avoid temporary files.
@@ -34,11 +34,10 @@ extension. Both are installed when you set up the environment with
 1. Create a feature branch and commit your changes.
 2. Run the full test suite:
    ```bash
-   poetry run pytest -q
-    poetry run pytest tests/behavior
-    ```
-    All testing commands should be executed with `poetry run` to use the
-    project's virtual environment.
+   pytest -q
+   pytest tests/behavior
+   ```
+   Ensure the `.venv` is active before running these commands.
 
 ### Running only fast tests
 
@@ -46,13 +45,13 @@ For quick feedback, you can skip heavy integration tests marked with
 `@pytest.mark.slow`:
 
 ```bash
-poetry run pytest -m "not slow" -q
-poetry run pytest -m "not slow" tests/behavior
+pytest -m "not slow" -q
+pytest -m "not slow" tests/behavior
 ```
 To run the heavier tests separately:
 
 ```bash
-poetry run pytest -m slow
+pytest -m slow
 ```
 Distributed execution scenarios and other long-running integrations are
 decorated with `@pytest.mark.slow`.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -16,10 +16,12 @@ Autoresearch uses a modular architecture with several key components. The PlantU
 
 ## Installation
 
-Use `poetry install --with dev` to set up a development environment:
+Use `uv venv` and `uv pip install --all-extras` to set up a development environment:
 
 ```bash
-poetry install --with dev
+uv venv
+uv pip install --all-extras
+uv pip install -e .
 ```
 
 `hdbscan` is built from source and needs compilation tools. Install `gcc`, `g++`,
@@ -39,7 +41,7 @@ export HDBSCAN_NO_OPENMP=1
 Alternatively install via pip:
 
 ```bash
-poetry run pip install -e .
+pip install -e .
 ```
 
 ## First search

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,13 +9,13 @@ This guide explains how to install Autoresearch and manage optional features.
 
 ## Development setup
 
-Use Poetry to manage the environment when working from a clone:
+Use `uv` to manage the environment when working from a clone:
 
 ```bash
-# Select Python 3.12 or newer
-poetry env use $(which python3)
-poetry lock --check || poetry lock
-poetry install --with dev --all-extras
+# Create the virtual environment
+uv venv
+uv pip install --all-extras
+uv pip install -e .
 ```
 Selecting Python 3.11 results in an error similar to:
 ```
@@ -26,10 +26,10 @@ Because autoresearch requires Python >=3.12,<4.0 and the current Python is
 Verify the environment by running:
 
 ```bash
-poetry run flake8 src tests
-poetry run mypy src
-poetry run pytest -q
-poetry run pytest tests/behavior
+flake8 src tests
+mypy src
+pytest -q
+pytest tests/behavior
 ```
 
 ## Minimal installation
@@ -51,13 +51,13 @@ extra needed for the test suite. Tests normally rely on stubbed versions of
 these extras, so running the suite without them is recommended. Extras such as
 `slowapi` may enable real behaviour (like rate limiting) that changes how
 assertions are evaluated. If you wish to revert to stub-only testing after
-running the helper, reinstall using `poetry install --with dev`. Optional
+running the helper, reinstall using `uv pip install --all-extras`. Optional
 features are disabled when their dependencies are missing. Specify extras
 explicitly with pip to enable additional features, e.g. ``pip install "autoresearch[minimal,nlp]"``.
 
 ## Optional extras
 
-Additional functionality is grouped into Poetry extras:
+Additional functionality is grouped into optional extras:
 
 - `nlp` – language processing via spaCy, BERTopic and Transformers
 - `parsers` – PDF and DOCX document ingestion
@@ -82,9 +82,7 @@ To upgrade an existing installation run:
 python scripts/upgrade.py
 ```
 
-The helper script detects whether Poetry or pip is used. It runs
-`poetry update autoresearch` when a `pyproject.toml` is present,
-otherwise it falls back to `pip install -U autoresearch`.
+The helper script installs or upgrades using `uv pip`. When a `pyproject.toml` is present it runs `uv pip install -U autoresearch`; otherwise it falls back to `pip install -U autoresearch`.
 
 Use pip extras when upgrading to ensure optional dependencies remain
 installed. For example:
@@ -114,7 +112,7 @@ long time or fail on low-memory machines.
 - If compilation hangs or exhausts memory, set `HDBSCAN_NO_OPENMP=1` to
   disable OpenMP optimizations.
 - Consider installing a pre-built wheel with `pip install hdbscan` prior
-  to running `poetry install`.
+  to running `uv pip install --all-extras`.
 - You can also omit heavy extras by removing `--all-extras` from the
   install command when rapid setup is more important than optional
   features.

--- a/docs/quickstart_guides.md
+++ b/docs/quickstart_guides.md
@@ -7,8 +7,10 @@ This document provides quickstart guides for each interface type of the Autorese
 ### Installation
 
 ```bash
-# Install with Poetry (recommended)
-poetry install --with dev
+# Install with uv (recommended)
+uv venv
+uv pip install --all-extras
+uv pip install -e .
 
 # Alternatively, use pip
 pip install autoresearch

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -24,7 +24,7 @@ The following tasks remain before publishing **0.1.0**:
 
 - Run the full unit, integration and behavior test suites across all supported storage and message backends.
 - Complete API reference and user guides, questioning assumptions and addressing counterarguments.
-- Ensure packaging metadata is accurate and verify `poetry build` and `scripts/publish_dev.py` operate correctly.
+- Ensure packaging metadata is accurate and verify `python -m build` and `scripts/publish_dev.py` operate correctly.
 - Assemble release notes and finalize README instructions.
 
 ## Release Phases
@@ -32,6 +32,6 @@ The following tasks remain before publishing **0.1.0**:
 1. **Planning** – finalize scope and update the roadmap.
 2. **Development** – implement features and expand test coverage.
 3. **Stabilization** – fix bugs, write documentation and run the full test suite.
-4. **Publish** – follow the workflow in `deployment.md`: bump the version, run tests, publish to TestPyPI using `./scripts/publish_dev.py`, then release to PyPI with `poetry publish --build`.
+4. **Publish** – follow the workflow in `deployment.md`: bump the version, run tests, publish to TestPyPI using `./scripts/publish_dev.py`, then release to PyPI with `twine upload dist/*`.
 
 Each milestone may include additional patch releases for critical fixes.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -144,9 +144,9 @@ This indicates that the RDFLib SQLAlchemy plugin is not properly registered. To 
    pip install rdflib-sqlalchemy
    ```
 
-2. If using Poetry, make sure it's in your dependencies:
+2. Ensure it appears in your `pyproject.toml` dependencies:
    ```toml
-   [tool.poetry.dependencies]
+   [project.dependencies]
    rdflib-sqlalchemy = "^0.5.0"
    ```
 
@@ -198,7 +198,7 @@ The following tutorial walks through a typical ontology workflow.
 4. **Run SPARQL queries with reasoning** directly from the CLI:
 
    ```bash
-   poetry run autoresearch sparql "SELECT ?s WHERE { ?s a <http://example.com/B> }"
+   autoresearch sparql "SELECT ?s WHERE { ?s a <http://example.com/B> }"
    ```
 
 5. **Query with reasoning programmatically** using a custom engine:
@@ -213,7 +213,7 @@ The following tutorial walks through a typical ontology workflow.
 6. **Visualize the graph** as a PNG image:
 
    ```bash
-   poetry run autoresearch visualize-rdf graph.png
+   autoresearch visualize-rdf graph.png
    ```
 
 The command writes `graph.png` containing a simple diagram of all triples.

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -12,7 +12,7 @@ Tests are organized into three categories:
 
 ## Running tests
 
-Use [Go Task](https://taskfile.dev/#/) to run specific suites inside the Poetry environment:
+Use [Go Task](https://taskfile.dev/#/) to run specific suites inside the project's virtual environment:
 
 ```bash
 task test:unit         # unit tests
@@ -25,7 +25,7 @@ task test:all          # entire suite including slow tests
 You can also invoke the slow suite directly with:
 
 ```bash
-poetry run pytest -m slow
+pytest -m slow
 ```
 
 `task test:fast` usually finishes in about **3 minutes**. The slow tests add roughly **7 minutes**, so `task test:all` takes around **10 minutes** total and is used by CI. Maintain at least **90% coverage**. When running suites separately, prefix each command with `coverage run -p` and merge the results using `coverage combine` before generating a report with `coverage html` or `coverage xml`.
@@ -290,7 +290,7 @@ accessibility, and log messages.
 
 ## Optional extras for tests
 
-The default development install (`poetry install --with dev`) does not
+The default development install (`uv pip install --all-extras`) does not
 include all optional extras. The full test suite uses several features
 that rely on these extras:
 
@@ -307,7 +307,7 @@ that rely on these extras:
 
 If these extras are missing the corresponding tests are skipped (or run
 with a stub in the case of the `distributed` extra). Install them with
-`poetry install --with dev --extras "ui,analysis,vss,distributed"` to run
+`uv pip install --extras "ui,analysis,vss,distributed"` to run
 every test.
 
 ## Updating Baselines
@@ -317,7 +317,7 @@ Some integration tests compare runtime metrics against JSON files in
 metrics (for example token counts), run the failing test to capture the
 new values and update the corresponding baseline file.
 
-1. Run the test with `poetry run pytest tests/integration/test_token_usage.py`.
+1. Run the test with `pytest tests/integration/test_token_usage.py`.
 2. Inspect the assertion failure to see the updated token counts.
 3. Edit the JSON baseline file to match the new values and commit the
    change alongside your code.

--- a/docs/ui_testing_procedures.md
+++ b/docs/ui_testing_procedures.md
@@ -17,7 +17,7 @@ Autoresearch uses a multi-layered testing approach for UI components:
 ### Prerequisites
 
 - Python 3.12+
-- Poetry (for dependency management)
+- uv (for dependency management)
 - pytest and pytest-bdd
 
 ### Installation
@@ -27,11 +27,13 @@ Autoresearch uses a multi-layered testing approach for UI components:
 git clone https://github.com/yourusername/autoresearch.git
 cd autoresearch
 
-# Install dependencies with Poetry
-poetry install --with dev
+# Install dependencies with uv
+uv venv
+uv pip install --all-extras
+uv pip install -e .
 
 # Alternatively, use pip
-poetry run pip install -e ".[dev]"
+pip install -e ".[dev]"
 ```
 
 ## Unit Testing UI Components
@@ -378,45 +380,45 @@ def test_consistent_error_handling():
 
 ```bash
 # Run all tests
-poetry run pytest
+pytest
 
 # Run with verbose output
-poetry run pytest -v
+pytest -v
 
 # Run with coverage report
-poetry run pytest --cov=autoresearch
+pytest --cov=autoresearch
 ```
 
 ### Running Specific Test Categories
 
 ```bash
 # Run unit tests
-poetry run pytest tests/unit/
+pytest tests/unit/
 
 # Run integration tests
-poetry run pytest tests/integration/
+pytest tests/integration/
 
 # Run behavior tests
-poetry run pytest tests/behavior/
+pytest tests/behavior/
 
 # Run tests for a specific file
-poetry run pytest tests/unit/test_output_format.py
+pytest tests/unit/test_output_format.py
 
 # Run a specific test
-poetry run pytest tests/unit/test_output_format.py::test_format_error
+pytest tests/unit/test_output_format.py::test_format_error
 ```
 
 ### Running BDD Tests
 
 ```bash
 # Run all BDD tests
-poetry run pytest tests/behavior/
+pytest tests/behavior/
 
 # Run tests for a specific feature
-poetry run pytest tests/behavior/steps/streamlit_gui_steps.py
+pytest tests/behavior/steps/streamlit_gui_steps.py
 
 # Run a specific scenario
-poetry run pytest tests/behavior/steps/streamlit_gui_steps.py::test_formatted_answer_display
+pytest tests/behavior/steps/streamlit_gui_steps.py::test_formatted_answer_display
 ```
 
 ## Continuous Integration
@@ -448,11 +450,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install poetry
-        poetry install --with dev
+        pip install uv
+        uv pip install --all-extras
+        uv pip install -e .
     - name: Run tests
       run: |
-        poetry run pytest --cov=autoresearch
+        pytest --cov=autoresearch
     - name: Upload coverage report
       uses: codecov/codecov-action@v3
 ```


### PR DESCRIPTION
## Summary
- update README development setup to use uv and add migration section
- replace Poetry references across docs with uv equivalents
- adjust installation and deployment instructions accordingly

## Testing
- `poetry run flake8 src tests` *(fails: F401)*
- `poetry run mypy src` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6882c98b78988333a8379cf97cc2345d