### PR TITLE
Remove Poetry references in docs

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-We welcome contributions via pull requests. Autoresearch now uses **uv** rather than Poetry for environment management.
+We welcome contributions via pull requests. Autoresearch uses **uv** for environment management.
 Install the development dependencies first:
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 Autoresearch can be deployed in several ways depending on your needs. This guide outlines common approaches.
 
-The project switched from Poetry to **uv** for dependency management. Example commands now use `uv`.
+The project uses **uv** for dependency management. Example commands use `uv`.
 
 ## Local Installation
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -2,8 +2,8 @@
 
 This guide describes how to set up a development environment and the expected workflow for contributing changes.
 
-The project now uses **uv** for dependency management instead of Poetry. All
-commands below rely on `uv`.
+The project uses **uv** for dependency management. All commands below rely on
+`uv`.
 
 ## Environment Setup
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,9 +2,7 @@
 
 This guide explains how to install Autoresearch and manage optional features.
 
-Autoresearch recently migrated from **Poetry** to **uv** for dependency
-management. The examples below use `uv`; legacy Poetry instructions are kept in
-[AGENTS.md](../AGENTS.md) for reference.
+Autoresearch uses **uv** for dependency management. The examples below use `uv`.
 
 ## Requirements
 

--- a/docs/ui_testing_procedures.md
+++ b/docs/ui_testing_procedures.md
@@ -20,7 +20,7 @@ Autoresearch uses a multi-layered testing approach for UI components:
 - uv (for dependency management)
 - pytest and pytest-bdd
 
-Autoresearch previously used Poetry. `uv` is now the recommended tool and the commands below reflect this change.
+Autoresearch uses `uv` for dependency management. The commands below use `uv`.
 
 ### Installation
 


### PR DESCRIPTION
## Summary
- drop legacy Poetry sentences from contributor docs
- keep all environment instructions UV-based
- confirm codex_setup.sh only appears in AGENTS.md

## Testing
- `uv run flake8 src tests`
- `uv run mypy src` *(fails: Interrupted)*
- `uv run pytest -q` *(fails: tests failing)*
- `uv run pytest tests/behavior` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688642b8d78483338a3e67e4eed37b5c