### PR TITLE
test: skip requires_git when GitPython missing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,8 @@ def pytest_runtest_setup(item):
         pytest.skip("ui extra not installed")
     if item.get_closest_marker("requires_vss") and not VSS_AVAILABLE:
         pytest.skip("vss extra not installed")
+    if item.get_closest_marker("requires_git") and not GITPYTHON_INSTALLED:
+        pytest.skip("git extra not installed")
 
 
 GITPYTHON_INSTALLED = _module_available("git")


### PR DESCRIPTION
## Summary
- Skip tests marked `requires_git` when GitPython isn't installed

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q --import-mode=importlib` *(fails: test_backup_create_error)*
- `uv run pytest tests/behavior -q` *(fails: test_one_cycle)*
- `uv run pytest --cov=src -q --import-mode=importlib` *(fails: test_backup_create_error)*
- `uv run pytest -m requires_git -vv --import-mode=importlib --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_688fc4da18388333964f835ca0934a3b