### PR TITLE
Verify Go Task presence after setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   - Install dependencies with `uv pip install -e '.[full,dev]'`.
   - Activate the environment using `source .venv/bin/activate` or prefix commands with `uv pip`.
   - When modifying `pyproject.toml`, regenerate the lock file with `uv lock` before reinstalling.
-  - Codex environments run `scripts/codex_setup.sh`, which delegates to `scripts/setup.sh` and installs all dev dependencies and extras so tools like `flake8`, `mypy`, and `pytest` are available and real rate limits are enforced. The setup script also installs [Go Task](https://taskfile.dev) system-wide so `task` commands work out of the box.
+  - Codex environments run `scripts/codex_setup.sh`, which delegates to `scripts/setup.sh` and installs all dev dependencies and extras so tools like `flake8`, `mypy`, and `pytest` are available and real rate limits are enforced. The setup script also installs [Go Task](https://taskfile.dev) system-wide so `task` commands work out of the box. After setup, verify `/usr/local/bin/task` exists; if missing, reinstall Go Task using `curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin`.
   - Confirm dev tools are installed with `uv pip list | grep flake8`.
 
 ## Verification steps

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -15,6 +15,13 @@ if ! command -v task >/dev/null 2>&1; then
     curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
 fi
 
+# Verify Go Task was installed
+if [ ! -x /usr/local/bin/task ]; then
+    echo "Go Task not found at /usr/local/bin/task." >&2
+    echo "Re-run: curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin" >&2
+    exit 1
+fi
+
 # Run the main setup script to install dev dependencies and extras with uv
 ./scripts/setup.sh
 # All Python setup is handled by setup.sh using uv pip


### PR DESCRIPTION
## Summary
- ensure `/usr/local/bin/task` exists in `scripts/codex_setup.sh`
- document Go Task verification step in `AGENTS.md`

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: ConfigError)*
- `uv run pytest tests/behavior` *(fails: ConfigError)*
- `task coverage` *(fails: ConfigError)*

------
https://chatgpt.com/codex/tasks/task_e_688957333d9083338a177e0bc01401a9