### PR TITLE
Fix coalition execution config

### DIFF
--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -375,8 +375,13 @@ class ConfigModel(BaseSettings):
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Skip CLI parsing when tests disable it."""
-        if kwargs.get("_cli_parse_args") is False:
+        if kwargs.get("_cli_parse_args") in (False, []):
             kwargs["_cli_parse_args"] = None
+        else:
+            # Ensure BaseModel cache is initialized to avoid mismatches during CLI parsing
+            from pydantic._internal._utils import import_cached_base_model
+
+            import_cached_base_model()
         return super()._settings_build_values(init_kwargs, **kwargs)
 
     @field_validator("reasoning_mode", mode="before")

--- a/tests/unit/test_coalition_execution.py
+++ b/tests/unit/test_coalition_execution.py
@@ -27,7 +27,13 @@ def test_coalition_agents_run_together(monkeypatch, tmp_path):
     AgentFactory.register("A", DummyAgent)
     AgentFactory.register("B", DummyAgent)
 
-    cfg = ConfigModel(agents=["team"], loops=1, coalitions={"team": ["A", "B"]})
+    cfg = ConfigModel(
+        agents=["team"],
+        loops=1,
+        coalitions={"team": ["A", "B"]},
+        _env_file=None,
+        _cli_parse_args=[],
+    )
 
     monkeypatch.setattr(
         "autoresearch.orchestration.orchestrator.AgentFactory.get", get_agent


### PR DESCRIPTION
## Summary
- update coalition execution test to supply env file and cli args
- stabilize config initialization when CLI args are disabled

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit/test_coalition_execution.py -q` *(fails: Input should be an instance of ConfigModel)*

------
https://chatgpt.com/codex/tasks/task_e_688794f421348333b6d2e16a63d260b4