### PR TITLE
test: isolate behavior test state

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -64,21 +64,6 @@ def bdd_storage_manager(storage_manager):
 
 
 @pytest.fixture
-def metrics_env(monkeypatch, tmp_path):
-    """Provide unique metric file paths for each scenario.
-
-    Many BDD steps rely on ``AUTORESEARCH_RELEASE_METRICS`` and
-    ``AUTORESEARCH_QUERY_TOKENS`` environment variables. Centralising their
-    setup here ensures tests do not leak state between each other.
-    """
-    release = tmp_path / "release_tokens.json"
-    query = tmp_path / "query_tokens.json"
-    monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", str(release))
-    monkeypatch.setenv("AUTORESEARCH_QUERY_TOKENS", str(query))
-    yield
-
-
-@pytest.fixture
 def storage_error_handler():
     """Fixture for handling storage errors in BDD tests.
 

--- a/tests/behavior/steps/agent_messages_steps.py
+++ b/tests/behavior/steps/agent_messages_steps.py
@@ -1,4 +1,5 @@
 from pytest_bdd import scenario, given, when, then
+from . import common_steps  # noqa: F401
 from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.agents.base import Agent, AgentRole
 from autoresearch.agents.registry import AgentFactory
@@ -79,7 +80,7 @@ def setup_agents(monkeypatch, tmp_path, config_model):
 
 
 @when("I execute a query", target_fixture="response")
-def run_query(config, metrics_env):
+def run_query(config):
     """Execute a simple query and capture the response."""
     return Orchestrator.run_query("ping", config)
 
@@ -116,7 +117,7 @@ def setup_coalition(monkeypatch, tmp_path, config_model):
 
 
 @when("the sender broadcasts to the coalition", target_fixture="response")
-def run_broadcast_query(config, metrics_env):
+def run_broadcast_query(config):
     """Run a query to trigger broadcast messaging."""
     return Orchestrator.run_query("ping", config)
 

--- a/tests/behavior/steps/agent_orchestration_steps.py
+++ b/tests/behavior/steps/agent_orchestration_steps.py
@@ -50,7 +50,7 @@ def set_primus_start(index: int, set_loops):
     parsers.parse('I run the orchestrator on query "{query}"'),
     target_fixture="run_orchestrator_on_query",
 )
-def run_orchestrator_on_query(query, metrics_env):
+def run_orchestrator_on_query(query):
     loader = ConfigLoader()
     loader._config = None
     cfg = loader.load_config()
@@ -122,7 +122,7 @@ def check_agent_groups(run_orchestrator_on_query, groups):
     parsers.parse('I submit a query via CLI `autoresearch search "{query}"`'),
     target_fixture="submit_query_via_cli",
 )
-def submit_query_via_cli(query, metrics_env, monkeypatch, cli_runner):
+def submit_query_via_cli(query, monkeypatch, cli_runner):
     agent_invocations: list[str] = []
     logger = logging.getLogger("autoresearch.test")
     logger.setLevel(logging.INFO)

--- a/tests/behavior/steps/cache_management_steps.py
+++ b/tests/behavior/steps/cache_management_steps.py
@@ -1,20 +1,8 @@
 """Step definitions for cache management feature."""
 
 from pytest_bdd import scenario, given, when, then, parsers
-import pytest
-
+from . import common_steps  # noqa: F401
 from autoresearch import cache
-
-
-@pytest.fixture(autouse=True)
-def temp_cache(tmp_path, monkeypatch):
-    """Use a temporary TinyDB path for each scenario and reset cache."""
-    db_path = tmp_path / "cache.json"
-    monkeypatch.setenv("TINYDB_PATH", str(db_path))
-    cache.teardown(remove_file=True)
-    cache.setup(str(db_path))
-    yield
-    cache.teardown(remove_file=True)
 
 
 # Scenarios

--- a/tests/behavior/steps/config_cli_steps.py
+++ b/tests/behavior/steps/config_cli_steps.py
@@ -28,7 +28,11 @@ def run_config_validate(cli_runner, bdd_context):
     bdd_context["result"] = result
 
 
-@when(parsers.parse('I run `autoresearch config reasoning --mode {mode} --loops {loops:d}`'))
+@when(
+    parsers.re(
+        r'^I run `autoresearch config reasoning --mode (?P<mode>\w+) --loops (?P<loops>\d+)`$'
+    )
+)
 def run_config_reasoning(cli_runner, bdd_context, mode: str, loops: int):
     result = cli_runner.invoke(
         cli_app, ["config", "reasoning", "--mode", mode, "--loops", str(loops)]

--- a/tests/behavior/steps/configuration_hot_reload_steps.py
+++ b/tests/behavior/steps/configuration_hot_reload_steps.py
@@ -1,8 +1,19 @@
 # flake8: noqa
 import os
-from pytest_bdd import scenario, when, then, parsers
+from pytest_bdd import scenario, when, then, parsers, given
 
+from . import common_steps  # noqa: F401
 from .common_steps import app_running, app_running_with_default, application_running
+
+
+@given("the application is running with default configuration")
+def _app_running_with_default(tmp_path, monkeypatch):
+    return application_running(tmp_path, monkeypatch)
+
+
+@given("the application is running")
+def _app_running(tmp_path, monkeypatch):
+    return application_running(tmp_path, monkeypatch)
 from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
 

--- a/tests/behavior/steps/tracing_steps.py
+++ b/tests/behavior/steps/tracing_steps.py
@@ -1,6 +1,6 @@
-import pytest
 from pytest_bdd import given, when, then, scenario
 
+from . import common_steps  # noqa: F401
 from autoresearch import tracing
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
 
@@ -20,18 +20,6 @@ class MemorySpanExporter(SpanExporter):
 
     def get_finished_spans(self):
         return list(self._spans)
-
-
-@pytest.fixture(autouse=True)
-def reset_tracer_provider():
-    """Reset global tracer provider before and after each scenario."""
-    if tracing._tracer_provider:
-        tracing._tracer_provider.shutdown()
-    tracing._tracer_provider = None
-    yield
-    if tracing._tracer_provider:
-        tracing._tracer_provider.shutdown()
-    tracing._tracer_provider = None
 
 
 @given("tracing is enabled")


### PR DESCRIPTION
## Summary
- add autouse fixtures to clear TinyDB cache, metrics files, and tracer provider per scenario
- drop per-test metrics and tracing setup in behavior steps
- import shared fixtures across steps for consistent state

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/behavior`

------
https://chatgpt.com/codex/tasks/task_e_6893c485fb1c833383d11133bd4eeef0