### PR TITLE
Switch setup to uv venv

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,17 +3,17 @@ version: '3'
 tasks:
   unit:
     cmds:
-      - poetry run pytest tests/unit -q
+      - .venv/bin/pytest tests/unit -q
     desc: "Run unit tests"
 
   integration:
     cmds:
-      - poetry run pytest tests/integration -m "not slow" -q
+      - .venv/bin/pytest tests/integration -m "not slow" -q
     desc: "Run integration tests"
 
   behavior:
     cmds:
-      - poetry run pytest tests/behavior -q
+      - .venv/bin/pytest tests/behavior -q
     desc: "Run BDD (behavior) tests"
 
   test:
@@ -22,37 +22,37 @@ tasks:
 
   test:unit:
     cmds:
-      - poetry run pytest tests/unit -q
+      - .venv/bin/pytest tests/unit -q
     desc: "Run unit tests"
 
   test:integration:
     cmds:
-      - poetry run pytest tests/integration -m "not slow" -q
+      - .venv/bin/pytest tests/integration -m "not slow" -q
     desc: "Run integration tests"
 
   test:behavior:
     cmds:
-      - poetry run pytest tests/behavior -q
+      - .venv/bin/pytest tests/behavior -q
     desc: "Run BDD (behavior) tests"
 
   test:all:
     cmds:
-      - poetry run pytest -q
+      - .venv/bin/pytest -q
     desc: "Run the entire test suite including slow tests"
 
   test:fast:
     cmds:
-      - poetry run pytest -m 'not slow'
+      - .venv/bin/pytest -m 'not slow'
     desc: "Run tests excluding those marked slow"
 
   test:slow:
     cmds:
-      - poetry run pytest -m slow
+      - .venv/bin/pytest -m slow
     desc: "Run only tests marked as slow"
 
   coverage:
     cmds:
-      - pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=xml --cov-report=term-missing tests
+      - .venv/bin/pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=xml --cov-report=term-missing tests
     desc: "Run full test suite with coverage reporting"
 
   clean:
@@ -63,7 +63,7 @@ tasks:
 
   check-baselines:
     cmds:
-      - poetry run python scripts/check_token_regression.py --threshold 5
+      - .venv/bin/python scripts/check_token_regression.py --threshold 5
     desc: "Validate token usage against baselines"
 
   wheels:
@@ -72,16 +72,16 @@ tasks:
 
   wheel-linux:
     cmds:
-      - poetry run cibuildwheel --platform linux --output-dir dist/linux
+      - .venv/bin/cibuildwheel --platform linux --output-dir dist/linux
     desc: "Build Linux wheel"
 
   wheel-windows:
     cmds:
-      - poetry run cibuildwheel --platform windows --output-dir dist/windows
+      - .venv/bin/cibuildwheel --platform windows --output-dir dist/windows
     desc: "Build Windows wheel"
 
   wheel-macos:
     cmds:
-      - poetry run cibuildwheel --platform macos --output-dir dist/macos
+      - .venv/bin/cibuildwheel --platform macos --output-dir dist/macos
     desc: "Build macOS wheel"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,4 @@ services:
       - "8000:8000"
     env_file:
       - .env
-    command: poetry run uvicorn autoresearch.api:app --host 0.0.0.0 --port 8000
+    command: .venv/bin/uvicorn autoresearch.api:app --host 0.0.0.0 --port 8000

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-#python -m pip install --upgrade pip
-#pip install poetry
-poetry env use $(which python3)
-# Install dev dependencies and all optional extras to ensure all tests can run
-poetry install --no-root --no-interaction --with dev --all-extras
-poetry run pip install -e .
+# Create uv virtual environment and install dependencies
+uv venv .venv
+uv pip install --python .venv/bin/python uv
+if ! .venv/bin/uv pip sync uv.lock; then
+    .venv/bin/uv pip sync pyproject.toml
+fi
+uv pip install --python .venv/bin/python uv
+.venv/bin/uv pip install -e '.[dev,parsers]'
 
 # Create extensions directory if it doesn't exist
 mkdir -p extensions
@@ -17,7 +19,7 @@ VSS_EXTENSION=$(find ./extensions -name "vss*.duckdb_extension" | head -n 1)
 
 if [ -z "$VSS_EXTENSION" ]; then
     echo "No packaged extension found. Attempting download..."
-    if poetry run scripts/download_duckdb_extensions.py --output-dir ./extensions; then
+    if .venv/bin/python scripts/download_duckdb_extensions.py --output-dir ./extensions; then
         VSS_EXTENSION=$(find ./extensions -name "vss*.duckdb_extension" | head -n 1)
     else
         echo "Download failed or skipped."
@@ -79,17 +81,14 @@ chmod +x scripts/smoke_test.py
 
 # Run smoke test to verify environment
 echo "Running smoke test to verify environment..."
-poetry run python scripts/smoke_test.py
+.venv/bin/python scripts/smoke_test.py
 
-# Verify that types-requests is installed so mypy can find request stubs
-echo "Verifying types-requests installation..."
-if ! poetry run pip show types-requests >/dev/null 2>&1; then
-    echo "types-requests not found, installing now..."
-    poetry run pip install types-requests
-fi
+# Install types-requests so mypy can find request stubs
+.venv/bin/uv pip install types-requests
 
 # Run mypy to ensure type hints are valid and request stubs are picked up
 echo "Running mypy..."
-poetry run mypy src
+.venv/bin/mypy src
 
 echo "Setup complete! VSS extension downloaded and configured."
+

--- a/src/autoresearch/api.py
+++ b/src/autoresearch/api.py
@@ -43,7 +43,7 @@ from .storage import StorageManager
 from pydantic import ValidationError
 # Lazily import SlowAPI and fall back to a minimal stub when unavailable
 from .error_utils import get_error_info, format_error_for_api
-from typing import TYPE_CHECKING, Callable, Any
+from typing import Callable, Any
 
 # Predeclare optional SlowAPI types for static analysis
 Limiter: Any


### PR DESCRIPTION
## Summary
- use `uv venv` and `uv pip` in setup script
- call tools from `.venv/bin` in Taskfile
- update docker-compose to use uv-managed environment
- drop unused import

## Testing
- `bash scripts/setup.sh`
- `.venv/bin/flake8 src tests`
- `.venv/bin/mypy src`
- `.venv/bin/pytest -m 'not slow' -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6882c97b10148333b230369bf0384965