### PR TITLE
Refactor token utilities

### DIFF
--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -24,12 +24,20 @@ The system is designed to be extensible, allowing for custom agents, reasoning m
 and execution strategies.
 """
 
-from typing import List, Dict, Any, Callable, Iterator, TypedDict, cast
+from typing import (
+    List,
+    Dict,
+    Any,
+    Callable,
+    Iterator,
+    TypedDict,
+    cast,
+    ContextManager,
+)
 import os
 import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
 import asyncio
 
 from ..agents.registry import AgentFactory, AgentRegistry
@@ -39,6 +47,10 @@ from ..models import QueryResponse
 from ..storage import StorageManager
 from .state import QueryState
 from .metrics import OrchestrationMetrics, record_query
+from .token_utils import (
+    _capture_token_usage as capture_token_usage,
+    _execute_with_adapter as execute_with_adapter,
+)
 from ..logging_utils import get_logger
 from ..tracing import setup_tracing, get_tracer
 from ..errors import OrchestrationError, AgentError, NotFoundError, TimeoutError
@@ -1488,44 +1500,8 @@ class Orchestrator:
     def _execute_with_adapter(
         agent: Any, state: QueryState, config: ConfigModel, adapter: Any
     ) -> Dict[str, Any]:
-        """Execute an agent with a specific adapter.
-
-        This method handles executing an agent with a specific adapter, either by:
-        1. Passing the adapter directly to the execute method if it supports it
-        2. Temporarily setting the adapter in the agent's context
-
-        Args:
-            agent: The agent to execute
-            state: The current query state
-            config: The system configuration
-            adapter: The adapter to use for LLM calls
-
-        Returns:
-            The result of agent execution
-        """
-        # Check if the agent's execute method accepts an adapter parameter
-        import inspect
-
-        sig = inspect.signature(agent.execute)
-
-        if "adapter" in sig.parameters:
-            # Agent supports direct adapter injection
-            return agent.execute(state, config, adapter=adapter)
-        elif hasattr(agent, "set_adapter"):
-            # Agent supports adapter setting via method
-            original_adapter = (
-                agent.get_adapter() if hasattr(agent, "get_adapter") else None
-            )
-            try:
-                agent.set_adapter(adapter)
-                return agent.execute(state, config)
-            finally:
-                if original_adapter is not None:
-                    agent.set_adapter(original_adapter)
-        else:
-            # No adapter injection support, just execute normally
-            # This won't count tokens, but at least it won't break
-            return agent.execute(state, config)
+        """Execute an agent with a specific adapter."""
+        return execute_with_adapter(agent, state, config, adapter)
 
     @staticmethod
     def _rotate_list(items: List[Any], start_idx: int) -> List[Any]:
@@ -1637,57 +1613,11 @@ class Orchestrator:
         return max(0.1, min(1.0, confidence))
 
     @staticmethod
-    @contextmanager
     def _capture_token_usage(
         agent_name: str, metrics: OrchestrationMetrics, config: ConfigModel
-    ) -> Iterator[tuple[dict[str, int], Any]]:
-        """Capture token usage for all LLM calls within the block.
-
-        This method uses the TokenCountingAdapter to count tokens for all LLM calls
-        made within the context manager block. It yields a tuple containing a dictionary
-        with token counts and the wrapped adapter that should be used for LLM calls.
-
-        Args:
-            agent_name: The name of the agent making the LLM calls
-            metrics: The metrics collector to record token usage
-            config: The system configuration containing the LLM backend
-
-        Yields:
-            A tuple containing (token_counter, wrapped_adapter)
-        """
-        from autoresearch.llm.token_counting import count_tokens
-        import autoresearch.llm as llm
-
-        # Get the adapter for the agent using the configured backend
-        backend = config.llm_backend
-        adapter = llm.get_pooled_adapter(backend)
-        token_budget: int | None = getattr(config, "token_budget", None)
-
-        # Use the count_tokens context manager to count tokens
-        # It returns both the token counter and the wrapped adapter
-        with count_tokens(agent_name, adapter, metrics, token_budget) as (
-            token_counter,
-            base_adapter,
-        ):
-            wrapped: Any = base_adapter
-            if token_budget is not None:
-                tb: int = token_budget
-
-                class PromptCompressAdapter:
-                    def __init__(self, inner: Any) -> None:
-                        self.inner = inner
-
-                    def generate(
-                        self, prompt: str, model: str | None = None, **kwargs: Any
-                    ) -> str:
-                        prompt = metrics.compress_prompt_if_needed(prompt, tb)
-                        return self.inner.generate(prompt, model=model, **kwargs)
-
-                    def __getattr__(self, name: str) -> Any:  # pragma: no cover
-                        return getattr(self.inner, name)
-
-                wrapped = PromptCompressAdapter(wrapped)
-            yield token_counter, wrapped
+    ) -> ContextManager[tuple[dict[str, int], Any]]:
+        """Capture token usage for all LLM calls within the block."""
+        return capture_token_usage(agent_name, metrics, config)
 
     # --------------------------------------------------------------
     # Storage helper shortcuts

--- a/src/autoresearch/orchestration/token_utils.py
+++ b/src/autoresearch/orchestration/token_utils.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator
+
+from ..config import ConfigModel
+from .metrics import OrchestrationMetrics
+from .state import QueryState  # for type hints in execute_with_adapter
+
+
+@contextmanager
+def _capture_token_usage(
+    agent_name: str, metrics: OrchestrationMetrics, config: ConfigModel
+) -> Iterator[tuple[dict[str, int], Any]]:
+    """Capture token usage for all LLM calls within the block.
+
+    This method uses the TokenCountingAdapter to count tokens for all LLM calls
+    made within the context manager block. It yields a tuple containing a dictionary
+    with token counts and the wrapped adapter that should be used for LLM calls.
+
+    Args:
+        agent_name: The name of the agent making the LLM calls
+        metrics: The metrics collector to record token usage
+        config: The system configuration containing the LLM backend
+
+    Yields:
+        A tuple containing (token_counter, wrapped_adapter)
+    """
+    from autoresearch.llm.token_counting import count_tokens
+    import autoresearch.llm as llm
+
+    backend = config.llm_backend
+    adapter = llm.get_pooled_adapter(backend)
+    token_budget: int | None = getattr(config, "token_budget", None)
+
+    with count_tokens(agent_name, adapter, metrics, token_budget) as (
+        token_counter,
+        base_adapter,
+    ):
+        wrapped: Any = base_adapter
+        if token_budget is not None:
+            tb: int = token_budget
+
+            class PromptCompressAdapter:
+                def __init__(self, inner: Any) -> None:
+                    self.inner = inner
+
+                def generate(
+                    self, prompt: str, model: str | None = None, **kwargs: Any
+                ) -> str:
+                    prompt = metrics.compress_prompt_if_needed(prompt, tb)
+                    return self.inner.generate(prompt, model=model, **kwargs)
+
+                def __getattr__(self, name: str) -> Any:  # pragma: no cover
+                    return getattr(self.inner, name)
+
+            wrapped = PromptCompressAdapter(wrapped)
+        yield token_counter, wrapped
+
+
+def _execute_with_adapter(
+    agent: Any, state: QueryState, config: ConfigModel, adapter: Any
+) -> Dict[str, Any]:
+    """Execute an agent with a specific adapter.
+
+    This method handles executing an agent with a specific adapter, either by:
+    1. Passing the adapter directly to the execute method if it supports it
+    2. Temporarily setting the adapter in the agent's context
+
+    Args:
+        agent: The agent to execute
+        state: The current query state
+        config: The system configuration
+        adapter: The adapter to use for LLM calls
+
+    Returns:
+        The result of agent execution
+    """
+    import inspect
+
+    sig = inspect.signature(agent.execute)
+
+    if "adapter" in sig.parameters:
+        return agent.execute(state, config, adapter=adapter)
+    elif hasattr(agent, "set_adapter"):
+        original_adapter = (
+            agent.get_adapter() if hasattr(agent, "get_adapter") else None
+        )
+        try:
+            agent.set_adapter(adapter)
+            return agent.execute(state, config)
+        finally:
+            if original_adapter is not None:
+                agent.set_adapter(original_adapter)
+    else:
+        return agent.execute(state, config)

--- a/tests/unit/test_token_utils_module.py
+++ b/tests/unit/test_token_utils_module.py
@@ -1,0 +1,63 @@
+from unittest.mock import MagicMock
+from typing import Any
+
+from autoresearch.config import ConfigModel
+from autoresearch.orchestration.metrics import OrchestrationMetrics
+from autoresearch.orchestration.state import QueryState
+from autoresearch.orchestration import token_utils
+import autoresearch.llm as llm
+
+
+def test_capture_token_usage_counts(monkeypatch, flexible_llm_adapter):
+    metrics = OrchestrationMetrics()
+    mock_config = MagicMock(spec=ConfigModel)
+    mock_config.llm_backend = "flexible"
+    monkeypatch.setattr(llm, "get_pooled_adapter", lambda name: flexible_llm_adapter)
+
+    with token_utils._capture_token_usage("agent", metrics, mock_config) as (
+        _counter,
+        adapter,
+    ):
+        adapter.generate("hello world")
+
+    counts = metrics.token_counts["agent"]
+    assert counts["in"] == 2
+    assert counts["out"] > 0
+
+
+def test_execute_with_adapter_injection_methods():
+    class AgentWithParam:
+        def __init__(self) -> None:
+            self.used: Any | None = None
+
+        def execute(self, state: QueryState, config: ConfigModel, *, adapter: Any = None):
+            self.used = adapter
+            return {"ok": True}
+
+    class AgentWithSetter:
+        def __init__(self) -> None:
+            self.adapter = "orig"
+
+        def set_adapter(self, adapter: Any) -> None:
+            self.adapter = adapter
+
+        def get_adapter(self) -> Any:
+            return self.adapter
+
+        def execute(self, state: QueryState, config: ConfigModel) -> dict[str, Any]:
+            return {"adapter": self.adapter}
+
+    state = QueryState(query="q")
+    cfg = ConfigModel.model_construct()
+    adapter = object()
+
+    agent1 = AgentWithParam()
+    result1 = token_utils._execute_with_adapter(agent1, state, cfg, adapter)
+    assert result1 == {"ok": True}
+    assert agent1.used is adapter
+
+    agent2 = AgentWithSetter()
+    result2 = token_utils._execute_with_adapter(agent2, state, cfg, adapter)
+    assert result2["adapter"] is adapter
+    # original adapter restored after execution
+    assert agent2.adapter == "orig"


### PR DESCRIPTION
## Summary
- add new `token_utils` helper module
- wrap `_capture_token_usage` and `_execute_with_adapter` in orchestrator to use the new module
- verify token counting and adapter injection

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: Configuration validation error)*

------
https://chatgpt.com/codex/tasks/task_e_688a873904288333a034278e7b6f9909