### PR TITLE
Check for python3.12 in setup scripts

### DIFF
--- a/.github/workflows.disabled/ci.yml
+++ b/.github/workflows.disabled/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI (Python 3.12)
 
 on:
   push:

--- a/.github/workflows.disabled/simple_ci.yml
+++ b/.github/workflows.disabled/simple_ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI (Python 3.12)
 on:
   push:
   pull_request:

--- a/.github/workflows.disabled/wheels.yml
+++ b/.github/workflows.disabled/wheels.yml
@@ -1,4 +1,4 @@
-name: Build wheels
+name: Build wheels (Python 3.12)
 
 on:
   push:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   - Python **3.12 or newer** is required. Confirm with `python --version`.
   - Create a virtual environment with `uv venv`.
     - `scripts/setup.sh` verifies the interpreter and fails if it is too old.
+    - Both setup scripts abort if `python3.12` is not found on your `PATH`.
   - Install dependencies with `uv pip install -e '.[full,dev]'`.
   - Activate the environment using `source .venv/bin/activate` or prefix commands with `uv pip`.
   - When modifying `pyproject.toml`, regenerate the lock file with `uv lock` before reinstalling.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ sure it is available on your `PATH`. On Debian/Ubuntu systems install it with
 `sudo apt-get install python3.12 python3.12-venv`. If you manage multiple
 interpreters via pyenv or another tool, specify the path when creating the
 environment, e.g. `uv venv -p python3.12`.
+Both setup scripts abort if `python3.12` cannot be located.
 The project recently transitioned from **Poetry** to
 [**uv**](https://github.com/astral-sh/uv) for dependency management. You can
 install the project using `uv` or plain **pip**.

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure Python 3.12 is available before proceeding
+if ! command -v python3.12 >/dev/null 2>&1; then
+    echo "python3.12 is required but was not found in PATH" >&2
+    exit 1
+fi
+
 echo "Setting up Codex environment..."
 
 export DEBIAN_FRONTEND=noninteractive

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,6 +2,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Abort if python3.12 is not available
+if ! command -v python3.12 >/dev/null 2>&1; then
+    echo "python3.12 is required but was not found in PATH" >&2
+    exit 1
+fi
+
 PYTHON_VERSION=$(python3.12 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
 if python3.12 - <<'EOF'
 import sys


### PR DESCRIPTION
## Summary
- verify python3.12 exists before running `scripts/setup.sh` or `scripts/codex_setup.sh`
- clarify the requirement in README and AGENTS docs
- tweak CI workflow names to note Python 3.12

## Testing
- `uv run flake8 src tests`
- `uv run mypy src` *(fails: Interrupted)*
- `uv run pytest -q` *(fails: ConfigError)*
- `uv run pytest tests/behavior` *(fails: ConfigError)*
- `task coverage` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68899c886be883338385b7acfb32315c