### PR TITLE
Document running full test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,15 @@ development cycles with:
 uv run pytest -m "not requires_ui and not requires_vss and not slow"
 ```
 
+When resources permit you can run the complete suite, including the slow tests
+and those that rely on optional extras. Install the extras and run pytest
+without filtering the markers:
+
+```bash
+uv sync --all-extras
+uv run pytest -m "slow or requires_ui or requires_vss"
+```
+
 ### Migrating from Poetry
 
 Previous versions used Poetry for environment management. `uv` now handles dependency installation and virtual environment creation for faster setup. If you have an existing Poetry environment, remove the `.venv` directory and recreate it with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ autoresearch = "autoresearch.main:app"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--maxfail=1 --disable-warnings -q --cov=src --cov=tests --cov-report=xml --cov-report=term-missing --cov-fail-under=85 -m 'not slow'"
+addopts = "--maxfail=1 --disable-warnings -q --cov=src --cov=tests --cov-report=xml --cov-report=term-missing --cov-fail-under=85 -m 'not slow and not requires_ui and not requires_vss'"
 testpaths = ["tests/unit", "tests/integration", "tests/behavior"]
 python_files = ["test_*.py", "*_steps.py"]
 markers = [


### PR DESCRIPTION
## Summary
- skip optional extra tests by default via pytest addopts
- document how to run all suites including `slow`, `requires_ui` and `requires_vss`

## Testing
- `uv run flake8 src tests` *(fails: F401, F821, E402, etc.)*
- `uv run mypy src` *(fails: missing stubs, Name "redis" not defined)*
- `uv run pytest -q` *(fails: ModuleNotFoundError: autoresearch.search.errors)*
- `uv run pytest tests/behavior` *(fails: ModuleNotFoundError: autoresearch.search.errors)*

------
https://chatgpt.com/codex/tasks/task_e_6883a1a87ca88333b834e6144ce61bf7