### PR TITLE
Use ellipsis for protocol method stub

### DIFF
--- a/src/autoresearch/orchestration/reasoning.py
+++ b/src/autoresearch/orchestration/reasoning.py
@@ -25,7 +25,7 @@ class ReasoningStrategy(Protocol):
 
     def run_query(self, query: str, config: ConfigModel) -> QueryResponse:
         """Execute reasoning for a query."""
-        raise NotImplementedError
+        ...
 
 
 class ChainOfThoughtStrategy:


### PR DESCRIPTION
## Summary
- Use ellipsis in `ReasoningStrategy.run_query` to align with protocol conventions

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q --import-mode=importlib` (fails: `test_cli_backup_extra.py::test_backup_create_error`)
- `uv run pytest tests/behavior -q` (fails: `agent_messages_steps.py::test_agent_message_exchange`)


------
https://chatgpt.com/codex/tasks/task_e_688facead9bc8333bed41961cefd6bd0