### PR TITLE
Add tests for search context and system monitor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ autoresearch = "autoresearch.main:app"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--maxfail=1 --disable-warnings -q --cov=autoresearch.orchestration.orchestrator --cov=autoresearch.storage --cov=autoresearch.storage_backends --cov=autoresearch.search.core --cov=autoresearch.streamlit_ui --cov-report=xml --cov-report=term-missing --cov-fail-under=0 -m 'not slow and not requires_ui and not requires_vss'"
+addopts = "--maxfail=1 --disable-warnings -q --cov=autoresearch.orchestration.orchestrator --cov=autoresearch.storage --cov=autoresearch.storage_backends --cov=autoresearch.search.core --cov=autoresearch.streamlit_ui --cov-report=xml --cov-report=term-missing --cov-fail-under=90 -m 'not slow and not requires_ui and not requires_vss'"
 testpaths = ["tests/unit", "tests/integration", "tests/behavior"]
 python_files = ["test_*.py", "*_steps.py"]
 markers = [

--- a/tests/unit/test_search_context_extract_entities_no_spacy.py
+++ b/tests/unit/test_search_context_extract_entities_no_spacy.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from autoresearch.search.context import SearchContext
+
+
+def make_config():
+    return SimpleNamespace(
+        search=SimpleNamespace(
+            context_aware=SimpleNamespace(
+                max_history_items=10,
+                enabled=True,
+                use_search_history=True,
+                use_query_expansion=True,
+                expansion_factor=0.5,
+            )
+        )
+    )
+
+
+@patch("autoresearch.search.context.get_config", make_config)
+@patch("autoresearch.search.context.SPACY_AVAILABLE", False)
+def test_extract_entities_without_spacy():
+    with SearchContext.temporary_instance() as ctx:
+        ctx.nlp = None
+        ctx._extract_entities("Hello World")
+        assert ctx.entities["hello"] == 1
+        assert ctx.entities["world"] == 1

--- a/tests/unit/test_search_context_history_trim.py
+++ b/tests/unit/test_search_context_history_trim.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from autoresearch.search.context import SearchContext
+
+
+def make_config(max_history):
+    return SimpleNamespace(
+        search=SimpleNamespace(
+            context_aware=SimpleNamespace(
+                max_history_items=max_history,
+                enabled=True,
+                use_search_history=True,
+                use_query_expansion=True,
+                expansion_factor=0.5,
+            )
+        )
+    )
+
+
+@patch("autoresearch.search.context.get_config", lambda: make_config(3))
+def test_add_to_history_trims_old_entries():
+    with SearchContext.temporary_instance() as ctx:
+        for i in range(4):
+            ctx.add_to_history(f"q{i}", [])
+        assert len(ctx.search_history) == 3
+        # should keep last 3 queries q1,q2,q3
+        assert [item["query"] for item in ctx.search_history] == ["q1", "q2", "q3"]

--- a/tests/unit/test_system_monitor.py
+++ b/tests/unit/test_system_monitor.py
@@ -17,3 +17,11 @@ def test_system_monitor_collects(monkeypatch):
 
     assert registry.get_sample_value("autoresearch_system_cpu_percent") == 12.0
     assert registry.get_sample_value("autoresearch_system_memory_percent") == 34.0
+
+
+def test_collect_returns_expected_dict(monkeypatch):
+    monkeypatch.setattr(psutil, "cpu_percent", lambda interval=None: 55.0)
+    mem = type("mem", (), {"percent": 44.0})()
+    monkeypatch.setattr(psutil, "virtual_memory", lambda: mem)
+    data = SystemMonitor.collect()
+    assert data == {"cpu_percent": 55.0, "memory_percent": 44.0}


### PR DESCRIPTION
## Summary
- add unit tests for SearchContext history trimming and entity extraction fallback
- add SystemMonitor coverage test
- enforce 90% coverage threshold in pytest configuration

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit/test_search_context_history_trim.py tests/unit/test_search_context_extract_entities_no_spacy.py tests/unit/test_system_monitor.py --cov=autoresearch.search.context --cov=autoresearch.monitor.system_monitor --cov-report=term-missing -o addopts=""`

------
https://chatgpt.com/codex/tasks/task_e_688fa85335ac8333aa2c89a5becd0152