### PR TITLE
Expand integration tests for orchestrator, storage, and hot reload

### DIFF
--- a/tests/integration/test_search_storage.py
+++ b/tests/integration/test_search_storage.py
@@ -9,6 +9,12 @@ from autoresearch.search import Search
 from autoresearch.storage import StorageManager
 from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
+from tests.conftest import VSS_AVAILABLE
+
+pytestmark = [
+    pytest.mark.requires_vss,
+    pytest.mark.skipif(not VSS_AVAILABLE, reason="VSS extension not available"),
+]
 
 
 @pytest.fixture(autouse=True)
@@ -50,8 +56,7 @@ def test_search_returns_persisted_claim(monkeypatch):
         lambda q, b, query_embedding=None: sum(b.values(), []),
     )
 
-    # Avoid vector extension and index refresh
-    monkeypatch.setattr(StorageManager, "has_vss", lambda: False)
+    # Avoid index refresh for simplicity
     monkeypatch.setattr(StorageManager, "refresh_vector_index", lambda: None)
     monkeypatch.setattr(StorageManager, "touch_node", lambda _id: None)
 


### PR DESCRIPTION
## Summary
- Rework orchestrator combination tests to use ConfigModel and handle more failure paths
- Add vss-gated storage search tests verifying persisted claims and cleanup
- Test config hot-reload through git-tracked config changes with proper extra markers

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest --no-cov tests/integration/test_orchestrator_combinations.py tests/integration/test_search_storage.py tests/integration/test_config_hot_reload.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fb6846cd483339b40174f5a86f705