### PR TITLE
Fix QueryResponse import and patchable SearchContext

### DIFF
--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -385,7 +385,7 @@ def search(
             visualize_metrics_cli(result.metrics)
     except Exception as e:
         # Create a valid QueryResponse object with error information
-        from .models import QueryResponse
+        from ..models import QueryResponse
 
         # Get error information with suggestions and code examples
         error_info = get_error_info(e)

--- a/src/autoresearch/search/__init__.py
+++ b/src/autoresearch/search/__init__.py
@@ -1,7 +1,13 @@
 """Search subpackage."""
 
 from .core import Search
-from .context import SearchContext
+from .context import (
+    SearchContext,
+    SPACY_AVAILABLE,
+    BERTOPIC_AVAILABLE,
+    SENTENCE_TRANSFORMERS_AVAILABLE,
+    spacy,
+)
 from .http import get_http_session, set_http_session, close_http_session, _http_session
 from ..config import get_config
 
@@ -13,4 +19,8 @@ __all__ = [
     "close_http_session",
     "_http_session",
     "get_config",
+    "SPACY_AVAILABLE",
+    "BERTOPIC_AVAILABLE",
+    "SENTENCE_TRANSFORMERS_AVAILABLE",
+    "spacy",
 ]


### PR DESCRIPTION
## Summary
- fix relative import for QueryResponse in CLI
- expose spaCy status in `autoresearch.search` and defer NLP imports
- make entity extraction fall back to simple tokenization
- reference package-level feature flags in topic modeling

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q tests/unit/test_config_watcher_cleanup.py::test_cli_watcher_cleanup tests/unit/test_config_watcher_cleanup.py::test_api_watcher_cleanup --override-ini addopts=""`

------
https://chatgpt.com/codex/tasks/task_e_688420e985c883339df379aaadbf3507