### PR TITLE
Add comprehensive integration tests

### DIFF
--- a/tests/integration/test_config_hot_reload_components.py
+++ b/tests/integration/test_config_hot_reload_components.py
@@ -1,0 +1,140 @@
+import time
+import tomli_w
+import tomllib
+from contextlib import contextmanager
+
+import git
+import pytest
+
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel
+from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
+from autoresearch.search import Search
+from autoresearch.storage import StorageManager
+from tests.conftest import GITPYTHON_INSTALLED
+
+pytestmark = [
+    pytest.mark.requires_git,
+    pytest.mark.skipif(not GITPYTHON_INSTALLED, reason="GitPython not installed"),
+]
+
+
+def make_agent(name, calls, stored):
+    class DummyAgent:
+        def __init__(self, name, llm_adapter=None):
+            self.name = name
+
+        def can_execute(self, state, config):
+            return True
+
+        def execute(self, state, config, **kwargs):
+            Search.external_lookup("q", max_results=1)
+            StorageManager.persist_claim({"id": self.name, "type": "fact", "content": self.name})
+            calls.append(self.name)
+            state.update({"results": {self.name: "ok"}, "claims": [{"id": self.name, "type": "fact", "content": self.name}]})
+            if self.name == "Synthesizer":
+                state.results["final_answer"] = f"Answer from {self.name}"
+            return {"results": {self.name: "ok"}}
+
+    return DummyAgent(name)
+
+
+def test_config_hot_reload_components(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    repo = git.Repo.init(tmp_path)
+    cfg_file = tmp_path / "autoresearch.toml"
+    cfg_file.write_text(
+        tomli_w.dumps(
+            {
+                "agents": ["AgentA"],
+                "search": {"backends": ["b1"], "context_aware": {"enabled": False}},
+            }
+        )
+    )
+    repo.index.add([str(cfg_file)])
+    repo.index.commit("init config")
+    ConfigLoader.reset_instance()
+
+    def fake_load(self):
+        data = tomllib.loads(cfg_file.read_text())
+        return ConfigModel.from_dict(
+            {
+                "agents": data["agents"],
+                "loops": 1,
+                "search": {
+                    "backends": data["search"]["backends"],
+                    "context_aware": {"enabled": False},
+                },
+            }
+        )
+
+    monkeypatch.setattr(ConfigLoader, "load_config", fake_load, raising=False)
+    loader = ConfigLoader()
+
+    calls: list[str] = []
+    search_calls: list[str] = []
+    stored: list[str] = []
+
+    def backend1(query: str, max_results: int = 5):
+        search_calls.append("b1")
+        return [{"title": "t1", "url": "u1"}]
+
+    def backend2(query: str, max_results: int = 5):
+        search_calls.append("b2")
+        return [{"title": "t2", "url": "u2"}]
+
+    monkeypatch.setitem(Search.backends, "b1", backend1)
+    monkeypatch.setitem(Search.backends, "b2", backend2)
+    monkeypatch.setattr(StorageManager, "persist_claim", lambda claim: stored.append(claim["id"]))
+    monkeypatch.setattr(
+        AgentFactory,
+        "get",
+        lambda name, llm_adapter=None: make_agent(name, calls, stored),
+    )
+
+    def external_lookup(query: str, max_results: int = 5):
+        cfg = loader.config
+        results = []
+        for b in cfg.search.backends:
+            results.extend(Search.backends[b](query, max_results))
+        for r in results:
+            StorageManager.persist_claim({"id": r["url"], "type": "source", "content": r["title"]})
+        return results
+
+    monkeypatch.setattr(Search, "external_lookup", external_lookup)
+
+    @contextmanager
+    def no_token_capture(agent_name, metrics, config):
+        yield (lambda *a, **k: None, None)
+
+    monkeypatch.setattr(Orchestrator, "_capture_token_usage", no_token_capture)
+
+    events: list[tuple[list[str], list[str]]] = []
+
+    def on_change(cfg):
+        events.append((cfg.agents, cfg.search.backends))
+
+    with loader.watching(on_change):
+        loader.load_config()
+        events.append((loader.config.agents, loader.config.search.backends))
+        Orchestrator.run_query("q", loader.config)
+        cfg_file.write_text(
+            tomli_w.dumps(
+                {
+                    "agents": ["AgentB"],
+                    "search": {
+                        "backends": ["b2"],
+                        "context_aware": {"enabled": False},
+                    },
+                }
+            )
+        )
+        repo.index.add([str(cfg_file)])
+        repo.index.commit("update config")
+        time.sleep(0.1)
+        Orchestrator.run_query("q", loader.config)
+
+    assert calls == ["AgentA", "AgentB"]
+    assert search_calls == ["b1", "b2"]
+    assert stored == ["u1", "AgentA", "u2", "AgentB"]
+    assert events[0] == (["AgentA"], ["b1"]) and events[-1] == (["AgentB"], ["b2"])

--- a/tests/integration/test_orchestrator_all_pairings.py
+++ b/tests/integration/test_orchestrator_all_pairings.py
@@ -1,0 +1,62 @@
+import itertools
+from contextlib import contextmanager
+
+import pytest
+
+from autoresearch.config.models import ConfigModel
+from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
+from autoresearch.search import Search
+from autoresearch.storage import StorageManager
+from autoresearch.models import QueryResponse
+
+
+def make_agent(name, calls, store_calls):
+    class DummyAgent:
+        def __init__(self, name: str, llm_adapter=None):
+            self.name = name
+
+        def can_execute(self, state, config):  # pragma: no cover - dummy
+            return True
+
+        def execute(self, state, config, **kwargs):
+            # Simulate search and storage interaction
+            Search.rank_results("q", [{"title": "t", "url": "u"}])
+            StorageManager.persist_claim({"id": name, "type": "fact", "content": name})
+            calls.append(name)
+            store_calls.append(name)
+            state.results[name] = "ok"
+            if name == "Synthesizer":
+                state.results["final_answer"] = f"Answer from {name}"
+            return {"results": {name: "ok"}}
+
+    return DummyAgent(name)
+
+
+pairs = list(itertools.permutations(["AgentA", "AgentB", "AgentC", "Synthesizer"], 2))
+
+
+@pytest.mark.parametrize("agents", pairs)
+def test_orchestrator_all_agent_pairings(monkeypatch, agents):
+    calls: list[str] = []
+    stored: list[str] = []
+
+    monkeypatch.setattr(Search, "rank_results", lambda q, r: r)
+    monkeypatch.setattr(StorageManager, "persist_claim", lambda claim: stored.append(claim["id"]))
+    monkeypatch.setattr(
+        AgentFactory, "get", lambda name, llm_adapter=None: make_agent(name, calls, stored)
+    )
+
+    @contextmanager
+    def no_token_capture(agent_name, metrics, config):
+        yield (lambda *a, **k: None, None)
+
+    monkeypatch.setattr(Orchestrator, "_capture_token_usage", no_token_capture)
+
+    cfg = ConfigModel(agents=list(agents), loops=1)
+    response = Orchestrator.run_query("q", cfg)
+
+    assert isinstance(response, QueryResponse)
+    assert calls == list(agents)
+    assert stored == list(agents)
+    expected = "Answer from Synthesizer" if "Synthesizer" in agents else "No answer synthesized"
+    assert response.answer == expected

--- a/tests/integration/test_query_latency_memory_tokens.py
+++ b/tests/integration/test_query_latency_memory_tokens.py
@@ -1,0 +1,53 @@
+import time
+from contextlib import contextmanager
+
+from autoresearch.config.models import ConfigModel
+from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
+from autoresearch.storage import StorageManager
+
+
+class BenchAgent:
+    def __init__(self, name: str, llm_adapter=None):
+        self.name = name
+
+    def can_execute(self, state, config):  # pragma: no cover - dummy
+        return True
+
+    def execute(self, state, config, adapter=None):
+        adapter("benchmark prompt")
+        state.results[self.name] = "ok"
+        state.results["final_answer"] = "answer"
+        return {"results": {self.name: "ok"}}
+
+
+def test_query_latency_memory_tokens(monkeypatch, token_baseline):
+    monkeypatch.setattr(AgentFactory, "get", lambda name, llm_adapter=None: BenchAgent(name))
+
+    @contextmanager
+    def capture(agent_name, metrics, config):
+        metrics.setdefault("execution_metrics", {}).setdefault("agent_tokens", {})
+        metrics["execution_metrics"]["agent_tokens"][agent_name] = {"in": 0, "out": 0}
+
+        def generate(prompt):
+            metrics["execution_metrics"]["agent_tokens"][agent_name]["in"] += len(prompt.split())
+            metrics["execution_metrics"]["agent_tokens"][agent_name]["out"] += 1
+            return "ok"
+
+        yield (generate, None)
+
+    monkeypatch.setattr(Orchestrator, "_capture_token_usage", capture)
+
+    cfg = ConfigModel(agents=["BenchAgent"], loops=1, llm_backend="dummy")
+    cfg.api.role_permissions["anonymous"] = ["query"]
+
+    memory_before = StorageManager._current_ram_mb()
+    start = time.perf_counter()
+    response = Orchestrator.run_query("q", cfg)
+    latency = time.perf_counter() - start
+    memory_after = StorageManager._current_ram_mb()
+
+    tokens = response.metrics["execution_metrics"]["agent_tokens"]
+    token_baseline(tokens)
+
+    assert latency < 1.0
+    assert memory_after - memory_before < 50


### PR DESCRIPTION
## Summary
- add exhaustive orchestrator pairing tests
- validate search results persistence and hot-reload across components
- benchmark query latency, memory usage, and token consumption

## Testing
- `uv run flake8 src tests`
- `uv run mypy src` *(failed: Interrupted)*
- `uv run pytest tests/integration --no-cov` *(failed: Type not yet supported: Ellipsis)*

------
https://chatgpt.com/codex/tasks/task_e_688fc1288d6c833396987a60e0a34110