### PR TITLE
Expand BDD scenarios for CLI and API

### DIFF
--- a/tests/behavior/features/api_misc.feature
+++ b/tests/behavior/features/api_misc.feature
@@ -1,0 +1,13 @@
+Feature: Misc API endpoints
+  Background:
+    Given the API server is running
+
+  Scenario: Health endpoint returns status
+    When I request the health endpoint
+    Then the response status should be 200
+    And the response body should contain "status" "ok"
+
+  Scenario: Capabilities endpoint lists reasoning modes
+    When I request the capabilities endpoint
+    Then the response status should be 200
+    And the response should include supported reasoning modes

--- a/tests/behavior/features/backup_cli.feature
+++ b/tests/behavior/features/backup_cli.feature
@@ -3,3 +3,14 @@ Feature: Backup CLI
     Given a temporary work directory
     When I run `autoresearch config backup create --dir backups`
     Then the backup directory should contain a backup file
+
+  Scenario: List backups
+    Given a temporary work directory
+    When I run `autoresearch config backup list --dir backups`
+    Then the CLI should exit successfully
+
+  Scenario: Restore backup
+    Given a temporary work directory
+    And a dummy backup file "backups/test.tar"
+    When I run `autoresearch config backup restore backups/test.tar --dir restore --force`
+    Then the CLI should exit successfully

--- a/tests/behavior/features/reasoning_mode.feature
+++ b/tests/behavior/features/reasoning_mode.feature
@@ -28,3 +28,11 @@ Feature: Reasoning Mode Selection
     Then the loops used should be 1
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     Then the agents executed should be "Contrarian, FactChecker, Synthesizer"
+
+  Scenario: Dialectical reasoning with a realistic query
+    Given loops is set to 1 in configuration
+    And reasoning mode is "dialectical"
+    When I run the orchestrator on query "Why is the sky blue?"
+    Then the loops used should be 1
+    And the agent groups should be "Synthesizer; Contrarian; FactChecker"
+    Then the agents executed should be "Synthesizer, Contrarian, FactChecker"

--- a/tests/behavior/steps/agent_orchestration_steps.py
+++ b/tests/behavior/steps/agent_orchestration_steps.py
@@ -258,3 +258,11 @@ def test_reasoning_chain():
 )
 def test_reasoning_dialectical():
     pass
+
+
+@scenario(
+    "../features/reasoning_mode.feature",
+    "Dialectical reasoning with a realistic query",
+)
+def test_reasoning_realistic():
+    pass

--- a/tests/behavior/steps/api_misc_steps.py
+++ b/tests/behavior/steps/api_misc_steps.py
@@ -1,0 +1,41 @@
+from pytest_bdd import scenario, when, then
+from autoresearch.config import ConfigModel, ConfigLoader, APIConfig
+
+
+@when("I request the health endpoint")
+def request_health(test_context):
+    client = test_context["client"]
+    resp = client.get("/health")
+    test_context["response"] = resp
+
+
+@then('the response body should contain "status" "ok"')
+def check_health_body(test_context):
+    assert test_context["response"].json() == {"status": "ok"}
+
+
+@when("I request the capabilities endpoint")
+def request_capabilities(test_context, monkeypatch):
+    cfg = ConfigModel(api=APIConfig())
+    cfg.api.role_permissions["anonymous"].append("capabilities")
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    resp = test_context["client"].get("/capabilities")
+    test_context["response"] = resp
+
+
+@then("the response should include supported reasoning modes")
+def check_capabilities(test_context):
+    data = test_context["response"].json()
+    assert "reasoning_modes" in data
+    for mode in ["direct", "dialectical", "chain-of-thought"]:
+        assert mode in data["reasoning_modes"]
+
+
+@scenario("../features/api_misc.feature", "Health endpoint returns status")
+def test_health_endpoint():
+    pass
+
+
+@scenario("../features/api_misc.feature", "Capabilities endpoint lists reasoning modes")
+def test_capabilities_endpoint():
+    pass

--- a/tests/behavior/steps/backup_cli_steps.py
+++ b/tests/behavior/steps/backup_cli_steps.py
@@ -1,8 +1,10 @@
 from pathlib import Path
+from datetime import datetime
 from pytest_bdd import scenario, given, when, then, parsers
 
 from autoresearch.main import app as cli_app
 from autoresearch.config import ConfigLoader
+from autoresearch.storage_backup import BackupManager, BackupInfo
 
 
 @given("a temporary work directory", target_fixture="work_dir")
@@ -12,11 +14,54 @@ def work_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
+@given(parsers.parse('a dummy backup file "{path}"'))
+def dummy_backup_file(work_dir, path):
+    file_path = work_dir / path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("dummy")
+    return file_path
+
+
 @when(parsers.parse('I run `autoresearch config backup create --dir {dir}`'))
 def run_backup_create(dir, cli_runner, bdd_context):
     result = cli_runner.invoke(cli_app, ["config", "backup", "create", "--dir", dir])
     bdd_context["result"] = result
     bdd_context["backup_dir"] = Path(dir)
+
+
+@when(parsers.parse('I run `autoresearch config backup list --dir {dir}`'))
+def run_backup_list(dir, cli_runner, bdd_context, monkeypatch):
+    monkeypatch.setattr(
+        BackupManager,
+        "list_backups",
+        lambda d: [
+            BackupInfo(
+                path=f"{dir}/dummy.tar",
+                timestamp=datetime.now(),
+                compressed=True,
+                size=10,
+            )
+        ],
+    )
+    result = cli_runner.invoke(cli_app, ["config", "backup", "list", "--dir", dir])
+    bdd_context["result"] = result
+
+
+@when(parsers.parse('I run `autoresearch config backup restore {path} --dir {dir} --force`'))
+def run_backup_restore(path, dir, cli_runner, bdd_context, monkeypatch):
+    monkeypatch.setattr(
+        BackupManager,
+        "restore_backup",
+        lambda backup_path, target_dir=None, db_filename="db.duckdb", rdf_filename="store.rdf": {
+            "db_path": "db.duckdb",
+            "rdf_path": "store.rdf",
+        },
+    )
+    result = cli_runner.invoke(
+        cli_app,
+        ["config", "backup", "restore", path, "--dir", dir, "--force"],
+    )
+    bdd_context["result"] = result
 
 
 @then("the backup directory should contain a backup file")
@@ -26,6 +71,21 @@ def check_backup(bdd_context, work_dir):
     assert bdd_context["result"].exit_code == 0
 
 
+@then("the CLI should exit successfully")
+def cli_success(bdd_context):
+    assert bdd_context["result"].exit_code == 0
+
+
 @scenario("../features/backup_cli.feature", "Create backup")
 def test_backup_create():
+    pass
+
+
+@scenario("../features/backup_cli.feature", "List backups")
+def test_backup_list():
+    pass
+
+
+@scenario("../features/backup_cli.feature", "Restore backup")
+def test_backup_restore_scenario():
     pass


### PR DESCRIPTION
## Summary
- add more backup management scenarios
- cover health and capabilities API endpoints
- test dialectical reasoning with a realistic query
- mock backup operations in BDD tests

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: ConfigError)*
- `uv run pytest tests/behavior` *(fails: ConfigError)*

------
https://chatgpt.com/codex/tasks/task_e_68884d3873dc8333b92f935ad87ef108