### PR TITLE
Add baseline checks for performance and token usage tests

### DIFF
--- a/tests/integration/test_performance.py
+++ b/tests/integration/test_performance.py
@@ -22,8 +22,10 @@ def test_query_time_and_memory(benchmark, token_baseline):
     """Queries should stay within expected time and memory bounds."""
 
     metrics = benchmark(run_benchmark)
-    token_baseline(metrics["tokens"])
-
     baseline = json.loads(BASELINE_PATH.read_text())
+
+    assert metrics["tokens"] == baseline["tokens"]
     assert metrics["memory_delta_mb"] <= baseline["memory_delta_mb"] + 5
     assert metrics["duration_seconds"] <= baseline["duration_seconds"] * 2
+
+    token_baseline(metrics["tokens"])


### PR DESCRIPTION
## Summary
- validate benchmark metrics against token, memory, and time baselines
- test token usage against stored baseline with configurable tolerance

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/integration/test_performance.py tests/integration/test_token_usage_integration.py -q --no-cov -m slow`

------
https://chatgpt.com/codex/tasks/task_e_688fb69707808333b05af457266b0564