### PR TITLE
Expand test coverage for core modules

### DIFF
--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -10,7 +10,7 @@ import typer
 from rich.console import Console
 from rich.prompt import Prompt
 from rich.progress import Progress
-from .mcp_interface import create_server
+from ..mcp_interface import create_server
 from .monitor import monitor_app
 import time
 

--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -77,12 +77,12 @@ except ImportError:
     BERTOPIC_AVAILABLE = False
 
 import atexit
-from .errors import ConfigError, SearchError
-from .logging_utils import get_logger
-from .cache import get_cached_results, cache_results
-from .config import get_config
+from ..errors import ConfigError, SearchError
+from ..logging_utils import get_logger
+from ..cache import get_cached_results, cache_results
+from ..config import get_config
 log = get_logger(__name__)
-from .storage import StorageManager
+from ..storage import StorageManager
 
 from .http import get_http_session, close_http_session, set_http_session
 from .context import SearchContext
@@ -807,7 +807,7 @@ class Search:
                 backend_results = backend(search_query, max_results)
             except requests.exceptions.Timeout as exc:
                 log.warning(f"{name} search timed out: {exc}")
-                from .errors import TimeoutError
+                from ..errors import TimeoutError
                 raise TimeoutError(
                     f"{name} search timed out",
                     cause=exc,

--- a/tests/integration/test_simple_orchestration.py
+++ b/tests/integration/test_simple_orchestration.py
@@ -1,0 +1,37 @@
+from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
+from autoresearch.config import ConfigModel, ConfigLoader
+from autoresearch.models import QueryResponse
+from autoresearch.storage import StorageManager
+
+
+def make_agent(name, calls):
+    class DummyAgent:
+        def __init__(self, name, llm_adapter=None):
+            self.name = name
+        def can_execute(self, state, config):
+            return True
+        def execute(self, state, config, **kwargs):
+            calls.append(self.name)
+            state.update({
+                "results": {self.name: "ok"},
+                "claims": [{"type": "fact", "content": self.name, "id": self.name}]
+            })
+            if self.name == "Synthesizer":
+                state.results["final_answer"] = f"Answer from {self.name}"
+            return {"results": {self.name: "ok"}, "claims": [{"type": "fact", "content": self.name, "id": self.name}]}
+    return DummyAgent(name)
+
+
+def test_orchestrator_run_query(monkeypatch):
+    calls = []
+    monkeypatch.setattr(StorageManager, "persist_claim", lambda claim: None)
+    monkeypatch.setattr(AgentFactory, "get", lambda name: make_agent(name, calls))
+
+    cfg = ConfigModel(agents=["Synthesizer"], loops=1)
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+
+    response = Orchestrator.run_query("q", cfg)
+    assert isinstance(response, QueryResponse)
+    assert calls == ["Synthesizer"]
+    assert response.answer == "Answer from Synthesizer"

--- a/tests/unit/test_core_modules_additional.py
+++ b/tests/unit/test_core_modules_additional.py
@@ -1,0 +1,93 @@
+import types
+
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.reasoning import ReasoningMode
+from autoresearch.config import ConfigModel, ConfigLoader
+from autoresearch.storage import StorageManager
+from autoresearch.search import Search
+from autoresearch.agents.specialized.planner import PlannerAgent
+from autoresearch.orchestration.state import QueryState
+
+
+def test_orchestrator_parse_config_basic():
+    cfg = ConfigModel(agents=["A", "B"], loops=2, reasoning_mode=ReasoningMode.DIALECTICAL)
+    params = Orchestrator._parse_config(cfg)
+    assert params["agents"] == ["A", "B"]
+    assert params["loops"] == 2
+    assert params["mode"] == ReasoningMode.DIALECTICAL
+    assert params["agent_groups"] == [["A"], ["B"]]
+
+
+def test_search_stub_backend(monkeypatch):
+    results = [{"title": "T", "url": "u"}]
+
+    @Search.register_backend("stub")
+    def _stub(query: str, max_results: int = 5):
+        return results
+
+    cfg = ConfigModel()
+    cfg.search.backends = ["stub"]
+    cfg.search.context_aware.enabled = False
+    monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
+    monkeypatch.setattr(Search, "embedding_lookup", lambda emb, max_results=5: {})
+    monkeypatch.setattr(Search, "add_embeddings", lambda res, emb: None)
+    monkeypatch.setattr("autoresearch.search.core.get_cached_results", lambda q, n: None)
+    monkeypatch.setattr("autoresearch.search.core.cache_results", lambda q, n, r: None)
+
+    out = Search.external_lookup("q", max_results=1)
+    assert out == results
+
+
+def test_planner_execute(monkeypatch):
+    agent = PlannerAgent()
+    state = QueryState(query="test")
+    cfg = ConfigModel()
+
+    class DummyAdapter:
+        def generate(self, prompt: str, model: str | None = None) -> str:  # noqa: D401
+            return "PLAN"
+
+    monkeypatch.setattr(PlannerAgent, "get_adapter", lambda self, config: DummyAdapter())
+    monkeypatch.setattr(PlannerAgent, "get_model", lambda self, config: "model")
+    monkeypatch.setattr(PlannerAgent, "generate_prompt", lambda self, name, **kw: "prompt")
+
+    result = agent.execute(state, cfg)
+    assert result["results"]["research_plan"] == "PLAN"
+
+def test_storage_setup_teardown(monkeypatch):
+    calls = {}
+    class FakeDuck:
+        def __init__(self):
+            self.conn = object()
+        def setup(self, path):
+            calls['duck'] = path
+        def get_connection(self):
+            return self.conn
+    class FakeKuzu:
+        def __init__(self):
+            self.conn = object()
+        def setup(self, path):
+            calls['kuzu'] = path
+        def get_connection(self):
+            return self.conn
+    class FakeGraph:
+        def __init__(self, *a, **k):
+            pass
+        def open(self, *a, **k):
+            pass
+    cfg = ConfigModel()
+    cfg.storage.use_kuzu = True
+    cfg.storage.kuzu_path = 'kuzu'
+    cfg.storage.rdf_backend = 'memory'
+    cfg.storage.duckdb_path = 'db.duckdb'
+    cfg.storage.vector_extension = False
+    monkeypatch.setattr(ConfigLoader, 'load_config', lambda self: cfg)
+    ConfigLoader()._config = None
+    monkeypatch.setattr('autoresearch.storage.DuckDBStorageBackend', lambda: FakeDuck())
+    monkeypatch.setattr('autoresearch.storage.KuzuStorageBackend', lambda: FakeKuzu())
+    monkeypatch.setattr('autoresearch.storage.rdflib', types.SimpleNamespace(Graph=lambda *a, **k: FakeGraph()))
+    from autoresearch import storage
+    storage.setup('db')
+    assert calls['duck'] == 'db'
+    assert calls['kuzu'] == 'kuzu'
+    storage.teardown()


### PR DESCRIPTION
## Summary
- fix search module imports to reference package-level helpers
- correct mcp_interface import path in main app
- add focused unit tests for orchestrator, storage, search, and planner agent
- add simple orchestration integration test

## Testing
- `uv run flake8 tests/unit/test_core_modules_additional.py tests/integration/test_simple_orchestration.py`
- `uv run mypy src/autoresearch/search/core.py` *(fails: Error importing plugin pydantic.mypy)*
- `uv run pytest tests/unit/test_core_modules_additional.py tests/integration/test_simple_orchestration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a471d9f8833382f5e7670e8fc9c3