### PR TITLE
Add extra module tests

### DIFF
--- a/tests/unit/test_cache_extra.py
+++ b/tests/unit/test_cache_extra.py
@@ -1,0 +1,13 @@
+from autoresearch import cache
+
+
+def test_get_db_after_teardown(tmp_path):
+    orig = cache._db_path
+    cache.teardown(remove_file=False)
+    cache._db_path = tmp_path / "c.json"
+    db1 = cache.get_db()
+    cache.teardown(remove_file=False)
+    db2 = cache.get_db()
+    assert db1 is not db2
+    cache.teardown(remove_file=True)
+    cache._db_path = orig

--- a/tests/unit/test_cli_backup_extra.py
+++ b/tests/unit/test_cli_backup_extra.py
@@ -1,0 +1,82 @@
+import builtins
+from datetime import datetime
+from typer.testing import CliRunner
+import pytest
+from autoresearch.cli_backup import backup_app, _format_size
+from autoresearch.errors import BackupError
+
+
+class DummyInfo:
+    def __init__(self, path="p", ts=None, size=0, compressed=True):
+        self.path = path
+        self.timestamp = ts or datetime.now()
+        self.size = size
+        self.compressed = compressed
+
+
+def test_format_size_units():
+    assert _format_size(512) == "512 B"
+    assert _format_size(2048).endswith("KB")
+    assert _format_size(2 * 1024 * 1024).endswith("MB")
+    assert _format_size(3 * 1024 * 1024 * 1024).endswith("GB")
+
+
+def test_backup_create_error(monkeypatch):
+    runner = CliRunner()
+
+    def fail(**_):
+        raise BackupError("boom", context={"suggestion": "try"})
+
+    monkeypatch.setattr("autoresearch.cli_backup.BackupManager.create_backup", fail)
+    result = runner.invoke(backup_app, ["create", "--dir", "d"], catch_exceptions=False)
+    assert result.exit_code == 1
+    assert "boom" in result.stdout
+    assert "try" in result.stdout
+
+
+def test_backup_restore_cancelled(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr("autoresearch.cli_backup.Prompt.ask", lambda *a, **k: "n")
+    result = runner.invoke(backup_app, ["restore", "p"])
+    assert "Restore cancelled" in result.stdout
+
+
+def test_backup_restore_error(monkeypatch):
+    runner = CliRunner()
+
+    def fail(**_):
+        raise BackupError("oops")
+
+    monkeypatch.setattr("autoresearch.cli_backup.BackupManager.restore_backup", fail)
+    monkeypatch.setattr("autoresearch.cli_backup.Prompt.ask", lambda *a, **k: "y")
+    result = runner.invoke(backup_app, ["restore", "p"])
+    assert result.exit_code == 1
+    assert "oops" in result.stdout
+
+
+def test_backup_list_no_backups(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr("autoresearch.cli_backup.BackupManager.list_backups", lambda *_: [])
+    result = runner.invoke(backup_app, ["list", "--dir", "d"])
+    assert "No backups found" in result.stdout
+
+
+def test_backup_recover_invalid_timestamp(monkeypatch):
+    runner = CliRunner()
+    result = runner.invoke(backup_app, ["recover", "bad"])
+    assert result.exit_code == 1
+    assert "Invalid timestamp" in result.stdout
+
+
+def test_backup_recover_error(monkeypatch):
+    runner = CliRunner()
+
+    def fail(**_):
+        raise BackupError("oops", context={"suggestion": "s"})
+
+    monkeypatch.setattr("autoresearch.cli_backup.BackupManager.restore_point_in_time", fail)
+    monkeypatch.setattr("autoresearch.cli_backup.Prompt.ask", lambda *a, **k: "y")
+    result = runner.invoke(backup_app, ["recover", "2020-01-01 00:00:00", "--force"])
+    assert result.exit_code == 1
+    assert "oops" in result.stdout
+    assert "s" in result.stdout

--- a/tests/unit/test_cli_utils_extra.py
+++ b/tests/unit/test_cli_utils_extra.py
@@ -1,0 +1,43 @@
+from autoresearch.cli_utils import (
+    format_error, format_success, format_warning, format_info,
+    print_error, set_verbosity, get_verbosity, print_verbose,
+    Verbosity, ascii_bar_graph, summary_table
+)
+from rich.console import Console
+
+
+def test_print_error_suggestion(monkeypatch):
+    records = []
+    monkeypatch.setattr(
+        "autoresearch.cli_utils.console.print",
+        lambda m: records.append(str(m)),
+    )
+    set_verbosity(Verbosity.VERBOSE)
+    print_error("msg", suggestion="do this", code_example="run")
+    assert any("do this" in r for r in records)
+    assert any("run" in r for r in records)
+
+
+def test_verbosity_roundtrip(monkeypatch):
+    set_verbosity(Verbosity.VERBOSE)
+    assert get_verbosity() == Verbosity.VERBOSE
+    records = []
+    monkeypatch.setattr("autoresearch.cli_utils.console.print", lambda m: records.append(m))
+    print_verbose("hi")
+    assert any("hi" in r for r in records)
+
+
+def test_ascii_and_table_empty():
+    assert ascii_bar_graph({}) == "(no data)"
+    table = summary_table({})
+    console = Console(record=True, color_system=None)
+    console.print(table)
+    out = console.export_text()
+    assert "(empty)" in out
+
+
+def test_format_functions():
+    assert "✓" in format_success("ok")
+    assert "✗" in format_error("bad")
+    assert "⚠" in format_warning("warn")
+    assert "ℹ" in format_info("info")

--- a/tests/unit/test_distributed_extra.py
+++ b/tests/unit/test_distributed_extra.py
@@ -1,0 +1,39 @@
+import sys
+import types
+
+# Stub heavy modules before importing distributed
+sys.modules.setdefault("ray", types.SimpleNamespace(remote=lambda f: f))
+sys.modules.setdefault(
+    "autoresearch.orchestration.state",
+    types.SimpleNamespace(QueryState=object)
+)
+sys.modules.setdefault(
+    "autoresearch.orchestration.orchestrator",
+    types.SimpleNamespace(AgentFactory=object)
+)
+sys.modules.setdefault("autoresearch.models", types.SimpleNamespace())
+
+from autoresearch.distributed import get_message_broker, RedisQueue, InMemoryBroker
+
+class FakeRedis:
+    def __init__(self):
+        self.list = []
+    def rpush(self, name, value):
+        self.list.append(value)
+    def blpop(self, names):
+        return names[0], self.list.pop(0).encode()
+    def close(self):
+        pass
+
+
+def test_get_message_broker_default():
+    broker = get_message_broker(None)
+    assert isinstance(broker, InMemoryBroker)
+    broker.shutdown()
+
+
+def test_redis_queue_roundtrip():
+    client = FakeRedis()
+    queue = RedisQueue(client, "q")
+    queue.put({"a": 1})
+    assert queue.get() == {"a": 1}

--- a/tests/unit/test_search_extra.py
+++ b/tests/unit/test_search_extra.py
@@ -1,0 +1,54 @@
+import sys
+import json
+import types
+import pytest
+
+# Provide dummy optional modules before importing Search
+sys.modules.setdefault("kuzu", types.SimpleNamespace())
+sys.modules.setdefault("spacy", types.SimpleNamespace(load=lambda *_: None, cli=types.SimpleNamespace(download=lambda *_: None)))
+sys.modules.setdefault("bertopic", types.SimpleNamespace())
+sys.modules.setdefault("sentence_transformers", types.SimpleNamespace(SentenceTransformer=lambda *_: None))
+
+from autoresearch.search import Search, get_http_session, close_http_session
+from autoresearch.config import ConfigModel
+from autoresearch.errors import SearchError
+
+
+def test_unknown_backend_raises(monkeypatch):
+    Search.backends = {}
+    cfg = ConfigModel(loops=1)
+    cfg.search.backends = ["missing"]
+    cfg.search.context_aware.enabled = False
+    monkeypatch.setattr("autoresearch.search.get_config", lambda: cfg)
+    was = sys.modules.pop('pytest')
+    try:
+        with pytest.raises(SearchError):
+            Search.external_lookup("q")
+    finally:
+        sys.modules['pytest'] = was
+
+
+def test_backend_json_error(monkeypatch):
+    def bad_backend(query, max_results=5):
+        raise json.JSONDecodeError("bad", "", 0)
+
+    Search.backends = {"bad": bad_backend}
+    cfg = ConfigModel(loops=1)
+    cfg.search.backends = ["bad"]
+    cfg.search.context_aware.enabled = False
+    monkeypatch.setattr("autoresearch.search.get_config", lambda: cfg)
+    was = sys.modules.pop('pytest')
+    try:
+        with pytest.raises(SearchError):
+            Search.external_lookup("q")
+    finally:
+        sys.modules['pytest'] = was
+
+
+def test_http_session_reuse():
+    close_http_session()
+    s1 = get_http_session()
+    s2 = get_http_session()
+    assert s1 is s2
+    close_http_session()
+    assert get_http_session() is not s1


### PR DESCRIPTION
## Summary
- add edge case tests for cli_backup, cli_utils, distributed, search and cache modules
- cover error handling for CLI backup operations
- ensure verbosity and console printing behaviour
- validate message broker and HTTP session helpers

## Testing
- `PYTHONPATH=src PYTEST_ADDOPTS="--cov=src --cov=tests --cov-fail-under=0" pytest -q tests/unit/test_cli_backup_extra.py tests/unit/test_cli_utils_extra.py tests/unit/test_search_extra.py tests/unit/test_distributed_extra.py tests/unit/test_cache_extra.py --confcutdir=tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_6882f6e8a49c8333ae0a0566cc12e1a5