### PR TITLE
Expand reasoning mode tests with chain-of-thought and mode switching

### DIFF
--- a/tests/behavior/features/reasoning_mode_api.feature
+++ b/tests/behavior/features/reasoning_mode_api.feature
@@ -14,6 +14,9 @@ Feature: Reasoning mode via API
     And the loops used should be 1
     And the agent groups should be "Synthesizer"
     And the agents executed should be "Synthesizer"
+    And the reasoning steps should be "Synthesizer-1"
+    And the metrics should record 1 cycles
+    And the metrics should list agents "Synthesizer"
 
   Scenario: Chain-of-thought mode via API
     Given loops is set to 2 in configuration
@@ -22,6 +25,9 @@ Feature: Reasoning mode via API
     And the loops used should be 2
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     And the agents executed should be "Synthesizer, Synthesizer"
+    And the reasoning steps should be "Synthesizer-1; Synthesizer-2"
+    And the metrics should record 2 cycles
+    And the metrics should list agents "Synthesizer"
 
   Scenario: Dialectical mode via API
     Given loops is set to 1 in configuration
@@ -30,3 +36,25 @@ Feature: Reasoning mode via API
     And the loops used should be 1
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     And the agents executed should be "Synthesizer, Contrarian, FactChecker"
+    And the reasoning steps should be "Synthesizer-1; Contrarian-2; FactChecker-3"
+    And the metrics should record 1 cycles
+    And the metrics should list agents "Synthesizer, Contrarian, FactChecker"
+
+  Scenario: Mode switching within a session via API
+    Given loops is set to 2 in configuration
+    When I send a query "mode test" with reasoning mode "direct" to the API
+    And I send a query "mode test" with reasoning mode "chain-of-thought" to the API
+    Then the response status should be 200
+    And the loops used should be 2
+    And the agent groups should be "Synthesizer; Contrarian; FactChecker"
+    And the agents executed should be "Synthesizer, Synthesizer"
+    And the reasoning steps should be "Synthesizer-1; Synthesizer-2"
+    And the metrics should record 2 cycles
+    And the metrics should list agents "Synthesizer"
+
+  Scenario: Invalid reasoning mode via API
+    Given loops is set to 2 in configuration
+    When I send a query "mode test" with reasoning mode "invalid" to the API
+    Then the response status should be 422
+    And a reasoning mode error should be returned
+    And no agents should execute

--- a/tests/behavior/features/reasoning_mode_cli.feature
+++ b/tests/behavior/features/reasoning_mode_cli.feature
@@ -11,6 +11,9 @@ Feature: Reasoning mode via CLI
     And the loops used should be 1
     And the agent groups should be "Synthesizer"
     And the agents executed should be "Synthesizer"
+    And the reasoning steps should be "Synthesizer-1"
+    And the metrics should record 1 cycles
+    And the metrics should list agents "Synthesizer"
 
   Scenario: Chain-of-thought mode via CLI
     Given loops is set to 2 in configuration
@@ -19,6 +22,9 @@ Feature: Reasoning mode via CLI
     And the loops used should be 2
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     And the agents executed should be "Synthesizer, Synthesizer"
+    And the reasoning steps should be "Synthesizer-1; Synthesizer-2"
+    And the metrics should record 2 cycles
+    And the metrics should list agents "Synthesizer"
 
   Scenario: Dialectical mode via CLI
     Given loops is set to 1 in configuration
@@ -27,3 +33,24 @@ Feature: Reasoning mode via CLI
     And the loops used should be 1
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     And the agents executed should be "Synthesizer, Contrarian, FactChecker"
+    And the reasoning steps should be "Synthesizer-1; Contrarian-2; FactChecker-3"
+    And the metrics should record 1 cycles
+    And the metrics should list agents "Synthesizer, Contrarian, FactChecker"
+
+  Scenario: Mode switching within a session via CLI
+    Given loops is set to 2 in configuration
+    When I run `autoresearch search "mode test" --mode direct`
+    And I run `autoresearch search "mode test" --mode chain-of-thought`
+    Then the CLI should exit successfully
+    And the loops used should be 2
+    And the agent groups should be "Synthesizer; Contrarian; FactChecker"
+    And the agents executed should be "Synthesizer, Synthesizer"
+    And the reasoning steps should be "Synthesizer-1; Synthesizer-2"
+    And the metrics should record 2 cycles
+    And the metrics should list agents "Synthesizer"
+
+  Scenario: Invalid reasoning mode via CLI
+    Given loops is set to 2 in configuration
+    When I run `autoresearch search "mode test" --mode invalid`
+    Then the CLI should exit with an error
+    And no agents should execute


### PR DESCRIPTION
## Summary
- assert reasoning steps and orchestration metrics for API and CLI reasoning modes
- cover mode switching within a session and invalid reasoning mode errors

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/behavior/steps/reasoning_mode_api_steps.py tests/behavior/steps/reasoning_mode_cli_steps.py` *(KeyboardInterrupt during teardown)*

------
https://chatgpt.com/codex/tasks/task_e_6893b94f3b608333994de468f6ae2231