### PR TITLE
test: add A2A serve scenario

### DIFF
--- a/tests/behavior/features/serve_commands.feature
+++ b/tests/behavior/features/serve_commands.feature
@@ -6,3 +6,8 @@ Feature: Server commands
   Scenario: Display help for serve-a2a
     When I run `autoresearch serve-a2a --help`
     Then the CLI should exit successfully
+
+  Scenario: Start serve-a2a
+    When I run `autoresearch serve-a2a`
+    Then the CLI should exit successfully
+    And the A2A server should start and stop

--- a/tests/behavior/steps/serve_cli_steps.py
+++ b/tests/behavior/steps/serve_cli_steps.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 from pytest_bdd import scenario, when, then
 
 from autoresearch.main import app as cli_app
@@ -15,11 +17,36 @@ def run_a2a_help(cli_runner, bdd_context):
     bdd_context["result"] = result
 
 
+@when("I run `autoresearch serve-a2a`")
+def run_a2a(cli_runner, monkeypatch, bdd_context):
+    mock_interface = MagicMock()
+    mock_ctor = MagicMock(return_value=mock_interface)
+    monkeypatch.setattr("autoresearch.a2a_interface.A2AInterface", mock_ctor)
+    monkeypatch.setattr(
+        "autoresearch.main.app.time.sleep", lambda _x: (_ for _ in ()).throw(KeyboardInterrupt())
+    )
+    result = cli_runner.invoke(cli_app, ["serve-a2a"])
+    bdd_context.update({"result": result, "mock_interface": mock_interface, "mock_ctor": mock_ctor})
+
+
 @then("the CLI should exit successfully")
 def cli_success(bdd_context):
     result = bdd_context["result"]
     assert result.exit_code == 0
     assert "usage:" in result.stdout.lower()
+
+
+@then("the A2A server should start and stop")
+def a2a_started_and_stopped(bdd_context):
+    result = bdd_context["result"]
+    mock_interface = bdd_context["mock_interface"]
+    mock_ctor = bdd_context["mock_ctor"]
+    assert result.exit_code == 0
+    assert "Starting A2A server" in result.stdout
+    assert "Server stopped" in result.stdout
+    assert mock_ctor.call_count == 1
+    assert mock_interface.start.call_count == 1
+    assert mock_interface.stop.call_count == 1
 
 
 @scenario("../features/serve_commands.feature", "Display help for serve")
@@ -29,4 +56,9 @@ def test_serve_help():
 
 @scenario("../features/serve_commands.feature", "Display help for serve-a2a")
 def test_serve_a2a_help():
+    pass
+
+
+@scenario("../features/serve_commands.feature", "Start serve-a2a")
+def test_serve_a2a_start():
     pass


### PR DESCRIPTION
## Summary
- cover `serve-a2a` command in behavior tests
- verify mocked A2A interface start/stop behavior

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6892971f47fc8333a70293f5b34cbd16