### PR TITLE
feat: allow temporary config injection

### DIFF
--- a/tests/unit/test_a2a_interface.py
+++ b/tests/unit/test_a2a_interface.py
@@ -56,13 +56,18 @@ def mock_orchestrator():
 
 @pytest.fixture
 def mock_config():
-    """Create a mock config."""
-    with patch("autoresearch.a2a_interface.get_config") as mock_get_config:
-        from autoresearch.config import ConfigModel
+    """Create a mock config and inject it for the duration of the test."""
+    from autoresearch.config import ConfigModel, ConfigLoader, temporary_config
 
-        cfg = ConfigModel()
-        mock_get_config.return_value = cfg
-        yield cfg
+    cfg = ConfigModel()
+
+    with temporary_config(cfg):
+        with patch.object(ConfigLoader, "load_config", lambda self: cfg):
+            ConfigLoader.reset_instance()
+            try:
+                yield cfg
+            finally:
+                ConfigLoader.reset_instance()
 
 
 class TestA2AInterface:


### PR DESCRIPTION
## Summary
- add `temporary_config` context manager to inject configuration overrides
- support context-based overrides in `get_config`
- update A2A interface tests to use temporary config injection

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: Configuration validation error)*
- `uv run pytest tests/behavior` *(fails: Configuration validation error)*
- `uv run pytest --cov=src` *(fails: Configuration validation error)*

------
https://chatgpt.com/codex/tasks/task_e_688ac4cb51b08333b5c88c44946bd9c7