### PR TITLE
Add BDD scenarios for configuration errors and dialectical CLI mode

### DIFF
--- a/tests/behavior/features/config_cli.feature
+++ b/tests/behavior/features/config_cli.feature
@@ -20,3 +20,10 @@ Feature: Configuration CLI
     Then the CLI should exit successfully
     And the configuration file should set reasoning mode to "dialectical"
     And the configuration file should set loops to 3
+
+  Scenario: Reject invalid reasoning mode
+    Given a temporary work directory
+    And I run `autoresearch config init --force` in a temporary directory
+    When I run `autoresearch config reasoning --mode invalid_mode`
+    Then the CLI should exit with an error
+    And the error message should contain "Invalid reasoning mode"

--- a/tests/behavior/features/reasoning_mode_cli.feature
+++ b/tests/behavior/features/reasoning_mode_cli.feature
@@ -11,3 +11,11 @@ Feature: Reasoning mode via CLI
     And the loops used should be 1
     And the agent groups should be "Synthesizer"
     And the agents executed should be "Synthesizer"
+
+  Scenario: Dialectical mode via CLI
+    Given loops is set to 1 in configuration
+    When I run `autoresearch search "mode test" --mode dialectical`
+    Then the CLI should exit successfully
+    And the loops used should be 1
+    And the agent groups should be "Synthesizer; Contrarian; FactChecker"
+    And the agents executed should be "Synthesizer, Contrarian, FactChecker"

--- a/tests/behavior/steps/config_cli_steps.py
+++ b/tests/behavior/steps/config_cli_steps.py
@@ -36,6 +36,12 @@ def run_config_reasoning(cli_runner, bdd_context, mode: str, loops: int):
     bdd_context["result"] = result
 
 
+@when(parsers.parse('I run `autoresearch config reasoning --mode {mode}`'))
+def run_config_reasoning_mode_only(cli_runner, bdd_context, mode: str):
+    result = cli_runner.invoke(cli_app, ["config", "reasoning", "--mode", mode])
+    bdd_context["result"] = result
+
+
 @then('the files "autoresearch.toml" and ".env" should be created')
 def check_config_files(work_dir):
     assert (work_dir / "autoresearch.toml").exists()
@@ -45,6 +51,11 @@ def check_config_files(work_dir):
 @then("the CLI should exit successfully")
 def cli_success(bdd_context):
     assert bdd_context["result"].exit_code == 0
+
+
+@then("the CLI should exit with an error")
+def cli_error(bdd_context):
+    assert bdd_context["result"].exit_code != 0
 
 
 @then(parsers.parse('the configuration file should set reasoning mode to "{mode}"'))
@@ -59,6 +70,13 @@ def assert_loops(work_dir, loops: int):
     assert f"loops = {loops}" in content
 
 
+@then(parsers.parse('the error message should contain "{text}"'))
+def error_message_contains(bdd_context, text: str):
+    exc = bdd_context["result"].exception
+    assert exc is not None, "Expected an exception but none occurred"
+    assert text in str(exc)
+
+
 @scenario("../features/config_cli.feature", "Initialize configuration files")
 def test_config_init():
     pass
@@ -71,4 +89,9 @@ def test_config_validate():
 
 @scenario("../features/config_cli.feature", "Update reasoning configuration")
 def test_config_reasoning():
+    pass
+
+
+@scenario("../features/config_cli.feature", "Reject invalid reasoning mode")
+def test_config_reasoning_invalid():
     pass

--- a/tests/behavior/steps/reasoning_mode_cli_steps.py
+++ b/tests/behavior/steps/reasoning_mode_cli_steps.py
@@ -15,6 +15,11 @@ def test_direct_mode_cli():
     pass
 
 
+@scenario("../features/reasoning_mode_cli.feature", "Dialectical mode via CLI")
+def test_dialectical_mode_cli():
+    pass
+
+
 @given(parsers.parse("loops is set to {count:d} in configuration"), target_fixture="config")
 def loops_config(count: int, monkeypatch):
     cfg = ConfigModel.model_construct(agents=["Synthesizer"], loops=count)


### PR DESCRIPTION
## Summary
- extend `config` CLI feature with scenario for invalid reasoning mode and implement supporting steps
- cover dialectical reasoning mode via CLI

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/behavior -q` *(fails: fixture 'response' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e324875b883339f10b86ee602cdc5