### PR TITLE
Fix search test config patch paths

### DIFF
--- a/tests/targeted/test_search_edgecases2.py
+++ b/tests/targeted/test_search_edgecases2.py
@@ -28,6 +28,6 @@ def test_rank_results_weight_error(monkeypatch):
         use_source_credibility = True
 
     cfg = types.SimpleNamespace(search=SCfg())
-    monkeypatch.setattr(search, "get_config", lambda: cfg)
+    monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
     with pytest.raises(ConfigError):
         search.Search.rank_results("q", [{"title": "t", "url": "u"}])

--- a/tests/unit/test_additional_coverage.py
+++ b/tests/unit/test_additional_coverage.py
@@ -79,7 +79,7 @@ def test_http_session_reuse_and_close(monkeypatch):
 
     cfg = Cfg()
     cfg.search = types.SimpleNamespace(http_pool_size=1)
-    monkeypatch.setattr(search, "get_config", lambda: cfg)
+    monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
     search.close_http_session()
     s1 = search.get_http_session()
     s2 = search.get_http_session()


### PR DESCRIPTION
## Summary
- patch config properly in HTTP session reuse test
- patch config properly in search edgecases test

## Testing
- `flake8 src tests`
- `mypy src` *(fails: Error importing plugin 'pydantic.mypy')*
- `pytest -q` *(fails: ModuleNotFoundError: 'autoresearch.main.models')*

------
https://chatgpt.com/codex/tasks/task_e_68841476a7b48333b45f26e52b901ce0