### PR TITLE
Replace Poetry commands in behavior README

### DIFF
--- a/tests/behavior/README.md
+++ b/tests/behavior/README.md
@@ -7,10 +7,10 @@ setup.
 ## Installing extras
 
 Behavior tests rely on optional features such as the Streamlit UI and the DuckDB
-VSS extension. Install all extras to ensure every scenario can run:
+VSS extension. Install all extras with **uv** before running the scenarios:
 
 ```bash
-poetry install --with dev --all-extras
+uv pip install -e '.[full,dev]'
 ```
 
 ## Running extra tests
@@ -21,13 +21,13 @@ run the entire suite. `requires_ui` scenarios need the `ui` extra while
 
 ```bash
 # Scenarios that need the UI extra
-poetry run pytest tests/behavior -m requires_ui
+uv run pytest tests/behavior -m requires_ui
 
 # Scenarios that need the VSS extra
-poetry run pytest tests/behavior -m requires_vss
+uv run pytest tests/behavior -m requires_vss
 ```
 
 Scenarios with these markers are skipped when the corresponding extras are not
-installed. After installing all extras you may simply run `pytest tests/behavior`
+installed. After installing all extras you may simply run `uv run pytest tests/behavior`
 to execute every scenario.
 


### PR DESCRIPTION
## Summary
- update tests/behavior README to use `uv` commands
- document how to install optional extras with `uv pip install -e '.[full,dev]'`

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: SettingsError)*
- `uv run pytest tests/behavior` *(fails: StorageError)*

------
https://chatgpt.com/codex/tasks/task_e_688579bc790c8333812d6f5613757704