### PR TITLE
Update docs to highlight uv environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ to arrive sometime after **July 20, 2025**. See
 
 ## Installation
 
-Autoresearch requires **Python 3.12 or newer**. You can install the project
-dependencies with either **Poetry** or **pip**. See
-[docs/installation.md](docs/installation.md) for details on optional features and
-upgrade instructions.
+Autoresearch requires **Python 3.12 or newer**. The project recently transitioned
+from **Poetry** to [**uv**](https://github.com/astral-sh/uv) for dependency
+management. You can install the project using `uv` or plain **pip**.
+See [docs/installation.md](docs/installation.md) for details on optional features
+and upgrade instructions.
 The `scripts/setup.sh` helper ensures the lock file is current and installs
 all optional extras so development and runtime dependencies are available for
 testing. The test suite works both with and without extras:
@@ -34,18 +35,17 @@ testing. The test suite works both with and without extras:
   SlowAPI's rate‑limiting middleware. This may change how certain tests
   behave and can make them slower.
 
-Reinstall with `poetry install --with dev` if you need to disable extras after
-running the setup script.
+Reinstall with `uv pip install --all-extras && uv pip install -e .` if you need
+to disable extras after running the setup script.
 
-### Using Poetry
-Python 3.12 or newer is required. When several Python versions are installed,
-select the interpreter **before** running `poetry install`:
+### Using uv
+Python 3.12 or newer is required. Set up the development environment with:
 ```bash
-# Use the `python3` executable from your PATH
-poetry env use $(which python3)
-poetry install --with dev --all-extras
+uv venv
+uv pip install --all-extras
+uv pip install -e .
 ```
-If Python 3.11 is selected, Poetry will fail with a message similar to:
+If Python 3.11 is selected, `uv` will fail with a message similar to:
 ```
 Because autoresearch requires Python >=3.12,<4.0 and the current Python is
 3.11.*, no compatible version could be found.
@@ -59,7 +59,7 @@ Install only the minimal optional dependencies using pip:
 pip install autoresearch[minimal]
 ```
 When working from a clone, run `scripts/setup.sh` which installs all
-development dependencies and optional extras via Poetry.
+development dependencies and optional extras via **uv**.
 Use extras to enable additional features, e.g. `pip install "autoresearch[minimal,nlp]"`.
 Local Git search requires the `git` extra.
 To upgrade a cloned environment run `python scripts/upgrade.py`.
@@ -89,7 +89,7 @@ Use the provided helper to update Autoresearch:
 ```bash
 python scripts/upgrade.py
 ```
-The script runs `poetry update autoresearch` when a `pyproject.toml` is present,
+The script runs `uv pip install -U autoresearch` when a `pyproject.toml` is present,
 otherwise it falls back to `pip install -U autoresearch`.
 Use extras with pip to manage optional dependencies, for example:
 ```bash

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,7 @@
 # Contributing
 
-We welcome contributions via pull requests. Install the development dependencies first:
+We welcome contributions via pull requests. Autoresearch now uses **uv** rather than Poetry for environment management.
+Install the development dependencies first:
 
 ```bash
 uv venv

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,8 @@
 
 Autoresearch can be deployed in several ways depending on your needs. This guide outlines common approaches.
 
+The project switched from Poetry to **uv** for dependency management. Example commands now use `uv`.
+
 ## Local Installation
 
 For personal use, run Autoresearch directly on your machine. Install the dependencies and invoke the CLI or API:

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -2,6 +2,9 @@
 
 This guide describes how to set up a development environment and the expected workflow for contributing changes.
 
+The project now uses **uv** for dependency management instead of Poetry. All
+commands below rely on `uv`.
+
 ## Environment Setup
 
 1. Create a virtual environment:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,10 @@
 
 This guide explains how to install Autoresearch and manage optional features.
 
+Autoresearch recently migrated from **Poetry** to **uv** for dependency
+management. The examples below use `uv`; legacy Poetry instructions are kept in
+[AGENTS.md](../AGENTS.md) for reference.
+
 ## Requirements
 
 - Python 3.12 or newer (but below 4.0)

--- a/docs/ui_testing_procedures.md
+++ b/docs/ui_testing_procedures.md
@@ -20,6 +20,8 @@ Autoresearch uses a multi-layered testing approach for UI components:
 - uv (for dependency management)
 - pytest and pytest-bdd
 
+Autoresearch previously used Poetry. `uv` is now the recommended tool and the commands below reflect this change.
+
 ### Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- mention uv migration in installation docs
- explain uv workflow in developer and contributor docs
- update deployment and UI testing docs to show uv usage
- replace Poetry instructions in the README

## Testing
- `poetry run flake8 src tests` *(fails: F401 imported but unused)*
- `poetry run mypy src` *(fails: missing type stubs for requests/tabulate)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: pdfminer)*
- `poetry run pytest tests/behavior` *(fails: ModuleNotFoundError: pdfminer)*

------
https://chatgpt.com/codex/tasks/task_e_6882d234214883338498b4c8fa0bd7c2