### PR TITLE
feat: add pluggable ontology reasoners and visualization

### DIFF
--- a/src/autoresearch/kg_reasoning.py
+++ b/src/autoresearch/kg_reasoning.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Dict, Optional
 
 import warnings
 import rdflib
@@ -22,10 +22,12 @@ except Exception:  # pragma: no cover - fallback for offline tests
     @dataclass(frozen=True)
     class OwlRLStub:
         OWLRL_Semantics: object
+        RDFS_Semantics: object
         DeductiveClosure: type
 
     owlrl = OwlRLStub(  # type: ignore
         OWLRL_Semantics=object(),
+        RDFS_Semantics=object(),
         DeductiveClosure=_DeductiveClosure,
     )
     warnings.warn(
@@ -37,22 +39,73 @@ from .config import ConfigLoader
 from .errors import StorageError
 
 
+# Registry for pluggable ontology reasoners
+_REASONER_PLUGINS: Dict[str, Callable[[rdflib.Graph], None]] = {}
+
+
+def register_reasoner(name: str) -> Callable[[Callable[[rdflib.Graph], None]], Callable[[rdflib.Graph], None]]:
+    """Register a reasoning plugin under ``name``.
+
+    The returned decorator registers ``func`` as the handler for the given
+    reasoner name, allowing ``run_ontology_reasoner`` to invoke it when
+    configured.
+    """
+
+    def decorator(func: Callable[[rdflib.Graph], None]) -> Callable[[rdflib.Graph], None]:
+        _REASONER_PLUGINS[name] = func
+        return func
+
+    return decorator
+
+
+@register_reasoner("owlrl")
+def _owlrl_reasoner(store: rdflib.Graph) -> None:
+    """Apply OWL RL reasoning using ``owlrl`` if available."""
+
+    try:  # pragma: no cover - optional dependency
+        owlrl.DeductiveClosure(owlrl.OWLRL_Semantics).expand(store)
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise StorageError(
+            "Failed to apply owlrl reasoning",
+            cause=exc,
+            suggestion="Ensure the owlrl package is installed",
+        )
+
+
+@register_reasoner("rdfs")
+def _rdfs_reasoner(store: rdflib.Graph) -> None:
+    """Apply RDFS reasoning using ``owlrl`` if available."""
+
+    try:  # pragma: no cover - optional dependency
+        owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(store)
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise StorageError(
+            "Failed to apply RDFS reasoning",
+            cause=exc,
+            suggestion="Ensure the owlrl package is installed",
+        )
+
+
 def run_ontology_reasoner(store: rdflib.Graph, engine: Optional[str] = None) -> None:
     """Apply ontology reasoning over ``store`` using the configured engine."""
+
     reasoner_setting = engine or getattr(
         ConfigLoader().config.storage, "ontology_reasoner", "owlrl"
     )
     reasoner = str(reasoner_setting)
-    if reasoner == "owlrl":
-        try:  # pragma: no cover - optional dependency
-            owlrl.DeductiveClosure(owlrl.OWLRL_Semantics).expand(store)
-        except Exception as exc:  # pragma: no cover - optional dependency
+
+    if reasoner in _REASONER_PLUGINS:
+        try:
+            _REASONER_PLUGINS[reasoner](store)
+        except StorageError:
+            raise
+        except Exception as exc:
             raise StorageError(
-                "Failed to apply owlrl reasoning",
+                f"Failed to apply {reasoner} reasoning",
                 cause=exc,
-                suggestion="Ensure the owlrl package is installed",
+                suggestion="Ensure the ontology reasoner plugin is correctly installed",
             )
-    else:  # pragma: no cover - external reasoners optional
+    elif ":" in reasoner:  # pragma: no cover - external reasoners optional
         try:
             module, func = reasoner.split(":", maxsplit=1)
             mod = import_module(module)
@@ -63,9 +116,22 @@ def run_ontology_reasoner(store: rdflib.Graph, engine: Optional[str] = None) -> 
                 cause=exc,
                 suggestion="Check storage.ontology_reasoner configuration",
             )
+    else:
+        raise StorageError(
+            f"Unknown ontology reasoner: {reasoner}",
+            suggestion="Register the reasoner via register_reasoner or use 'module:function'",
+        )
 
 
 def query_with_reasoning(store: rdflib.Graph, query: str, engine: Optional[str] = None):
     """Run a SPARQL query after applying ontology reasoning."""
+
     run_ontology_reasoner(store, engine)
     return store.query(query)
+
+
+__all__ = [
+    "run_ontology_reasoner",
+    "query_with_reasoning",
+    "register_reasoner",
+]

--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -37,6 +37,7 @@ from .logging_utils import get_logger
 from .orchestration.metrics import EVICTION_COUNTER
 from .storage_backends import DuckDBStorageBackend, KuzuStorageBackend
 from .kg_reasoning import run_ontology_reasoner
+from .visualization import save_rdf_graph
 
 
 @dataclass
@@ -1345,21 +1346,4 @@ class StorageManager:
         """Generate a simple PNG visualization of the RDF graph."""
         StorageManager._ensure_storage_initialized()
         store = StorageManager.get_rdf_store()
-
-        g: nx.DiGraph[Any] = nx.DiGraph()
-        for s, p, o in store:
-            g.add_edge(str(s), str(o), label=str(p))
-
-        import matplotlib
-
-        matplotlib.use("Agg")
-        import matplotlib.pyplot as plt
-
-        plt.figure(figsize=(8, 6))
-        pos = nx.spring_layout(g, seed=42)
-        nx.draw(g, pos, with_labels=True, node_color="lightblue", font_size=8)
-        edge_labels = nx.get_edge_attributes(g, "label")
-        nx.draw_networkx_edge_labels(g, pos, edge_labels=edge_labels, font_size=6)
-        plt.tight_layout()
-        plt.savefig(output_path)
-        plt.close()
+        save_rdf_graph(store, output_path)


### PR DESCRIPTION
## Summary
- support pluggable ontology reasoning engines with default OWL RL and RDFS implementations
- add lightweight RDF graph visualization utility and wire into storage manager
- test subclass inference via custom reasoner and ensure visualization file generation

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit/test_kg_reasoning.py tests/unit/test_visualization.py tests/integration/test_ontology_reasoning.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ee56a7ad08333bcb3ae6bc8dc049e