### PR TITLE
test: add extended error recovery feature

### DIFF
--- a/tests/behavior/features/error_recovery_extended.feature
+++ b/tests/behavior/features/error_recovery_extended.feature
@@ -1,0 +1,15 @@
+@behavior
+Feature: Extended Error Recovery
+  As a user
+  I want the system to recover from timeouts and agent failures
+  So queries can continue even when components misbehave
+
+  Scenario: Recovery after agent timeout
+    Given an agent that times out during execution
+    When I run the orchestrator on query "Explain the theory of relativity"
+    Then the response should list a timeout error
+
+  Scenario: Recovery after agent failure
+    Given an agent that fails during execution
+    When I run the orchestrator on query "Describe the process of photosynthesis"
+    Then the response should list an agent execution error

--- a/tests/behavior/steps/error_recovery_steps.py
+++ b/tests/behavior/steps/error_recovery_steps.py
@@ -7,6 +7,7 @@ from pytest_bdd import scenario, given, when, then, parsers
 
 from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
+from autoresearch.errors import AgentError, TimeoutError
 from autoresearch.orchestration import ReasoningMode
 from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
 
@@ -35,6 +36,22 @@ def test_error_recovery_cot():
     pass
 
 
+@scenario(
+    "../features/error_recovery_extended.feature",
+    "Recovery after agent timeout",
+)
+def test_error_recovery_timeout():
+    pass
+
+
+@scenario(
+    "../features/error_recovery_extended.feature",
+    "Recovery after agent failure",
+)
+def test_error_recovery_agent_failure():
+    pass
+
+
 @given("an agent that raises a transient error", target_fixture="config")
 def flaky_agent(monkeypatch):
     cfg = ConfigModel.model_construct(agents=["Flaky"], loops=1)
@@ -46,8 +63,40 @@ def flaky_agent(monkeypatch):
         def execute(self, *args, **kwargs) -> dict:
             raise RuntimeError("temporary network issue")
 
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self, *a, **k: cfg)
     monkeypatch.setattr(AgentFactory, "get", lambda self, name: FlakyAgent())
+    return cfg
+
+
+@given("an agent that times out during execution", target_fixture="config")
+def timeout_agent(monkeypatch):
+    cfg = ConfigModel.model_construct(agents=["Slowpoke"], loops=1)
+
+    class TimeoutAgent:
+        def can_execute(self, *args, **kwargs) -> bool:
+            return True
+
+        def execute(self, *args, **kwargs) -> dict:
+            raise TimeoutError("simulated timeout")
+
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self, *a, **k: cfg)
+    monkeypatch.setattr(AgentFactory, "get", lambda self, name: TimeoutAgent())
+    return cfg
+
+
+@given("an agent that fails during execution", target_fixture="config")
+def failing_agent(monkeypatch):
+    cfg = ConfigModel.model_construct(agents=["Faulty"], loops=1)
+
+    class FailingAgent:
+        def can_execute(self, *args, **kwargs) -> bool:
+            return True
+
+        def execute(self, *args, **kwargs) -> dict:
+            raise AgentError("agent execution failed")
+
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self, *a, **k: cfg)
+    monkeypatch.setattr(AgentFactory, "get", lambda self, name: FailingAgent())
     return cfg
 
 
@@ -77,9 +126,11 @@ def run_orchestrator(query: str, config: ConfigModel, recovery_context: dict):
         "autoresearch.orchestration.orchestrator.Orchestrator._apply_recovery_strategy",
         side_effect=spy_apply,
     ):
-        Orchestrator.run_query(query, config)
+        response = Orchestrator.run_query(query, config)
 
-    return {"recovery_info": dict(recovery_context)}
+    # Expose metrics as metadata for test assertions
+    response.metadata = response.metrics
+    return {"recovery_info": dict(recovery_context), "response": response}
 
 
 @then(parsers.parse('a recovery strategy "{strategy}" should be recorded'))
@@ -92,3 +143,15 @@ def assert_strategy(run_result: dict, strategy: str) -> None:
 def assert_recovery_applied(run_result: dict) -> None:
     assert run_result["recovery_info"], "Recovery info should not be empty"
     assert run_result["recovery_info"].get("recovery_applied") is True
+
+
+@then("the response should list a timeout error")
+def assert_timeout_error(run_result: dict) -> None:
+    errors = run_result["response"].metadata.get("errors", [])
+    assert any(e.get("error_type") == "TimeoutError" for e in errors), errors
+
+
+@then("the response should list an agent execution error")
+def assert_agent_error(run_result: dict) -> None:
+    errors = run_result["response"].metadata.get("errors", [])
+    assert any(e.get("error_type") == "AgentError" for e in errors), errors


### PR DESCRIPTION
## Summary
- add BDD scenarios for timeout and agent failure recovery
- assert orchestrator populates metadata errors for handled failures

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/behavior -q` *(fails: StepDefinitionNotFound in api_streaming_steps.py)*

------
https://chatgpt.com/codex/tasks/task_e_6890f476a0ac8333b8daa17d81e987a8