### PR TITLE
Install full dev extras in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See [docs/installation.md](docs/installation.md) for details on optional feature
 and upgrade instructions.
 The `scripts/setup.sh` helper ensures the lock file is current and installs
 all optional extras so development and runtime dependencies are available for
-testing. Run `uv lock` after editing `pyproject.toml` and use `uv sync --all-extras`
+testing. Run `uv lock` after editing `pyproject.toml` and use `uv pip install -e '.[full,dev]'`
 to install the updated dependencies. The test suite works both with and without extras:
 
 - **Without extras** – stub implementations of optional packages like
@@ -38,15 +38,14 @@ to install the updated dependencies. The test suite works both with and without 
   SlowAPI's rate‑limiting middleware. This may change how certain tests
   behave and can make them slower.
 
-Reinstall with `uv sync --all-extras && uv pip install -e .` if you need
+Reinstall with `uv pip install -e '.[full,dev]'` if you need
 to disable extras after running the setup script.
 
 ### Using uv
 Python 3.12 or newer is required. Set up the development environment with:
 ```bash
 uv venv
-uv sync --all-extras
-uv pip install -e .
+uv pip install -e '.[full,dev]'
 ```
 If Python 3.11 is selected, `uv` will fail with a message similar to:
 ```
@@ -465,8 +464,7 @@ Create a virtual environment, run `uv lock` if `pyproject.toml` changed, and ins
 
 ```bash
 uv venv
-uv sync --all-extras
-uv pip install -e .
+uv pip install -e '.[full,dev]'
 ```
 
 Alternatively you can run the helper script:
@@ -475,7 +473,7 @@ Alternatively you can run the helper script:
 ./scripts/setup.sh
 ```
 
-The helper installs all dependencies with `uv sync --all-extras` and
+The helper installs all dependencies with `uv pip install -e '.[full,dev]'` and
 links the package in editable mode. Tools such as `flake8`, `mypy`, `pytest` and `tomli_w`
 are therefore available for development and testing. Tests will run even without
 extras because stub versions of optional packages are bundled, but coverage is
@@ -490,7 +488,7 @@ real behaviour – including SlowAPI rate limiting – is only exercised when th
 extras are installed. Install them with:
 
 ```bash
-uv sync --all-extras
+uv pip install -e '.[full,dev]'
 ```
 
 Execute linting and type checks once the development environment is ready:
@@ -517,7 +515,7 @@ uv run pytest -m slow
 ```
 
 Several unit and integration tests rely on `gitpython` and the DuckDB VSS
-extension. These extras are installed when running `uv sync --all-extras`.
+extension. These extras are installed when running `uv pip install -e '.[full,dev]'`.
 
 All testing commands are wrapped by `task`, which activates the `.venv`
 environment before running each tool.
@@ -554,7 +552,7 @@ and those that rely on optional extras. Install the extras and run pytest
 without filtering the markers:
 
 ```bash
-uv sync --all-extras
+uv pip install -e '.[full,dev]'
 uv run pytest -m "slow or requires_ui or requires_vss"
 ```
 
@@ -564,15 +562,14 @@ Previous versions used Poetry for environment management. `uv` now handles depen
 
 ```bash
 uv venv
-uv sync --all-extras
-uv pip install -e .
+uv pip install -e '.[full,dev]'
 ```
 
 Activate the environment with `source .venv/bin/activate` before running commands.
 
 ### Troubleshooting
 
-- If tests fail with `ModuleNotFoundError`, ensure all dependencies are installed in the virtual environment using `uv sync --all-extras` and `uv pip install -e .`.
+- If tests fail with `ModuleNotFoundError`, ensure all dependencies are installed in the virtual environment using `uv pip install -e '.[full,dev]'`.
 - When starting the API with `uvicorn autoresearch.api:app --reload`, install `uvicorn` if the command is not found and verify that port `8000` is free.
 
 ### Smoke test

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,13 +5,12 @@ Install the development dependencies first:
 
 ```bash
 uv venv
-uv sync --all-extras
-uv pip install -e .
+uv pip install -e '.[full,dev]'
 ```
 Run `uv lock` after modifying dependencies to update `uv.lock` before syncing.
 
 You can alternatively run the helper script. It refreshes the lock file when
-needed, installs all extras with `uv pip install --all-extras` and links the
+needed, installs all extras with `uv pip install -e '.[full,dev]'` and links the
 package in editable mode:
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,8 +10,7 @@ For personal use, run Autoresearch directly on your machine. Install the depende
 
 ```bash
 uv venv
-uv pip install --all-extras
-uv pip install -e .
+uv pip install -e '.[full,dev]'
 autoresearch search "example query"
 ```
 
@@ -34,8 +33,7 @@ FROM python:3.12-slim
 WORKDIR /app
 COPY . /app
 RUN pip install uv \
-    && uv pip install --all-extras \
-    && uv pip install -e .
+    && uv pip install -e '.[full,dev]'
 EXPOSE 8000
 CMD ["uvicorn", "autoresearch.api:app", "--host", "0.0.0.0", "--port", "8000"]
 ```
@@ -145,10 +143,10 @@ extras.
 ## Release workflow
 
 1. Bump the version in `pyproject.toml` and in `autoresearch.__version__`.
-2. Regenerate the lock file and sync dependencies:
+2. Regenerate the lock file and reinstall dependencies:
    ```bash
    uv lock
-   uv sync --all-extras
+   uv pip install -e '.[full,dev]'
    ```
 3. Run the unit and behavior test suites.
 4. Publish a development build to TestPyPI:

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -13,15 +13,14 @@ commands below rely on `uv`.
    ```
 2. Install dependencies including development tools and all optional extras:
    ```bash
-   uv sync --all-extras
-   uv pip install -e .
+   uv pip install -e '.[full,dev]'
    ```
    Run `uv lock` whenever `pyproject.toml` changes so the lock file stays current.
 3. Activate the environment with `source .venv/bin/activate` before running commands.
 
 Several unit and integration tests require `gitpython` and the DuckDB VSS
 extension. Both are installed when you set up the environment with
-`uv pip install --all-extras`.
+`uv pip install -e '.[full,dev]'`.
 
 ## Code Style
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -16,12 +16,11 @@ Autoresearch uses a modular architecture with several key components. The PlantU
 
 ## Installation
 
-Use `uv venv` and `uv pip install --all-extras` to set up a development environment:
+Use `uv venv` and `uv pip install -e '.[full,dev]'` to set up a development environment:
 
 ```bash
 uv venv
-uv pip install --all-extras
-uv pip install -e .
+uv pip install -e '.[full,dev]'
 ```
 
 `hdbscan` is built from source and needs compilation tools. Install `gcc`, `g++`,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,8 +18,7 @@ Use `uv` to manage the environment when working from a clone:
 ```bash
 # Create the virtual environment
 uv venv
-uv sync --all-extras
-uv pip install -e .
+uv pip install -e '.[full,dev]'
 ```
 Run `uv lock` whenever you change `pyproject.toml` to update `uv.lock` before syncing.
 Selecting Python 3.11 results in an error similar to:
@@ -56,7 +55,7 @@ extra needed for the test suite. Tests normally rely on stubbed versions of
 these extras, so running the suite without them is recommended. Extras such as
 `slowapi` may enable real behaviour (like rate limiting) that changes how
 assertions are evaluated. If you wish to revert to stub-only testing after
-running the helper, reinstall using `uv pip install --all-extras`. Optional
+running the helper, reinstall using `uv pip install -e '.[full,dev]'`. Optional
 features are disabled when their dependencies are missing. Specify extras
 explicitly with pip to enable additional features, e.g. ``pip install "autoresearch[minimal,nlp]"``.
 
@@ -117,8 +116,8 @@ long time or fail on low-memory machines.
 - If compilation hangs or exhausts memory, set `HDBSCAN_NO_OPENMP=1` to
   disable OpenMP optimizations.
 - Consider installing a pre-built wheel with `pip install hdbscan` prior
-  to running `uv pip install --all-extras`.
-- You can also omit heavy extras by removing `--all-extras` from the
-  install command when rapid setup is more important than optional
-  features.
+  to running `uv pip install -e '.[full,dev]'`.
+- You can omit heavy extras by specifying only the groups you need,
+  e.g. `uv pip install -e '.[minimal]'` when rapid setup is more important
+  than optional features.
 

--- a/docs/quickstart_guides.md
+++ b/docs/quickstart_guides.md
@@ -9,8 +9,7 @@ This document provides quickstart guides for each interface type of the Autorese
 ```bash
 # Install with uv (recommended)
 uv venv
-uv pip install --all-extras
-uv pip install -e .
+uv pip install -e '.[full,dev]'
 
 # Alternatively, use pip
 pip install autoresearch

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -290,7 +290,7 @@ accessibility, and log messages.
 
 ## Optional extras for tests
 
-The default development install (`uv pip install --all-extras`) does not
+The default development install (`uv pip install -e '.[full,dev]'`) does not
 include all optional extras. The full test suite uses several features
 that rely on these extras:
 

--- a/docs/ui_testing_procedures.md
+++ b/docs/ui_testing_procedures.md
@@ -31,8 +31,7 @@ cd autoresearch
 
 # Install dependencies with uv
 uv venv
-uv pip install --all-extras
-uv pip install -e .
+uv pip install -e '.[full,dev]'
 
 # Alternatively, use pip
 pip install -e ".[dev]"
@@ -453,8 +452,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-        uv pip install --all-extras
-        uv pip install -e .
+        uv pip install -e '.[full,dev]'
     - name: Run tests
       run: |
         pytest --cov=autoresearch

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Create a Python 3.12+ virtual environment and install dependencies with uv
+# Create a Python 3.12+ virtual environment and install all extras in editable mode
 uv venv
-uv pip install --all-extras
-uv pip install -e .
+uv pip install -e '.[full,dev]'
 
 # Create extensions directory if it doesn't exist
 mkdir -p extensions


### PR DESCRIPTION
## Summary
- install all extras with dev tools in editable mode
- document new install command across README and guides

## Testing
- `./scripts/setup.sh`
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: ModuleNotFoundError)*
- `uv run pytest tests/behavior` *(fails: assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_68841481ec24833384ac72bfbb2ea844