### PR TITLE
Add hypothesis properties for ranking weights

### DIFF
--- a/tests/unit/test_property_ranking_weights.py
+++ b/tests/unit/test_property_ranking_weights.py
@@ -64,6 +64,42 @@ def test_rank_results_sorted(monkeypatch, results, weights):
 
 
 @given(
+    results=st.lists(
+        st.fixed_dictionaries({"title": st.text(min_size=1), "url": st.just("https://example.com")}),
+        min_size=1,
+        max_size=5,
+    ),
+    weights=st.tuples(
+        st.floats(min_value=0, max_value=1),
+        st.floats(min_value=0, max_value=1),
+        st.floats(min_value=0, max_value=1),
+    ).filter(lambda t: sum(t) > 0),
+)
+def test_rank_results_weight_sum_one(monkeypatch, results, weights):
+    w1, w2, w3 = weights
+    total = w1 + w2 + w3
+    w1, w2, w3 = w1 / total, w2 / total, w3 / total
+    cfg = ConfigModel(
+        search=SearchConfig(
+            bm25_weight=w1,
+            semantic_similarity_weight=w2,
+            source_credibility_weight=w3,
+        )
+    )
+
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+
+    monkeypatch.setattr(Search, "calculate_bm25_scores", lambda q, r: [1.0] * len(r))
+    monkeypatch.setattr(Search, "calculate_semantic_similarity", lambda q, r, query_embedding=None: [1.0] * len(r))
+    monkeypatch.setattr(Search, "assess_source_credibility", lambda r: [1.0] * len(r))
+
+    ranked = Search.rank_results("q", results)
+    scores = [res["relevance_score"] for res in ranked]
+    assert scores == sorted(scores, reverse=True)
+
+
+@given(
     backend_results=st.dictionaries(
         st.text(min_size=1, max_size=5),
         st.lists(
@@ -103,3 +139,36 @@ def test_cross_backend_rank_sorted(monkeypatch, backend_results, weights):
     ranked = Search.cross_backend_rank("q", backend_results)
     scores = [res["relevance_score"] for res in ranked]
     assert scores == sorted(scores, reverse=True)
+
+
+@given(
+    results=st.lists(
+        st.fixed_dictionaries({"title": st.text(min_size=1), "url": st.just("https://example.com")}),
+        min_size=1,
+        max_size=5,
+    ),
+    weights=st.tuples(
+        st.floats(min_value=0, max_value=1),
+        st.floats(min_value=0, max_value=1),
+        st.floats(min_value=0, max_value=1),
+    ).filter(lambda t: abs(sum(t) - 1.0) > 0.001),
+)
+def test_rank_results_invalid_sum(monkeypatch, results, weights):
+    w1, w2, w3 = weights
+    cfg = ConfigModel.model_construct(
+        search=SearchConfig.model_construct(
+            bm25_weight=w1,
+            semantic_similarity_weight=w2,
+            source_credibility_weight=w3,
+        )
+    )
+
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+
+    monkeypatch.setattr(Search, "calculate_bm25_scores", lambda q, r: [1.0] * len(r))
+    monkeypatch.setattr(Search, "calculate_semantic_similarity", lambda q, r, query_embedding=None: [1.0] * len(r))
+    monkeypatch.setattr(Search, "assess_source_credibility", lambda r: [1.0] * len(r))
+
+    with pytest.raises(ConfigError):
+        Search.rank_results("q", results)


### PR DESCRIPTION
## Summary
- extend property-based tests for `Search.rank_results` with weight triples normalized to sum to one
- verify ConfigError is raised when ranking weights sum outside the allowed tolerance

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: ConfigModel ValidationError)*
- `uv run pytest tests/behavior` *(fails: loops parsed as string)*

------
https://chatgpt.com/codex/tasks/task_e_6887fc88c9388333841150540ad786f0