### PR TITLE
chore(tests): add missing pytest import

### DIFF
--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -2,6 +2,7 @@ import sys
 import importlib
 import types
 from pathlib import Path
+import pytest
 from typer.testing import CliRunner
 
 
@@ -101,7 +102,6 @@ def test_search_help_includes_visualize(monkeypatch):
 
 
 def test_search_loops_option(monkeypatch):
-    import pytest
     pytest.skip("loops option CLI interaction fails under test environment")
     dummy_storage = types.ModuleType("autoresearch.storage")
 


### PR DESCRIPTION
## Summary
- ensure CLI help tests import pytest at module scope
- verify auth and config tests import required utilities

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/behavior -q` *(fails: test_agent_message_exchange)*
- `uv run pytest --cov=src -q` *(fails: import mismatch for test_a2a_interface)*

------
https://chatgpt.com/codex/tasks/task_e_688faccda6e48333b60363fd8540062c