### PR TITLE
Handle invalid configuration gracefully

### DIFF
--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -250,6 +250,13 @@ class ConfigModel(BaseModel):
         try:
             return cls(**data)
         except ValidationError:
-            return cls.model_construct(**data)
+            model = cls()
+            for field, value in data.items():
+                if field in cls.model_fields:
+                    try:
+                        setattr(model, field, value)
+                    except Exception:  # pragma: no cover - ignore bad fields
+                        continue
+            return model
 
     model_config = SettingsConfigDict(extra="ignore")

--- a/tests/unit/test_config_loader_defaults.py
+++ b/tests/unit/test_config_loader_defaults.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from autoresearch.config.loader import ConfigLoader
+
+
+def test_invalid_env_falls_back_to_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid environment values should not raise and use defaults instead."""
+    monkeypatch.setenv("STORAGE__HNSW_EF_SEARCH", "bad")
+
+    loader = ConfigLoader.new_for_tests()
+    cfg = loader.load_config()
+
+    assert cfg.storage.hnsw_ef_search == 10


### PR DESCRIPTION
## Summary
- ensure ConfigLoader reads relevant environment variables and safely ignores invalid config values
- default to usable config when validation fails in ConfigModel
- cover fallback behavior with a unit test

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit/test_config_loader_defaults.py -q`
- `uv run pytest tests/unit/test_config_errors.py -q`
- `uv run pytest -q` *(failed: process terminated after no progress)*
- `uv run pytest tests/behavior -q` *(failed: process terminated after no progress)*

------
https://chatgpt.com/codex/tasks/task_e_688d19f28e2c83339e74c9d161fb9624