### PR TITLE
Fix ConfigModel init in coalition test

### DIFF
--- a/tests/unit/test_coalition_execution.py
+++ b/tests/unit/test_coalition_execution.py
@@ -27,8 +27,8 @@ def test_coalition_agents_run_together(monkeypatch, tmp_path):
     AgentFactory.register("A", DummyAgent)
     AgentFactory.register("B", DummyAgent)
 
-    cfg = ConfigModel.model_construct(
-        loops=1, agents=["team"], coalitions={"team": ["A", "B"]}
+    cfg = ConfigModel.from_dict(
+        {"loops": 1, "agents": ["team"], "coalitions": {"team": ["A", "B"]}}
     )
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- use `ConfigModel.from_dict` in `test_coalition_execution`

## Testing
- `uv run pytest -q tests/unit/test_coalition_execution.py::test_coalition_agents_run_together --no-cov -s`
- `uv run flake8 src tests`
- `uv run mypy src` *(fails: Interrupted)*
- `uv run pytest tests/behavior -q --no-cov` *(fails: TypeError: 'str' object cannot be interpreted as an integer)*

------
https://chatgpt.com/codex/tasks/task_e_6889039b7c3c833389d57cc2985507b4