### PR TITLE
Fix ConfigModel parsing in tests

### DIFF
--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -356,11 +356,17 @@ class ConfigModel(BaseSettings):
     )
     distributed_config: DistributedConfig = Field(default_factory=DistributedConfig)
 
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ConfigModel":
+        """Create a configuration instance from a dictionary without env parsing."""
+        return cls.__pydantic_validator__.validate_python(data)
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
         env_nested_delimiter="__",
         extra="ignore",
+        cli_parse_args=False,
     )
 
     @field_validator("reasoning_mode", mode="before")

--- a/tests/integration/test_api_additional.py
+++ b/tests/integration/test_api_additional.py
@@ -8,7 +8,7 @@ import time
 
 
 def _setup(monkeypatch):
-    cfg = ConfigModel()
+    cfg = ConfigModel(_env_file=None, _cli_parse_args=[])
     # allow all permissions for anonymous for simplicity
     cfg.api.role_permissions["anonymous"] = ["query", "metrics", "capabilities"]
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)

--- a/tests/unit/test_agent_communication.py
+++ b/tests/unit/test_agent_communication.py
@@ -49,11 +49,13 @@ def test_agent_registry_coalitions():
 def test_orchestrator_handles_coalitions(monkeypatch, tmp_path):
     AgentFactory.register("A1", SimpleAgent)
     AgentFactory.register("A2", SimpleAgent)
-    cfg = ConfigModel.model_validate({
-        "agents": ["team"],
-        "loops": 1,
-        "coalitions": {"team": ["A1", "A2"]},
-    })
+    cfg = ConfigModel(
+        agents=["team"],
+        loops=1,
+        coalitions={"team": ["A1", "A2"]},
+        _env_file=None,
+        _cli_parse_args=[],
+    )
     executed: list[str] = []
 
     def fake_get(name):


### PR DESCRIPTION
## Summary
- add `ConfigModel.from_dict` helper using pydantic validator
- disable CLI arg parsing in `ConfigModel` model config
- instantiate configs directly in tests with explicit `_env_file` and `_cli_parse_args` parameters

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit/test_agent_communication.py::test_orchestrator_handles_coalitions -q`


------
https://chatgpt.com/codex/tasks/task_e_688566a19d688333b0c82e7df8508532