### PR TITLE
Expand error recovery behavior coverage

### DIFF
--- a/tests/behavior/features/error_recovery.feature
+++ b/tests/behavior/features/error_recovery.feature
@@ -4,8 +4,23 @@ Feature: Error Recovery
   I want the system to apply recovery strategies
   So transient errors do not halt execution
 
-  Scenario: Transient error triggers recovery
+  Scenario: Error recovery in dialectical reasoning mode
     Given an agent that raises a transient error
+    And reasoning mode is "dialectical"
+    When I run the orchestrator on query "recover test"
+    Then a recovery strategy "retry_with_backoff" should be recorded
+    And recovery should be applied
+
+  Scenario: Error recovery in direct reasoning mode
+    Given an agent that raises a transient error
+    And reasoning mode is "direct"
+    When I run the orchestrator on query "recover test"
+    Then a recovery strategy "retry_with_backoff" should be recorded
+    And recovery should be applied
+
+  Scenario: Error recovery in chain-of-thought reasoning mode
+    Given an agent that raises a transient error
+    And reasoning mode is "chain-of-thought"
     When I run the orchestrator on query "recover test"
     Then a recovery strategy "retry_with_backoff" should be recorded
     And recovery should be applied


### PR DESCRIPTION
## Summary
- test error recovery under direct, dialectical, and chain-of-thought reasoning modes
- add assertion/cleanup fixture for recovery steps

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/behavior` *(fails: Step definition is not found: Given "the Autoresearch application is running" in api_streaming_webhook.feature)*


------
https://chatgpt.com/codex/tasks/task_e_688fca876d5483339109885d086e205b