### PR TITLE
feat: ensure a2a-sdk available for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,8 @@ llm = [
 ]
 # Dependencies needed only for running tests
 test = [
-    "owlrl >=7.1.3"
+    "owlrl >=7.1.3",
+    "a2a-sdk >=0.2.16",
 ]
 # Full install: all features for power users and development
 full = [

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -55,7 +55,7 @@ fi
 # Confirm required extras are installed
 echo "Verifying required extras..."
 missing=0
-for pkg in pytest-cov hypothesis tomli_w duckdb-extension-vss; do
+for pkg in pytest-cov hypothesis tomli_w duckdb-extension-vss a2a-sdk; do
     if ! uv pip show "$pkg" >/dev/null 2>&1; then
         echo "Missing required package: $pkg" >&2
         missing=1
@@ -65,7 +65,7 @@ if [ "$missing" -ne 0 ]; then
     echo "Required packages are missing. Check setup logs." >&2
     exit 1
 fi
-uv pip list | grep -E 'pytest-cov|hypothesis|tomli_w|duckdb-extension-vss'
+uv pip list | grep -E 'pytest-cov|hypothesis|tomli_w|duckdb-extension-vss|a2a-sdk'
 
 # Helper for retrying flaky network operations
 retry() {

--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 import os
-from typing import Optional, Any, List, Tuple
+from typing import Optional, Any, Tuple
 
 import typer
 from rich.console import Console

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <4.0"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -299,6 +299,7 @@ parsers = [
     { name = "python-docx" },
 ]
 test = [
+    { name = "a2a-sdk" },
     { name = "owlrl" },
 ]
 ui = [
@@ -311,6 +312,7 @@ vss = [
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.2.16" },
+    { name = "a2a-sdk", marker = "extra == 'test'", specifier = ">=0.2.16" },
     { name = "bertopic", marker = "extra == 'full'", specifier = ">=0.17.3" },
     { name = "bertopic", marker = "extra == 'nlp'", specifier = ">=0.17.3" },
     { name = "cibuildwheel", marker = "extra == 'dev'", specifier = ">=3.0.1" },


### PR DESCRIPTION
## Summary
- include a2a-sdk in test dependencies and verify its presence during setup
- clean up unused import in CLI app module

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: import file mismatch tests/integration/test_a2a_interface.py)*
- `uv run pytest tests/unit -q` *(fails: assert 2 == 1)*
- `uv run pytest tests/integration -q` *(fails: ImportError: cannot import name 'RootModel' from 'pydantic.root_model')*
- `uv run pytest tests/behavior -q` *(fails: fixture 'response' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fa3c56d7c8333a38eec9d0fd8a3a6