### PR TITLE
Add vector_search malformed embedding test

### DIFF
--- a/tests/unit/test_coalition_execution.py
+++ b/tests/unit/test_coalition_execution.py
@@ -27,12 +27,8 @@ def test_coalition_agents_run_together(monkeypatch, tmp_path):
     AgentFactory.register("A", DummyAgent)
     AgentFactory.register("B", DummyAgent)
 
-    cfg = ConfigModel(
-        agents=["team"],
-        loops=1,
-        coalitions={"team": ["A", "B"]},
-        _env_file=None,
-        _cli_parse_args=[],
+    cfg = ConfigModel.from_dict(
+        {"agents": ["team"], "loops": 1, "coalitions": {"team": ["A", "B"]}}
     )
 
     monkeypatch.setattr(

--- a/tests/unit/test_property_vector_search.py
+++ b/tests/unit/test_property_vector_search.py
@@ -4,6 +4,7 @@ import pytest
 
 
 from autoresearch.storage import StorageManager
+from autoresearch.errors import StorageError
 
 
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
@@ -17,8 +18,8 @@ def test_vector_search_calls_backend(monkeypatch, query_embedding, k):
     monkeypatch.setattr("autoresearch.storage._db_backend", backend, raising=False)
     monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
     monkeypatch.setattr(StorageManager, "has_vss", lambda: True)
-
     result = StorageManager.vector_search(query_embedding, k)
+
     backend.vector_search.assert_called_once_with(query_embedding, k)
     assert isinstance(result, list)
 
@@ -33,3 +34,32 @@ def test_vector_search_invalid(monkeypatch, query_embedding, k):
     monkeypatch.setattr(StorageManager, "has_vss", lambda: True)
     with pytest.raises(Exception):
         StorageManager.vector_search(query_embedding, k)
+
+
+@st.composite
+def malformed_embeddings(draw):
+    """Return embeddings containing NaNs or with wrong dimension."""
+    use_nan = draw(st.booleans())
+    if use_nan:
+        size = draw(st.integers(min_value=1, max_value=5))
+        values = draw(st.lists(st.floats(allow_nan=False, allow_infinity=False), min_size=size, max_size=size))
+        index = draw(st.integers(min_value=0, max_value=size - 1))
+        values[index] = float('nan')
+        return values
+    size = draw(st.integers(min_value=1, max_value=5))
+    return draw(st.lists(st.floats(allow_nan=False, allow_infinity=False), min_size=size, max_size=size))
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(malformed_embeddings(), st.integers(min_value=1, max_value=5))
+def test_vector_search_malformed_embedding(monkeypatch, query_embedding, k):
+    backend = MagicMock()
+    backend.vector_search.side_effect = RuntimeError("bad embedding")
+    monkeypatch.setattr("autoresearch.storage._db_backend", backend, raising=False)
+    monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
+    monkeypatch.setattr(StorageManager, "has_vss", lambda: True)
+
+    with pytest.raises(StorageError):
+        StorageManager.vector_search(query_embedding, k)
+
+    backend.vector_search.assert_called_once_with(query_embedding, k)


### PR DESCRIPTION
## Summary
- add property-based test for vector_search error handling
- update coalition execution test to use ConfigModel.from_dict

## Testing
- `flake8 src tests`
- `mypy src`
- `pytest -q` *(fails: ValidationError in ConfigModel)*

------
https://chatgpt.com/codex/tasks/task_e_6887c9f9308083339b814444d94467f0