### PR TITLE
Improve setup reliability and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,14 @@ By participating in this project, you agree to maintain a respectful and inclusi
   task verify
   ```
 
+### Troubleshooting
+
+- **Missing tools**: If commands like `flake8` or `pytest` are not found, make sure the
+  virtual environment is activated with `source .venv/bin/activate`. Reinstall
+  dependencies using `uv pip install -e '.[full,dev]'` if necessary.
+- **Missing `task` command**: Run `which task` to verify Go Task is installed.
+  Re-run `scripts/setup.sh` if the command is unavailable.
+
 ## Code Style Guidelines
 
 Autoresearch follows strict code style guidelines to maintain consistency across the codebase:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Python 3.12 or newer is required. Set up the development environment with:
 ```bash
 uv venv
 uv pip install -e '.[full,dev]'
+source .venv/bin/activate
 ```
 If Python 3.11 is selected, `uv` will fail with a message similar to:
 ```
@@ -463,6 +464,7 @@ Create a virtual environment, run `uv lock` if `pyproject.toml` changed, and ins
 ```bash
 uv venv
 uv pip install -e '.[full,dev]'
+source .venv/bin/activate
 ```
 
 Alternatively you can run the helper script:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 # Create a Python 3.12+ virtual environment and install all extras in editable mode
 uv venv
+# Install locked dependencies along with all optional extras
+uv sync --all-extras
+# Link the project in editable mode so tools are available
 uv pip install -e '.[full,dev]'
 
 # Create extensions directory if it doesn't exist


### PR DESCRIPTION
## Summary
- install extras using `uv sync --all-extras` in `scripts/setup.sh`
- mention activating `.venv` when setting up the dev environment
- add troubleshooting tips for missing tools

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: test_search_visualize_option)*
- `uv run pytest tests/behavior` *(fails: test_one_cycle)*

------
https://chatgpt.com/codex/tasks/task_e_6886c6b51e5083338f9aec401551a2c9