### PR TITLE
Fix ConfigModel validation in agent communication test

### DIFF
--- a/tests/unit/test_agent_communication.py
+++ b/tests/unit/test_agent_communication.py
@@ -54,7 +54,7 @@ def test_orchestrator_handles_coalitions(monkeypatch, tmp_path):
         loops=1,
         coalitions={"team": ["A1", "A2"]},
         _env_file=None,
-        _cli_parse_args=[],
+        _cli_parse_args=False,
     )
     executed: list[str] = []
 


### PR DESCRIPTION
## Summary
- avoid CLI parsing when initializing `ConfigModel` in the coalition test

## Testing
- `uv run pytest -q -c /dev/null -p no:cov tests/unit/test_agent_communication.py`

------
https://chatgpt.com/codex/tasks/task_e_688588a015b4833392bb0d0d9fed8aef