### PR TITLE
Fix StorageManager path usage in agent message tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,11 +45,17 @@ if "duckdb" not in sys.modules:
     duckdb_stub = types.ModuleType("duckdb")
 
     class _Conn:
+        def __init__(self):
+            self._rows: list = []
+
         def execute(self, *a, **k):
             return self
 
         def fetchall(self):
-            return []
+            return self._rows
+
+        def fetchone(self):
+            return self._rows[0] if self._rows else None
 
         def close(self):
             pass


### PR DESCRIPTION
## Summary
- improve duckdb stub with fetchone support
- configure temporary database path for agent messaging BDD tests

## Testing
- `uv run flake8 src tests`
- `uv run mypy src/autoresearch/storage.py tests/behavior/steps/agent_messages_steps.py`
- `uv run pytest tests/behavior/steps/agent_messages_steps.py::test_agent_message_exchange -q`
- `uv run pytest tests/behavior/steps/agent_messages_steps.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68858daa761c8333bc5ab732ec8391c0