### PR TITLE
test: add CLI and recovery behavior scenarios

### DIFF
--- a/tests/behavior/README.md
+++ b/tests/behavior/README.md
@@ -31,3 +31,13 @@ Scenarios with these markers are skipped when the corresponding extras are not
 installed. After installing all extras you may simply run `uv run pytest tests/behavior`
 to execute every scenario.
 
+
+## Running CLI and recovery scenarios
+
+Run the CLI and error-recovery features individually when developing:
+
+```bash
+uv run pytest tests/behavior/features/config_cli.feature::Update_reasoning_configuration
+uv run pytest tests/behavior/features/reasoning_mode_cli.feature
+uv run pytest tests/behavior/features/error_recovery.feature
+```

--- a/tests/behavior/features/config_cli.feature
+++ b/tests/behavior/features/config_cli.feature
@@ -1,3 +1,4 @@
+@behavior
 Feature: Configuration CLI
   Scenarios covering configuration commands
 
@@ -11,3 +12,11 @@ Feature: Configuration CLI
     And I run `autoresearch config init --force` in a temporary directory
     When I run `autoresearch config validate`
     Then the CLI should exit successfully
+
+  Scenario: Update reasoning configuration
+    Given a temporary work directory
+    And I run `autoresearch config init --force` in a temporary directory
+    When I run `autoresearch config reasoning --mode dialectical --loops 3`
+    Then the CLI should exit successfully
+    And the configuration file should set reasoning mode to "dialectical"
+    And the configuration file should set loops to 3

--- a/tests/behavior/features/error_recovery.feature
+++ b/tests/behavior/features/error_recovery.feature
@@ -1,0 +1,11 @@
+@behavior
+Feature: Error Recovery
+  As a user
+  I want the system to apply recovery strategies
+  So transient errors do not halt execution
+
+  Scenario: Transient error triggers recovery
+    Given an agent that raises a transient error
+    When I run the orchestrator on query "recover test"
+    Then a recovery strategy "retry_with_backoff" should be recorded
+    And recovery should be applied

--- a/tests/behavior/features/reasoning_mode_cli.feature
+++ b/tests/behavior/features/reasoning_mode_cli.feature
@@ -1,0 +1,13 @@
+@behavior
+Feature: Reasoning mode via CLI
+  As a user
+  I want to override reasoning mode on the command line
+  So that agent execution adapts accordingly
+
+  Scenario: Direct mode via CLI
+    Given loops is set to 2 in configuration
+    When I run `autoresearch search "mode test" --mode direct`
+    Then the CLI should exit successfully
+    And the loops used should be 1
+    And the agent groups should be "Synthesizer"
+    And the agents executed should be "Synthesizer"

--- a/tests/behavior/steps/config_cli_steps.py
+++ b/tests/behavior/steps/config_cli_steps.py
@@ -1,4 +1,4 @@
-from pytest_bdd import scenario, given, when, then
+from pytest_bdd import scenario, given, when, then, parsers
 
 from autoresearch.main import app as cli_app
 from autoresearch.config import ConfigLoader
@@ -27,6 +27,14 @@ def run_config_validate(cli_runner, bdd_context):
     bdd_context["result"] = result
 
 
+@when(parsers.parse('I run `autoresearch config reasoning --mode {mode} --loops {loops:d}`'))
+def run_config_reasoning(cli_runner, bdd_context, mode: str, loops: int):
+    result = cli_runner.invoke(
+        cli_app, ["config", "reasoning", "--mode", mode, "--loops", str(loops)]
+    )
+    bdd_context["result"] = result
+
+
 @then('the files "autoresearch.toml" and ".env" should be created')
 def check_config_files(work_dir):
     assert (work_dir / "autoresearch.toml").exists()
@@ -38,6 +46,18 @@ def cli_success(bdd_context):
     assert bdd_context["result"].exit_code == 0
 
 
+@then(parsers.parse('the configuration file should set reasoning mode to "{mode}"'))
+def assert_reasoning_mode(work_dir, mode: str):
+    content = (work_dir / "autoresearch.toml").read_text()
+    assert f'reasoning_mode = "{mode}"' in content
+
+
+@then(parsers.parse("the configuration file should set loops to {loops:d}"))
+def assert_loops(work_dir, loops: int):
+    content = (work_dir / "autoresearch.toml").read_text()
+    assert f"loops = {loops}" in content
+
+
 @scenario("../features/config_cli.feature", "Initialize configuration files")
 def test_config_init():
     pass
@@ -45,4 +65,9 @@ def test_config_init():
 
 @scenario("../features/config_cli.feature", "Validate configuration files")
 def test_config_validate():
+    pass
+
+
+@scenario("../features/config_cli.feature", "Update reasoning configuration")
+def test_config_reasoning():
     pass

--- a/tests/behavior/steps/error_recovery_steps.py
+++ b/tests/behavior/steps/error_recovery_steps.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from pytest_bdd import scenario, given, when, then, parsers
+
+from autoresearch.config import ConfigModel, ConfigLoader
+from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
+
+
+@scenario("../features/error_recovery.feature", "Transient error triggers recovery")
+def test_transient_error_recovery():
+    pass
+
+
+@given("an agent that raises a transient error", target_fixture="config")
+def flaky_agent(monkeypatch):
+    cfg = ConfigModel.model_construct(agents=["Flaky"], loops=1)
+
+    class FlakyAgent:
+        def can_execute(self, *args, **kwargs) -> bool:
+            return True
+
+        def execute(self, *args, **kwargs) -> dict:
+            raise RuntimeError("temporary network issue")
+
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setattr(AgentFactory, "get", lambda self, name: FlakyAgent())
+    return cfg
+
+
+@when(parsers.parse('I run the orchestrator on query "{query}"'), target_fixture="run_result")
+def run_orchestrator(query: str, config: ConfigModel):
+    recovery_info: dict = {}
+    original_apply = Orchestrator._apply_recovery_strategy
+
+    def spy_apply(agent_name: str, error_category: str, e: Exception, state):
+        info = original_apply(agent_name, error_category, e, state)
+        recovery_info.update(info)
+        return info
+
+    with patch(
+        "autoresearch.orchestration.orchestrator.Orchestrator._apply_recovery_strategy",
+        side_effect=spy_apply,
+    ):
+        Orchestrator.run_query(query, config)
+
+    return {"recovery_info": recovery_info}
+
+
+@then(parsers.parse('a recovery strategy "{strategy}" should be recorded'))
+def assert_strategy(run_result: dict, strategy: str) -> None:
+    assert run_result["recovery_info"].get("recovery_strategy") == strategy
+
+
+@then("recovery should be applied")
+def assert_recovery_applied(run_result: dict) -> None:
+    assert run_result["recovery_info"].get("recovery_applied") is True

--- a/tests/behavior/steps/reasoning_mode_cli_steps.py
+++ b/tests/behavior/steps/reasoning_mode_cli_steps.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from pytest_bdd import scenario, given, when, then, parsers
+
+from autoresearch.config import ConfigModel, ConfigLoader
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.main import app as cli_app
+
+
+@scenario("../features/reasoning_mode_cli.feature", "Direct mode via CLI")
+def test_direct_mode_cli():
+    pass
+
+
+@given(parsers.parse("loops is set to {count:d} in configuration"), target_fixture="config")
+def loops_config(count: int, monkeypatch):
+    cfg = ConfigModel.model_construct(agents=["Synthesizer"], loops=count)
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    return cfg
+
+
+@when(
+    parsers.parse('I run `autoresearch search "{query}" --mode {mode}`'),
+    target_fixture="run_result",
+)
+def run_search(query: str, mode: str, config: ConfigModel, cli_runner):
+    record: list[str] = []
+    params: dict = {}
+
+    class DummyAgent:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def can_execute(self, *args, **kwargs) -> bool:
+            return True
+
+        def execute(self, *args, **kwargs) -> dict:
+            record.append(self.name)
+            return {}
+
+    def get_agent(name: str) -> DummyAgent:
+        return DummyAgent(name)
+
+    original_parse = Orchestrator._parse_config
+
+    def spy_parse(cfg: ConfigModel):
+        out = original_parse(cfg)
+        params.update(out)
+        return out
+
+    with patch(
+        "autoresearch.orchestration.orchestrator.AgentFactory.get",
+        side_effect=get_agent,
+    ), patch(
+        "autoresearch.orchestration.orchestrator.Orchestrator._parse_config",
+        side_effect=spy_parse,
+    ):
+        result = cli_runner.invoke(cli_app, ["search", query, "--mode", mode])
+
+    return {"record": record, "config_params": params, "exit_code": result.exit_code}
+
+
+@then("the CLI should exit successfully")
+def cli_success(run_result):
+    assert run_result["exit_code"] == 0
+
+
+@then(parsers.parse("the loops used should be {count:d}"))
+def assert_loops(run_result: dict, count: int) -> None:
+    assert run_result["config_params"].get("loops") == count
+
+
+@then(parsers.parse('the agent groups should be "{groups}"'))
+def assert_groups(run_result: dict, groups: str) -> None:
+    expected = [[a.strip() for a in grp.split(",") if a.strip()] for grp in groups.split(";")]
+    assert run_result["config_params"].get("agent_groups") == expected
+
+
+@then(parsers.parse('the agents executed should be "{order}"'))
+def assert_order(run_result: dict, order: str) -> None:
+    expected = [a.strip() for a in order.split(",")]
+    assert run_result["record"] == expected


### PR DESCRIPTION
## Summary
- cover reasoning mode selection via CLI and transient error recovery
- expand configuration CLI tests for reasoning updates
- document running CLI and recovery scenarios

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/behavior` *(fails: Configuration validation error)*

------
https://chatgpt.com/codex/tasks/task_e_688ab75d86088333862ebd3a77fde258