### PR TITLE
feat: install extras and cache models in setup

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -28,8 +28,19 @@ if [ ! -x /usr/local/bin/task ]; then
     exit 1
 fi
 
-# Run the main setup script to install dev dependencies and extras with uv
-# Use the lightweight dev-minimal extras for faster CI setup
-./scripts/setup.sh dev-minimal
+# Run the main setup script to install all extras needed for testing
+./scripts/setup.sh full,dev
+
+# Pre-download models so tests can run without network access
+uv run python - <<'PY'
+from sentence_transformers import SentenceTransformer
+SentenceTransformer("all-MiniLM-L6-v2")
+PY
+
+uv run python -m spacy download en_core_web_sm
+
+# Cache DuckDB extensions for offline use (vss by default)
+uv run python scripts/download_duckdb_extensions.py --output-dir ./extensions
+
 # All Python setup is handled by setup.sh using uv pip
 


### PR DESCRIPTION
## Summary
- Ensure `scripts/codex_setup.sh` installs full and dev extras
- Pre-download SentenceTransformer and spaCy models for offline tests
- Cache DuckDB extensions during setup to avoid runtime network access

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: Configuration validation error)*
- `uv run pytest tests/behavior` *(fails: Configuration validation error)*
- `uv run pytest --cov=src` *(fails: Configuration validation error)*

------
https://chatgpt.com/codex/tasks/task_e_688acbef7c60833384feca98214be0a4