### PR TITLE
chore: use default config in tests

### DIFF
--- a/tests/data/autoresearch.toml
+++ b/tests/data/autoresearch.toml
@@ -1,4 +1,0 @@
-[search]
-semantic_similarity_weight = 0.5
-bm25_weight = 0.3
-source_credibility_weight = 0.2

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from autoresearch.config.loader import ConfigLoader
@@ -9,10 +7,14 @@ from autoresearch.config.loader import ConfigLoader
 
 @pytest.fixture()
 def config_loader() -> ConfigLoader:
-    """Provide a ConfigLoader instance using the test configuration file."""
+    """Provide a ConfigLoader instance for tests.
+
+    The loader uses its built-in defaults and does not rely on an external
+    ``autoresearch.toml`` file. This keeps unit tests self-contained and makes
+    configuration behaviour consistent regardless of the working directory.
+    """
     loader = ConfigLoader.new_for_tests()
-    test_cfg = Path(__file__).resolve().parents[1] / "data" / "autoresearch.toml"
-    loader.search_paths = [test_cfg]
+    # Ensure watch paths reflect the default search paths
     loader._update_watch_paths()
     return loader
 


### PR DESCRIPTION
## Summary
- simplify config fixture so tests rely on built-in defaults rather than a test-specific `autoresearch.toml`
- drop redundant test configuration file

## Testing
- `uv run pytest tests/unit/test_config_errors.py tests/unit/test_config_profiles.py tests/unit/test_config_validation_errors.py -q`
- `uv run flake8 src tests`
- `uv run mypy src`


------
https://chatgpt.com/codex/tasks/task_e_688eb0eb594c8333bb790dd42b577d81