### PR TITLE
Ensure Python 3.12 requirement is explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,15 @@ schedule and outstanding tasks.
 
 ## Installation
 
-Autoresearch requires **Python 3.12 or newer**. The project recently transitioned
-from **Poetry** to [**uv**](https://github.com/astral-sh/uv) for dependency
-management. You can install the project using `uv` or plain **pip**.
+Autoresearch requires **Python 3.12 or newer**. The `scripts/setup.sh` helper
+invokes `python3.12` directly when checking the interpreter version, so make
+sure it is available on your `PATH`. On Debian/Ubuntu systems install it with
+`sudo apt-get install python3.12 python3.12-venv`. If you manage multiple
+interpreters via pyenv or another tool, specify the path when creating the
+environment, e.g. `uv venv -p python3.12`.
+The project recently transitioned from **Poetry** to
+[**uv**](https://github.com/astral-sh/uv) for dependency management. You can
+install the project using `uv` or plain **pip**.
 See [docs/installation.md](docs/installation.md) for details on optional features
 and upgrade instructions.
 The `scripts/setup.sh` helper ensures the lock file is current and installs

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,8 +2,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PYTHON_VERSION=$(python -c 'import sys; print("%d.%d" % sys.version_info[:2])')
-if python - <<'EOF'
+PYTHON_VERSION=$(python3.12 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
+if python3.12 - <<'EOF'
 import sys
 sys.exit(0 if sys.version_info >= (3, 12) else 1)
 EOF


### PR DESCRIPTION
## Summary
- enforce interpreter check in `scripts/setup.sh` with `python3.12`
- clarify Python 3.12 availability in installation docs

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: ConfigError)*
- `uv run pytest tests/behavior` *(fails: 1 error)*
- `task coverage` *(fails: ConfigError)*

------
https://chatgpt.com/codex/tasks/task_e_6888eb2850bc8333884854e21ac69d25