### PR TITLE
test: add metrics fixture and assert CLI output

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -64,6 +64,21 @@ def bdd_storage_manager(storage_manager):
 
 
 @pytest.fixture
+def metrics_env(monkeypatch, tmp_path):
+    """Provide unique metric file paths for each scenario.
+
+    Many BDD steps rely on ``AUTORESEARCH_RELEASE_METRICS`` and
+    ``AUTORESEARCH_QUERY_TOKENS`` environment variables. Centralising their
+    setup here ensures tests do not leak state between each other.
+    """
+    release = tmp_path / "release_tokens.json"
+    query = tmp_path / "query_tokens.json"
+    monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", str(release))
+    monkeypatch.setenv("AUTORESEARCH_QUERY_TOKENS", str(query))
+    yield
+
+
+@pytest.fixture
 def storage_error_handler():
     """Fixture for handling storage errors in BDD tests.
 

--- a/tests/behavior/steps/agent_messages_steps.py
+++ b/tests/behavior/steps/agent_messages_steps.py
@@ -78,10 +78,9 @@ def setup_agents(monkeypatch, tmp_path, config_model):
     return cfg
 
 
-@when("I execute a query")
-def run_query(config, monkeypatch):
-    monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", "/tmp/release_tokens.json")
-    monkeypatch.setenv("AUTORESEARCH_QUERY_TOKENS", "/tmp/query_tokens.json")
+@when("I execute a query", target_fixture="response")
+def run_query(config, metrics_env):
+    """Execute a simple query and capture the response."""
     return Orchestrator.run_query("ping", config)
 
 
@@ -116,10 +115,9 @@ def setup_coalition(monkeypatch, tmp_path, config_model):
     return cfg
 
 
-@when("the sender broadcasts to the coalition")
-def run_broadcast_query(config, monkeypatch):
-    monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", "/tmp/release_tokens.json")
-    monkeypatch.setenv("AUTORESEARCH_QUERY_TOKENS", "/tmp/query_tokens.json")
+@when("the sender broadcasts to the coalition", target_fixture="response")
+def run_broadcast_query(config, metrics_env):
+    """Run a query to trigger broadcast messaging."""
     return Orchestrator.run_query("ping", config)
 
 

--- a/tests/behavior/steps/agent_orchestration_steps.py
+++ b/tests/behavior/steps/agent_orchestration_steps.py
@@ -50,19 +50,10 @@ def set_primus_start(index: int, set_loops):
     parsers.parse('I run the orchestrator on query "{query}"'),
     target_fixture="run_orchestrator_on_query",
 )
-def run_orchestrator_on_query(query, monkeypatch, tmp_path):
+def run_orchestrator_on_query(query, metrics_env):
     loader = ConfigLoader()
     loader._config = None
     cfg = loader.load_config()
-
-    monkeypatch.setenv(
-        "AUTORESEARCH_RELEASE_METRICS",
-        str(tmp_path / "release_tokens.json"),
-    )
-    monkeypatch.setenv(
-        "AUTORESEARCH_QUERY_TOKENS",
-        str(tmp_path / "query_tokens.json"),
-    )
 
     from autoresearch.orchestration.reasoning import ReasoningMode
 
@@ -131,7 +122,7 @@ def check_agent_groups(run_orchestrator_on_query, groups):
     parsers.parse('I submit a query via CLI `autoresearch search "{query}"`'),
     target_fixture="submit_query_via_cli",
 )
-def submit_query_via_cli(query, monkeypatch, cli_runner, tmp_path):
+def submit_query_via_cli(query, metrics_env, monkeypatch, cli_runner):
     agent_invocations: list[str] = []
     logger = logging.getLogger("autoresearch.test")
     logger.setLevel(logging.INFO)
@@ -161,13 +152,6 @@ def submit_query_via_cli(query, monkeypatch, cli_runner, tmp_path):
 
     main_mod._config_loader = ConfigLoader()
     main_mod._config_loader._config = cfg
-
-    monkeypatch.setenv(
-        "AUTORESEARCH_RELEASE_METRICS", str(tmp_path / "release_tokens.json")
-    )
-    monkeypatch.setenv(
-        "AUTORESEARCH_QUERY_TOKENS", str(tmp_path / "query_tokens.json")
-    )
 
     with patch(
         "autoresearch.orchestration.orchestrator.AgentFactory.get",

--- a/tests/behavior/steps/completion_cli_steps.py
+++ b/tests/behavior/steps/completion_cli_steps.py
@@ -11,7 +11,9 @@ def run_completion(cli_runner, bdd_context):
 
 @then("the CLI should exit successfully")
 def cli_success(bdd_context):
-    assert bdd_context["result"].exit_code == 0
+    result = bdd_context["result"]
+    assert result.exit_code == 0
+    assert "complete" in result.stdout.lower()
 
 
 @scenario("../features/completion_cli.feature", "Generate shell completion script")

--- a/tests/behavior/steps/serve_cli_steps.py
+++ b/tests/behavior/steps/serve_cli_steps.py
@@ -17,7 +17,9 @@ def run_a2a_help(cli_runner, bdd_context):
 
 @then("the CLI should exit successfully")
 def cli_success(bdd_context):
-    assert bdd_context["result"].exit_code == 0
+    result = bdd_context["result"]
+    assert result.exit_code == 0
+    assert "usage:" in result.stdout.lower()
 
 
 @scenario("../features/serve_commands.feature", "Display help for serve")


### PR DESCRIPTION
## Summary
- centralize metrics environment setup in a fixture
- reuse metrics fixture in agent message/orchestration steps
- assert help and completion text in CLI behavior tests

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q --ignore=tests/integration/test_a2a_interface.py` *(fails: assert 2 == 1 in tests/unit/test_cli_backup_extra.py)*
- `uv run pytest tests/behavior` *(fails: RuntimeError: Type not yet supported: Ellipsis)*
- `uv run pytest --cov=src --ignore=tests/integration/test_a2a_interface.py` *(fails: assert 2 == 1 in tests/unit/test_cli_backup_extra.py)*

------
https://chatgpt.com/codex/tasks/task_e_688fbadbb4cc83339a0a18b622e9f4c5