### PR TITLE
Switch setup scripts to uv

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -9,4 +9,4 @@ rm -rf /var/lib/apt/lists/*
 
 # Run the main setup script which installs dev dependencies and all extras
 ./scripts/setup.sh
-# All Python/Poetry setup is handled by setup.sh using --all-extras
+# All Python/uv setup is handled by setup.sh using uv pip


### PR DESCRIPTION
## Summary
- use `uv` in `scripts/setup.sh`
- remove Poetry commands and the invalid `--with dev` flag
- update `scripts/codex_setup.sh` comments

## Testing
- `bash scripts/codex_setup.sh` *(fails: error: Requesting extras requires a `pyproject.toml`, `setup.cfg`, or `setup.py` file. Use `<dir>[extra]` syntax or `-r <file>` instead.)*


------
https://chatgpt.com/codex/tasks/task_e_68839ce403a88333a2436fad0ab28d78