### PR TITLE
test: add feature coverage for CLI and API

### DIFF
--- a/tests/behavior/features/api_async_query.feature
+++ b/tests/behavior/features/api_async_query.feature
@@ -1,0 +1,14 @@
+Feature: Asynchronous query API
+  Background:
+    Given the API server is running
+
+  Scenario: Submit async query and retrieve result
+    When I submit an async query "Explain AI ethics"
+    Then the response should include a query ID
+    When I request the status for that query ID
+    Then the response should contain an answer
+
+  Scenario: Cancel a running async query
+    Given an async query has been submitted
+    When I cancel the async query
+    Then the response should indicate cancellation

--- a/tests/behavior/features/api_documentation.feature
+++ b/tests/behavior/features/api_documentation.feature
@@ -1,0 +1,13 @@
+Feature: API documentation endpoints
+  Background:
+    Given the API server is running
+
+  Scenario: Access Swagger UI
+    When I request the docs endpoint
+    Then the response status should be 200
+    And the response body should contain "Swagger UI"
+
+  Scenario: Retrieve OpenAPI schema
+    When I request the openapi endpoint
+    Then the response status should be 200
+    And the response body should contain "openapi"

--- a/tests/behavior/features/api_metrics.feature
+++ b/tests/behavior/features/api_metrics.feature
@@ -1,0 +1,12 @@
+Feature: Metrics API
+  Background:
+    Given the API server is running
+
+  Scenario: Retrieve Prometheus metrics
+    When I request the metrics endpoint with authorization
+    Then the response status should be 200
+    And the response body should contain "process_cpu_seconds_total"
+
+  Scenario: Metrics endpoint without permission
+    When I request the metrics endpoint
+    Then the response status should be 403

--- a/tests/behavior/features/gui_cli.feature
+++ b/tests/behavior/features/gui_cli.feature
@@ -1,0 +1,10 @@
+Feature: GUI CLI
+  Scenarios for launching the Streamlit GUI
+
+  Scenario: Launch GUI without opening a browser
+    When I run `autoresearch gui --port 8502 --no-browser`
+    Then the CLI should exit successfully
+
+  Scenario: Display help for GUI command
+    When I run `autoresearch gui --help`
+    Then the CLI should exit successfully

--- a/tests/behavior/features/interface_test_cli.feature
+++ b/tests/behavior/features/interface_test_cli.feature
@@ -1,0 +1,18 @@
+Feature: Interface test commands
+  Scenarios for MCP and A2A interface testing utilities
+
+  Scenario: Run MCP interface tests
+    When I run `autoresearch test_mcp --host 127.0.0.1 --port 8080`
+    Then the CLI should exit successfully
+
+  Scenario: Fail to connect to MCP server
+    When I run `autoresearch test_mcp --port 9`
+    Then the CLI should exit with an error
+
+  Scenario: Run A2A interface tests
+    When I run `autoresearch test_a2a --host 127.0.0.1 --port 8765`
+    Then the CLI should exit successfully
+
+  Scenario: Fail to connect to A2A server
+    When I run `autoresearch test_a2a --port 9`
+    Then the CLI should exit with an error

--- a/tests/behavior/features/search_cli.feature
+++ b/tests/behavior/features/search_cli.feature
@@ -1,0 +1,10 @@
+Feature: Search CLI
+  Scenarios covering the search command
+
+  Scenario: Run a basic search query
+    When I run `autoresearch search "What is artificial intelligence?" --reasoning-mode direct`
+    Then the CLI should exit successfully
+
+  Scenario: Missing query argument
+    When I run `autoresearch search`
+    Then the CLI should exit with an error

--- a/tests/behavior/features/sparql_cli.feature
+++ b/tests/behavior/features/sparql_cli.feature
@@ -1,0 +1,10 @@
+Feature: SPARQL CLI
+  Scenarios for running SPARQL queries from the command line
+
+  Scenario: Execute a SPARQL query with reasoning
+    When I run `autoresearch sparql "SELECT ?s WHERE { ?s a <http://example.com/B> }"`
+    Then the CLI should exit successfully
+
+  Scenario: Invalid SPARQL query
+    When I run `autoresearch sparql "INVALID QUERY"`
+    Then the CLI should exit with an error

--- a/tests/behavior/features/visualization_cli.feature
+++ b/tests/behavior/features/visualization_cli.feature
@@ -1,0 +1,15 @@
+Feature: Visualization CLI
+  Scenarios for graph visualization commands
+
+  Scenario: Generate a query graph PNG
+    When I run `autoresearch visualize "What is quantum computing?" graph.png`
+    Then the CLI should exit successfully
+    And the file "graph.png" should be created
+
+  Scenario: Render RDF graph to PNG
+    When I run `autoresearch visualize-rdf rdf_graph.png`
+    Then the CLI should exit successfully
+
+  Scenario: Missing output file for visualization
+    When I run `autoresearch visualize "What is quantum computing?"`
+    Then the CLI should exit with an error


### PR DESCRIPTION
## Summary
- document search CLI usage and missing-query error
- specify visualization, SPARQL, GUI, and interface test commands
- add coverage for metrics, async query, and documentation API endpoints

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`


------
https://chatgpt.com/codex/tasks/task_e_68928661eba08333919963b0ea2de6ce