### PR TITLE
Fix config patching in CLI visualize tests

### DIFF
--- a/tests/behavior/steps/agent_orchestration_steps.py
+++ b/tests/behavior/steps/agent_orchestration_steps.py
@@ -11,7 +11,7 @@ from autoresearch.orchestration import ReasoningMode
 
 @given("the agents Synthesizer, Contrarian, and Fact-Checker are enabled")
 def enable_agents(monkeypatch):
-    config = ConfigModel(agents=["Synthesizer", "Contrarian", "FactChecker"], loops=2)
+    config = ConfigModel.model_construct(agents=["Synthesizer", "Contrarian", "FactChecker"], loops=2)
     monkeypatch.setattr(
         "autoresearch.config.ConfigLoader.load_config", lambda self: config
     )
@@ -23,7 +23,7 @@ def enable_agents(monkeypatch):
     target_fixture="set_loops",
 )
 def set_loops(loops: int, monkeypatch):
-    config = ConfigModel(
+    config = ConfigModel.model_construct(
         agents=["Synthesizer", "Contrarian", "FactChecker"], loops=loops
     )
     monkeypatch.setattr(
@@ -148,7 +148,9 @@ def submit_query_via_cli(query, monkeypatch, cli_runner):
         )
 
     monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
-    cfg = ConfigModel(agents=["Synthesizer", "Contrarian", "Synthesizer"], loops=1)
+    cfg = ConfigModel.model_construct(
+        agents=["Synthesizer", "Contrarian", "Synthesizer"], loops=1
+    )
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     from autoresearch import main as main_mod
 
@@ -200,7 +202,7 @@ def run_two_queries(monkeypatch):
 
     monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
 
-    config = ConfigModel(
+    config = ConfigModel.model_construct(
         agents=["Synthesizer", "Contrarian", "FactChecker"],
         loops=3,
         primus_start=0,


### PR DESCRIPTION
## Summary
- avoid validation errors in CLI visualize test by constructing config directly
- patch dummy storage in CLI visualize test to prevent VSS downloads
- mirror ConfigModel construction fix in BDD step implementations

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit/test_cli_visualize.py::test_search_visualize_option -q`
- `uv run pytest tests/behavior/steps/agent_orchestration_steps.py::test_one_cycle -q`


------
https://chatgpt.com/codex/tasks/task_e_6886faa759248333ac8b634d26da0901