### PR TITLE
Switch to uv build & twine upload

### DIFF
--- a/scripts/publish_dev.py
+++ b/scripts/publish_dev.py
@@ -1,15 +1,33 @@
 #!/usr/bin/env python
 """Publish a development build to the TestPyPI repository."""
+
 from __future__ import annotations
+
+import shutil
 import subprocess
 import sys
+from pathlib import Path
 
-CMD = [
-    "poetry",
-    "publish",
-    "--build",
-    "--repository",
-    "testpypi",
-]
 
-sys.exit(subprocess.call(CMD))
+def main() -> int:
+    """Build the package and upload it to TestPyPI using ``twine``."""
+
+    dist = Path("dist")
+    if dist.exists():
+        shutil.rmtree(dist)
+
+    build_cmd = ["uv", "run", "python", "-m", "build"]
+    if subprocess.call(build_cmd):
+        return 1
+
+    files = [str(p) for p in dist.glob("*") if p.is_file()]
+    if not files:
+        print("No distribution files found in 'dist'")
+        return 1
+
+    upload_cmd = ["uv", "run", "twine", "upload", "--repository", "testpypi", *files]
+    return subprocess.call(upload_cmd)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- use `uv run python -m build` and `uv run twine upload` for TestPyPI publishing

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: SettingsError)*
- `uv run pytest tests/behavior` *(fails: StorageError)*
- `task coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885834ac7188333bdff09ab06c11d47