### PR TITLE
Enforce Python 3.12 requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 
 ## Environment setup
 - Use **uv** for dependency management and project interactions.
+  - Python **3.12 or newer** is required. Confirm with `python --version`.
   - Create a virtual environment with `uv venv`.
+    - `scripts/setup.sh` verifies the interpreter and fails if it is too old.
   - Install dependencies with `uv pip install -e '.[full,dev]'`.
   - Activate the environment using `source .venv/bin/activate` or prefix commands with `uv pip`.
   - When modifying `pyproject.toml`, regenerate the lock file with `uv lock` before reinstalling.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,8 +1,27 @@
+# Ensure we are running with Python 3.12 or newer
 #!/usr/bin/env bash
 set -euo pipefail
 
+PYTHON_VERSION=$(python -c 'import sys; print("%d.%d" % sys.version_info[:2])')
+if python - <<'EOF'
+import sys
+sys.exit(0 if sys.version_info >= (3, 12) else 1)
+EOF
+then
+    echo "Using Python $PYTHON_VERSION"
+else
+    echo "Python 3.12 or newer is required. Found $PYTHON_VERSION" >&2
+    exit 1
+fi
+
 # Create a Python 3.12+ virtual environment and install all extras in editable mode
 uv venv
+VENV_PYTHON="./.venv/bin/python"
+"$VENV_PYTHON" - <<'EOF'
+import sys
+if sys.version_info < (3, 12):
+    raise SystemExit(f"uv venv created Python {sys.version.split()[0]}, but >=3.12 is required")
+EOF
 # Install locked dependencies along with all optional extras
 uv sync --all-extras
 # Link the project in editable mode so tools are available


### PR DESCRIPTION
## Summary
- document the Python version requirement in AGENTS.md
- check the interpreter version in setup.sh and fail early if < 3.12

## Testing
- `uv pip install -e '.[full,dev]'`
- `uv run flake8 src tests`
- `uv run mypy src` *(fails: KeyboardInterrupt)*
- `uv run pytest -q` *(fails: KeyboardInterrupt)*
- `uv run pytest tests/behavior` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6886fad3f7c883338cfac5fa6d5de5a3