### PR TITLE
Remove xfail on config profile tests

### DIFF
--- a/tests/unit/test_config_profiles.py
+++ b/tests/unit/test_config_profiles.py
@@ -7,7 +7,6 @@ users to define and switch between different configuration profiles.
 import pytest
 from unittest.mock import patch, mock_open
 
-pytestmark = pytest.mark.xfail(reason="Config profiles not supported in tests")
 import time  # noqa: E402
 import stat  # noqa: E402
 


### PR DESCRIPTION
## Summary
- run configuration profile tests normally by dropping xfail marker

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit/test_config_profiles.py`
- `uv run pytest -q` *(fails: process terminated after extended runtime)*
- `uv run pytest tests/behavior -q` *(fails: process terminated after extended runtime)*

------
https://chatgpt.com/codex/tasks/task_e_688c3ee409388333a5b7c091e25f534f