### PR TITLE
test: exercise registry combinations via ConfigLoader

### DIFF
--- a/tests/integration/test_orchestrator_combinations_complete.py
+++ b/tests/integration/test_orchestrator_combinations_complete.py
@@ -1,0 +1,92 @@
+import itertools
+
+import pytest
+
+from autoresearch.agents import AgentRegistry, AgentFactory
+from autoresearch.agents.feedback import FeedbackEvent
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.storage import StorageManager
+
+
+# Register a coalition to exercise coalition handling
+AgentRegistry.create_coalition("ReviewTeam", ["Contrarian", "FactChecker"])
+
+ALL_PAIRS = list(itertools.combinations(AgentRegistry.list_available(), 2))
+COALITIONS = AgentRegistry.list_coalitions()
+
+
+def make_agent(name: str, order: list[str]):
+    class DummyAgent:
+        def __init__(self, name: str, llm_adapter=None) -> None:
+            self.name = name
+
+        def can_execute(self, state, config):  # noqa: D401
+            return True
+
+        def execute(self, state, config, **kwargs):  # noqa: D401
+            state.update(
+                {
+                    "claims": [
+                        {"id": self.name, "type": "fact", "content": self.name}
+                    ],
+                    "results": {self.name: "ok"},
+                }
+            )
+            if self.name == "Contrarian" and "FactChecker" in order:
+                state.add_feedback_event(
+                    FeedbackEvent(
+                        source="Contrarian",
+                        target="FactChecker",
+                        content="check",
+                        cycle=state.cycle,
+                    )
+                )
+            if self.name == "FactChecker":
+                _ = state.get_feedback_events(recipient="FactChecker")
+            if self.name == "Synthesizer" or self.name == order[-1]:
+                state.results["final_answer"] = f"Answer from {self.name}"
+            return {"results": {self.name: "ok"}}
+
+    return DummyAgent(name)
+
+
+@pytest.mark.parametrize("agents", ALL_PAIRS)
+def test_all_agent_pairs(monkeypatch, agents):
+    order = list(agents)
+    monkeypatch.setattr(StorageManager, "persist_claim", lambda claim: None)
+    monkeypatch.setattr(
+        AgentFactory, "get", lambda name, llm_adapter=None: make_agent(name, order)
+    )
+
+    loader = ConfigLoader.new_for_tests()
+    cfg = loader.config
+    cfg.agents = order
+    cfg.loops = 1
+    cfg.enable_feedback = True
+
+    response = Orchestrator.run_query("q", cfg)
+    assert isinstance(response, QueryResponse)
+    assert response.answer
+
+
+@pytest.mark.parametrize("coalition", COALITIONS)
+def test_registered_coalitions(monkeypatch, coalition):
+    members = AgentRegistry.get_coalition(coalition)
+    order = ["Synthesizer"] + members
+    monkeypatch.setattr(StorageManager, "persist_claim", lambda claim: None)
+    monkeypatch.setattr(
+        AgentFactory, "get", lambda name, llm_adapter=None: make_agent(name, order)
+    )
+
+    loader = ConfigLoader.new_for_tests()
+    cfg = loader.config
+    cfg.agents = ["Synthesizer", coalition]
+    cfg.coalitions = {coalition: members}
+    cfg.loops = 1
+    cfg.enable_feedback = True
+
+    response = Orchestrator.run_query("q", cfg)
+    assert isinstance(response, QueryResponse)
+    assert response.answer


### PR DESCRIPTION
## Summary
- add integration tests that run orchestrator for every registered agent pair and coalition using ConfigLoader.new_for_tests
- ensure contrarian/fact-checker coalition triggers feedback paths and every run yields a non-empty answer

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/integration/test_orchestrator_combinations_complete.py -q --no-cov`
- `uv run pytest tests/integration/test_orchestrator_combinations_complete.py -q --cov=src --cov-fail-under=0`
- `uv run pytest tests/behavior -q --no-cov` *(fails: Step definition is not found: Given "the Autoresearch application is running")*

------
https://chatgpt.com/codex/tasks/task_e_6890373e5cb48333843f2249aace6988