### PR TITLE
Fix VSS stub to skip HNSW index

### DIFF
--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -40,7 +40,6 @@ from ..cli_utils import (
 )
 from ..error_utils import get_error_info, format_error_for_cli
 from ..cli_helpers import handle_command_not_found
-from .config_cli import config_app, config_init
 
 
 app = typer.Typer(
@@ -58,6 +57,9 @@ app = typer.Typer(
 )
 configure_logging()
 _config_loader: ConfigLoader = ConfigLoader()
+
+from .config_cli import config_app, config_init  # noqa: E402
+
 app.add_typer(config_app, name="config")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -396,6 +396,10 @@ def stub_vss_extension_download(monkeypatch, request, tmp_path):
         "verify_extension",
         lambda _c, verbose=True: True,
     )
+    monkeypatch.setattr(
+        "autoresearch.storage_backends.DuckDBStorageBackend.create_hnsw_index",
+        lambda self: None,
+    )
     yield
     if stub_path:
         monkeypatch.delenv("VECTOR_EXTENSION_PATH", raising=False)


### PR DESCRIPTION
## Summary
- avoid circular import in CLI app by moving config import
- skip HNSW index creation during tests to silence DuckDB errors

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q`
- `uv run pytest tests/behavior`

------
https://chatgpt.com/codex/tasks/task_e_6883c8ca574483338c4ee213d8b1fa37