### PR TITLE
Patch context-aware search tests

### DIFF
--- a/src/autoresearch/search/context.py
+++ b/src/autoresearch/search/context.py
@@ -62,7 +62,7 @@ class SearchContext:
         self._initialize_nlp()
 
     def _initialize_nlp(self) -> None:
-        from . import spacy as pkg_spacy, SPACY_AVAILABLE as pkg_SPACY_AVAILABLE
+        from .context import spacy as pkg_spacy, SPACY_AVAILABLE as pkg_SPACY_AVAILABLE
 
         if not pkg_SPACY_AVAILABLE:
             return
@@ -100,7 +100,7 @@ class SearchContext:
             self._extract_entities(result.get("snippet", ""))
 
     def _extract_entities(self, text: str) -> None:
-        from . import SPACY_AVAILABLE as pkg_SPACY_AVAILABLE
+        from .context import SPACY_AVAILABLE as pkg_SPACY_AVAILABLE
 
         if not pkg_SPACY_AVAILABLE or self.nlp is None:
             for token in text.split():

--- a/tests/unit/test_context_aware_search.py
+++ b/tests/unit/test_context_aware_search.py
@@ -73,8 +73,8 @@ def test_search_context_singleton(reset_search_context):
     assert context1 is context2
 
 
-@patch("autoresearch.search.SPACY_AVAILABLE", True)
-@patch("autoresearch.search.spacy")
+@patch("autoresearch.search.context.SPACY_AVAILABLE", True)
+@patch("autoresearch.search.context.spacy")
 def test_initialize_nlp(mock_spacy, reset_search_context):
     """Test that the NLP model is initialized correctly."""
     # Setup mock
@@ -90,8 +90,8 @@ def test_initialize_nlp(mock_spacy, reset_search_context):
 
 
 @patch.dict(os.environ, {"AUTORESEARCH_AUTO_DOWNLOAD_SPACY_MODEL": "true"})
-@patch("autoresearch.search.SPACY_AVAILABLE", True)
-@patch("autoresearch.search.spacy")
+@patch("autoresearch.search.context.SPACY_AVAILABLE", True)
+@patch("autoresearch.search.context.spacy")
 def test_initialize_nlp_downloads_model_when_env_set(mock_spacy, reset_search_context):
     """spaCy model is downloaded if missing and env var is set."""
     second_load = MagicMock()
@@ -105,8 +105,8 @@ def test_initialize_nlp_downloads_model_when_env_set(mock_spacy, reset_search_co
 
 
 @patch.dict(os.environ, {}, clear=True)
-@patch("autoresearch.search.SPACY_AVAILABLE", True)
-@patch("autoresearch.search.spacy")
+@patch("autoresearch.search.context.SPACY_AVAILABLE", True)
+@patch("autoresearch.search.context.spacy")
 def test_initialize_nlp_no_download_by_default(mock_spacy, reset_search_context):
     """No download occurs if model missing and env var is unset."""
     mock_spacy.load.side_effect = OSError()
@@ -137,7 +137,7 @@ def test_add_to_history(
     assert "timestamp" in context.search_history[0]
 
 
-@patch("autoresearch.search.SPACY_AVAILABLE", True)
+@patch("autoresearch.search.context.SPACY_AVAILABLE", True)
 @patch("autoresearch.search.core.get_config")
 def test_extract_entities(mock_get_config, mock_context_config, reset_search_context):
     """Test entity extraction from text."""
@@ -301,7 +301,7 @@ def test_context_aware_search_disabled(
             mock_context.expand_query.assert_not_called()
 
 
-@patch("autoresearch.search.SPACY_AVAILABLE", False)
+@patch("autoresearch.search.context.SPACY_AVAILABLE", False)
 @patch("autoresearch.search.BERTOPIC_AVAILABLE", False)
 @patch("autoresearch.search.core.get_config")
 def test_expand_query_respects_settings(
@@ -317,7 +317,7 @@ def test_expand_query_respects_settings(
     assert result == "django"
 
 
-@patch("autoresearch.search.SPACY_AVAILABLE", False)
+@patch("autoresearch.search.context.SPACY_AVAILABLE", False)
 @patch("autoresearch.search.BERTOPIC_AVAILABLE", False)
 @patch("autoresearch.search.core.get_config")
 def test_expand_query_expansion_factor(


### PR DESCRIPTION
## Summary
- update tests to patch `autoresearch.search.context` values
- adjust `SearchContext` to import spaCy utilities from the context module

## Testing
- `PYTEST_ADDOPTS="--maxfail=1 --disable-warnings -q --cov=src --cov=tests --cov-report=xml --cov-report=term-missing --cov-fail-under=0 -m 'not slow and not requires_ui and not requires_vss'" uv run pytest tests/unit/test_context_aware_search.py`

------
https://chatgpt.com/codex/tasks/task_e_6884f9f736808333ba28d5822c9aaee7