### PR TITLE
Update coverage instructions and Codex setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,8 @@ cython_debug/
 # Autoresearch cache
 cache.json
 
+
+# Codex setup artifacts
+CODEX_ENVIRONMENT_SETUP_FAILED
+kg.duckdb
+rdf_store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   - Install dependencies with `uv pip install -e '.[full,dev]'`.
   - Activate the environment using `source .venv/bin/activate` or prefix commands with `uv pip`.
   - When modifying `pyproject.toml`, regenerate the lock file with `uv lock` before reinstalling.
-  - Codex environments run `scripts/codex_setup.sh`, which delegates to `scripts/setup.sh` and installs all dev dependencies and extras so tools like `flake8`, `mypy`, and `pytest` are available and real rate limits are enforced.
+  - Codex environments run `scripts/codex_setup.sh`, which delegates to `scripts/setup.sh` and installs all dev dependencies and extras so tools like `flake8`, `mypy`, and `pytest` are available and real rate limits are enforced. The setup script also installs [Go Task](https://taskfile.dev) system-wide so `task` commands work out of the box.
   - Confirm dev tools are installed with `uv pip list | grep flake8`.
 
 ## Verification steps
@@ -18,7 +18,7 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 - Verify type hints with `uv run mypy src`.
 - Run the unit suite: `uv run pytest -q`.
 - Execute BDD tests in `tests/behavior`: `uv run pytest tests/behavior`.
-- Run the entire suite with coverage using `task coverage`.
+- Run the entire suite with coverage using `task coverage`. If `task` is unavailable, run `uv run pytest --cov=src` instead.
 
 ## Commit etiquette
 - Keep commits focused and write clear messages detailing your reasoning.

--- a/README.md
+++ b/README.md
@@ -519,14 +519,15 @@ All testing commands are wrapped by `task`, which activates the `.venv`
 environment before running each tool.
 
 Run `task coverage` after installing the extras to execute the full suite with
-coverage enabled.
+coverage enabled. If `task` is not installed you can run `uv run pytest --cov=src`
+to produce a coverage report.
 
 Integration tests can leverage the helper classes in `autoresearch.test_tools`.
 `MCPTestClient` and `A2ATestClient` provide simple interfaces for exercising
 the CLI and API endpoints while capturing formatted results. They are fully
 tested and ship with the package for external use.
 
-Maintain at least 90% test coverage and remove temporary files before submitting a pull request. Use `task coverage` to run the entire suite with coverage enabled. If you run suites separately, prefix each invocation with `coverage run -p` to create partial results, then merge them with `coverage combine` before generating the final report with `coverage html` or `coverage xml`.
+Maintain at least 90% test coverage and remove temporary files before submitting a pull request. Use `task coverage` to run the entire suite with coverage enabled. If `task` is not available, run `uv run pytest --cov=src`. When running suites separately, prefix each invocation with `coverage run -p` to create partial results, then merge them with `coverage combine` before generating the final report with `coverage html` or `coverage xml`.
 
 ### Running all suites together
 

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -6,9 +6,14 @@ echo "Setting up Codex environment..."
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y \
-	build-essential python3-dev python3-venv cmake pkg-config git libssl-dev libffi-dev libxml2-dev libargon2-dev libblas-dev liblapack-dev libopenblas-dev liblmdb-dev libz3-dev libcurl4-openssl-dev
+        build-essential python3-dev python3-venv cmake pkg-config git libssl-dev libffi-dev libxml2-dev libargon2-dev libblas-dev liblapack-dev libopenblas-dev liblmdb-dev libz3-dev libcurl4-openssl-dev
 apt-get clean
 rm -rf /var/lib/apt/lists/*
+
+# Install Go Task for running Taskfile commands if not already installed
+if ! command -v task >/dev/null 2>&1; then
+    curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
+fi
 
 # Run the main setup script to install dev dependencies and extras with uv
 ./scripts/setup.sh


### PR DESCRIPTION
## Summary
- note that `codex_setup.sh` installs Go Task
- document `uv run pytest --cov=src` as an alternative to `task coverage`
- ignore Codex setup artifacts

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: ConfigModel is not subclass of BaseModel)*
- `uv run pytest tests/behavior` *(fails: ConfigModel is not subclass of BaseModel)*
- `uv run pytest --cov=src` *(fails: ConfigModel is not subclass of BaseModel)*

------
https://chatgpt.com/codex/tasks/task_e_688639de269c8333824e70e4788ca9cc