### PR TITLE
Fix flake8 issues across project

### DIFF
--- a/src/autoresearch/distributed/coordinator.py
+++ b/src/autoresearch/distributed/coordinator.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import multiprocessing
-import os
 from multiprocessing.synchronize import Event
-from queue import Queue
-from typing import Any, Tuple, cast
+from typing import Any
 
 from ..config import ConfigModel
 from .. import storage

--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -16,19 +16,22 @@ The module includes:
 
 from __future__ import annotations
 
+import csv
 import json
+import math
 import os
 import re
-import sys
-import time
-import threading
-from concurrent.futures import ThreadPoolExecutor, as_completed
 import subprocess
 import shutil
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
-from collections import defaultdict
+
 import requests
+import numpy as np
+from docx import Document
+from pdfminer.high_level import extract_text as extract_pdf_text
 try:
     from git import Repo
 
@@ -43,11 +46,6 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
         "Install with `pip install \"autoresearch[git]\"` to enable it.",
         stacklevel=2,
     )
-import numpy as np
-import csv
-import math
-from pdfminer.high_level import extract_text as extract_pdf_text
-from docx import Document
 
 try:
     from rank_bm25 import BM25Okapi
@@ -72,24 +70,16 @@ except ImportError:  # pragma: no cover - optional dependency
     spacy = None  # type: ignore[assignment]
     SPACY_AVAILABLE = False
 
-try:
-    from bertopic import BERTopic
-
-    BERTOPIC_AVAILABLE = True
-except ImportError:
-    BERTOPIC_AVAILABLE = False
-
-import atexit
 from ..errors import ConfigError, SearchError
 from ..logging_utils import get_logger
 from ..cache import get_cached_results, cache_results
 from ..config import get_config
-log = get_logger(__name__)
 from ..storage import StorageManager
 
-from .http import get_http_session, close_http_session, set_http_session
+from .http import close_http_session, get_http_session
 from .context import SearchContext
 
+log = get_logger(__name__)
 
 
 class Search:

--- a/tests/integration/test_simple_orchestration.py
+++ b/tests/integration/test_simple_orchestration.py
@@ -5,11 +5,14 @@ from autoresearch.storage import StorageManager
 
 
 def make_agent(name, calls):
+
     class DummyAgent:
         def __init__(self, name, llm_adapter=None):
             self.name = name
+
         def can_execute(self, state, config):
             return True
+
         def execute(self, state, config, **kwargs):
             calls.append(self.name)
             state.update({
@@ -18,7 +21,10 @@ def make_agent(name, calls):
             })
             if self.name == "Synthesizer":
                 state.results["final_answer"] = f"Answer from {self.name}"
-            return {"results": {self.name: "ok"}, "claims": [{"type": "fact", "content": self.name, "id": self.name}]}
+            return {
+                "results": {self.name: "ok"},
+                "claims": [{"type": "fact", "content": self.name, "id": self.name}],
+            }
     return DummyAgent(name)
 
 

--- a/tests/unit/test_cli_backup_extra.py
+++ b/tests/unit/test_cli_backup_extra.py
@@ -1,7 +1,5 @@
-import builtins
 from datetime import datetime
 from typer.testing import CliRunner
-import pytest
 from autoresearch.cli_backup import backup_app, _format_size
 from autoresearch.errors import BackupError
 

--- a/tests/unit/test_core_modules_additional.py
+++ b/tests/unit/test_core_modules_additional.py
@@ -3,7 +3,6 @@ import types
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.orchestration.reasoning import ReasoningMode
 from autoresearch.config import ConfigModel, ConfigLoader
-from autoresearch.storage import StorageManager
 from autoresearch.search import Search
 from autoresearch.agents.specialized.planner import PlannerAgent
 from autoresearch.orchestration.state import QueryState
@@ -54,25 +53,34 @@ def test_planner_execute(monkeypatch):
     result = agent.execute(state, cfg)
     assert result["results"]["research_plan"] == "PLAN"
 
+
 def test_storage_setup_teardown(monkeypatch):
     calls = {}
+
     class FakeDuck:
         def __init__(self):
             self.conn = object()
+
         def setup(self, path):
             calls['duck'] = path
+
         def get_connection(self):
             return self.conn
+
     class FakeKuzu:
         def __init__(self):
             self.conn = object()
+
         def setup(self, path):
             calls['kuzu'] = path
+
         def get_connection(self):
             return self.conn
+
     class FakeGraph:
         def __init__(self, *a, **k):
             pass
+
         def open(self, *a, **k):
             pass
     cfg = ConfigModel()

--- a/tests/unit/test_distributed_extra.py
+++ b/tests/unit/test_distributed_extra.py
@@ -13,15 +13,23 @@ sys.modules.setdefault(
 )
 sys.modules.setdefault("autoresearch.models", types.SimpleNamespace())
 
-from autoresearch.distributed import get_message_broker, RedisQueue, InMemoryBroker
+from autoresearch.distributed import (  # noqa: E402
+    get_message_broker,
+    RedisQueue,
+    InMemoryBroker,
+)
+
 
 class FakeRedis:
     def __init__(self):
         self.list = []
+
     def rpush(self, name, value):
         self.list.append(value)
+
     def blpop(self, names):
         return names[0], self.list.pop(0).encode()
+
     def close(self):
         pass
 

--- a/tests/unit/test_search_extra.py
+++ b/tests/unit/test_search_extra.py
@@ -7,11 +7,18 @@ import pytest
 sys.modules.setdefault("kuzu", types.SimpleNamespace())
 sys.modules.setdefault("spacy", types.SimpleNamespace(load=lambda *_: None, cli=types.SimpleNamespace(download=lambda *_: None)))
 sys.modules.setdefault("bertopic", types.SimpleNamespace())
-sys.modules.setdefault("sentence_transformers", types.SimpleNamespace(SentenceTransformer=lambda *_: None))
+sys.modules.setdefault(
+    "sentence_transformers",
+    types.SimpleNamespace(SentenceTransformer=lambda *_: None),
+)
 
-from autoresearch.search import Search, get_http_session, close_http_session
-from autoresearch.config import ConfigModel
-from autoresearch.errors import SearchError
+from autoresearch.search import (  # noqa: E402
+    Search,
+    get_http_session,
+    close_http_session,
+)
+from autoresearch.config import ConfigModel  # noqa: E402
+from autoresearch.errors import SearchError  # noqa: E402
 
 
 def test_unknown_backend_raises(monkeypatch):


### PR DESCRIPTION
## Summary
- clean unused imports in coordinator and search core modules
- tidy nested definitions in tests
- silence E402 warnings for stub-based tests

## Testing
- `uv run flake8 src tests`
- `uv run mypy src` *(fails: Error importing plugin `pydantic.mypy`)*
- `uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6883e04dbb488333ae5935d657192b5d