### PR TITLE
test: validate reasoning modes and recovery

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -7,12 +7,15 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))  # noqa: E402
 
+import os  # noqa: E402
 import pytest  # noqa: E402
 
 from autoresearch.api import reset_request_log  # noqa: E402
 from tests.conftest import reset_limiter_state, VSS_AVAILABLE  # noqa: E402
 from autoresearch.orchestration.state import QueryState  # noqa: E402
 from autoresearch.config.models import ConfigModel  # noqa: E402
+from autoresearch.config.loader import ConfigLoader  # noqa: E402
+from autoresearch.storage import StorageManager, StorageContext  # noqa: E402
 
 
 @pytest.fixture
@@ -61,6 +64,18 @@ def reset_api_request_log():
 def bdd_storage_manager(storage_manager):
     """Use the global temporary storage fixture for behavior tests."""
     yield storage_manager
+
+
+@pytest.fixture(autouse=True)
+def reset_global_state():
+    """Reset ConfigLoader, environment variables, and storage after each scenario."""
+    original_env = os.environ.copy()
+    ConfigLoader.reset_instance()
+    yield
+    ConfigLoader.reset_instance()
+    StorageManager.context = StorageContext()
+    os.environ.clear()
+    os.environ.update(original_env)
 
 
 @pytest.fixture

--- a/tests/behavior/features/error_recovery.feature
+++ b/tests/behavior/features/error_recovery.feature
@@ -8,27 +8,43 @@ Feature: Error Recovery
     Given an agent that raises a transient error
     And reasoning mode is "dialectical"
     When I run the orchestrator on query "recover test"
-    Then a recovery strategy "retry_with_backoff" should be recorded
+    Then the reasoning mode selected should be "dialectical"
+    And the loops used should be 1
+    And the agent groups should be "Flaky"
+    And the agents executed should be "Flaky"
+    And a recovery strategy "retry_with_backoff" should be recorded
     And recovery should be applied
 
   Scenario: Error recovery in direct reasoning mode
     Given an agent that raises a transient error
     And reasoning mode is "direct"
     When I run the orchestrator on query "recover test"
-    Then a recovery strategy "retry_with_backoff" should be recorded
+    Then the reasoning mode selected should be "direct"
+    And the loops used should be 1
+    And the agent groups should be "Synthesizer"
+    And the agents executed should be "Synthesizer"
+    And a recovery strategy "retry_with_backoff" should be recorded
     And recovery should be applied
 
   Scenario: Error recovery in chain-of-thought reasoning mode
     Given an agent that raises a transient error
     And reasoning mode is "chain-of-thought"
     When I run the orchestrator on query "recover test"
-    Then a recovery strategy "retry_with_backoff" should be recorded
+    Then the reasoning mode selected should be "chain-of-thought"
+    And the loops used should be 1
+    And the agent groups should be "Flaky"
+    And the agents executed should be "Flaky"
+    And a recovery strategy "retry_with_backoff" should be recorded
     And recovery should be applied
 
   Scenario: Recovery after storage failure
     Given a storage layer that raises a StorageError
     When I run the orchestrator on query "recover test"
-    Then a recovery strategy "fail_gracefully" should be recorded
+    Then the reasoning mode selected should be "dialectical"
+    And the loops used should be 1
+    And the agent groups should be "StoreFail"
+    And the agents executed should be "StoreFail"
+    And a recovery strategy "fail_gracefully" should be recorded
     And error category "critical" should be recorded
     And recovery should be applied
     And the response should list an error of type "StorageError"
@@ -36,7 +52,11 @@ Feature: Error Recovery
   Scenario: Recovery after persistent network outage
     Given an agent facing a persistent network outage
     When I run the orchestrator on query "recover test"
-    Then a recovery strategy "fallback_agent" should be recorded
+    Then the reasoning mode selected should be "dialectical"
+    And the loops used should be 1
+    And the agent groups should be "Offline"
+    And the agents executed should be "Offline"
+    And a recovery strategy "fallback_agent" should be recorded
     And error category "recoverable" should be recorded
     And recovery should be applied
     And the response should list an error of type "AgentError"

--- a/tests/behavior/features/error_recovery_extended.feature
+++ b/tests/behavior/features/error_recovery_extended.feature
@@ -6,10 +6,26 @@ Feature: Extended Error Recovery
 
   Scenario: Recovery after agent timeout
     Given an agent that times out during execution
+    And reasoning mode is "chain-of-thought"
     When I run the orchestrator on query "Explain the theory of relativity"
-    Then the response should list a timeout error
+    Then the reasoning mode selected should be "chain-of-thought"
+    And the loops used should be 1
+    And the agent groups should be "Slowpoke"
+    And the agents executed should be "Slowpoke"
+    And a recovery strategy "retry_with_backoff" should be recorded
+    And error category "transient" should be recorded
+    And recovery should be applied
+    And the response should list a timeout error
 
   Scenario: Recovery after agent failure
     Given an agent that fails during execution
+    And reasoning mode is "dialectical"
     When I run the orchestrator on query "Describe the process of photosynthesis"
-    Then the response should list an agent execution error
+    Then the reasoning mode selected should be "dialectical"
+    And the loops used should be 1
+    And the agent groups should be "Faulty"
+    And the agents executed should be "Faulty"
+    And a recovery strategy "fail_gracefully" should be recorded
+    And error category "critical" should be recorded
+    And recovery should be applied
+    And the response should list an agent execution error

--- a/tests/behavior/features/reasoning_mode.feature
+++ b/tests/behavior/features/reasoning_mode.feature
@@ -10,6 +10,7 @@ Feature: Reasoning Mode Selection
     Given reasoning mode is "direct"
     When I run the orchestrator on query "mode test"
     Then the loops used should be 1
+    And the reasoning mode selected should be "direct"
     And the agent groups should be "Synthesizer"
     Then the agents executed should be "Synthesizer"
 
@@ -17,6 +18,7 @@ Feature: Reasoning Mode Selection
     Given reasoning mode is "chain-of-thought"
     When I run the orchestrator on query "mode test"
     Then the loops used should be 2
+    And the reasoning mode selected should be "chain-of-thought"
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     Then the agents executed should be "Synthesizer, Synthesizer"
 
@@ -26,6 +28,7 @@ Feature: Reasoning Mode Selection
     And primus start is 1
     When I run the orchestrator on query "mode test"
     Then the loops used should be 1
+    And the reasoning mode selected should be "dialectical"
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     Then the agents executed should be "Contrarian, FactChecker, Synthesizer"
 
@@ -34,6 +37,7 @@ Feature: Reasoning Mode Selection
     And reasoning mode is "dialectical"
     When I run the orchestrator on query "Why is the sky blue?"
     Then the loops used should be 1
+    And the reasoning mode selected should be "dialectical"
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     Then the agents executed should be "Synthesizer, Contrarian, FactChecker"
 

--- a/tests/behavior/features/reasoning_mode_api.feature
+++ b/tests/behavior/features/reasoning_mode_api.feature
@@ -12,6 +12,7 @@ Feature: Reasoning mode via API
     When I send a query "mode test" with reasoning mode "direct" to the API
     Then the response status should be 200
     And the loops used should be 1
+    And the reasoning mode selected should be "direct"
     And the agent groups should be "Synthesizer"
     And the agents executed should be "Synthesizer"
     And the reasoning steps should be "Synthesizer-1"
@@ -23,6 +24,7 @@ Feature: Reasoning mode via API
     When I send a query "mode test" with reasoning mode "chain-of-thought" to the API
     Then the response status should be 200
     And the loops used should be 2
+    And the reasoning mode selected should be "chain-of-thought"
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     And the agents executed should be "Synthesizer, Synthesizer"
     And the reasoning steps should be "Synthesizer-1; Synthesizer-2"
@@ -34,6 +36,7 @@ Feature: Reasoning mode via API
     When I send a query "mode test" with reasoning mode "dialectical" to the API
     Then the response status should be 200
     And the loops used should be 1
+    And the reasoning mode selected should be "dialectical"
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     And the agents executed should be "Synthesizer, Contrarian, FactChecker"
     And the reasoning steps should be "Synthesizer-1; Contrarian-2; FactChecker-3"
@@ -46,6 +49,7 @@ Feature: Reasoning mode via API
     And I send a query "mode test" with reasoning mode "chain-of-thought" to the API
     Then the response status should be 200
     And the loops used should be 2
+    And the reasoning mode selected should be "chain-of-thought"
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     And the agents executed should be "Synthesizer, Synthesizer"
     And the reasoning steps should be "Synthesizer-1; Synthesizer-2"

--- a/tests/behavior/features/reasoning_mode_cli.feature
+++ b/tests/behavior/features/reasoning_mode_cli.feature
@@ -9,6 +9,7 @@ Feature: Reasoning mode via CLI
     When I run `autoresearch search "mode test" --mode direct`
     Then the CLI should exit successfully
     And the loops used should be 1
+    And the reasoning mode selected should be "direct"
     And the agent groups should be "Synthesizer"
     And the agents executed should be "Synthesizer"
     And the reasoning steps should be "Synthesizer-1"
@@ -20,6 +21,7 @@ Feature: Reasoning mode via CLI
     When I run `autoresearch search "mode test" --mode chain-of-thought`
     Then the CLI should exit successfully
     And the loops used should be 2
+    And the reasoning mode selected should be "chain-of-thought"
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     And the agents executed should be "Synthesizer, Synthesizer"
     And the reasoning steps should be "Synthesizer-1; Synthesizer-2"
@@ -31,6 +33,7 @@ Feature: Reasoning mode via CLI
     When I run `autoresearch search "mode test" --mode dialectical`
     Then the CLI should exit successfully
     And the loops used should be 1
+    And the reasoning mode selected should be "dialectical"
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     And the agents executed should be "Synthesizer, Contrarian, FactChecker"
     And the reasoning steps should be "Synthesizer-1; Contrarian-2; FactChecker-3"
@@ -43,6 +46,7 @@ Feature: Reasoning mode via CLI
     And I run `autoresearch search "mode test" --mode chain-of-thought`
     Then the CLI should exit successfully
     And the loops used should be 2
+    And the reasoning mode selected should be "chain-of-thought"
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     And the agents executed should be "Synthesizer, Synthesizer"
     And the reasoning steps should be "Synthesizer-1; Synthesizer-2"

--- a/tests/behavior/steps/agent_orchestration_steps.py
+++ b/tests/behavior/steps/agent_orchestration_steps.py
@@ -109,6 +109,11 @@ def check_loops_used(run_orchestrator_on_query, count):
     assert run_orchestrator_on_query["config_params"].get("loops") == count
 
 
+@then(parsers.parse('the reasoning mode selected should be "{mode}"'))
+def check_reasoning_mode(run_orchestrator_on_query, mode):
+    assert run_orchestrator_on_query["config_params"].get("mode") == ReasoningMode(mode)
+
+
 @then(parsers.parse('the agent groups should be "{groups}"'))
 def check_agent_groups(run_orchestrator_on_query, groups):
     expected = [

--- a/tests/behavior/steps/reasoning_mode_api_steps.py
+++ b/tests/behavior/steps/reasoning_mode_api_steps.py
@@ -6,6 +6,7 @@ from pytest_bdd import scenario, given, when, then, parsers
 
 from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
+from autoresearch.orchestration import ReasoningMode
 from autoresearch.orchestration.orchestrator import Orchestrator
 
 
@@ -119,6 +120,11 @@ def assert_status(test_context: dict, status: int) -> None:
 @then(parsers.parse("the loops used should be {count:d}"))
 def assert_loops(run_result: dict, count: int) -> None:
     assert run_result["config_params"].get("loops") == count
+
+
+@then(parsers.parse('the reasoning mode selected should be "{mode}"'))
+def assert_mode(run_result: dict, mode: str) -> None:
+    assert run_result["config_params"].get("mode") == ReasoningMode(mode)
 
 
 @then(parsers.parse('the agent groups should be "{groups}"'))

--- a/tests/behavior/steps/reasoning_mode_cli_steps.py
+++ b/tests/behavior/steps/reasoning_mode_cli_steps.py
@@ -7,6 +7,7 @@ from pytest_bdd import scenario, given, when, then, parsers
 
 from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
+from autoresearch.orchestration import ReasoningMode
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.main import app as cli_app
 
@@ -135,6 +136,11 @@ def cli_success(run_result):
 @then(parsers.parse("the loops used should be {count:d}"))
 def assert_loops(run_result: dict, count: int) -> None:
     assert run_result["config_params"].get("loops") == count
+
+
+@then(parsers.parse('the reasoning mode selected should be "{mode}"'))
+def assert_mode(run_result: dict, mode: str) -> None:
+    assert run_result["config_params"].get("mode") == ReasoningMode(mode)
 
 
 @then(parsers.parse('the agent groups should be "{groups}"'))

--- a/tests/behavior/steps/reasoning_mode_steps.py
+++ b/tests/behavior/steps/reasoning_mode_steps.py
@@ -124,6 +124,11 @@ def assert_loops(run_result: dict, count: int) -> None:
     assert run_result["config_params"].get("loops") == count
 
 
+@then(parsers.parse('the reasoning mode selected should be "{mode}"'))
+def assert_mode(run_result: dict, mode: str) -> None:
+    assert run_result["config_params"].get("mode") == ReasoningMode(mode)
+
+
 @then(parsers.parse('the agent groups should be "{groups}"'))
 def assert_groups(run_result: dict, groups: str) -> None:
     expected = [[a.strip() for a in grp.split(",") if a.strip()] for grp in groups.split(";")]


### PR DESCRIPTION
## Summary
- assert selected reasoning modes, loop counts, agent grouping, and execution order across API, CLI, and orchestrator steps
- capture and verify recovery metadata including retry strategy, error category, and agent execution tracing
- add fixture to reset ConfigLoader, environment variables, and storage context after behavior scenarios
- expand behavior scenarios to cover reasoning-mode failures and error classifications

## Testing
- `uv run flake8 src tests`
- `uv run mypy src` *(failed: command interrupted)*
- `uv run pytest -q` *(failed: KeyboardInterrupt)*
- `uv run pytest tests/behavior` *(failed: KeyboardInterrupt after completion)*

------
https://chatgpt.com/codex/tasks/task_e_6893f5fffc68833383d3dbc1de5f8ff8