### PR TITLE
Add verify task and update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,9 @@ By participating in this project, you agree to maintain a respectful and inclusi
 
   # Run the entire suite including slow tests
   task test:all
+
+  # Lint, type check and run all tests with coverage
+  task verify
   ```
 
 ## Code Style Guidelines
@@ -192,6 +195,12 @@ uv run pytest tests/behavior
 
 # Run with coverage report
 uv run pytest --cov=src
+```
+
+For convenience you can run linting, type checks, and the full test suite with coverage using:
+
+```bash
+task verify
 ```
 
 The BDD tests live under `tests/behavior` and can be executed separately if you

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,6 +57,15 @@ tasks:
       - uv run pytest tests/behavior --cov=src --cov-report=xml --cov-report=term-missing
     desc: "Run full test suite with coverage reporting"
 
+  verify:
+    cmds:
+      - uv run flake8 src tests
+      - uv run mypy src
+      - uv run pytest tests/unit --cov=src --cov-report=term-missing --cov-append
+      - uv run pytest tests/integration -m "not slow" --cov=src --cov-report=term-missing --cov-append
+      - uv run pytest tests/behavior --cov=src --cov-report=xml --cov-report=term-missing
+    desc: "Run linting, type checks and all test suites with coverage"
+
   clean:
     cmds:
       - find . -type d -name '__pycache__' -exec rm -rf {} +


### PR DESCRIPTION
## Summary
- add `verify` task for linting, type checks and tests with coverage
- document the new task in `CONTRIBUTING.md`

## Testing
- `uv run flake8 src tests` *(fails: various style violations)*
- `uv run mypy src` *(fails: found 14 errors)*
- `uv run pytest tests/unit -q` *(fails: ModuleNotFoundError: autoresearch.search.errors)*

------
https://chatgpt.com/codex/tasks/task_e_6883a1b5797483339aa452da8be34c17