### PR TITLE
Add property-based tests for vector search validation

### DIFF
--- a/tests/unit/test_property_vector_search.py
+++ b/tests/unit/test_property_vector_search.py
@@ -26,6 +26,28 @@ def test_vector_search_calls_backend(monkeypatch, query_embedding, k):
 
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(
+    st.lists(
+        st.floats(min_value=-1, max_value=1, allow_nan=False, allow_infinity=False),
+        min_size=2,
+        max_size=10,
+    ),
+    st.integers(min_value=1, max_value=10),
+)
+def test_vector_search_backend_receives_exact(monkeypatch, query_embedding, k):
+    """Backend should receive the exact query embedding and k."""
+    backend = MagicMock()
+    backend.vector_search.return_value = []
+    monkeypatch.setattr("autoresearch.storage._db_backend", backend, raising=False)
+    monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
+    monkeypatch.setattr(StorageManager, "has_vss", lambda: True)
+
+    StorageManager.vector_search(query_embedding, k)
+
+    backend.vector_search.assert_called_once_with(query_embedding, k)
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
     st.one_of(st.none(), st.text(), st.integers(), st.lists(st.text())),
     st.integers(max_value=0)
 )
@@ -63,3 +85,32 @@ def test_vector_search_malformed_embedding(monkeypatch, query_embedding, k):
         StorageManager.vector_search(query_embedding, k)
 
     backend.vector_search.assert_called_once_with(query_embedding, k)
+
+
+@st.composite
+def bad_embeddings(draw):
+    """Generate embeddings with non-numeric items or empty lists."""
+    if draw(st.booleans()):
+        return []
+    size = draw(st.integers(min_value=1, max_value=5))
+    non_numeric = draw(st.text(min_size=1))
+    rest = draw(
+        st.lists(
+            st.one_of(
+                st.floats(min_value=-1, max_value=1, allow_nan=False, allow_infinity=False),
+                st.text(min_size=1),
+                st.none(),
+            ),
+            min_size=size - 1,
+            max_size=size - 1,
+        )
+    )
+    return [non_numeric] + rest
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(bad_embeddings(), st.integers(min_value=1, max_value=5))
+def test_validate_vector_search_params_rejects_malformed(query_embedding, k):
+    """_validate_vector_search_params should reject malformed embeddings."""
+    with pytest.raises(StorageError):
+        StorageManager._validate_vector_search_params(query_embedding, k)


### PR DESCRIPTION
## Summary
- expand property-based tests around StorageManager.vector_search
- ensure backend receives proper parameters
- validate malformed embeddings raise `StorageError`

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: test_coalition_agents_run_together)*
- `uv run pytest --cov=src` *(fails: test_coalition_agents_run_together)*

------
https://chatgpt.com/codex/tasks/task_e_6887fc953aa48333980eaeee3b2744bf