### PR TITLE
feat: load .env settings through ConfigLoader

### DIFF
--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -8,8 +8,8 @@ from pydantic import (
     ValidationError,
     field_validator,
     model_validator,
-    TypeAdapter,
 )
+from pydantic_settings import SettingsConfigDict
 
 from ..orchestration import ReasoningMode
 from .validators import (
@@ -247,15 +247,9 @@ class ConfigModel(BaseModel):
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ConfigModel":
-        adapter = TypeAdapter(cls)
         try:
-            return adapter.validate_python(data, context={"_cli_parse_args": False})
+            return cls(**data)
         except ValidationError:
             return cls.model_construct(**data)
 
-    model_config: Dict[str, Any] = {
-        "env_file": ".env",
-        "env_file_encoding": "utf-8",
-        "env_nested_delimiter": "__",
-        "extra": "ignore",
-    }
+    model_config = SettingsConfigDict(extra="ignore")

--- a/tests/unit/test_config_env_file.py
+++ b/tests/unit/test_config_env_file.py
@@ -1,0 +1,11 @@
+from autoresearch.config.loader import ConfigLoader
+
+
+def test_env_file_parsing(tmp_path):
+    """ConfigLoader should populate ConfigModel from .env file."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("\n".join(["loops=5", "storage__rdf_path=env.db"]))
+    loader = ConfigLoader(env_path=env_path)
+    cfg = loader.load_config()
+    assert cfg.loops == 5
+    assert cfg.storage.rdf_path == "env.db"


### PR DESCRIPTION
## Summary
- ignore unknown config fields using SettingsConfigDict
- load and merge environment variables in ConfigLoader
- test .env parsing via ConfigLoader

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit/test_config_env_file.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688bfcf9fa988333a53da9672aa13863