### PR TITLE
test: add first run behavior scenarios

### DIFF
--- a/tests/behavior/features/first_run.feature
+++ b/tests/behavior/features/first_run.feature
@@ -1,0 +1,10 @@
+Feature: First run experience
+  Ensures the CLI greets users only on first launch when no configuration exists.
+
+  Scenario: No config present shows welcome and prompt
+    When I run the CLI without a config file
+    Then the welcome banner and initialization prompt are shown
+
+  Scenario: Config exists suppresses welcome
+    When I run the CLI with an existing config file
+    Then the welcome banner is suppressed

--- a/tests/behavior/steps/first_run_steps.py
+++ b/tests/behavior/steps/first_run_steps.py
@@ -1,0 +1,58 @@
+# flake8: noqa
+from pytest_bdd import scenario, when, then
+from typer.testing import CliRunner
+import importlib
+import typer
+
+from .common_steps import cli_app  # ensure common fixtures are loaded
+from autoresearch.config.loader import ConfigLoader
+
+app_mod = importlib.import_module("autoresearch.main.app")
+
+
+@when("I run the CLI without a config file", target_fixture="no_config_result")
+def run_without_config(tmp_path, monkeypatch, cli_runner: CliRunner):
+    monkeypatch.chdir(tmp_path)
+    loader = ConfigLoader.new_for_tests()
+    loader.search_paths = [tmp_path / "missing.toml"]
+    loader._update_watch_paths()
+    monkeypatch.setattr(app_mod, "_config_loader", loader)
+    monkeypatch.setattr(typer, "confirm", lambda *a, **k: False)
+    result = cli_runner.invoke(cli_app)
+    return result
+
+
+@then("the welcome banner and initialization prompt are shown")
+def check_welcome(no_config_result):
+    assert no_config_result.exit_code == 2
+    assert "Welcome to Autoresearch!" in no_config_result.stdout
+    assert "Would you like to initialize the configuration now?" in no_config_result.stdout
+
+
+@when("I run the CLI with an existing config file", target_fixture="with_config_result")
+def run_with_config(tmp_path, monkeypatch, cli_runner: CliRunner):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = tmp_path / "autoresearch.toml"
+    cfg_path.write_text("[core]\nloops = 1\n")
+    loader = ConfigLoader.new_for_tests()
+    loader.search_paths = [cfg_path]
+    loader._update_watch_paths()
+    monkeypatch.setattr(app_mod, "_config_loader", loader)
+    result = cli_runner.invoke(cli_app)
+    return result
+
+
+@then("the welcome banner is suppressed")
+def check_no_banner(with_config_result):
+    assert with_config_result.exit_code == 0
+    assert "Welcome to Autoresearch!" not in with_config_result.stdout
+
+
+@scenario("../features/first_run.feature", "No config present shows welcome and prompt")
+def test_first_run_welcome():
+    pass
+
+
+@scenario("../features/first_run.feature", "Config exists suppresses welcome")
+def test_existing_config_suppresses_banner():
+    pass


### PR DESCRIPTION
## Summary
- add BDD feature for first-run banner behavior
- implement steps to check banner visibility based on config presence

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/behavior/steps/first_run_steps.py` *(fails: `AssertionError: assert 'Welcome to Autoresearch!' in ...`)*

------
https://chatgpt.com/codex/tasks/task_e_6892919b752c833384bda1934218a328