### PR TITLE
Fix CLI parsing in ConfigModel

### DIFF
--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -366,8 +366,18 @@ class ConfigModel(BaseSettings):
         env_file_encoding="utf-8",
         env_nested_delimiter="__",
         extra="ignore",
-        cli_parse_args=False,
+        cli_parse_args=None,
     )
+
+    def _settings_build_values(  # type: ignore[override]
+        self,
+        init_kwargs: Dict[str, Any],
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Skip CLI parsing when tests disable it."""
+        if kwargs.get("_cli_parse_args") is False:
+            kwargs["_cli_parse_args"] = None
+        return super()._settings_build_values(init_kwargs, **kwargs)
 
     @field_validator("reasoning_mode", mode="before")
     def validate_reasoning_mode(cls, v: ReasoningMode | str) -> ReasoningMode:


### PR DESCRIPTION
## Summary
- prevent command line parsing during tests by setting `cli_parse_args=None`
- handle `_cli_parse_args=False` to skip CLI parsing

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: ConfigModel is not subclass of BaseModel)*

------
https://chatgpt.com/codex/tasks/task_e_68867ce9973483338286f23d14cefe7f