### PR TITLE
Add hybrid search docs and optimize_weights test

### DIFF
--- a/docs/search_backends.md
+++ b/docs/search_backends.md
@@ -1,0 +1,33 @@
+# Configuring Search Backends
+
+Autoresearch can combine results from multiple search backends. By default the
+system merges all responses and ranks them together using a hybrid algorithm
+that mixes BM25 keyword scores, semantic similarity of embeddings and the
+credibility of each source.
+
+Enable or disable backends in the `[search]` section of `autoresearch.toml`:
+
+```toml
+[search]
+backends = ["serper", "local_file", "local_git"]
+embedding_backends = ["duckdb"]
+hybrid_query = true
+```
+
+When `hybrid_query` is `true` every query is converted to a vector embedding in
+addition to regular keyword lookup. Scores from BM25, semantic similarity and
+source credibility are combined according to their weights to produce a unified
+ranking across all backends.
+
+Weights are configured as follows and must sum to `1.0`:
+
+```toml
+[search]
+semantic_similarity_weight = 0.6
+bm25_weight = 0.3
+source_credibility_weight = 0.1
+```
+
+Use `scripts/optimize_search_weights.py` with a labelled evaluation dataset to
+automatically discover good values. The script runs a grid search and updates the
+configuration file with the best-performing weights.

--- a/tests/unit/test_optimize_weights_unit.py
+++ b/tests/unit/test_optimize_weights_unit.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from autoresearch.search import Search
+
+
+def test_optimize_weights_improves_score():
+    data_path = Path(__file__).resolve().parents[1] / "data" / "eval" / "sample_eval.csv"
+    data = Search.load_evaluation_data(data_path)
+    baseline = Search.evaluate_weights((0.5, 0.3, 0.2), data)
+    best, score = Search.optimize_weights(data, step=0.1)
+    assert score >= baseline
+    assert abs(sum(best) - 1.0) < 0.01


### PR DESCRIPTION
## Summary
- document how to configure hybrid ranking of search backends
- add unit test covering `Search.optimize_weights`

## Testing
- `uv run flake8 src tests`
- `timeout 60s uv run mypy src` *(fails: no output)*
- `uv run pytest tests/unit/test_optimize_weights_unit.py -q`
- `uv run pytest tests/behavior -q` *(fails: ConfigModel error)*

------
https://chatgpt.com/codex/tasks/task_e_688677db15a08333a3eae34046b8ee86