### PR TITLE
Document temporary search context APIs

### DIFF
--- a/docs/api_reference/config.md
+++ b/docs/api_reference/config.md
@@ -5,6 +5,16 @@ This page documents the Configuration API, which provides configuration manageme
 ## Config Loader
 
 The `ConfigLoader` class is responsible for loading and watching configuration changes.
+Use the :py:meth:`~autoresearch.config.ConfigLoader.temporary_instance` context
+manager when you need a separate configuration loader for a short period.
+
+```python
+from autoresearch.config import ConfigLoader
+
+with ConfigLoader.temporary_instance() as loader:
+    loader.load("custom.yaml")
+    # operate with the temporary configuration here
+```
 
 ::: autoresearch.config.ConfigLoader
 

--- a/docs/api_reference/search.md
+++ b/docs/api_reference/search.md
@@ -25,6 +25,15 @@ The `SearchContext` class manages search context using a singleton pattern. The
 singleton instance can be cleared with `reset_instance()` or temporarily
 replaced using `temporary_instance()` when an isolated context is required.
 
+```python
+from autoresearch.search import SearchContext
+
+SearchContext.reset_instance()  # ensure a clean state
+with SearchContext.temporary_instance() as ctx:
+    ctx.add_to_history("example", [])
+    # queries inside this block do not affect the global context
+```
+
 ::: autoresearch.search.SearchContext
 
 ## Context-Aware Search


### PR DESCRIPTION
## Summary
- mention `temporary_instance` for `ConfigLoader`
- show how to reset or temporarily replace `SearchContext`

## Testing
- `mkdocs build`
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: Configuration validation error)*
- `uv run pytest tests/behavior` *(fails: Configuration validation error)*
- `task coverage` *(fails: Configuration validation error)*

------
https://chatgpt.com/codex/tasks/task_e_688a586796a48333af9cea6f3d5e1608