### PR TITLE
Move dependency stubs before imports

### DIFF
--- a/src/autoresearch/api.py
+++ b/src/autoresearch/api.py
@@ -43,7 +43,7 @@ from .storage import StorageManager
 from pydantic import ValidationError
 # Lazily import SlowAPI and fall back to a minimal stub when unavailable
 from .error_utils import get_error_info, format_error_for_api
-from typing import TYPE_CHECKING, Callable, Any
+from typing import Callable, Any
 
 # Predeclare optional SlowAPI types for static analysis
 Limiter: Any

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,22 +16,11 @@ if importlib.util.find_spec("autoresearch") is None:
     src_path = Path(__file__).resolve().parents[1] / "src"
     sys.path.insert(0, str(src_path))
 
-from autoresearch.api import app as api_app, SLOWAPI_STUB, reset_request_log
-import typer
-from autoresearch import cache, storage
-from autoresearch.config import ConfigLoader
-from autoresearch.agents.registry import (
-    AgentFactory,
-    AgentRegistry,
-)
-from autoresearch.llm.registry import LLMFactory
-from autoresearch.storage import (
-    set_delegate as set_storage_delegate,
-)
-from autoresearch.extensions import VSSExtensionLoader
-import duckdb
 
-_orig_option = typer.Option
+# ----------------------------------------------------
+# Optional dependency stubs (inserted before project imports)
+# ----------------------------------------------------
+
 # Provide a lightweight stub for the optional ``ray`` dependency so that
 # ``autoresearch`` can be imported without the actual package installed.
 if "ray" not in sys.modules:
@@ -305,6 +294,23 @@ sys.modules.setdefault("sentence_transformers", dummy_st_module)
 # Mock heavy optional dependencies to avoid model downloads during tests.
 sys.modules.setdefault("bertopic", MagicMock())
 sys.modules.setdefault("transformers", MagicMock())
+
+
+from autoresearch.api import app as api_app, SLOWAPI_STUB, reset_request_log  # noqa: E402
+import typer  # noqa: E402
+from autoresearch import cache, storage  # noqa: E402
+from autoresearch.config import ConfigLoader  # noqa: E402
+from autoresearch.agents.registry import (  # noqa: E402
+    AgentFactory,
+    AgentRegistry,
+)  # noqa: E402
+from autoresearch.llm.registry import LLMFactory  # noqa: E402
+from autoresearch.storage import (  # noqa: E402
+    set_delegate as set_storage_delegate,
+)  # noqa: E402
+from autoresearch.extensions import VSSExtensionLoader  # noqa: E402
+import duckdb  # noqa: E402
+_orig_option = typer.Option
 
 
 def _compat_option(*args, **kwargs):


### PR DESCRIPTION
## Summary
- insert optional dependency stubs before importing project modules
- remove unused `TYPE_CHECKING` import
- adjust flake8 directives

## Testing
- `uv run flake8 src tests`
- `uv run mypy src` *(fails: Error importing plugin 'pydantic.mypy')*
- `uv run pytest -q` *(fails: ModuleNotFoundError or long runtime)*
- `uv run pytest tests/behavior -q` *(fails: assertion 200 == 429)*

------
https://chatgpt.com/codex/tasks/task_e_6882ea08e48483339e2eff9471b57611