### PR TITLE
fix: correct config env parsing

### DIFF
--- a/src/autoresearch/config/loader.py
+++ b/src/autoresearch/config/loader.py
@@ -116,7 +116,10 @@ class ConfigLoader:
 
         env_settings: Dict[str, Any] = {}
         for key, value in raw_env.items():
-            parts = key.lower().split("__")
+            key_lower = key.lower()
+            if key_lower.startswith("autoresearch_"):
+                key_lower = key_lower[len("autoresearch_"):]
+            parts = key_lower.split("__")
             d = env_settings
             for part in parts[:-1]:
                 d = d.setdefault(part, {})

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -6,15 +6,10 @@ from autoresearch.config.loader import ConfigLoader
 
 
 @pytest.fixture()
-def config_loader() -> ConfigLoader:
-    """Provide a ConfigLoader instance for tests.
-
-    The loader uses its built-in defaults and does not rely on an external
-    ``autoresearch.toml`` file. This keeps unit tests self-contained and makes
-    configuration behaviour consistent regardless of the working directory.
-    """
+def config_loader(tmp_path) -> ConfigLoader:
+    """Provide a ConfigLoader instance backed by a minimal config file."""
+    (tmp_path / "autoresearch.toml").write_text("[core]\n")
     loader = ConfigLoader.new_for_tests()
-    # Ensure watch paths reflect the default search paths
     loader._update_watch_paths()
     return loader
 


### PR DESCRIPTION
## Summary
- fix ConfigLoader env parsing to strip AUTORESEARCH_ prefix
- add minimal config loader test fixture

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `task coverage` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6891758c927c8333ad6019f0bcae72d8