### PR TITLE
refactor: remove wildcard imports in behavior tests

### DIFF
--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 import os
-from typing import Optional, Any, List, Tuple
+from typing import Optional, Any, Tuple
 
 import typer
 from rich.console import Console

--- a/tests/behavior/steps/__init__.py
+++ b/tests/behavior/steps/__init__.py
@@ -1,5 +1,12 @@
 """Behavior step package."""
 
+from .common_steps import (
+    app_running,
+    app_running_with_default,
+    application_running,
+    cli_app,
+)  # noqa: F401
+
 # Import step modules so pytest-bdd discovers them when running the package.
 from . import distributed_execution_steps  # noqa: F401
 from . import config_cli_steps  # noqa: F401
@@ -7,3 +14,10 @@ from . import backup_cli_steps  # noqa: F401
 from . import serve_cli_steps  # noqa: F401
 from . import completion_cli_steps  # noqa: F401
 from . import capabilities_cli_steps  # noqa: F401
+
+__all__ = [
+    "app_running",
+    "app_running_with_default",
+    "application_running",
+    "cli_app",
+]

--- a/tests/behavior/steps/agent_orchestration_steps.py
+++ b/tests/behavior/steps/agent_orchestration_steps.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from pytest_bdd import scenario, given, when, then, parsers
 import logging
 
-from .common_steps import *  # noqa: F401,F403
+from .common_steps import app_running, app_running_with_default, application_running, cli_app
 from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.orchestration.orchestrator import Orchestrator

--- a/tests/behavior/steps/api_streaming_steps.py
+++ b/tests/behavior/steps/api_streaming_steps.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import responses
 import requests
 
-from .common_steps import *  # noqa: F401,F403
+from .common_steps import app_running, app_running_with_default, application_running
 from fastapi.testclient import TestClient
 from autoresearch.api import app as api_app
 from autoresearch.orchestration.state import QueryState

--- a/tests/behavior/steps/cli_options_steps.py
+++ b/tests/behavior/steps/cli_options_steps.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from pytest_bdd import scenario, when, then, parsers
 
-from .common_steps import *  # noqa: F401,F403
+from .common_steps import app_running, app_running_with_default, application_running, cli_app
 from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.orchestration.orchestrator import Orchestrator

--- a/tests/behavior/steps/configuration_hot_reload_steps.py
+++ b/tests/behavior/steps/configuration_hot_reload_steps.py
@@ -2,7 +2,7 @@
 import os
 from pytest_bdd import scenario, when, then, parsers
 
-from .common_steps import *  # noqa: F401,F403
+from .common_steps import app_running, app_running_with_default, application_running
 from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
 

--- a/tests/behavior/steps/interactive_monitor_steps.py
+++ b/tests/behavior/steps/interactive_monitor_steps.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from pytest_bdd import scenario, when, then, parsers
 
-from .common_steps import *  # noqa: F401,F403
+from .common_steps import app_running, app_running_with_default, application_running, cli_app
 
 
 @when(parsers.parse('I start `autoresearch monitor run` and enter "{text}"'))

--- a/tests/behavior/steps/local_sources_steps.py
+++ b/tests/behavior/steps/local_sources_steps.py
@@ -2,7 +2,7 @@
 import subprocess
 from pytest_bdd import scenario, given, when, then, parsers
 
-from .common_steps import *  # noqa: F401,F403
+from .common_steps import app_running, app_running_with_default, application_running
 from autoresearch.config.models import ConfigModel
 from autoresearch.search import Search
 from pdfminer.high_level import extract_text

--- a/tests/behavior/steps/output_formatting_steps.py
+++ b/tests/behavior/steps/output_formatting_steps.py
@@ -2,7 +2,7 @@
 import json
 from pytest_bdd import scenario, when, then, parsers
 
-from .common_steps import *  # noqa: F401,F403
+from .common_steps import app_running, app_running_with_default, application_running, cli_app
 
 
 @when(parsers.parse('I run `autoresearch search "{query}"` in TTY mode'))

--- a/tests/behavior/steps/query_interface_steps.py
+++ b/tests/behavior/steps/query_interface_steps.py
@@ -2,7 +2,7 @@
 import json
 from pytest_bdd import scenario, when, then, parsers
 
-from .common_steps import *  # noqa: F401,F403
+from .common_steps import app_running, app_running_with_default, application_running, cli_app
 
 
 @when(parsers.parse('I run `autoresearch search "{query}"` in a terminal'))

--- a/tests/behavior/steps/streamlit_gui_steps.py
+++ b/tests/behavior/steps/streamlit_gui_steps.py
@@ -5,7 +5,7 @@ from pytest_bdd import scenario, given, when, then, parsers
 import pytest
 from unittest.mock import patch, MagicMock
 
-from .common_steps import *  # noqa: F401,F403
+from .common_steps import app_running, app_running_with_default, application_running
 from autoresearch.models import QueryResponse
 
 


### PR DESCRIPTION
## Summary
- replace wildcard imports in behavior step modules with explicit names
- expose shared step utilities in `tests/behavior/steps/__init__.py`
- remove unused typing import for linting

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: import file mismatch for tests/integration/test_a2a_interface.py)*
- `uv run pytest tests/behavior` *(fails: fixture 'response' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fa3d253248333ae48a2cf36d9b1a6