### PR TITLE
refactor: extract shared orchestration utils

### DIFF
--- a/src/autoresearch/orchestration/parallel.py
+++ b/src/autoresearch/orchestration/parallel.py
@@ -14,52 +14,13 @@ from ..agents.registry import AgentFactory
 from ..errors import AgentError, OrchestrationError, TimeoutError
 from ..logging_utils import get_logger
 from ..tracing import get_tracer, setup_tracing
+from .utils import (
+    get_memory_usage as _get_memory_usage,
+    calculate_result_confidence as _calculate_result_confidence,
+)
 
 
 log = get_logger(__name__)
-
-
-def _get_memory_usage() -> float:
-    """Get current memory usage in MB."""
-    try:
-        import psutil  # type: ignore
-
-        process = psutil.Process()
-        memory_info = process.memory_info()
-        return memory_info.rss / (1024 * 1024)
-    except ImportError:  # pragma: no cover - fallback path
-        import resource
-
-        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-
-
-def _calculate_result_confidence(result: QueryResponse) -> float:
-    """Compute a naive confidence score for a query result."""
-    confidence = 0.5
-
-    if getattr(result, "citations", None):
-        citation_count = len(result.citations)
-        confidence += min(0.3, 0.05 * citation_count)
-
-    if getattr(result, "reasoning", None):
-        reasoning_length = len(result.reasoning)
-        confidence += min(0.2, 0.01 * reasoning_length)
-
-    if getattr(result, "metrics", None) and "token_usage" in result.metrics:
-        tokens = result.metrics["token_usage"]
-        if "total" in tokens and "max_tokens" in tokens:
-            ratio = tokens["total"] / max(1, tokens["max_tokens"])
-            if 0.3 <= ratio <= 0.9:
-                confidence += 0.1
-            elif ratio > 0.9:
-                confidence -= 0.1
-
-    if getattr(result, "metrics", None) and "errors" in result.metrics:
-        error_count = len(result.metrics["errors"])
-        if error_count > 0:
-            confidence -= min(0.4, 0.1 * error_count)
-
-    return max(0.1, min(1.0, confidence))
 
 
 def execute_parallel_query(

--- a/src/autoresearch/orchestration/utils.py
+++ b/src/autoresearch/orchestration/utils.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from ..models import QueryResponse
+
+
+def get_memory_usage() -> float:
+    """Get current memory usage in MB."""
+    try:
+        import psutil  # type: ignore
+
+        process = psutil.Process()
+        memory_info = process.memory_info()
+        return memory_info.rss / (1024 * 1024)
+    except ImportError:  # pragma: no cover - fallback path
+        import resource
+
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+
+
+def calculate_result_confidence(result: QueryResponse) -> float:
+    """Compute a naive confidence score for a query result."""
+    confidence = 0.5
+
+    if getattr(result, "citations", None):
+        citation_count = len(result.citations)
+        confidence += min(0.3, 0.05 * citation_count)
+
+    if getattr(result, "reasoning", None):
+        reasoning_length = len(result.reasoning)
+        confidence += min(0.2, 0.01 * reasoning_length)
+
+    if getattr(result, "metrics", None) and "token_usage" in result.metrics:
+        tokens = result.metrics["token_usage"]
+        if "total" in tokens and "max_tokens" in tokens:
+            ratio = tokens["total"] / max(1, tokens["max_tokens"])
+            if 0.3 <= ratio <= 0.9:
+                confidence += 0.1
+            elif ratio > 0.9:
+                confidence -= 0.1
+
+    if getattr(result, "metrics", None) and "errors" in result.metrics:
+        error_count = len(result.metrics["errors"])
+        if error_count > 0:
+            confidence -= min(0.4, 0.1 * error_count)
+
+    return max(0.1, min(1.0, confidence))

--- a/tests/unit/test_orchestration_utils_module.py
+++ b/tests/unit/test_orchestration_utils_module.py
@@ -1,0 +1,45 @@
+import builtins
+import sys
+import types
+
+from autoresearch.orchestration import utils
+from autoresearch.models import QueryResponse
+
+
+def test_get_memory_usage_psutil(monkeypatch):
+    fake_psutil = types.SimpleNamespace(
+        Process=lambda: types.SimpleNamespace(memory_info=lambda: types.SimpleNamespace(rss=42 * 1024 * 1024))
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    assert utils.get_memory_usage() == 42.0
+
+
+def test_get_memory_usage_fallback(monkeypatch):
+    if "psutil" in sys.modules:
+        del sys.modules["psutil"]
+
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "psutil":
+            raise ImportError
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    fake_resource = types.SimpleNamespace(
+        getrusage=lambda *a, **k: types.SimpleNamespace(ru_maxrss=2048),
+        RUSAGE_SELF=0,
+    )
+    monkeypatch.setitem(sys.modules, "resource", fake_resource)
+    assert utils.get_memory_usage() == 2.0
+
+
+def test_calculate_result_confidence():
+    resp = QueryResponse(
+        answer="a",
+        citations=["c1", "c2"],
+        reasoning=["r"] * 5,
+        metrics={"token_usage": {"total": 50, "max_tokens": 100}, "errors": []},
+    )
+    score = utils.calculate_result_confidence(resp)
+    assert 0.5 <= score <= 1.0


### PR DESCRIPTION
## Summary
- add orchestration utils for memory usage and confidence scoring
- use shared utils in orchestrator and parallel modules
- cover new utilities with unit tests

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: import file mismatch in integration tests)*
- `uv run pytest tests/behavior` *(fails: fixture 'response' not found)*


------
https://chatgpt.com/codex/tasks/task_e_688fb16bcee8833385b8aa644a4a4dec