### PR TITLE
Add MCP integration tests

### DIFF
--- a/tests/integration/test_mcp_reasoning_modes.py
+++ b/tests/integration/test_mcp_reasoning_modes.py
@@ -1,0 +1,95 @@
+import pytest
+
+from autoresearch.test_tools import MCPTestClient
+from autoresearch.config import ConfigModel, ConfigLoader
+from autoresearch.orchestration import ReasoningMode
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.models import QueryResponse
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, json_data=None, text=""):
+        self.status_code = status_code
+        self._json = json_data
+        self.text = text
+
+    def json(self):
+        return self._json
+
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture()
+def mcp_setup(monkeypatch):
+    config = ConfigModel(agents=["Synthesizer", "Contrarian", "FactChecker"], loops=1)
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: config)
+
+    def dummy_run_query(query, cfg, callbacks=None, **kwargs):
+        if query == "fail":
+            raise RuntimeError("boom")
+        if cfg.reasoning_mode == ReasoningMode.DIRECT:
+            order = ["Synthesizer"]
+        elif cfg.reasoning_mode == ReasoningMode.CHAIN_OF_THOUGHT:
+            order = ["Synthesizer"] * cfg.loops
+        else:
+            order = []
+            for _ in range(cfg.loops):
+                order.extend(cfg.agents)
+        reasoning = [{"content": name} for name in order]
+        return QueryResponse(answer=order[-1], citations=[], reasoning=reasoning, metrics={})
+
+    monkeypatch.setattr(Orchestrator, "run_query", dummy_run_query)
+
+    def mock_post(url, json=None, **_kwargs):
+        try:
+            resp = dummy_run_query(json["query"], config)
+            data = {
+                "answer": resp.answer,
+                "citations": resp.citations,
+                "reasoning": resp.reasoning,
+                "metrics": resp.metrics,
+            }
+        except Exception as exc:  # pragma: no cover - error path
+            data = {"error": str(exc)}
+        return DummyResponse(status_code=200, json_data=data)
+
+    monkeypatch.setattr("requests.post", mock_post)
+    monkeypatch.setattr("requests.get", lambda *_a, **_k: DummyResponse(status_code=200, text="ok"))
+
+    return config
+
+
+def test_dialectical_mode_agents(monkeypatch, mcp_setup):
+    config = mcp_setup
+    config.reasoning_mode = ReasoningMode.DIALECTICAL
+    client = MCPTestClient()
+    result = client.test_research_tool("query")
+    assert result["status"] == "success"
+    names = [step["content"] for step in result["response"]["reasoning"]]
+    assert names == ["Synthesizer", "Contrarian", "FactChecker"]
+
+
+def test_direct_and_cot_modes(monkeypatch, mcp_setup):
+    config = mcp_setup
+    client = MCPTestClient()
+
+    config.reasoning_mode = ReasoningMode.DIRECT
+    direct = client.test_research_tool("q")
+    assert [s["content"] for s in direct["response"]["reasoning"]] == ["Synthesizer"]
+
+    config.reasoning_mode = ReasoningMode.CHAIN_OF_THOUGHT
+    config.loops = 2
+    cot = client.test_research_tool("q")
+    assert [s["content"] for s in cot["response"]["reasoning"]] == ["Synthesizer", "Synthesizer"]
+
+
+def test_failure_recovery(monkeypatch, mcp_setup):
+    config = mcp_setup
+    config.reasoning_mode = ReasoningMode.DIALECTICAL
+    client = MCPTestClient()
+    results = client.run_test_suite(["ok", "fail"])
+
+    assert results["connection_test"]["status"] == "success"
+    assert results["research_tests"][0]["result"]["status"] == "success"
+    assert "error" in results["research_tests"][1]["result"]


### PR DESCRIPTION
## Summary
- test MCP workflows with dialectical, direct and chain-of-thought modes
- ensure failure recovery using `MCPTestClient`

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: ModuleNotFoundError: autoresearch.main.models)*
- `uv run pytest tests/behavior -q` *(fails: AssertionError in batch pagination)*

------
https://chatgpt.com/codex/tasks/task_e_6883f8fbfbe8833383cb0016757124ad