### PR TITLE
Pin a2a-sdk for pydantic 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.12,<4.0"
 packages = [{include = "autoresearch", from = "src"}]
 dependencies = [
-    "a2a-sdk >=0.2.8",
+    "a2a-sdk >=0.2.16",
     "dspy-ai >=2.6.24",
     "duckdb >=1.3.0",
     "fastapi>=0.115.12",

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,4 @@
+try:
+    import pydantic.root_model  # noqa: F401
+except Exception:
+    pass

--- a/src/autoresearch/__init__.py
+++ b/src/autoresearch/__init__.py
@@ -4,6 +4,19 @@ This package provides a local-first research assistant with multiple
 interfaces and a modular architecture.
 """
 
+# Ensure compatibility with libraries that expect ``pydantic.root_model`` to be
+# loaded (e.g. ``a2a-sdk`` with Pydantic 2). Explicitly import the module and
+# register it in ``sys.modules`` to avoid `KeyError` issues during model
+# creation.
+import importlib
+import sys
+
+try:  # pragma: no cover - best effort patch
+    module = importlib.import_module("pydantic.root_model")
+    sys.modules.setdefault("pydantic.root_model", module)
+except Exception:  # pragma: no cover
+    pass
+
 __version__ = "0.1.0"
 
 try:  # pragma: no cover - optional distributed extras

--- a/src/autoresearch/a2a_interface.py
+++ b/src/autoresearch/a2a_interface.py
@@ -19,6 +19,13 @@ from threading import Thread
 import httpx
 import uvicorn
 
+# Import ``pydantic.root_model`` early to avoid compatibility issues when the
+# A2A SDK uses generics with Pydantic 2.
+try:  # pragma: no cover - runtime import patch
+    import pydantic.root_model  # noqa: F401
+except Exception:  # pragma: no cover - best effort
+    pass
+
 try:
     from a2a.client import A2AClient as SDKA2AClient
 

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ vss = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.2.8" },
+    { name = "a2a-sdk", specifier = ">=0.2.16" },
     { name = "bertopic", marker = "extra == 'full'", specifier = ">=0.17.3" },
     { name = "bertopic", marker = "extra == 'nlp'", specifier = ">=0.17.3" },
     { name = "cibuildwheel", marker = "extra == 'dev'", specifier = ">=3.0.1" },


### PR DESCRIPTION
## Summary
- pin a2a-sdk >=0.2.16
- load pydantic.root_model early for compatibility
- add sitecustomize helper

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: KeyError: 'pydantic.root_model')*

------
https://chatgpt.com/codex/tasks/task_e_68852ad9af188333994f000fa3f8eff8