### PR TITLE
Add recovery scenarios for storage and network failures

### DIFF
--- a/tests/behavior/features/error_recovery.feature
+++ b/tests/behavior/features/error_recovery.feature
@@ -24,3 +24,19 @@ Feature: Error Recovery
     When I run the orchestrator on query "recover test"
     Then a recovery strategy "retry_with_backoff" should be recorded
     And recovery should be applied
+
+  Scenario: Recovery after storage failure
+    Given a storage layer that raises a StorageError
+    When I run the orchestrator on query "recover test"
+    Then a recovery strategy "fail_gracefully" should be recorded
+    And error category "critical" should be recorded
+    And recovery should be applied
+    And the response should list an error of type "StorageError"
+
+  Scenario: Recovery after persistent network outage
+    Given an agent facing a persistent network outage
+    When I run the orchestrator on query "recover test"
+    Then a recovery strategy "fallback_agent" should be recorded
+    And error category "recoverable" should be recorded
+    And recovery should be applied
+    And the response should list an error of type "AgentError"


### PR DESCRIPTION
## Summary
- Extend error recovery feature tests to cover storage layer failures and persistent network outages
- Implement step definitions that patch storage and network components and verify recovery metadata
- Capture error categories and types when orchestration fails

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest --no-cov tests/behavior/steps/error_recovery_steps.py -q`
- `uv run pytest tests/behavior/features/error_recovery.feature` *(fails: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893b96f3c50833381acd94d7a257c94