### PR TITLE
Document build and test status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Update release plan to align milestones with the 2025 development timeline.
+- Verified source and wheel builds succeed; TestPyPI upload failed with 403 Forbidden.
+- `flake8` and `mypy` pass, but unit and behavior tests require fixes and coverage task was interrupted.
 
 ## [0.1.0] - Unreleased
 Planned first public release bringing the core research workflow to life.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,14 +1,14 @@
 # Autoresearch Roadmap
 
 This roadmap summarizes planned features for upcoming releases. Dates and milestones align with the [release plan](docs/release_plan.md).
-Last updated **August 3, 2025**.
+Last updated **August 4, 2025**.
 Phase 2 testing tasks are still in progress, so Phase 3 (stabilization/testing/documentation) items remain planned.
 
 ## Milestones
 
 | Version | Target Date | Key Goals |
 | ------- | ----------- | --------- |
-| 0.1.0 | TBD | Finalize packaging, docs and CI checks |
+| 0.1.0 | 2025-09-01 | Finalize packaging, docs and CI checks |
 | 0.1.1 | 2026-02-01 | Bug fixes and documentation updates |
 | 0.2.0 | 2026-04-15 | API stabilization, configuration hot-reload, improved search backends |
 | 0.3.0 | 2026-07-15 | Distributed execution support, monitoring utilities |
@@ -25,7 +25,7 @@ complete documentation. Key activities include:
 
 Tests are still failing due to configuration errors and overall coverage is below the **90%** target.
 Final package validation and documentation work remain in progress. The
-**0.1.0** release date is now **TBD** until these Phase 2 tasks pass.
+**0.1.0** release date is now targeted for **September 1, 2025** pending successful test and coverage runs.
 
 ## 0.1.1 – Bug fixes and documentation updates
 


### PR DESCRIPTION
## Summary
- note build and publish script execution and test status in changelog
- set roadmap target date for 0.1.0 to 2025-09-01

## Testing
- `python -m build`
- `python scripts/publish_dev.py` *(fails: HTTPError 403 Forbidden)*
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/behavior` *(fails: StepDefinitionNotFoundError)*
- `task coverage` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_688febba882c8333809da7ba81019919