### PR TITLE
docs: mark specialized agents complete

### DIFF
--- a/CODE_COMPLETE_PLAN.md
+++ b/CODE_COMPLETE_PLAN.md
@@ -17,9 +17,9 @@ Based on a thorough analysis of the Autoresearch codebase, I've developed a comp
 
 ### 1.2 Agent System
 - **Complete the implementation of specialized agents**
-  - Implement the Moderator agent for managing complex dialogues
-  - Develop the Specialist agent for domain-specific knowledge
-  - Create a User agent to represent user preferences
+  - ~~Implement the Moderator agent for managing complex dialogues~~ (implemented in `src/autoresearch/agents/specialized/moderator.py`)
+  - ~~Develop the Specialist agent for domain-specific knowledge~~ (implemented in `src/autoresearch/agents/specialized/domain_specialist.py`)
+  - ~~Create a User agent to represent user preferences~~ (implemented in `src/autoresearch/agents/specialized/user_agent.py`)
 - **Enhance agent interaction patterns**
   - Implement agent-to-agent communication protocols
   - Add support for agent coalitions in complex queries

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,9 +36,7 @@ Before publishing 0.1.0 the release plan lists several checks:
 - Ensure packaging metadata and publish scripts work correctly.
 
 Any remaining issues from these tasks will be addressed in 0.1.1.
-- CLI backup commands, testing utilities and all specialized agents are
-  planned to have full implementations and comprehensive unit tests once
-  testing passes.
+- CLI backup commands and testing utilities remain pending, while specialized agents—Moderator, Specialist, and User—are already implemented (`src/autoresearch/agents/specialized/moderator.py`, `src/autoresearch/agents/specialized/domain_specialist.py`, `src/autoresearch/agents/specialized/user_agent.py`) and will receive comprehensive unit tests once testing passes.
 The 0.1.1 release is planned for **February 1, 2026**.
 
 ## 0.2.0 – API stabilization and improved search


### PR DESCRIPTION
## Summary
- Mark Moderator, Specialist, and User agents as implemented
- Link documentation to `src/autoresearch/agents/specialized` modules for traceability

## Testing
- `uv run flake8 src tests` *(fails: F401 'typing.List' imported but unused)*
- `uv run mypy src`
- `uv run pytest -q` *(fails: import file mismatch in tests/integration/test_a2a_interface.py)*
- `uv run pytest tests/behavior` *(fails: test_agent_message_exchange)*

------
https://chatgpt.com/codex/tasks/task_e_688fa3da6c5c83338f855c32c462723c