### PR TITLE
Improve optional Ray support

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,16 @@ if "ray" not in sys.modules:
         shutdown=lambda *a, **k: None,
         remote=_remote,
         get=lambda x: x,
+        put=lambda x: x,
+        ObjectRef=object,
     )
     sys.modules["ray"] = ray_stub
+    dag_mod = types.ModuleType("ray.dag")
+    compiled = types.ModuleType("ray.dag.compiled_dag_node")
+    compiled._shutdown_all_compiled_dags = lambda: None
+    sys.modules.setdefault("ray.dag", dag_mod)
+    sys.modules.setdefault("ray.dag.compiled_dag_node", compiled)
+    ray_stub.dag = dag_mod
 
 # Provide a minimal stub for GitPython used by the Search module
 if "git" not in sys.modules:


### PR DESCRIPTION
## Summary
- allow `executors` to run when Ray isn't installed
- expand the Ray stub used in tests to include `ray.dag`

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: ValidationError for ConfigModel)*
- `uv run pytest tests/behavior` *(fails: ValidationError for ConfigModel)*
- `task coverage` *(fails: ValidationError for ConfigModel)*

------
https://chatgpt.com/codex/tasks/task_e_68868d108dc48333b766732f77c78df8