### PR TITLE
docs: update release details and test status

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Autoresearch is currently in the **Development** phase preparing for the
 upcoming **0.1.0** release. The version is defined in
 `autoresearch.__version__` and mirrored in `pyproject.toml`, but it has
 **not** been published yet. The first official release was originally
- planned for **July 20, 2025**, but the schedule slipped. Tests
- currently fail and coverage goals are still being worked on. The release is
- re-targeted for **November 2025**. See
-[docs/release_plan.md](docs/release_plan.md) for the full milestone
+ planned for **July 20, 2025**, but the schedule slipped. Tests still fail
+ and coverage goals are being worked on. Packaging checks and documentation
+ continue, so the milestone is now targeted for **November 15, 2025**.
+See [docs/release_plan.md](docs/release_plan.md) for the full milestone
 schedule and outstanding tasks.
 
 ## Installation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ Phase 2 testing tasks are nearly complete after resolving prior failures; Phase 
 
 | Version | Target Date | Key Goals |
 | ------- | ----------- | --------- |
-| 0.1.0 | 2025-09-15 | Finalize packaging, docs and CI checks |
+| 0.1.0 | 2025-11-15 | Finalize packaging, docs and CI checks |
 | 0.1.1 | 2026-02-01 | Bug fixes and documentation updates |
 | 0.2.0 | 2026-04-15 | API stabilization, configuration hot-reload, improved search backends |
 | 0.3.0 | 2026-07-15 | Distributed execution support, monitoring utilities |
@@ -23,9 +23,11 @@ complete documentation. Key activities include:
 - Finalizing API reference and user guides.
 - Verifying packaging metadata and TestPyPI uploads.
 
-All unit, integration and behavior tests now pass, but overall coverage is below the **90%** target.
-Completion of **Phase 2**—integration & behavior tests passing with at least **90%** total coverage—remains a prerequisite for the
-**0.1.0** milestone, which is now targeted for **September 15, 2025** pending final package validation and documentation work.
+Tests still fail and overall coverage is below the **90%** target.
+Completion of **Phase 2**—integration & behavior tests passing with at least
+**90%** total coverage—remains a prerequisite for the **0.1.0** milestone,
+which is now targeted for **November 15, 2025** while final package
+validation and documentation work continue.
 
 ## 0.1.1 – Bug fixes and documentation updates
 

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -12,13 +12,17 @@ Phase 2 testing tasks are nearly complete after resolving prior failures, so Pha
 
 | Version | Target Date | Key Goals |
 | ------- | ----------- | --------- |
-| **0.1.0** | 2025-09-15 | Finalize packaging, docs and CI checks; complete Phase 2 (integration & behavior tests passing, ≥90% coverage) |
+| **0.1.0** | 2025-11-15 | Finalize packaging, docs and CI checks; complete Phase 2 (integration & behavior tests passing, ≥90% coverage) |
 | **0.1.1** | 2026-02-01 | Bug fixes and documentation updates |
 | **0.2.0** | 2026-04-15 | API stabilization, configuration hot-reload, improved search backends |
 | **0.3.0** | 2026-07-15 | Distributed execution support, monitoring utilities |
 | **1.0.0** | 2026-10-01 | Full feature set, performance tuning and stable interfaces |
 
-The **0.1.0** release was originally aimed for **July 20, 2025**. All unit, integration and behavior tests now pass, but overall coverage remains below the **90%** target. Packaging checks and documentation work continue, so the milestone is now targeted for **September 15, 2025** while coverage and packaging issues are resolved.
+The **0.1.0** release was originally aimed for **July 20, 2025**, but the
+schedule slipped. Tests still fail and total coverage remains below the
+**90%** target. Packaging checks and documentation work continue, so the
+milestone is now targeted for **November 15, 2025** while coverage and
+packaging tasks are completed.
 
 The following tasks remain before publishing **0.1.0**:
 


### PR DESCRIPTION
## Summary
- sync README, release plan, and roadmap with new 0.1.0 target date
- note that tests are still failing and coverage remains below goal

## Testing
- `uv run flake8 src tests`
- `timeout 30s uv run mypy src` *(timeout)*
- `uv run pytest tests/behavior -q` *(fails: StepDefinitionNotFoundError)*
- `task coverage` *(terminated early)*
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_6891849fc6488333884f6c4b5d5654ea