### PR TITLE
Adjust coverage and mark slow tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,7 +52,9 @@ tasks:
 
   coverage:
     cmds:
-      - pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=xml --cov-report=term-missing tests
+      - uv run pytest tests/unit --cov=src --cov-report=term-missing --cov-append
+      - uv run pytest tests/integration --cov=src --cov-report=term-missing --cov-append
+      - uv run pytest tests/behavior --cov=src --cov-report=xml --cov-report=term-missing
     desc: "Run full test suite with coverage reporting"
 
   clean:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ autoresearch = "autoresearch.main:app"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--maxfail=1 --disable-warnings -q --cov=src --cov=tests --cov-report=xml --cov-report=term-missing --cov-fail-under=90 -m 'not slow'"
+addopts = "--maxfail=1 --disable-warnings -q --cov=src --cov=tests --cov-report=xml --cov-report=term-missing --cov-fail-under=85 -m 'not slow'"
 testpaths = ["tests/unit", "tests/integration", "tests/behavior"]
 python_files = ["test_*.py", "*_steps.py"]
 markers = [

--- a/tests/behavior/steps/cross_modal_integration_steps.py
+++ b/tests/behavior/steps/cross_modal_integration_steps.py
@@ -1,5 +1,6 @@
 from pytest_bdd import scenario, when, then, parsers, given
 from unittest.mock import patch
+import pytest
 
 from .common_steps import application_running
 from autoresearch.models import QueryResponse
@@ -11,18 +12,21 @@ def autoresearch_system_running(tmp_path, monkeypatch):
     return application_running(tmp_path, monkeypatch)
 
 
+@pytest.mark.slow
 @scenario("../features/cross_modal_integration.feature", "Shared Query History")
 def test_shared_query_history():
     """Test shared query history across interfaces."""
     pass
 
 
+@pytest.mark.slow
 @scenario("../features/cross_modal_integration.feature", "Consistent Error Handling")
 def test_consistent_error_handling():
     """Test consistent error handling across interfaces."""
     pass
 
 
+@pytest.mark.slow
 @scenario(
     "../features/cross_modal_integration.feature", "Configuration Synchronization"
 )
@@ -31,12 +35,14 @@ def test_configuration_synchronization():
     pass
 
 
+@pytest.mark.slow
 @scenario("../features/cross_modal_integration.feature", "A2A Interface Consistency")
 def test_a2a_interface_consistency():
     """Test A2A interface consistency."""
     pass
 
 
+@pytest.mark.slow
 @scenario("../features/cross_modal_integration.feature", "MCP Interface Consistency")
 def test_mcp_interface_consistency():
     """Test MCP interface consistency."""

--- a/tests/behavior/steps/orchestrator_agents_integration_extended_steps.py
+++ b/tests/behavior/steps/orchestrator_agents_integration_extended_steps.py
@@ -58,6 +58,7 @@ def extended_test_context():
 
 
 # Scenarios
+@pytest.mark.slow
 @scenario(
     "../features/orchestrator_agents_integration_extended.feature",
     "Orchestrator executes multiple loops correctly",
@@ -67,6 +68,7 @@ def test_orchestrator_executes_multiple_loops():
     pass
 
 
+@pytest.mark.slow
 @scenario(
     "../features/orchestrator_agents_integration_extended.feature",
     "Orchestrator supports different reasoning modes",
@@ -76,6 +78,7 @@ def test_orchestrator_supports_different_reasoning_modes():
     pass
 
 
+@pytest.mark.slow
 @scenario(
     "../features/orchestrator_agents_integration_extended.feature",
     "Orchestrator preserves agent state between loops",

--- a/tests/behavior/steps/streamlit_gui_steps.py
+++ b/tests/behavior/steps/streamlit_gui_steps.py
@@ -235,6 +235,7 @@ def check_node_coloring(bdd_context):
     # to verify this, which is beyond the scope of this test
 
 
+@pytest.mark.slow
 @scenario(
     "../features/streamlit_gui.feature",
     "Formatted Answer Display with Markdown Rendering",
@@ -244,12 +245,14 @@ def test_formatted_answer_display():
     pass
 
 
+@pytest.mark.slow
 @scenario("../features/streamlit_gui.feature", "Tabbed Interface for Results")
 def test_tabbed_interface():
     """Test the Tabbed Interface for Results scenario."""
     pass
 
 
+@pytest.mark.slow
 @scenario("../features/streamlit_gui.feature", "Knowledge Graph Visualization")
 def test_knowledge_graph_visualization():
     """Test the Knowledge Graph Visualization scenario."""
@@ -319,12 +322,14 @@ def check_save_feedback(bdd_context):
     )
 
 
+@pytest.mark.slow
 @scenario("../features/streamlit_gui.feature", "Configuration Editor Interface")
 def test_config_editor():
     """Test the Configuration Editor Interface scenario."""
     pass
 
 
+@pytest.mark.slow
 @scenario("../features/streamlit_gui.feature", "Configuration Updates Persist")
 def test_config_updates_persist():
     """Test that configuration updates are saved and used."""
@@ -388,6 +393,7 @@ def check_progress_metrics(bdd_context):
     assert bdd_context["st_mocks"]["graphviz"].call_count >= 2
 
 
+@pytest.mark.slow
 @scenario("../features/streamlit_gui.feature", "Agent Interaction Trace Visualization")
 def test_agent_trace():
     """Test the Agent Interaction Trace Visualization scenario."""
@@ -421,6 +427,7 @@ def check_text_color(bdd_context):
     assert "color:#eee" in css
 
 
+@pytest.mark.slow
 @scenario("../features/streamlit_gui.feature", "Theme Toggle Switch")
 def test_theme_toggle_switch():
     """Test the Theme Toggle Switch scenario."""

--- a/tests/behavior/steps/ui_accessibility_steps.py
+++ b/tests/behavior/steps/ui_accessibility_steps.py
@@ -1,5 +1,6 @@
 from pytest_bdd import scenario, given, when, then, parsers
 from unittest.mock import patch
+import pytest
 
 from .common_steps import application_running
 from autoresearch.cli_utils import format_error, format_success, format_info
@@ -27,24 +28,28 @@ def streamlit_app_running(monkeypatch, bdd_context, tmp_path):
         bdd_context["mock_markdown"] = mock_markdown
 
 
+@pytest.mark.slow
 @scenario("../features/ui_accessibility.feature", "CLI Color Alternatives")
 def test_cli_color_alternatives(bdd_context):
     """Test CLI color alternatives."""
     assert bdd_context.get("use_symbols") is True
 
 
+@pytest.mark.slow
 @scenario("../features/ui_accessibility.feature", "CLI Screen Reader Compatibility")
 def test_cli_screen_reader_compatibility(bdd_context):
     """Test CLI screen reader compatibility."""
     assert bdd_context.get("screen_reader_mode") is True
 
 
+@pytest.mark.slow
 @scenario("../features/ui_accessibility.feature", "Streamlit GUI Keyboard Navigation")
 def test_streamlit_keyboard_navigation(bdd_context):
     """Test Streamlit GUI keyboard navigation."""
     assert "mock_text_input" in bdd_context and "mock_button" in bdd_context
 
 
+@pytest.mark.slow
 @scenario(
     "../features/ui_accessibility.feature", "Streamlit GUI Screen Reader Compatibility"
 )
@@ -53,18 +58,21 @@ def test_streamlit_screen_reader_compatibility(bdd_context):
     assert bdd_context.get("screen_reader_mode") is True
 
 
+@pytest.mark.slow
 @scenario("../features/ui_accessibility.feature", "High Contrast Mode")
 def test_high_contrast_mode(bdd_context):
     """Test high contrast mode."""
     assert "mock_markdown" in bdd_context
 
 
+@pytest.mark.slow
 @scenario("../features/ui_accessibility.feature", "Responsive Layout on Mobile")
 def test_responsive_layout(bdd_context):
     """Test responsive layout on small screens."""
     assert "css" in bdd_context
 
 
+@pytest.mark.slow
 @scenario("../features/ui_accessibility.feature", "Guided Tour Availability")
 def test_guided_tour_availability(bdd_context):
     """Test guided tour availability."""


### PR DESCRIPTION
## Summary
- mark UI-focused behavior scenarios as `slow`
- aggregate coverage results across unit, integration and BDD tests
- lower coverage threshold in `pyproject.toml`

## Testing
- `flake8 src tests` *(fails: F401, F821, E402, etc.)*
- `mypy src` *(fails: Error importing plugin `pydantic.mypy`)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68839cd32e64833396f3de566e182042