### PR TITLE
Ensure config weights and env vars for tests

### DIFF
--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -20,13 +20,19 @@ def config_loader() -> ConfigLoader:
 
 
 @pytest.fixture()
-def config(config_loader: ConfigLoader):
+def config(config_loader: ConfigLoader, monkeypatch: pytest.MonkeyPatch):
     """Return the ConfigModel loaded from the test configuration.
 
     The fixture ensures search ranking weights are explicitly set so that
     downstream tests always operate with a complete, valid configuration.
+    Additionally, required environment variables are provided so tests do not
+    depend on external configuration.
     """
+    # Provide required environment variables for search backends.
+    monkeypatch.setenv("SERPER_API_KEY", "test_key")
+
     cfg = config_loader.load_config()
+    # Ensure relevance ranking weights sum to 1.0
     cfg.search.semantic_similarity_weight = 0.5
     cfg.search.bm25_weight = 0.3
     cfg.search.source_credibility_weight = 0.2

--- a/tests/unit/test_config_validation_errors.py
+++ b/tests/unit/test_config_validation_errors.py
@@ -1,5 +1,6 @@
 import pytest
 
+from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel, StorageConfig, SearchConfig
 from autoresearch.errors import ConfigError
 
@@ -20,3 +21,13 @@ def test_weights_must_sum_to_one():
                 source_credibility_weight=0.5,
             )
         )
+
+
+def test_default_config_loads_without_error():
+    """Default ConfigModel should load without raising ConfigError."""
+    loader = ConfigLoader.new_for_tests()
+    loader._update_watch_paths()
+    try:
+        loader.load_config()
+    except ConfigError as exc:  # pragma: no cover - should not happen
+        pytest.fail(f"ConfigModel failed to load: {exc}")


### PR DESCRIPTION
## Summary
- set SERPER_API_KEY and explicit ranking weights in the shared config fixture to keep tests self-contained
- add regression test verifying that default ConfigModel loads without ConfigError

## Testing
- `uv run flake8 src tests`
- `uv run mypy src` *(fails: BrokenPipeError after KeyboardInterrupt)*
- `uv run pytest tests/unit/test_config_validation_errors.py::test_default_config_loads_without_error -q` *(fails: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68902e7f033c8333a9326b1d9a6a3458