### PR TITLE
feat: add token usage threshold test

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -320,12 +320,14 @@ every test.
 Some integration tests compare runtime metrics against JSON files in
 `tests/integration/baselines`. When legitimate changes modify these
 metrics (for example token counts), run the failing test to capture the
-new values and update the corresponding baseline file.
+new values and update the corresponding baseline file. Token-based tests
+allow a small overage configurable via the ``TOKEN_USAGE_THRESHOLD``
+environment variable.
 
-1. Run the test with `pytest tests/integration/test_token_usage.py`.
+1. Run the test with ``pytest tests/integration/test_token_usage_integration.py``.
 2. Inspect the assertion failure to see the updated token counts.
-3. Edit the JSON baseline file to match the new values and commit the
-   change alongside your code.
+3. Edit ``tests/integration/baselines/token_usage.json`` to match the new
+   values and commit the change alongside your code.
 
 Keeping baselines in sync ensures that performance regressions are
 intentional and reviewed.

--- a/tests/integration/test_token_usage_integration.py
+++ b/tests/integration/test_token_usage_integration.py
@@ -1,6 +1,7 @@
 """Integration test for token usage tracking against baselines."""
 
 import json
+import os
 from pathlib import Path
 
 from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
@@ -8,6 +9,8 @@ from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
 
 BASELINE_PATH = Path(__file__).resolve().parent / "baselines" / "token_usage.json"
+# Allow tokens to exceed the baseline by this many tokens before failing
+THRESHOLD = int(os.getenv("TOKEN_USAGE_THRESHOLD", "0"))
 
 
 class DummyAgent:
@@ -26,7 +29,7 @@ class DummyAgent:
         return {"results": {self.name: "ok"}}
 
 
-def test_token_usage_matches_baseline(monkeypatch, benchmark):
+def test_token_usage_matches_baseline(monkeypatch):
     """Token counts should match the stored baseline."""
 
     # Setup a minimal configuration and agent
@@ -36,15 +39,16 @@ def test_token_usage_matches_baseline(monkeypatch, benchmark):
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader()._config = None
 
-    def run():
-        response = Orchestrator.run_query("q", cfg)
-        return response.metrics["execution_metrics"]["agent_tokens"]
-
-    tokens = benchmark.pedantic(run, iterations=1, rounds=1)
+    response = Orchestrator.run_query("q", cfg)
+    tokens = response.metrics["execution_metrics"]["agent_tokens"]
 
     baseline = json.loads(BASELINE_PATH.read_text())
     assert tokens.keys() == baseline.keys()
     for agent, counts in baseline.items():
         measured = tokens[agent]
-        assert measured["in"] <= counts["in"]
-        assert measured["out"] <= counts["out"]
+        assert measured["in"] <= counts["in"] + THRESHOLD, (
+            f"Inbound tokens for {agent} exceed baseline by more than {THRESHOLD}"
+        )
+        assert measured["out"] <= counts["out"] + THRESHOLD, (
+            f"Outbound tokens for {agent} exceed baseline by more than {THRESHOLD}"
+        )


### PR DESCRIPTION
## Summary
- enforce token usage baseline in integration tests with optional threshold
- document how to refresh token baselines and configure threshold

## Testing
- `uv run flake8 tests/integration/test_token_usage_integration.py`
- `uv run mypy src`
- `uv run pytest tests/integration/test_token_usage_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e495dbe0083338356d2f0e45c7985