### PR TITLE
Improve test skip messaging for optional extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,10 @@ coverage run -p -m pytest tests/behavior -q
 coverage combine
 ```
 
-Heavy tests are marked with `requires_ui`, `requires_vss` or `slow`. Skip them during quick development cycles with:
+Heavy tests are marked with `requires_ui`, `requires_vss` or `slow`.
+`requires_ui` tests need the `ui` extra (Streamlit) while `requires_vss` tests
+depend on the `vss` extra (DuckDB VSS extension). Skip them during quick
+development cycles with:
 
 ```bash
 uv run pytest -m "not requires_ui and not requires_vss and not slow"

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -71,7 +71,9 @@ coverage run -p -m pytest tests/behavior -q
 coverage combine
 ```
 
-Use the markers `requires_ui`, `requires_vss` and `slow` to skip heavy tests during development:
+Use the markers `requires_ui`, `requires_vss` and `slow` to skip heavy tests during development.
+`requires_ui` indicates tests that rely on the `ui` extra while `requires_vss`
+marks tests that depend on the `vss` extra. Skip them with:
 
 ```bash
 uv run pytest -m "not requires_ui and not requires_vss and not slow"

--- a/tests/behavior/README.md
+++ b/tests/behavior/README.md
@@ -16,7 +16,8 @@ poetry install --with dev --all-extras
 ## Running extra tests
 
 Use pytest markers to execute these scenarios separately if you do not want to
-run the entire suite:
+run the entire suite. `requires_ui` scenarios need the `ui` extra while
+`requires_vss` scenarios depend on the `vss` extra:
 
 ```bash
 # Scenarios that need the UI extra

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -348,8 +348,16 @@ def _module_available(name: str) -> bool:
     return bool(spec and spec.origin)
 
 
+def pytest_runtest_setup(item):
+    if item.get_closest_marker("requires_ui") and not UI_AVAILABLE:
+        pytest.skip("ui extra not installed")
+    if item.get_closest_marker("requires_vss") and not VSS_AVAILABLE:
+        pytest.skip("vss extra not installed")
+
+
 GITPYTHON_INSTALLED = _module_available("git")
 POLARS_INSTALLED = _module_available("polars")
+UI_AVAILABLE = _module_available("streamlit")
 
 
 def _check_vss() -> bool:


### PR DESCRIPTION
## Summary
- skip UI/VSS marked tests when extras not installed
- clarify extras in README and developer docs
- document behavior test markers requiring extras

## Testing
- `uv run flake8 src tests` *(fails: F401 unused imports, E402 module level import not at top of file, etc.)*
- `uv run mypy src` *(fails: library stubs not installed, etc.)*
- `uv run pytest -q` *(fails: ModuleNotFoundError: autoresearch.search.errors)*
- `uv run pytest tests/behavior` *(fails: ModuleNotFoundError: autoresearch.search.errors)*

------
https://chatgpt.com/codex/tasks/task_e_6883968f4950833384b4b9abc4d6cfb0