### PR TITLE
Add tracing BDD tests

### DIFF
--- a/tests/behavior/features/tracing.feature
+++ b/tests/behavior/features/tracing.feature
@@ -1,0 +1,10 @@
+Feature: Tracing
+  Scenario: Tracing enabled emits spans
+    Given tracing is enabled
+    When I perform a traced operation
+    Then a span is recorded with name "test-span" and attribute "foo"="bar"
+
+  Scenario: Tracing disabled emits no spans
+    Given tracing is disabled
+    When I perform a traced operation
+    Then no spans are recorded

--- a/tests/behavior/steps/tracing_steps.py
+++ b/tests/behavior/steps/tracing_steps.py
@@ -1,0 +1,88 @@
+import pytest
+from pytest_bdd import given, when, then, scenario
+
+from autoresearch import tracing
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+
+class MemorySpanExporter(SpanExporter):
+    """Collect spans in memory for verification."""
+
+    def __init__(self) -> None:
+        self._spans = []
+
+    def export(self, spans):  # type: ignore[override]
+        self._spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:  # type: ignore[override]
+        self._spans.clear()
+
+    def get_finished_spans(self):
+        return list(self._spans)
+
+
+@pytest.fixture(autouse=True)
+def reset_tracer_provider():
+    """Reset global tracer provider before and after each scenario."""
+    if tracing._tracer_provider:
+        tracing._tracer_provider.shutdown()
+    tracing._tracer_provider = None
+    yield
+    if tracing._tracer_provider:
+        tracing._tracer_provider.shutdown()
+    tracing._tracer_provider = None
+
+
+@given("tracing is enabled")
+def enable_tracing(test_context, monkeypatch):
+    exporter = MemorySpanExporter()
+    monkeypatch.setattr(tracing, "ConsoleSpanExporter", lambda: exporter)
+    monkeypatch.setattr(tracing, "BatchSpanProcessor", SimpleSpanProcessor)
+    tracing.setup_tracing(True)
+    test_context["exporter"] = exporter
+    test_context["tracer"] = tracing.get_tracer("bdd")
+
+
+@given("tracing is disabled")
+def disable_tracing(test_context, monkeypatch):
+    exporter = MemorySpanExporter()
+    monkeypatch.setattr(tracing, "ConsoleSpanExporter", lambda: exporter)
+    monkeypatch.setattr(tracing, "BatchSpanProcessor", SimpleSpanProcessor)
+    tracing.setup_tracing(False)
+    test_context["exporter"] = exporter
+    test_context["tracer"] = tracing.get_tracer("bdd")
+
+
+@when("I perform a traced operation")
+def perform_traced_operation(test_context):
+    tracer = test_context["tracer"]
+    with tracer.start_as_current_span("test-span") as span:
+        span.set_attribute("foo", "bar")
+
+
+@then('a span is recorded with name "test-span" and attribute "foo"="bar"')
+def assert_span_recorded(test_context):
+    exporter = test_context["exporter"]
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "test-span"
+    assert span.attributes.get("foo") == "bar"
+
+
+@then("no spans are recorded")
+def assert_no_spans(test_context):
+    exporter = test_context["exporter"]
+    spans = exporter.get_finished_spans()
+    assert spans == []
+
+
+@scenario("../features/tracing.feature", "Tracing enabled emits spans")
+def test_tracing_enabled():
+    pass
+
+
+@scenario("../features/tracing.feature", "Tracing disabled emits no spans")
+def test_tracing_disabled():
+    pass


### PR DESCRIPTION
## Summary
- cover enabling and disabling tracing in behavior specs
- verify spans and attributes with in-memory exporter

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `PYTEST_ADDOPTS="--no-cov" uv run pytest tests/behavior/steps/tracing_steps.py::test_tracing_enabled -q`
- `PYTEST_ADDOPTS="--no-cov" uv run pytest tests/behavior/steps/tracing_steps.py::test_tracing_disabled -q`


------
https://chatgpt.com/codex/tasks/task_e_6893a0d939948333868b3aac10a255b5