### PR TITLE
Add integration and CLI behavior tests

### DIFF
--- a/tests/behavior/features/backup_cli.feature
+++ b/tests/behavior/features/backup_cli.feature
@@ -1,0 +1,5 @@
+Feature: Backup CLI
+  Scenario: Create backup
+    Given a temporary work directory
+    When I run `autoresearch config backup create --dir backups`
+    Then the backup directory should contain a backup file

--- a/tests/behavior/features/capabilities_cli.feature
+++ b/tests/behavior/features/capabilities_cli.feature
@@ -1,0 +1,4 @@
+Feature: Capabilities CLI
+  Scenario: List available capabilities
+    When I run `autoresearch capabilities`
+    Then the CLI should exit successfully

--- a/tests/behavior/features/completion_cli.feature
+++ b/tests/behavior/features/completion_cli.feature
@@ -1,0 +1,4 @@
+Feature: Completion CLI
+  Scenario: Generate shell completion script
+    When I run `autoresearch completion bash`
+    Then the CLI should exit successfully

--- a/tests/behavior/features/config_cli.feature
+++ b/tests/behavior/features/config_cli.feature
@@ -1,0 +1,13 @@
+Feature: Configuration CLI
+  Scenarios covering configuration commands
+
+  Scenario: Initialize configuration files
+    Given a temporary work directory
+    When I run `autoresearch config init --force` in a temporary directory
+    Then the files "autoresearch.toml" and ".env" should be created
+
+  Scenario: Validate configuration files
+    Given a temporary work directory
+    And I run `autoresearch config init --force` in a temporary directory
+    When I run `autoresearch config validate`
+    Then the CLI should exit successfully

--- a/tests/behavior/features/serve_commands.feature
+++ b/tests/behavior/features/serve_commands.feature
@@ -1,0 +1,8 @@
+Feature: Server commands
+  Scenario: Display help for serve
+    When I run `autoresearch serve --help`
+    Then the CLI should exit successfully
+
+  Scenario: Display help for serve-a2a
+    When I run `autoresearch serve-a2a --help`
+    Then the CLI should exit successfully

--- a/tests/behavior/steps/__init__.py
+++ b/tests/behavior/steps/__init__.py
@@ -2,3 +2,8 @@
 
 # Import step modules so pytest-bdd discovers them when running the package.
 from . import distributed_execution_steps  # noqa: F401
+from . import config_cli_steps  # noqa: F401
+from . import backup_cli_steps  # noqa: F401
+from . import serve_cli_steps  # noqa: F401
+from . import completion_cli_steps  # noqa: F401
+from . import capabilities_cli_steps  # noqa: F401

--- a/tests/behavior/steps/backup_cli_steps.py
+++ b/tests/behavior/steps/backup_cli_steps.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from pytest_bdd import scenario, given, when, then, parsers
+
+from autoresearch.main import app as cli_app
+from autoresearch.config import ConfigLoader
+
+
+@given("a temporary work directory", target_fixture="work_dir")
+def work_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    ConfigLoader.reset_instance()
+    return tmp_path
+
+
+@when(parsers.parse('I run `autoresearch config backup create --dir {dir}`'))
+def run_backup_create(dir, cli_runner, bdd_context):
+    result = cli_runner.invoke(cli_app, ["config", "backup", "create", "--dir", dir])
+    bdd_context["result"] = result
+    bdd_context["backup_dir"] = Path(dir)
+
+
+@then("the backup directory should contain a backup file")
+def check_backup(bdd_context, work_dir):
+    backup_dir = work_dir / bdd_context["backup_dir"]
+    assert backup_dir.exists() and any(backup_dir.iterdir())
+    assert bdd_context["result"].exit_code == 0
+
+
+@scenario("../features/backup_cli.feature", "Create backup")
+def test_backup_create():
+    pass

--- a/tests/behavior/steps/capabilities_cli_steps.py
+++ b/tests/behavior/steps/capabilities_cli_steps.py
@@ -1,0 +1,19 @@
+from pytest_bdd import scenario, when, then
+
+from autoresearch.main import app as cli_app
+
+
+@when("I run `autoresearch capabilities`")
+def run_capabilities(cli_runner, bdd_context):
+    result = cli_runner.invoke(cli_app, ["capabilities"])
+    bdd_context["result"] = result
+
+
+@then("the CLI should exit successfully")
+def cli_success(bdd_context):
+    assert bdd_context["result"].exit_code == 0
+
+
+@scenario("../features/capabilities_cli.feature", "List available capabilities")
+def test_capabilities_cmd():
+    pass

--- a/tests/behavior/steps/cli_options_steps.py
+++ b/tests/behavior/steps/cli_options_steps.py
@@ -28,6 +28,7 @@ def test_parallel_groups(bdd_context):
 
 @when(parsers.re(r'I run `autoresearch search "(?P<query>.+)" --loops (?P<loops>\d+) --token-budget (?P<budget>\d+) --no-ontology-reasoning'))
 def run_with_budget(query, loops, budget, monkeypatch, cli_runner, bdd_context):
+    ConfigLoader.reset_instance()
     def mock_run_query(q, cfg, callbacks=None):
         bdd_context["cfg"] = cfg
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
@@ -51,6 +52,7 @@ def check_budget_config(bdd_context, loops, budget):
 
 @when(parsers.parse('I run `autoresearch search "{query}" --agents {agents}`'))
 def run_with_agents(query, agents, monkeypatch, cli_runner, bdd_context):
+    ConfigLoader.reset_instance()
     def mock_run_query(q, cfg, callbacks=None):
         bdd_context["cfg"] = cfg
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
@@ -71,6 +73,7 @@ def check_agents_config(bdd_context, agents):
 
 @when(parsers.parse('I run `autoresearch search --parallel --agent-groups "{g1}" "{g2}" "{query}"'))
 def run_parallel_cli(g1, g2, query, monkeypatch, cli_runner, bdd_context):
+    ConfigLoader.reset_instance()
     groups = [[a.strip() for a in g1.split(",")], [a.strip() for a in g2.split(",")]]
 
     def mock_parallel(q, cfg, agent_groups):

--- a/tests/behavior/steps/completion_cli_steps.py
+++ b/tests/behavior/steps/completion_cli_steps.py
@@ -1,0 +1,19 @@
+from pytest_bdd import scenario, when, then
+
+from autoresearch.main import app as cli_app
+
+
+@when("I run `autoresearch completion bash`")
+def run_completion(cli_runner, bdd_context):
+    result = cli_runner.invoke(cli_app, ["completion", "bash"])
+    bdd_context["result"] = result
+
+
+@then("the CLI should exit successfully")
+def cli_success(bdd_context):
+    assert bdd_context["result"].exit_code == 0
+
+
+@scenario("../features/completion_cli.feature", "Generate shell completion script")
+def test_completion_script():
+    pass

--- a/tests/behavior/steps/config_cli_steps.py
+++ b/tests/behavior/steps/config_cli_steps.py
@@ -1,0 +1,48 @@
+from pytest_bdd import scenario, given, when, then
+
+from autoresearch.main import app as cli_app
+from autoresearch.config import ConfigLoader
+
+
+def pytest_configure(config):  # pragma: no cover - silence unused warning
+    pass
+
+
+@given("a temporary work directory", target_fixture="work_dir")
+def work_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    ConfigLoader.reset_instance()
+    return tmp_path
+
+
+@when("I run `autoresearch config init --force` in a temporary directory")
+def run_config_init(work_dir, cli_runner, bdd_context):
+    result = cli_runner.invoke(cli_app, ["config", "init", "--force"])
+    bdd_context["result"] = result
+
+
+@when("I run `autoresearch config validate`")
+def run_config_validate(cli_runner, bdd_context):
+    result = cli_runner.invoke(cli_app, ["config", "validate"])
+    bdd_context["result"] = result
+
+
+@then('the files "autoresearch.toml" and ".env" should be created')
+def check_config_files(work_dir):
+    assert (work_dir / "autoresearch.toml").exists()
+    assert (work_dir / ".env").exists()
+
+
+@then("the CLI should exit successfully")
+def cli_success(bdd_context):
+    assert bdd_context["result"].exit_code == 0
+
+
+@scenario("../features/config_cli.feature", "Initialize configuration files")
+def test_config_init():
+    pass
+
+
+@scenario("../features/config_cli.feature", "Validate configuration files")
+def test_config_validate():
+    pass

--- a/tests/behavior/steps/configuration_hot_reload_steps.py
+++ b/tests/behavior/steps/configuration_hot_reload_steps.py
@@ -11,6 +11,7 @@ from autoresearch.config import ConfigLoader, ConfigModel
     target_fixture="modify_config_enable_agent",
 )
 def modify_config_enable_agent(file, tmp_path):
+    ConfigLoader.reset_instance()
     loader = ConfigLoader()
     reloaded: list[ConfigModel] = []
 
@@ -49,6 +50,7 @@ def check_agent_visible(check_hot_reload: ConfigModel):
 
 @when("I start the application", target_fixture="start_application")
 def start_application():
+    ConfigLoader.reset_instance()
     loader = ConfigLoader()
     cfg = loader.load_config()
     return cfg

--- a/tests/behavior/steps/dkg_persistence_steps.py
+++ b/tests/behavior/steps/dkg_persistence_steps.py
@@ -489,6 +489,7 @@ def visualize_graph(tmp_path, file):
 def check_visualization(tmp_path, file, viz_path):
     path = viz_path
     assert path.exists() and path.stat().st_size > 0
+    path.unlink()
 
 
 @scenario("../features/dkg_persistence.feature", "Ontology reasoning infers subclass relationships")

--- a/tests/behavior/steps/query_interface_steps.py
+++ b/tests/behavior/steps/query_interface_steps.py
@@ -95,6 +95,7 @@ def run_visualize_rdf_cli(file, tmp_path, bdd_context, cli_runner):
 def check_viz_file(file, bdd_context):
     path = bdd_context["viz_path"]
     assert path.exists() and path.stat().st_size > 0
+    path.unlink()
 
 
 @then(

--- a/tests/behavior/steps/reasoning_parameters_steps.py
+++ b/tests/behavior/steps/reasoning_parameters_steps.py
@@ -17,6 +17,8 @@ def test_adaptive_budget_flags(bdd_context):
 
 @when(parsers.parse('I run `autoresearch search "{query}" --circuit-breaker-threshold {threshold:d} --circuit-breaker-cooldown {cooldown:d} --no-ontology-reasoning'))
 def run_breaker_cli(query, threshold, cooldown, monkeypatch, cli_runner, bdd_context):
+    ConfigLoader.reset_instance()
+
     def mock_run_query(q, cfg, callbacks=None):
         bdd_context["cfg"] = cfg
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
@@ -48,6 +50,8 @@ def check_breaker_config(bdd_context, threshold, cooldown):
 
 @when(parsers.parse('I run `autoresearch search "{query}" --adaptive-max-factor {factor:d} --adaptive-min-buffer {buffer:d} --no-ontology-reasoning'))
 def run_adaptive_cli(query, factor, buffer, monkeypatch, cli_runner, bdd_context):
+    ConfigLoader.reset_instance()
+
     def mock_run_query(q, cfg, callbacks=None):
         bdd_context["cfg"] = cfg
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})

--- a/tests/behavior/steps/serve_cli_steps.py
+++ b/tests/behavior/steps/serve_cli_steps.py
@@ -1,0 +1,30 @@
+from pytest_bdd import scenario, when, then
+
+from autoresearch.main import app as cli_app
+
+
+@when("I run `autoresearch serve --help`")
+def run_serve_help(cli_runner, bdd_context):
+    result = cli_runner.invoke(cli_app, ["serve", "--help"])
+    bdd_context["result"] = result
+
+
+@when("I run `autoresearch serve-a2a --help`")
+def run_a2a_help(cli_runner, bdd_context):
+    result = cli_runner.invoke(cli_app, ["serve-a2a", "--help"])
+    bdd_context["result"] = result
+
+
+@then("the CLI should exit successfully")
+def cli_success(bdd_context):
+    assert bdd_context["result"].exit_code == 0
+
+
+@scenario("../features/serve_commands.feature", "Display help for serve")
+def test_serve_help():
+    pass
+
+
+@scenario("../features/serve_commands.feature", "Display help for serve-a2a")
+def test_serve_a2a_help():
+    pass

--- a/tests/integration/test_config_hot_reload.py
+++ b/tests/integration/test_config_hot_reload.py
@@ -1,0 +1,25 @@
+import time
+import tomli_w
+from autoresearch.config import ConfigLoader
+
+
+def test_config_hot_reload(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = tmp_path / "autoresearch.toml"
+    cfg_path.write_text(tomli_w.dumps({"core": {"loops": 1}}))
+    ConfigLoader.reset_instance()
+    loader = ConfigLoader()
+    events: list[int] = []
+
+    def fake_watch(*paths, stop_event=None):
+        yield {(str(cfg_path), 2)}
+        stop_event.set()
+
+    monkeypatch.setattr("autoresearch.config.watch", fake_watch)
+
+    with loader.watching(lambda c: events.append(c.loops)):
+        loader.load_config()
+        cfg_path.write_text(tomli_w.dumps({"core": {"loops": 2}}))
+        time.sleep(0.1)
+
+    assert events and events[-1] == 2

--- a/tests/integration/test_orchestrator_search_storage.py
+++ b/tests/integration/test_orchestrator_search_storage.py
@@ -1,0 +1,47 @@
+from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
+from autoresearch.config import ConfigModel, ConfigLoader
+from autoresearch.search import Search
+from autoresearch.storage import StorageManager
+from autoresearch.models import QueryResponse
+
+
+def _make_agent(calls, stored):
+    class SearchAgent:
+        def __init__(self, name: str, llm_adapter=None):
+            self.name = name
+
+        def can_execute(self, state, config):  # pragma: no cover - dummy
+            return True
+
+        def execute(self, state, config, **kwargs):
+            results = Search.external_lookup(state.query, max_results=2)
+            for r in results:
+                StorageManager.persist_claim({"id": r["url"], "type": "source", "content": r["title"]})
+                stored.append(r["url"])
+            calls.append(self.name)
+            state.results[self.name] = "ok"
+            state.results["final_answer"] = "done"
+            return {"results": {self.name: "ok"}}
+
+    return SearchAgent("TestAgent")
+
+
+def test_orchestrator_search_storage(monkeypatch):
+    calls: list[str] = []
+    stored: list[str] = []
+    monkeypatch.setattr(Search, "external_lookup", lambda q, max_results=2: [
+        {"title": "Doc1", "url": "u1"},
+        {"title": "Doc2", "url": "u2"},
+    ])
+    monkeypatch.setattr(StorageManager, "persist_claim", lambda claim: stored.append(claim["id"]))
+    monkeypatch.setattr(AgentFactory, "get", lambda name: _make_agent(calls, stored))
+
+    cfg = ConfigModel(agents=["TestAgent"], loops=1)
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+
+    resp = Orchestrator.run_query("q", cfg)
+    assert isinstance(resp, QueryResponse)
+    assert calls == ["TestAgent"]
+    assert stored == ["u1", "u2"]
+    assert resp.answer == "done"


### PR DESCRIPTION
## Summary
- add integration tests for orchestrator interactions and config hot reload
- expand BDD features for CLI commands
- implement step definitions for new features
- ensure better test isolation in existing steps

## Testing
- `uv run flake8 src tests`
- `uv run mypy src` *(failed: environment timed out)*
- `uv run pytest -q` *(failed: ConfigModel SettingsError)*
- `uv run pytest tests/behavior` *(failed: SettingsError in setup)*


------
https://chatgpt.com/codex/tasks/task_e_68866caed6b083339652680424fe78d6