### PR TITLE
Add integration tests and benchmark task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,6 +50,11 @@ tasks:
       - uv run pytest -m slow
     desc: "Run only tests marked as slow with uv"
 
+  test:benchmarks:
+    cmds:
+      - uv run pytest tests/integration/test_query_performance_benchmark.py -q
+    desc: "Run performance benchmark tests with uv"
+
   coverage:
     cmds:
       - uv run pytest tests/unit --cov=src --cov-report=term-missing --cov-append

--- a/tests/integration/test_orchestrator_registered_pairs.py
+++ b/tests/integration/test_orchestrator_registered_pairs.py
@@ -1,0 +1,50 @@
+import itertools
+
+import pytest
+
+from autoresearch.agents.registry import AgentRegistry
+from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
+from autoresearch.models import QueryResponse
+from autoresearch.search import Search
+from autoresearch.storage import StorageManager
+from autoresearch.config import ConfigModel
+
+
+@pytest.mark.parametrize("pair", list(itertools.combinations(AgentRegistry.list_available(), 2)))
+def test_orchestrator_all_registered_pairs(monkeypatch, pair):
+    """Run the orchestrator with every pair of registered agents."""
+
+    # Setup
+    calls: list[str] = []
+    pair = list(pair)
+
+    def make_agent(name: str):
+        class DummyAgent:
+            def __init__(self, name: str, llm_adapter=None) -> None:
+                self.name = name
+
+            def can_execute(self, state, config) -> bool:
+                return True
+
+            def execute(self, state, config, **_: object) -> dict:
+                calls.append(name)
+                state.results[name] = "ok"
+                if name == pair[-1]:
+                    state.results["final_answer"] = f"answer from {name}"
+                return {"results": {name: "ok"}}
+
+        return DummyAgent(name)
+
+    monkeypatch.setattr(Search, "rank_results", lambda q, r: r)
+    monkeypatch.setattr(StorageManager, "persist_claim", lambda c: None)
+    monkeypatch.setattr(AgentFactory, "get", lambda name: make_agent(name))
+
+    cfg = ConfigModel(agents=pair, loops=1)
+
+    # Execute
+    response = Orchestrator.run_query("q", cfg)
+
+    # Verify
+    assert isinstance(response, QueryResponse)
+    assert calls == pair
+    assert response.answer == f"answer from {pair[-1]}"

--- a/tests/integration/test_query_performance_benchmark.py
+++ b/tests/integration/test_query_performance_benchmark.py
@@ -1,0 +1,79 @@
+import json
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
+from autoresearch.config import ConfigModel, ConfigLoader
+from autoresearch.search import Search
+from autoresearch.storage import StorageManager
+
+pytestmark = pytest.mark.slow
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "benchmark_token_memory.py"
+spec = importlib.util.spec_from_file_location("benchmark_token_memory", SCRIPT_PATH)
+benchmark_module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(benchmark_module)  # type: ignore
+run_benchmark = benchmark_module.run_benchmark
+
+BASELINE_PATH = Path(__file__).resolve().parent / "baselines" / "token_memory.json"
+BUDGET_BASELINE_PATH = Path(__file__).resolve().parent / "baselines" / "token_usage_budget.json"
+
+
+class DummyAgent:
+    """Minimal agent used for benchmarks."""
+
+    def __init__(self, name: str, llm_adapter=None) -> None:
+        self.name = name
+
+    def can_execute(self, state, config) -> bool:  # pragma: no cover - dummy
+        return True
+
+    def execute(self, state, config, adapter=None):  # pragma: no cover - dummy
+        adapter.generate("one two three four five six")
+        state.results[self.name] = "ok"
+        state.results["final_answer"] = "answer"
+        return {"results": {self.name: "ok"}}
+
+
+def test_query_performance_memory_tokens(benchmark):
+    """Benchmark query processing and verify memory and token usage."""
+
+    # Setup
+    query = "performance benchmark"
+    memory_before = StorageManager._current_ram_mb()
+
+    def run():
+        Search.generate_queries(query)
+
+    # Execute
+    benchmark(run)
+    metrics = run_benchmark()
+    memory_after = StorageManager._current_ram_mb()
+
+    # Verify
+    baseline = json.loads(BASELINE_PATH.read_text())
+    assert metrics["tokens"] == baseline["tokens"]
+    assert metrics["memory_delta_mb"] <= baseline["memory_delta_mb"] + 5
+    assert memory_after - memory_before < 10
+
+
+def test_token_budget_limit(monkeypatch):
+    """Token usage should respect the configured budget."""
+
+    # Setup
+    monkeypatch.setattr(AgentFactory, "get", lambda name, llm_adapter=None: DummyAgent(name))
+    cfg = ConfigModel(agents=["Dummy"], loops=1, llm_backend="dummy", token_budget=4)
+    cfg.api.role_permissions["anonymous"] = ["query"]
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+
+    # Execute
+    response = Orchestrator.run_query("q", cfg)
+    tokens = response.metrics["execution_metrics"]["agent_tokens"]
+
+    # Verify
+    baseline = json.loads(BUDGET_BASELINE_PATH.read_text())
+    assert tokens == baseline


### PR DESCRIPTION
## Summary
- add integration test covering orchestrator execution for every agent pair
- ensure search and storage interact with config hot reloading
- provide performance benchmark tests for memory usage and token budgeting
- add `test:benchmarks` target to `Taskfile.yml`

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit -q` *(fails: ConfigError)*
- `uv run pytest tests/integration -m "not slow" -q` *(fails: ValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_688940ab73f8833391158ecb69c52090