### PR TITLE
Add BDD coverage for CLI monitoring, API streaming and UI

### DIFF
--- a/tests/behavior/features/api_streaming_webhook.feature
+++ b/tests/behavior/features/api_streaming_webhook.feature
@@ -1,0 +1,16 @@
+Feature: API Streaming and Webhook Notifications
+  As a developer
+  I want to receive streaming updates or webhook callbacks
+  So that I can integrate Autoresearch with other systems
+
+  Background:
+    Given the Autoresearch application is running
+
+  Scenario: Streaming query responses
+    When I send a streaming query "Stream test" to the API
+    Then the streaming response should contain multiple JSON lines
+
+  Scenario: Webhook notifications on query completion
+    When I send a query with webhook URL "http://hook" to the API
+    Then the request should succeed
+    And the webhook endpoint should be called

--- a/tests/behavior/features/interactive_monitor.feature
+++ b/tests/behavior/features/interactive_monitor.feature
@@ -33,3 +33,13 @@ Feature: Interactive Monitoring
     When I run `autoresearch search "Test graph" --visualize`
     Then the search command should exit successfully
     And the search output should display graph data
+
+  Scenario: Record resource usage
+    When I run `autoresearch monitor resources --duration 1`
+    Then the monitor should exit successfully
+    And the monitor output should display resource usage
+
+  Scenario: Start monitoring service
+    When I run `autoresearch monitor start --interval 0.1`
+    Then the monitor should exit successfully
+    And the monitor output should indicate it started

--- a/tests/behavior/features/query_interface.feature
+++ b/tests/behavior/features/query_interface.feature
@@ -25,3 +25,7 @@ Feature: Query Interface
   Scenario: Visualize query results via CLI
     When I run `autoresearch visualize "What is Promise Theory?" graph.png`
     Then the visualization file "graph.png" should exist
+
+  Scenario: Visualize RDF graph via CLI
+    When I run `autoresearch visualize-rdf rdf_graph.png`
+    Then the visualization file "rdf_graph.png" should exist

--- a/tests/behavior/features/ui_accessibility.feature
+++ b/tests/behavior/features/ui_accessibility.feature
@@ -56,3 +56,9 @@ Feature: UI Accessibility
     When I open the page for the first time
     Then a guided tour modal should describe the main features
     And I should be able to dismiss the tour
+
+  @requires_ui
+  Scenario: Skip to content link
+    Given the Streamlit application is running
+    When I load the Streamlit page
+    Then a skip to main content link should be present

--- a/tests/behavior/steps/api_streaming_steps.py
+++ b/tests/behavior/steps/api_streaming_steps.py
@@ -1,0 +1,74 @@
+# flake8: noqa
+from pytest_bdd import scenario, when, then, parsers
+from unittest.mock import patch
+import responses
+
+from .common_steps import *  # noqa: F401,F403
+from fastapi.testclient import TestClient
+from autoresearch.api import app as api_app
+from autoresearch.orchestration.state import QueryState
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.config import ConfigModel, ConfigLoader, APIConfig
+
+
+@when(parsers.parse('I send a streaming query "{query}" to the API'))
+def send_streaming_query(query, monkeypatch, api_client, bdd_context):
+    def dummy_run_query(q, config, callbacks=None, **kwargs):
+        state = QueryState(query=q)
+        if callbacks and "on_cycle_end" in callbacks:
+            callbacks["on_cycle_end"](0, state)
+            callbacks["on_cycle_end"](1, state)
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+
+    cfg = ConfigModel(loops=2, api=APIConfig())
+    cfg.api.role_permissions["anonymous"] = ["query"]
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setattr(Orchestrator, "run_query", dummy_run_query)
+
+    with api_client.stream("POST", "/query?stream=true", json={"query": query}) as resp:
+        bdd_context["stream_status"] = resp.status_code
+        bdd_context["stream_chunks"] = [line for line in resp.iter_lines()]
+
+
+@then("the streaming response should contain multiple JSON lines")
+def check_streaming_lines(bdd_context):
+    assert bdd_context["stream_status"] == 200
+    assert len(bdd_context["stream_chunks"]) >= 3
+
+
+@when(parsers.parse('I send a query with webhook URL "{url}" to the API'))
+def send_query_with_webhook(url, monkeypatch, api_client, bdd_context):
+    cfg = ConfigModel(api=APIConfig(webhook_timeout=1))
+    cfg.api.role_permissions["anonymous"] = ["query"]
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setattr(
+        Orchestrator,
+        "run_query",
+        lambda q, c, callbacks=None, **k: QueryResponse(answer="ok", citations=[], reasoning=[], metrics={}),
+    )
+    with responses.RequestsMock() as rsps:
+        rsps.post(url, status=200)
+        resp = api_client.post("/query", json={"query": "hi", "webhook_url": url})
+        bdd_context["api_status"] = resp.status_code
+        bdd_context["webhook_calls"] = len(rsps.calls)
+
+
+@then("the request should succeed")
+def check_api_success(bdd_context):
+    assert bdd_context["api_status"] == 200
+
+
+@then("the webhook endpoint should be called")
+def check_webhook_called(bdd_context):
+    assert bdd_context["webhook_calls"] == 1
+
+
+@scenario("../features/api_streaming_webhook.feature", "Streaming query responses")
+def test_streaming_query_responses():
+    pass
+
+
+@scenario("../features/api_streaming_webhook.feature", "Webhook notifications on query completion")
+def test_webhook_notifications():
+    pass

--- a/tests/behavior/steps/interactive_monitor_steps.py
+++ b/tests/behavior/steps/interactive_monitor_steps.py
@@ -62,6 +62,52 @@ def run_search_visualize(query, monkeypatch, bdd_context, cli_runner):
     bdd_context["visual_result"] = result
 
 
+@when('I run `autoresearch monitor resources --duration 1`')
+def run_monitor_resources(monkeypatch, bdd_context, cli_runner):
+    class DummyMetrics:
+        def record_system_resources(self):
+            pass
+
+        def get_summary(self):
+            return {
+                "resource_usage": [
+                    {
+                        "timestamp": 0,
+                        "cpu_percent": 10.0,
+                        "memory_mb": 5.0,
+                        "gpu_percent": 0.0,
+                        "gpu_memory_mb": 0.0,
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(
+        "autoresearch.monitor.orch_metrics.OrchestrationMetrics", lambda: DummyMetrics()
+    )
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    result = cli_runner.invoke(
+        cli_app, ["monitor", "resources", "--duration", "1"]
+    )
+    bdd_context["monitor_result"] = result
+
+
+@when('I run `autoresearch monitor start --interval 0.1`')
+def run_monitor_start(monkeypatch, bdd_context, cli_runner):
+    monkeypatch.setattr(
+        "autoresearch.monitor.ResourceMonitor.start", lambda self, prometheus_port=None: None
+    )
+    monkeypatch.setattr("autoresearch.monitor.ResourceMonitor.stop", lambda self: None)
+    monkeypatch.setattr("autoresearch.monitor.SystemMonitor.start", lambda self: None)
+    monkeypatch.setattr("autoresearch.monitor.SystemMonitor.stop", lambda self: None)
+
+    def _raise(_):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr("time.sleep", _raise)
+    result = cli_runner.invoke(cli_app, ["monitor", "start", "--interval", "0.1"])
+    bdd_context["monitor_result"] = result
+
+
 @then("the monitor should exit successfully")
 def monitor_exit_successfully(bdd_context):
     assert bdd_context["monitor_result"].exit_code == 0
@@ -94,6 +140,19 @@ def search_output_contains_graph(bdd_context):
     assert "Answer" in output
 
 
+@then("the monitor output should display resource usage")
+def monitor_output_contains_resources(bdd_context):
+    output = bdd_context["monitor_result"].stdout
+    assert "Resource Usage" in output
+    assert "CPU %" in output
+
+
+@then("the monitor output should indicate it started")
+def monitor_output_started(bdd_context):
+    output = bdd_context["monitor_result"].stdout
+    assert "Monitoring started" in output
+
+
 @scenario("../features/interactive_monitor.feature", "Interactive monitoring")
 def test_interactive_monitor(bdd_context):
     assert bdd_context["monitor_result"].exit_code == 0
@@ -122,3 +181,13 @@ def test_monitor_graph_tui(bdd_context):
 @scenario("../features/interactive_monitor.feature", "Visualize search results")
 def test_search_visualization(bdd_context):
     assert bdd_context["visual_result"].exit_code == 0
+
+
+@scenario("../features/interactive_monitor.feature", "Record resource usage")
+def test_monitor_resources(bdd_context):
+    assert bdd_context["monitor_result"].exit_code == 0
+
+
+@scenario("../features/interactive_monitor.feature", "Start monitoring service")
+def test_monitor_start_service(bdd_context):
+    assert bdd_context["monitor_result"].exit_code == 0

--- a/tests/behavior/steps/query_interface_steps.py
+++ b/tests/behavior/steps/query_interface_steps.py
@@ -83,6 +83,14 @@ def run_visualize_cli(query, file, tmp_path, bdd_context, cli_runner):
     bdd_context["viz_path"] = out
 
 
+@when(parsers.re(r'I run `autoresearch visualize-rdf (?P<file>.+)`'))
+def run_visualize_rdf_cli(file, tmp_path, bdd_context, cli_runner):
+    out = tmp_path / file
+    result = cli_runner.invoke(cli_app, ["visualize-rdf", str(out)])
+    bdd_context["viz_result"] = result
+    bdd_context["viz_path"] = out
+
+
 @then(parsers.parse('the visualization file "{file}" should exist'))
 def check_viz_file(file, bdd_context):
     path = bdd_context["viz_path"]
@@ -130,4 +138,9 @@ def test_interactive_query():
 
 @scenario("../features/query_interface.feature", "Visualize query results via CLI")
 def test_visualize_query():
+    pass
+
+
+@scenario("../features/query_interface.feature", "Visualize RDF graph via CLI")
+def test_visualize_rdf_cli():
     pass

--- a/tests/behavior/steps/ui_accessibility_steps.py
+++ b/tests/behavior/steps/ui_accessibility_steps.py
@@ -79,6 +79,13 @@ def test_guided_tour_availability(bdd_context):
     assert bdd_context.get("tour_modal", False) is True
 
 
+@pytest.mark.slow
+@scenario("../features/ui_accessibility.feature", "Skip to content link")
+def test_skip_link(bdd_context):
+    """Skip link should be present on the page."""
+    assert any("skip-link" in call for call in bdd_context.get("markdown_calls", []))
+
+
 @when("I use the CLI with color output disabled")
 def use_cli_without_color(bdd_context):
     """Simulate using the CLI with color output disabled."""
@@ -398,3 +405,22 @@ def dismiss_tour():
         import streamlit as st
 
         assert st.session_state.show_tour is False
+
+
+@when("I load the Streamlit page")
+def load_streamlit_page(bdd_context):
+    with (
+        patch("streamlit.markdown") as mock_markdown,
+        patch("streamlit.session_state", {}),
+    ):
+        import importlib
+        import autoresearch.streamlit_app as app
+
+        importlib.reload(app)
+
+        bdd_context["markdown_calls"] = [c.args[0] for c in mock_markdown.call_args_list]
+
+
+@then("a skip to main content link should be present")
+def check_skip_link(bdd_context):
+    assert any("skip-link" in call for call in bdd_context.get("markdown_calls", []))


### PR DESCRIPTION
## Summary
- add streaming and webhook feature
- extend interactive monitor feature with resources and start scenarios
- cover CLI `visualize-rdf` command
- test skip link accessibility
- implement step definitions for new scenarios

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `uv run pytest tests/behavior` *(fails: ModuleNotFoundError: No module named 'rdflib')*

------
https://chatgpt.com/codex/tasks/task_e_688404b8a2048333b23b24b2d558a518