### PR TITLE
Ensure config watcher cleanup

### DIFF
--- a/src/autoresearch/api.py
+++ b/src/autoresearch/api.py
@@ -366,9 +366,12 @@ def _stop_config_watcher() -> None:
         None
     """
     global _watch_ctx
-    if _watch_ctx is not None:
-        _watch_ctx.__exit__(None, None, None)
-        _watch_ctx = None
+    try:
+        if _watch_ctx is not None:
+            _watch_ctx.__exit__(None, None, None)
+            _watch_ctx = None
+    finally:
+        config_loader.stop_watching()
 
 
 @app.post("/query", response_model=None)

--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -160,7 +160,14 @@ def start_watcher(
 
     watch_ctx = _config_loader.watching()
     watch_ctx.__enter__()
-    ctx.call_on_close(lambda: watch_ctx.__exit__(None, None, None))
+
+    def _stop_watcher() -> None:
+        try:
+            watch_ctx.__exit__(None, None, None)
+        finally:
+            _config_loader.stop_watching()
+
+    ctx.call_on_close(_stop_watcher)
 
 
 @app.command()


### PR DESCRIPTION
## Summary
- stop config file watcher for CLI and API shutdown
- assert config watcher threads terminate in cleanup tests

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit/test_config_watcher_cleanup.py::test_cli_watcher_cleanup -q --import-mode=importlib`
- `uv run pytest tests/behavior -q` *(fails: fixture 'response' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f898e3c0c833389e9150b062f732b