### PR TITLE
Add test helpers for ConfigLoader

### DIFF
--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -490,16 +490,20 @@ class ConfigLoader:
                 cls._instance = None
 
     @classmethod
+    def new_for_tests(cls) -> "ConfigLoader":
+        """Return a fresh loader instance for isolated tests."""
+        cls.reset_instance()
+        return cls()
+
+    @classmethod
     @contextmanager
     def temporary_instance(cls) -> Iterator["ConfigLoader"]:
-        """Yield a new temporary instance while preserving the original."""
-        old = cls._instance
-        cls._instance = None
+        """Provide a temporary loader instance for tests."""
+        instance = cls.new_for_tests()
         try:
-            instance = cls()
             yield instance
         finally:
-            cls._instance = old
+            cls.reset_instance()
 
     def __new__(cls) -> "ConfigLoader":
         """Create or return the singleton instance of ConfigLoader.


### PR DESCRIPTION
## Summary
- expand `ConfigLoader` with a test factory and context manager

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: Configuration validation error)*
- `uv run pytest tests/behavior` *(fails: Configuration validation error)*
- `task coverage` *(fails: Configuration validation error)*

------
https://chatgpt.com/codex/tasks/task_e_688a5a3e8394833398a81abaa596dec4