### PR TITLE
refactor: add search and config cleanup APIs

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -32,6 +32,16 @@ extension. Include the `git` extra when setting up the environment, for example:
 - Public modules and functions should include concise docstrings.
 - Keep commits focused and avoid temporary files.
 
+## Lifecycle Management
+
+Some components maintain global state such as configuration watchers and HTTP
+sessions. Tests must clean up these resources to avoid interference:
+
+- Use ``with ConfigLoader() as loader`` or call ``ConfigLoader.reset_instance()``
+  to stop watcher threads and clear cached configuration.
+- Call ``Search.reset()`` to restore backend registries, release any loaded
+  sentence transformer model and close pooled HTTP sessions.
+
 ## Pull Request Process
 
 1. Create a feature branch and commit your changes.

--- a/tests/unit/test_search_reset.py
+++ b/tests/unit/test_search_reset.py
@@ -1,0 +1,12 @@
+from autoresearch.search import Search
+
+
+def test_reset_clears_state_and_session():
+    session1 = Search.get_http_session()
+    Search.backends["dummy"] = lambda q, max_results: []
+    Search._sentence_transformer = object()
+    Search.reset()
+    assert "dummy" not in Search.backends
+    assert Search._sentence_transformer is None
+    session2 = Search.get_http_session()
+    assert session1 is not session2


### PR DESCRIPTION
## Summary
- add context manager support to `ConfigLoader`
- provide `Search.reset()` and temporary state for per-test isolation
- document lifecycle cleanup expectations for config and search
- guard storage setup/teardown against config load errors

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: Configuration validation error)*
- `uv run pytest tests/behavior -q` *(fails: Configuration validation error)*

------
https://chatgpt.com/codex/tasks/task_e_688ae159765883339b3bb998056d9073