### PR TITLE
Update release status docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ CLI utilities are provided via Typer and the HTTP API is powered by FastAPI.
 Autoresearch is currently in the **Development** phase preparing for the
 upcoming **0.1.0** release. The version is defined in
 `autoresearch.__version__` and mirrored in `pyproject.toml`, but it has
-**not** been published yet.
-The first official release was previously targeted for **July 20, 2025**.
-Development has slipped past that date, so the release is now expected
-to arrive sometime after **July 20, 2025**. See
-[docs/release_plan.md](docs/release_plan.md) for the full milestone schedule.
+**not** been published yet. The first official release was originally
+planned for **July 20, 2025**. Work has slipped past that date and
+several unit and behavior tests are still failing. The release has been
+re-targeted for sometime after **August 15, 2025** once CI passes with at
+least **90%** coverage. See
+[docs/release_plan.md](docs/release_plan.md) for the full milestone
+schedule and outstanding tasks.
 
 ## Installation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,9 +22,11 @@ complete documentation. Key activities include:
 - Finalizing API reference and user guides.
 - Verifying packaging metadata and TestPyPI uploads.
 
-All of these tasks are complete in the codebase. The remaining blocker for
-**0.1.0** is ensuring optional dependencies are installed so the full test suite
-runs successfully in CI.
+Work on these tasks is underway but the automated test suites currently
+fail and code coverage is below the **90%** target. Optional dependencies
+must be installed so the full unit, integration and behavior tests can run
+in CI. Fixing these issues is the primary blocker for releasing
+**0.1.0**.
 
 ## 0.1.1 – Bug fixes and documentation updates
 

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -18,11 +18,15 @@ the codebase currently sits at the **unreleased 0.1.0** version defined in
 | **1.0.0** | 2026-03-01 | Full feature set, performance tuning and stable interfaces |
 
 The **0.1.0** release was originally aimed for **July 20, 2025**. Ongoing work has
-shifted the timeline. The milestone is now planned for **August 15, 2025**.
+shifted the timeline. Several unit and behavior tests currently fail and
+coverage sits below the **90%** target, so the milestone has been pushed
+back to **after August 15, 2025**.
 
 The following tasks remain before publishing **0.1.0**:
 
-- Ensure optional dependencies are installed so the full unit, integration and behavior test suites run successfully in CI.
+- Fix failing unit and behavior tests so CI passes.
+- Install optional dependencies so the full unit, integration and behavior test suites run successfully.
+- Achieve at least **90%** coverage across all suites.
 - Verify `python -m build` and `scripts/publish_dev.py` create valid packages across platforms.
 - Assemble final release notes and confirm README instructions.
 
@@ -34,3 +38,13 @@ The following tasks remain before publishing **0.1.0**:
 4. **Publish** – follow the workflow in `deployment.md`: bump the version, run tests, publish to TestPyPI using `./scripts/publish_dev.py`, then release to PyPI with `twine upload dist/*`.
 
 Each milestone may include additional patch releases for critical fixes.
+
+## CI Checklist
+
+Before tagging **0.1.0**, ensure the following checks pass:
+
+- [ ] `uv run flake8 src tests`
+- [ ] `uv run mypy src`
+- [ ] `uv run pytest -q`
+- [ ] `uv run pytest tests/behavior`
+- [ ] `task coverage` reports at least **90%** total coverage


### PR DESCRIPTION
## Summary
- clarify unreleased 0.1.0 status in README and ROADMAP
- highlight failing tests and 90% coverage goal in release plan
- add CI checklist to release docs

## Testing
- `uv run flake8 src tests` *(fails: F401, E402, E306, etc.)*
- `uv run mypy src`
- `uv run pytest -q` *(fails: test_search_uses_cache)*
- `uv run pytest tests/behavior` *(fails: test_api_batch_pagination)*

------
https://chatgpt.com/codex/tasks/task_e_6883d2d566c4833398b4028f052f5409