### PR TITLE
Guard Ray shutdown in executors

### DIFF
--- a/src/autoresearch/distributed/executors.py
+++ b/src/autoresearch/distributed/executors.py
@@ -176,7 +176,8 @@ class RayExecutor:
                 self.result_broker.shutdown()
             except Exception as e:
                 log.warning("Failed to shutdown result broker", exc_info=e)
-        ray.shutdown()
+        if ray and hasattr(ray, "shutdown"):
+            ray.shutdown()
 
 
 class ProcessExecutor:

--- a/tests/behavior/steps/distributed_execution_steps.py
+++ b/tests/behavior/steps/distributed_execution_steps.py
@@ -97,6 +97,7 @@ def run_distributed_query(bdd_context):
     executor = executor_cls(cfg)
     resp = executor.run_query("q")
     assert isinstance(resp, QueryResponse)
+    os.environ["RAY_IGNORE_UNHANDLED_ERRORS"] = "1"
     executor.shutdown()
     bdd_context["response"] = resp
 

--- a/tests/integration/test_distributed_agent_storage.py
+++ b/tests/integration/test_distributed_agent_storage.py
@@ -38,6 +38,7 @@ def test_distributed_storage_with_executor(tmp_path, monkeypatch):
     executor = RayExecutor(cfg)
     executor.run_query("q")
     assert len(set(pids)) > 1
+    os.environ["RAY_IGNORE_UNHANDLED_ERRORS"] = "1"
     executor.shutdown()
     StorageManager.setup(str(tmp_path / "kg.duckdb"))
     conn = StorageManager.get_duckdb_conn()

--- a/tests/integration/test_distributed_results.py
+++ b/tests/integration/test_distributed_results.py
@@ -38,5 +38,6 @@ def test_result_aggregation_multi_process(monkeypatch):
     assert isinstance(resp, QueryResponse)
     assert len(set(pids)) > 1
     assert len(executor.result_aggregator.results) == len(cfg.agents)
+    os.environ["RAY_IGNORE_UNHANDLED_ERRORS"] = "1"
     executor.shutdown()
     ray.shutdown()

--- a/tests/integration/test_distributed_storage.py
+++ b/tests/integration/test_distributed_storage.py
@@ -33,6 +33,7 @@ def test_distributed_storage(tmp_path):
     broker.publish({"action": "stop"})
     coordinator.join()
     broker.shutdown()
+    os.environ["RAY_IGNORE_UNHANDLED_ERRORS"] = "1"
     ray.shutdown()
 
     StorageManager.setup(str(tmp_path / "kg.duckdb"))

--- a/tests/unit/test_agent_communication.py
+++ b/tests/unit/test_agent_communication.py
@@ -49,7 +49,11 @@ def test_agent_registry_coalitions():
 def test_orchestrator_handles_coalitions(monkeypatch, tmp_path):
     AgentFactory.register("A1", SimpleAgent)
     AgentFactory.register("A2", SimpleAgent)
-    cfg = ConfigModel(agents=["team"], loops=1, coalitions={"team": ["A1", "A2"]})
+    cfg = ConfigModel.model_validate({
+        "agents": ["team"],
+        "loops": 1,
+        "coalitions": {"team": ["A1", "A2"]},
+    })
     executed: list[str] = []
 
     def fake_get(name):


### PR DESCRIPTION
## Summary
- guard `ray.shutdown()` with an attribute check
- silence Ray unhandled error warnings in distributed tests
- adjust unit test for coalition handling

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'ray.dag')*

------
https://chatgpt.com/codex/tasks/task_e_688541b9d8848333b5c628c92735eef9