### PR TITLE
Add evaluation data fixture and flexible LLM adapter

### DIFF
--- a/tests/integration/test_grid_search_optimization.py
+++ b/tests/integration/test_grid_search_optimization.py
@@ -1,11 +1,8 @@
-from pathlib import Path
-
 from autoresearch.search import Search
 
 
-def test_optimize_weights_returns_better_score():
-    data_path = Path(__file__).resolve().parents[1] / "data" / "eval" / "sample_eval.csv"
-    data = Search.load_evaluation_data(data_path)
+def test_optimize_weights_returns_better_score(sample_eval_data):
+    data = sample_eval_data
 
     baseline = Search.evaluate_weights((0.5, 0.3, 0.2), data)
     best, score = Search.optimize_weights(data, step=0.1)

--- a/tests/integration/test_search_weights.py
+++ b/tests/integration/test_search_weights.py
@@ -9,15 +9,14 @@ import pytest
 pytestmark = pytest.mark.slow
 
 
-def test_optimize_script_updates_weights(tmp_path):
-    dataset = Path(__file__).resolve().parents[2] / "examples" / "search_evaluation.csv"
+def test_optimize_script_updates_weights(tmp_path, sample_eval_data):
+    dataset = Path(__file__).resolve().parents[1] / "data" / "eval" / "sample_eval.csv"
     cfg = tmp_path / "cfg.toml"
     cfg.write_text(
         """[search]\nsemantic_similarity_weight = 0.5\nbm25_weight = 0.3\nsource_credibility_weight = 0.2\n"""
     )
 
-    baseline_data = Search.load_evaluation_data(dataset)
-    baseline = Search.evaluate_weights((0.5, 0.3, 0.2), baseline_data)
+    baseline = Search.evaluate_weights((0.5, 0.3, 0.2), sample_eval_data)
 
     script = Path(__file__).resolve().parents[2] / "scripts" / "optimize_search_weights.py"
     subprocess.run(
@@ -31,7 +30,7 @@ def test_optimize_script_updates_weights(tmp_path):
         tuned["bm25_weight"],
         tuned["source_credibility_weight"],
     )
-    tuned_score = Search.evaluate_weights(tuned_weights, baseline_data)
+    tuned_score = Search.evaluate_weights(tuned_weights, sample_eval_data)
 
     assert tuned_score >= baseline
     assert abs(sum(tuned_weights) - 1.0) < 0.01

--- a/tests/unit/test_optimize_weights_unit.py
+++ b/tests/unit/test_optimize_weights_unit.py
@@ -1,11 +1,8 @@
-from pathlib import Path
-
 from autoresearch.search import Search
 
 
-def test_optimize_weights_improves_score():
-    data_path = Path(__file__).resolve().parents[1] / "data" / "eval" / "sample_eval.csv"
-    data = Search.load_evaluation_data(data_path)
+def test_optimize_weights_improves_score(sample_eval_data):
+    data = sample_eval_data
     baseline = Search.evaluate_weights((0.5, 0.3, 0.2), data)
     best, score = Search.optimize_weights(data, step=0.1)
     assert score >= baseline

--- a/tests/unit/test_property_weight_tuning.py
+++ b/tests/unit/test_property_weight_tuning.py
@@ -1,19 +1,12 @@
 import pytest
-from pathlib import Path
 from hypothesis import given, strategies as st
 
 from autoresearch.search import Search
 
 
-def load_data() -> dict:
-    base = Path(__file__).resolve().parents[1]
-    path = base / "data" / "eval" / "sample_eval.csv"
-    return Search.load_evaluation_data(path)
-
-
 @given(st.floats(min_value=0.05, max_value=0.3))
-def test_tune_weights_improves_ndcg(step):
-    data = load_data()
+def test_tune_weights_improves_ndcg(step, sample_eval_data):
+    data = sample_eval_data
     baseline = Search.evaluate_weights((0.5, 0.3, 0.2), data)
     tuned = Search.tune_weights(data, step=step)
     assert pytest.approx(sum(tuned), 0.001) == 1.0


### PR DESCRIPTION
## Summary
- add `sample_eval_data` and `flexible_llm_adapter` fixtures
- use the fixtures in search weight optimization tests

## Testing
- `flake8 src tests`
- `mypy src` *(fails: process interrupted)*
- `pytest -q` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6887d17f487c8333a799ce8eaea9c2ca