### PR TITLE
Add orchestrator combination tests and benchmark markings

### DIFF
--- a/tests/data/token_baselines.json
+++ b/tests/data/token_baselines.json
@@ -5,6 +5,12 @@
       "out": 7
     }
   },
+  "tests/integration/test_query_latency_memory_tokens.py::test_query_latency_memory_tokens": {
+    "BenchAgent": {
+      "in": 2,
+      "out": 1
+    }
+  },
   "tests/integration/test_query_performance_benchmark.py::test_query_performance_memory_tokens": {
     "Dummy": {
       "in": 2,

--- a/tests/integration/test_config_hot_reload_components.py
+++ b/tests/integration/test_config_hot_reload_components.py
@@ -14,6 +14,8 @@ from autoresearch.storage import StorageManager
 from tests.conftest import GITPYTHON_INSTALLED
 
 pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
     pytest.mark.requires_git,
     pytest.mark.skipif(not GITPYTHON_INSTALLED, reason="GitPython not installed"),
 ]

--- a/tests/integration/test_orchestrator_all_agent_combinations.py
+++ b/tests/integration/test_orchestrator_all_agent_combinations.py
@@ -1,0 +1,77 @@
+import itertools
+from contextlib import contextmanager
+
+import pytest
+
+from autoresearch.config.models import ConfigModel
+from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
+from autoresearch.search import Search
+from autoresearch.storage import StorageManager
+from autoresearch.models import QueryResponse
+
+pytestmark = pytest.mark.integration
+
+AGENTS = ["AgentA", "AgentB", "AgentC", "Synthesizer"]
+
+
+def make_agent(name, calls, search_calls):
+    class DummyAgent:
+        def __init__(self, name, llm_adapter=None):
+            self.name = name
+
+        def can_execute(self, state, config):  # pragma: no cover - dummy
+            return True
+
+        def execute(self, state, config, **kwargs):  # pragma: no cover - dummy
+            Search.rank_results("q", [{"title": "t", "url": "u"}])
+            StorageManager.persist_claim(
+                {"id": self.name, "type": "fact", "content": self.name}
+            )
+            calls.append(self.name)
+            search_calls.append(self.name)
+            state.results[self.name] = "ok"
+            if self.name == "Synthesizer":
+                state.results["final_answer"] = f"Answer from {self.name}"
+            return {"results": {self.name: "ok"}}
+
+    return DummyAgent(name)
+
+
+def all_permutations():
+    for r in range(1, len(AGENTS) + 1):
+        yield from itertools.permutations(AGENTS, r)
+
+
+@pytest.mark.parametrize("agents", list(all_permutations()))
+def test_orchestrator_all_agent_combinations(monkeypatch, agents):
+    calls: list[str] = []
+    search_calls: list[str] = []
+    store_calls: list[str] = []
+
+    monkeypatch.setattr(Search, "rank_results", lambda q, r: r)
+    monkeypatch.setattr(
+        StorageManager, "persist_claim", lambda claim: store_calls.append(claim["id"])
+    )
+    monkeypatch.setattr(
+        AgentFactory,
+        "get",
+        lambda name, llm_adapter=None: make_agent(name, calls, search_calls),
+    )
+
+    @contextmanager
+    def no_token_capture(agent_name, metrics, config):
+        yield (lambda *a, **k: None, None)
+
+    monkeypatch.setattr(Orchestrator, "_capture_token_usage", no_token_capture)
+
+    cfg = ConfigModel(agents=list(agents), loops=1)
+    response = Orchestrator.run_query("q", cfg)
+
+    assert isinstance(response, QueryResponse)
+    assert calls == list(agents)
+    assert search_calls == list(agents)
+    assert store_calls == list(agents)
+    expected = (
+        "Answer from Synthesizer" if "Synthesizer" in agents else "No answer synthesized"
+    )
+    assert response.answer == expected

--- a/tests/integration/test_query_performance_benchmark.py
+++ b/tests/integration/test_query_performance_benchmark.py
@@ -10,7 +10,9 @@ from autoresearch.config.loader import ConfigLoader
 from autoresearch.search import Search
 from autoresearch.storage import StorageManager
 
-pytestmark = pytest.mark.slow
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
+pytest.importorskip("pytest_benchmark")
 
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "benchmark_token_memory.py"
 spec = importlib.util.spec_from_file_location("benchmark_token_memory", SCRIPT_PATH)


### PR DESCRIPTION
## Summary
- exercise the orchestrator across all agent permutations
- mark config hot-reload and performance tests as integration/slow
- benchmark query latency and memory with token tracking

## Testing
- `uv run flake8 src tests`
- `uv run mypy src` *(fails: Interrupted)*
- `uv run pytest tests/integration/test_orchestrator_all_agent_combinations.py tests/integration/test_config_hot_reload_components.py tests/integration/test_query_latency_memory_tokens.py tests/integration/test_query_performance_benchmark.py -q -p no:cov -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_689230accc808333bc3ee0b560f79086