### PR TITLE
test: add unsupported reasoning mode scenario

### DIFF
--- a/tests/behavior/features/reasoning_mode.feature
+++ b/tests/behavior/features/reasoning_mode.feature
@@ -36,3 +36,9 @@ Feature: Reasoning Mode Selection
     Then the loops used should be 1
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     Then the agents executed should be "Synthesizer, Contrarian, FactChecker"
+
+  Scenario: Unsupported reasoning mode fails gracefully
+    Given loops is set to 1 in configuration
+    When I run the orchestrator on query "mode test" with unsupported reasoning mode "quantum"
+    Then a reasoning mode error should be raised
+    And no agents should execute


### PR DESCRIPTION
## Summary
- add behavior test covering unsupported reasoning mode
- implement steps that validate graceful failure with no agents run

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/behavior/steps/reasoning_mode_steps.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68924c53039c83339e3ce1be87715a20