### PR TITLE
Refactor storage context

### DIFF
--- a/tests/behavior/steps/dkg_persistence_steps.py
+++ b/tests/behavior/steps/dkg_persistence_steps.py
@@ -326,7 +326,8 @@ def perform_vector_search(persisted_claims):
     # Mock has_vss to return True and _db_backend.vector_search to return mock_results
     with patch("autoresearch.storage.StorageManager.has_vss", return_value=True):
         with patch(
-            "autoresearch.storage._db_backend.vector_search", return_value=mock_results
+            "autoresearch.storage.StorageManager.context.db_backend.vector_search",
+            return_value=mock_results,
         ):
             # Limit to 2 results since we only have 3 claims now
             results = StorageManager.vector_search(query_embedding, k=2)

--- a/tests/behavior/steps/vector_extension_handling_steps.py
+++ b/tests/behavior/steps/vector_extension_handling_steps.py
@@ -545,7 +545,7 @@ def check_vector_search_works(monkeypatch, bdd_context):
             # Mock the _db_backend.vector_search method to return expected results
             mock_results = [{"node_id": "test1", "embedding": [0.1, 0.2, 0.3]}]
             with patch(
-                "autoresearch.storage._db_backend.vector_search",
+                "autoresearch.storage.StorageManager.context.db_backend.vector_search",
                 return_value=mock_results,
             ):
                 # Try to perform a vector search

--- a/tests/behavior/steps/vector_search_performance_steps.py
+++ b/tests/behavior/steps/vector_search_performance_steps.py
@@ -15,9 +15,12 @@ def measure_vector_search_time(persisted_claims, bdd_context):
     start = time.time()
     orig_has_vss = StorageManager.has_vss
     from autoresearch import storage as storage_module
-    orig_vector_search = storage_module._db_backend.vector_search
+    orig_vector_search = storage_module.StorageManager.context.db_backend.vector_search
     with patch("autoresearch.storage.StorageManager.has_vss", return_value=True) as mock_has_vss:
-        with patch("autoresearch.storage._db_backend.vector_search", return_value=[]) as mock_vs:
+        with patch(
+            "autoresearch.storage.StorageManager.context.db_backend.vector_search",
+            return_value=[],
+        ) as mock_vs:
             StorageManager.vector_search([0.0, 0.0], k=1)
             bdd_context["vs_call"] = mock_vs.call_args
             bdd_context["has_vss_called"] = mock_has_vss.called
@@ -44,4 +47,7 @@ def storage_methods_restored(bdd_context):
     from autoresearch import storage as storage_module
 
     assert StorageManager.has_vss is bdd_context["orig_has_vss"]
-    assert storage_module._db_backend.vector_search is bdd_context["orig_vector_search"]
+    assert (
+        storage_module.StorageManager.context.db_backend.vector_search
+        is bdd_context["orig_vector_search"]
+    )

--- a/tests/integration/test_connection_pool.py
+++ b/tests/integration/test_connection_pool.py
@@ -117,7 +117,7 @@ def test_duckdb_connection_pool_concurrency(tmp_path):
         for _ in range(10):
             ex.submit(use_conn)
 
-    backend = storage._db_backend
+    backend = storage.StorageManager.context.db_backend
     assert backend is not None
     assert len(set(ids)) <= backend._max_connections
     storage.teardown(remove_db=True)

--- a/tests/integration/test_rdf_persistence.py
+++ b/tests/integration/test_rdf_persistence.py
@@ -22,8 +22,8 @@ def cleanup_rdf_store():
     yield
 
     # Teardown
-    if hasattr(StorageManager, "_rdf_store"):
-        StorageManager._rdf_store = None
+    if StorageManager.context.rdf_store is not None:
+        StorageManager.context.rdf_store = None
     ConfigLoader.reset_instance()
 
 

--- a/tests/targeted/test_storage_edgecases2.py
+++ b/tests/targeted/test_storage_edgecases2.py
@@ -18,5 +18,5 @@ def test_current_ram_fallback(monkeypatch):
 
 
 def test_pop_low_score_empty(monkeypatch):
-    monkeypatch.setattr(storage, "_graph", None)
+    monkeypatch.setattr(storage.StorageManager.context, "graph", None)
     assert storage.StorageManager._pop_low_score() is None

--- a/tests/targeted/test_storage_extra.py
+++ b/tests/targeted/test_storage_extra.py
@@ -6,7 +6,7 @@ def test_pop_low_score(monkeypatch):
     g = nx.DiGraph()
     g.add_node('a', confidence=0.2)
     g.add_node('b', confidence=0.5)
-    monkeypatch.setattr(storage, '_graph', g)
+    monkeypatch.setattr(storage.StorageManager.context, 'graph', g)
     monkeypatch.setattr(storage, '_lru', storage.OrderedDict())
     popped = storage.StorageManager._pop_low_score()
     assert popped == 'a'

--- a/tests/unit/test_additional_coverage.py
+++ b/tests/unit/test_additional_coverage.py
@@ -93,7 +93,7 @@ def test_set_get_delegate():
         called = False
 
         @classmethod
-        def setup(cls, db_path=None):
+        def setup(cls, db_path=None, context=None):
             cls.called = True
     set_delegate(Dummy)
     StorageManager.setup(db_path=None)
@@ -106,7 +106,7 @@ def test_pop_low_score_missing_confidence(monkeypatch):
     graph = MagicMock()
     graph.nodes = {"a": {}, "b": {"confidence": 0.1}}
     lru = OrderedDict([("a", 0), ("b", 0)])
-    monkeypatch.setattr("autoresearch.storage._graph", graph)
+    monkeypatch.setattr(StorageManager.context, "graph", graph)
     monkeypatch.setattr("autoresearch.storage._lru", lru)
     node = StorageManager._pop_low_score()
     assert node == "a"

--- a/tests/unit/test_core_modules_additional.py
+++ b/tests/unit/test_core_modules_additional.py
@@ -106,7 +106,7 @@ def test_storage_setup_teardown(monkeypatch):
     monkeypatch.setattr('autoresearch.storage.KuzuStorageBackend', lambda: FakeKuzu())
     monkeypatch.setattr('autoresearch.storage.rdflib', types.SimpleNamespace(Graph=lambda *a, **k: FakeGraph()))
     from autoresearch import storage
-    storage._db_backend = None
+    storage.StorageManager.context.db_backend = None
     storage._kuzu_backend = None
     storage.setup('db')
     assert calls['duck'] == 'db'

--- a/tests/unit/test_failure_paths.py
+++ b/tests/unit/test_failure_paths.py
@@ -51,7 +51,7 @@ def test_vector_search_vss_unavailable(monkeypatch):
     """StorageManager.vector_search raises StorageError when VSS is missing."""
     monkeypatch.setattr(StorageManager, "has_vss", lambda: False)
     monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
-    monkeypatch.setattr("autoresearch.storage._db_backend", object())
+    monkeypatch.setattr(StorageManager.context, "db_backend", object())
     with pytest.raises(StorageError):
         StorageManager.vector_search([0.1, 0.2, 0.3])
 

--- a/tests/unit/test_incremental_updates.py
+++ b/tests/unit/test_incremental_updates.py
@@ -11,7 +11,7 @@ def _basic_config():
 
 def test_refresh_vector_index_calls_backend(monkeypatch):
     backend = MagicMock()
-    monkeypatch.setattr("autoresearch.storage._db_backend", backend, raising=False)
+    monkeypatch.setattr(StorageManager.context, "db_backend", backend, raising=False)
     monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
 
     StorageManager.refresh_vector_index()
@@ -23,9 +23,9 @@ def test_persist_claim_triggers_index_refresh(monkeypatch):
     backend = MagicMock()
     graph = MagicMock()
     store = MagicMock()
-    monkeypatch.setattr("autoresearch.storage._db_backend", backend, raising=False)
-    monkeypatch.setattr("autoresearch.storage._graph", graph, raising=False)
-    monkeypatch.setattr("autoresearch.storage._rdf_store", store, raising=False)
+    monkeypatch.setattr(StorageManager.context, "db_backend", backend, raising=False)
+    monkeypatch.setattr(StorageManager.context, "graph", graph, raising=False)
+    monkeypatch.setattr(StorageManager.context, "rdf_store", store, raising=False)
     monkeypatch.setattr(StorageManager, "_enforce_ram_budget", lambda budget: None)
     monkeypatch.setattr(StorageManager, "has_vss", lambda: True)
     monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 0)
@@ -46,7 +46,7 @@ def test_persist_claim_triggers_index_refresh(monkeypatch):
 
 def test_update_rdf_claim_wrapper(monkeypatch):
     store = MagicMock()
-    monkeypatch.setattr("autoresearch.storage._rdf_store", store, raising=False)
+    monkeypatch.setattr(StorageManager.context, "rdf_store", store, raising=False)
     monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
 
     with patch("autoresearch.storage.StorageManager._update_rdf_claim") as upd:

--- a/tests/unit/test_property_ranking_weights.py
+++ b/tests/unit/test_property_ranking_weights.py
@@ -1,5 +1,4 @@
 from hypothesis import given, strategies as st
-from hypothesis import given, strategies as st
 import pytest
 
 from autoresearch.search import Search

--- a/tests/unit/test_property_storage.py
+++ b/tests/unit/test_property_storage.py
@@ -22,7 +22,7 @@ def test_pop_low_score(monkeypatch, node_conf):
     for node, score in node_conf.items():
         graph.add_node(node, confidence=float(score))
     lru = OrderedDict((node, 0.0) for node in node_conf)
-    monkeypatch.setattr(storage, "_graph", graph, raising=False)
+    monkeypatch.setattr(storage.StorageManager.context, "graph", graph, raising=False)
     monkeypatch.setattr(storage, "_lru", lru, raising=False)
 
     expected = min(node_conf, key=node_conf.get)

--- a/tests/unit/test_property_vector_search.py
+++ b/tests/unit/test_property_vector_search.py
@@ -15,7 +15,7 @@ from autoresearch.errors import StorageError
 def test_vector_search_calls_backend(monkeypatch, query_embedding, k):
     backend = MagicMock()
     backend.vector_search.return_value = [{"node_id": "n", "embedding": [0.1]}]
-    monkeypatch.setattr("autoresearch.storage._db_backend", backend, raising=False)
+    monkeypatch.setattr(StorageManager.context, "db_backend", backend, raising=False)
     monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
     monkeypatch.setattr(StorageManager, "has_vss", lambda: True)
     result = StorageManager.vector_search(query_embedding, k)
@@ -37,7 +37,7 @@ def test_vector_search_backend_receives_exact(monkeypatch, query_embedding, k):
     """Backend should receive the exact query embedding and k."""
     backend = MagicMock()
     backend.vector_search.return_value = []
-    monkeypatch.setattr("autoresearch.storage._db_backend", backend, raising=False)
+    monkeypatch.setattr(StorageManager.context, "db_backend", backend, raising=False)
     monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
     monkeypatch.setattr(StorageManager, "has_vss", lambda: True)
 
@@ -77,7 +77,7 @@ def malformed_embeddings(draw):
 def test_vector_search_malformed_embedding(monkeypatch, query_embedding, k):
     backend = MagicMock()
     backend.vector_search.side_effect = RuntimeError("bad embedding")
-    monkeypatch.setattr("autoresearch.storage._db_backend", backend, raising=False)
+    monkeypatch.setattr(StorageManager.context, "db_backend", backend, raising=False)
     monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
     monkeypatch.setattr(StorageManager, "has_vss", lambda: True)
 

--- a/tests/unit/test_rdf_update.py
+++ b/tests/unit/test_rdf_update.py
@@ -12,7 +12,7 @@ def _patch_reasoner():
 def test_update_rdf_claim_replace():
     store = MagicMock()
     store.triples.return_value = [("s", "p", "o"), ("s", "p2", "o2")]
-    with patch("autoresearch.storage._rdf_store", store), _patch_reasoner() as r:
+    with patch.object(StorageManager.context, "rdf_store", store), _patch_reasoner() as r:
         with patch("rdflib.URIRef", side_effect=lambda x: x), patch(
             "rdflib.Literal", side_effect=lambda x: x
         ):
@@ -29,7 +29,7 @@ def test_update_rdf_claim_replace():
 def test_update_rdf_claim_partial():
     store = MagicMock()
     store.triples.return_value = [("s", "p", "o")]
-    with patch("autoresearch.storage._rdf_store", store), _patch_reasoner() as r:
+    with patch.object(StorageManager.context, "rdf_store", store), _patch_reasoner() as r:
         with patch("rdflib.URIRef", side_effect=lambda x: x), patch(
             "rdflib.Literal", side_effect=lambda x: x
         ):

--- a/tests/unit/test_storage_backup.py
+++ b/tests/unit/test_storage_backup.py
@@ -8,6 +8,8 @@ import os
 import shutil
 import tempfile
 from unittest.mock import patch
+
+from autoresearch.storage import StorageManager
 import pytest
 import duckdb
 import rdflib
@@ -58,8 +60,8 @@ def mock_storage(temp_dir):
 
     # Mock the StorageManager to use these test files
     with (
-        patch("autoresearch.storage._db_backend") as mock_db_backend,
-        patch("autoresearch.storage._rdf_store") as mock_rdf_store,
+        patch.object(StorageManager.context, "db_backend") as mock_db_backend,
+        patch.object(StorageManager.context, "rdf_store") as mock_rdf_store,
     ):
         mock_db_backend._path = db_path
         mock_db_backend.get_connection.return_value = conn

--- a/tests/unit/test_storage_errors.py
+++ b/tests/unit/test_storage_errors.py
@@ -21,9 +21,9 @@ def test_setup_rdf_store_error(mock_config, assert_error):
     mock_graph_instance.open.side_effect = Exception("RDF store error")
 
     # Execute
-    with patch("autoresearch.storage._graph", None):
-        with patch("autoresearch.storage._db_backend", None):
-            with patch("autoresearch.storage._rdf_store", None):
+    with patch.object(StorageManager.context, "graph", None):
+        with patch.object(StorageManager.context, "db_backend", None):
+            with patch.object(StorageManager.context, "rdf_store", None):
                 with patch(
                     "autoresearch.storage.DuckDBStorageBackend",
                     return_value=mock_db_backend,
@@ -48,9 +48,9 @@ def test_setup_rdf_plugin_missing(mock_config, assert_error):
     mock_graph_instance = MagicMock()
     mock_graph_instance.open.side_effect = Exception("No plugin registered: SQLite")
 
-    with patch("autoresearch.storage._graph", None):
-        with patch("autoresearch.storage._db_backend", None):
-            with patch("autoresearch.storage._rdf_store", None):
+    with patch.object(StorageManager.context, "graph", None):
+        with patch.object(StorageManager.context, "db_backend", None):
+            with patch.object(StorageManager.context, "rdf_store", None):
                 with patch(
                     "autoresearch.storage.DuckDBStorageBackend",
                     return_value=mock_db_backend,

--- a/tests/unit/test_storage_eviction.py
+++ b/tests/unit/test_storage_eviction.py
@@ -42,7 +42,7 @@ def test_pop_low_score():
     }
     mock_lru = OrderedDict([("a", 1), ("b", 2), ("c", 3)])
 
-    with patch("autoresearch.storage._graph", mock_graph):
+    with patch.object(StorageManager.context, "graph", mock_graph):
         with patch("autoresearch.storage._lru", mock_lru):
             # Execute
             node_id = StorageManager._pop_low_score()
@@ -55,7 +55,7 @@ def test_pop_low_score():
 def test_pop_low_score_empty():
     """Test that _pop_low_score returns None when the graph is empty."""
     # Setup
-    with patch("autoresearch.storage._graph", None):
+    with patch.object(StorageManager.context, "graph", None):
         # Execute
         node_id = StorageManager._pop_low_score()
 
@@ -66,7 +66,7 @@ def test_pop_low_score_empty():
     mock_graph = MagicMock()
     mock_graph.nodes = {}
 
-    with patch("autoresearch.storage._graph", mock_graph):
+    with patch.object(StorageManager.context, "graph", mock_graph):
         # Execute
         node_id = StorageManager._pop_low_score()
 
@@ -81,7 +81,7 @@ def test_enforce_ram_budget_lru_policy():
     mock_graph.has_node.return_value = True
     mock_lru = OrderedDict([("a", 1), ("b", 2), ("c", 3)])
 
-    with patch("autoresearch.storage._graph", mock_graph):
+    with patch.object(StorageManager.context, "graph", mock_graph):
         with patch("autoresearch.storage._lru", mock_lru):
             with patch(
                 "autoresearch.storage.StorageManager._current_ram_mb",
@@ -127,7 +127,7 @@ def test_enforce_ram_budget_score_policy():
 
     mock_graph.remove_node.side_effect = mock_remove_node
 
-    with patch("autoresearch.storage._graph", mock_graph):
+    with patch.object(StorageManager.context, "graph", mock_graph):
         with patch("autoresearch.storage._lru", mock_lru):
             with patch(
                 "autoresearch.storage.StorageManager._current_ram_mb",
@@ -155,7 +155,7 @@ def test_enforce_ram_budget_zero_budget():
     # Setup
     mock_graph = MagicMock()
 
-    with patch("autoresearch.storage._graph", mock_graph):
+    with patch.object(StorageManager.context, "graph", mock_graph):
         # Execute
         StorageManager._enforce_ram_budget(0)
 
@@ -170,7 +170,7 @@ def test_enforce_ram_budget_no_nodes_to_evict():
     mock_graph.has_node.return_value = False
     mock_lru = OrderedDict()
 
-    with patch("autoresearch.storage._graph", mock_graph):
+    with patch.object(StorageManager.context, "graph", mock_graph):
         with patch("autoresearch.storage._lru", mock_lru):
             with patch(
                 "autoresearch.storage.StorageManager._current_ram_mb", return_value=100

--- a/tests/unit/test_storage_persistence.py
+++ b/tests/unit/test_storage_persistence.py
@@ -8,9 +8,9 @@ from autoresearch.errors import StorageError
 def test_ensure_storage_initialized_success():
     """Test that _ensure_storage_initialized succeeds when storage is initialized."""
     # Mock the global variables
-    with patch("autoresearch.storage._db_backend", MagicMock()):
-        with patch("autoresearch.storage._graph", MagicMock()):
-            with patch("autoresearch.storage._rdf_store", MagicMock()):
+    with patch.object(StorageManager.context, "db_backend", MagicMock()):
+        with patch.object(StorageManager.context, "graph", MagicMock()):
+            with patch.object(StorageManager.context, "rdf_store", MagicMock()):
                 # Should not raise an exception
                 StorageManager._ensure_storage_initialized()
 
@@ -18,17 +18,17 @@ def test_ensure_storage_initialized_success():
 def test_ensure_storage_initialized_calls_setup():
     """Test that _ensure_storage_initialized calls setup when storage is not initialized."""
     # Mock the global variables to be None
-    with patch("autoresearch.storage._db_backend", None):
-        with patch("autoresearch.storage._graph", None):
-            with patch("autoresearch.storage._rdf_store", None):
+    with patch.object(StorageManager.context, "db_backend", None):
+        with patch.object(StorageManager.context, "graph", None):
+            with patch.object(StorageManager.context, "rdf_store", None):
                 with patch("autoresearch.storage.setup") as mock_setup:
                     # Mock the setup function to set the global variables
                     def mock_setup_impl():
                         import autoresearch.storage as storage
 
-                        storage._db_backend = MagicMock()
-                        storage._graph = MagicMock()
-                        storage._rdf_store = MagicMock()
+                        storage.StorageManager.context.db_backend = MagicMock()
+                        storage.StorageManager.context.graph = MagicMock()
+                        storage.StorageManager.context.rdf_store = MagicMock()
 
                     mock_setup.side_effect = mock_setup_impl
 
@@ -42,9 +42,9 @@ def test_ensure_storage_initialized_calls_setup():
 def test_ensure_storage_initialized_setup_fails():
     """Test that _ensure_storage_initialized raises StorageError when setup fails."""
     # Mock the global variables to be None
-    with patch("autoresearch.storage._db_backend", None):
-        with patch("autoresearch.storage._graph", None):
-            with patch("autoresearch.storage._rdf_store", None):
+    with patch.object(StorageManager.context, "db_backend", None):
+        with patch.object(StorageManager.context, "graph", None):
+            with patch.object(StorageManager.context, "rdf_store", None):
                 with patch(
                     "autoresearch.storage.setup", side_effect=Exception("Setup failed")
                 ):
@@ -61,9 +61,9 @@ def test_ensure_storage_initialized_setup_fails():
 def test_ensure_storage_initialized_db_still_none():
     """Test that _ensure_storage_initialized raises StorageError when db_backend is still None after setup."""
     # Mock the global variables
-    with patch("autoresearch.storage._db_backend", None):
-        with patch("autoresearch.storage._graph", MagicMock()):
-            with patch("autoresearch.storage._rdf_store", MagicMock()):
+    with patch.object(StorageManager.context, "db_backend", None):
+        with patch.object(StorageManager.context, "graph", MagicMock()):
+            with patch.object(StorageManager.context, "rdf_store", MagicMock()):
                 with patch("autoresearch.storage.setup"):
                     # Should raise StorageError
                     with pytest.raises(StorageError) as excinfo:
@@ -75,9 +75,9 @@ def test_ensure_storage_initialized_db_still_none():
 def test_ensure_storage_initialized_graph_still_none():
     """Test that _ensure_storage_initialized raises StorageError when graph is still None after setup."""
     # Mock the global variables
-    with patch("autoresearch.storage._db_backend", MagicMock()):
-        with patch("autoresearch.storage._graph", None):
-            with patch("autoresearch.storage._rdf_store", MagicMock()):
+    with patch.object(StorageManager.context, "db_backend", MagicMock()):
+        with patch.object(StorageManager.context, "graph", None):
+            with patch.object(StorageManager.context, "rdf_store", MagicMock()):
                 with patch("autoresearch.storage.setup"):
                     # Should raise StorageError
                     with pytest.raises(StorageError) as excinfo:
@@ -89,9 +89,9 @@ def test_ensure_storage_initialized_graph_still_none():
 def test_ensure_storage_initialized_rdf_still_none():
     """Test that _ensure_storage_initialized raises StorageError when rdf_store is still None after setup."""
     # Mock the global variables
-    with patch("autoresearch.storage._db_backend", MagicMock()):
-        with patch("autoresearch.storage._graph", MagicMock()):
-            with patch("autoresearch.storage._rdf_store", None):
+    with patch.object(StorageManager.context, "db_backend", MagicMock()):
+        with patch.object(StorageManager.context, "graph", MagicMock()):
+            with patch.object(StorageManager.context, "rdf_store", None):
                 with patch("autoresearch.storage.setup"):
                     # Should raise StorageError
                     with pytest.raises(StorageError) as excinfo:
@@ -124,7 +124,7 @@ def test_persist_to_networkx():
         ],
     }
 
-    with patch("autoresearch.storage._graph", mock_graph):
+    with patch.object(StorageManager.context, "graph", mock_graph):
         with patch("autoresearch.storage._lru", mock_lru):
             # Call the method
             StorageManager._persist_to_networkx(claim)
@@ -159,7 +159,7 @@ def test_persist_to_duckdb():
         "embedding": [0.1, 0.2, 0.3],
     }
 
-    with patch("autoresearch.storage._db_backend", mock_db_backend):
+    with patch.object(StorageManager.context, "db_backend", mock_db_backend):
         # Call the method
         StorageManager._persist_to_duckdb(claim)
 
@@ -175,7 +175,7 @@ def test_persist_to_rdf():
     # Create a test claim
     claim = {"id": "test-id", "attributes": {"verified": True, "source": "test-source"}}
 
-    with patch("autoresearch.storage._rdf_store", mock_rdf_store):
+    with patch.object(StorageManager.context, "rdf_store", mock_rdf_store):
         with patch("rdflib.URIRef") as mock_uri_ref:
             with patch("rdflib.Literal") as mock_literal:
                 # Set up the mocks

--- a/tests/unit/test_storage_ram_usage.py
+++ b/tests/unit/test_storage_ram_usage.py
@@ -23,7 +23,7 @@ def test_current_ram_mb_empty_graph():
     mock_resource.getrusage.return_value = mock_rusage
 
     with (
-        patch("autoresearch.storage._graph", mock_graph),
+        patch.object(StorageManager.context, "graph", mock_graph),
         patch.dict("sys.modules", {"psutil": None}),
         patch.dict("sys.modules", {"resource": mock_resource}),
         patch("resource.getrusage", return_value=mock_rusage),
@@ -45,7 +45,7 @@ def test_current_ram_mb_with_nodes(realistic_claim_batch):
         claim_id = data.pop("id")
         mock_graph.add_node(claim_id, **data)
 
-    with patch("autoresearch.storage._graph", mock_graph):
+    with patch.object(StorageManager.context, "graph", mock_graph):
         result = StorageManager._current_ram_mb()
         assert result > 0
 
@@ -60,7 +60,7 @@ def test_current_ram_mb_with_attributes(realistic_claim_batch):
     data.setdefault("attributes", {"key": "val"})
     mock_graph.add_node(claim_id, **data)
 
-    with patch("autoresearch.storage._graph", mock_graph):
+    with patch.object(StorageManager.context, "graph", mock_graph):
         result = StorageManager._current_ram_mb()
         assert result > 0
 
@@ -75,7 +75,7 @@ def test_current_ram_mb_none_graph():
     mock_resource.getrusage.return_value = mock_rusage
 
     with (
-        patch("autoresearch.storage._graph", None),
+        patch.object(StorageManager.context, "graph", None),
         patch.dict("sys.modules", {"psutil": None}),
         patch.dict("sys.modules", {"resource": mock_resource}),
         patch("resource.getrusage", return_value=mock_rusage),
@@ -105,7 +105,7 @@ def test_current_ram_mb_large_graph():
     mock_resource_large.getrusage.return_value = mock_rusage_large
 
     with (
-        patch("autoresearch.storage._graph", mock_graph),
+        patch.object(StorageManager.context, "graph", mock_graph),
         patch.dict("sys.modules", {"psutil": None}),
         patch.dict("sys.modules", {"resource": mock_resource_large}),
         patch("resource.getrusage", return_value=mock_rusage_large),
@@ -130,7 +130,7 @@ def test_current_ram_mb_large_graph():
         mock_resource_small.getrusage.return_value = mock_rusage_small
 
         with (
-            patch("autoresearch.storage._graph", small_graph),
+            patch.object(StorageManager.context, "graph", small_graph),
             patch.dict("sys.modules", {"psutil": None}),
             patch.dict("sys.modules", {"resource": mock_resource_small}),
             patch("resource.getrusage", return_value=mock_rusage_small),

--- a/tests/unit/test_vector_search.py
+++ b/tests/unit/test_vector_search.py
@@ -65,7 +65,7 @@ def _mock_config():
 def test_create_hnsw_index(monkeypatch):
     dummy = DummyConn()
     mock_backend = MockDuckDBBackend(dummy)
-    monkeypatch.setattr("autoresearch.storage._db_backend", mock_backend, raising=False)
+    monkeypatch.setattr(StorageManager.context, "db_backend", mock_backend, raising=False)
     monkeypatch.setattr(
         ConfigLoader,
         "load_config",
@@ -84,7 +84,7 @@ def test_create_hnsw_index(monkeypatch):
 def test_vector_search_builds_query(monkeypatch):
     dummy = DummyConn()
     mock_backend = MockDuckDBBackend(dummy)
-    monkeypatch.setattr("autoresearch.storage._db_backend", mock_backend, raising=False)
+    monkeypatch.setattr(StorageManager.context, "db_backend", mock_backend, raising=False)
     monkeypatch.setattr(
         ConfigLoader,
         "load_config",
@@ -105,7 +105,7 @@ def test_vector_search_builds_query(monkeypatch):
 def test_vector_search_uses_config_nprobe(monkeypatch):
     dummy = DummyConn()
     mock_backend = MockDuckDBBackend(dummy)
-    monkeypatch.setattr("autoresearch.storage._db_backend", mock_backend, raising=False)
+    monkeypatch.setattr(StorageManager.context, "db_backend", mock_backend, raising=False)
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: _mock_config())
     monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
     monkeypatch.setattr(StorageManager, "has_vss", lambda: True)
@@ -128,7 +128,7 @@ class FailingBackend(MockDuckDBBackend):
 def test_vector_search_failure(monkeypatch):
     dummy = FailingConn()
     mock_backend = FailingBackend(dummy)
-    monkeypatch.setattr("autoresearch.storage._db_backend", mock_backend, raising=False)
+    monkeypatch.setattr(StorageManager.context, "db_backend", mock_backend, raising=False)
     monkeypatch.setattr(
         ConfigLoader,
         "load_config",
@@ -151,7 +151,7 @@ def test_vector_search_failure(monkeypatch):
 
 def test_refresh_vector_index(monkeypatch):
     backend = MagicMock()
-    monkeypatch.setattr("autoresearch.storage._db_backend", backend, raising=False)
+    monkeypatch.setattr(StorageManager.context, "db_backend", backend, raising=False)
     monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
 
     StorageManager.refresh_vector_index()
@@ -163,9 +163,9 @@ def test_embedding_update_triggers_index_refresh(monkeypatch):
     backend = MagicMock()
     graph = nx.DiGraph()
     store = MagicMock()
-    monkeypatch.setattr("autoresearch.storage._db_backend", backend, raising=False)
-    monkeypatch.setattr("autoresearch.storage._graph", graph, raising=False)
-    monkeypatch.setattr("autoresearch.storage._rdf_store", store, raising=False)
+    monkeypatch.setattr(StorageManager.context, "db_backend", backend, raising=False)
+    monkeypatch.setattr(StorageManager.context, "graph", graph, raising=False)
+    monkeypatch.setattr(StorageManager.context, "rdf_store", store, raising=False)
     monkeypatch.setattr(StorageManager, "_enforce_ram_budget", lambda budget: None)
     monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 0)
     monkeypatch.setattr(StorageManager, "has_vss", lambda: True)


### PR DESCRIPTION
## Summary
- Encapsulate global storage state in a `StorageContext` dataclass
- Inject storage context into StorageManager and test helpers
- Provide testing factory for isolated storage contexts

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d6682d39483338f176bd26c5db484