### PR TITLE
test: add reasoning mode failure scenarios

### DIFF
--- a/tests/behavior/features/reasoning_mode.feature
+++ b/tests/behavior/features/reasoning_mode.feature
@@ -42,6 +42,44 @@ Feature: Reasoning Mode Selection
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     Then the agents executed should be "Synthesizer, Contrarian, FactChecker"
 
+  Scenario: Direct mode agent failure triggers fallback
+    Given reasoning mode is "direct"
+    When I run the orchestrator on query "mode test" with a failing agent
+    Then the fallback agent should be "Synthesizer"
+    And a recovery strategy "fallback_agent" should be recorded
+    And recovery should be applied
+    And the logs should include "recovery for Synthesizer"
+    And the system state should be restored
+
+  Scenario: Chain-of-thought mode agent failure triggers fallback
+    Given reasoning mode is "chain-of-thought"
+    When I run the orchestrator on query "mode test" with a failing agent
+    Then the fallback agent should be "Synthesizer"
+    And a recovery strategy "fallback_agent" should be recorded
+    And recovery should be applied
+    And the logs should include "recovery for Synthesizer"
+    And the system state should be restored
+
+  Scenario: Dialectical mode agent failure triggers fallback
+    Given loops is set to 1 in configuration
+    And reasoning mode is "dialectical"
+    When I run the orchestrator on query "mode test" with a failing agent
+    Then the fallback agent should be "Synthesizer"
+    And a recovery strategy "fallback_agent" should be recorded
+    And recovery should be applied
+    And the logs should include "recovery for Synthesizer"
+    And the system state should be restored
+
+  Scenario: Loop overflow triggers recovery
+    Given loops is set to 1 in configuration
+    And reasoning mode is "dialectical"
+    When I run the orchestrator on query "mode test" exceeding loop limit
+    Then the fallback agent should be "Synthesizer"
+    And a recovery strategy "fallback_agent" should be recorded
+    And recovery should be applied
+    And the logs should include "loop overflow"
+    And the system state should be restored
+
   Scenario: Unsupported reasoning mode fails gracefully
     Given loops is set to 1 in configuration
     When I run the orchestrator on query "mode test" with unsupported reasoning mode "quantum"

--- a/tests/behavior/steps/reasoning_mode_steps.py
+++ b/tests/behavior/steps/reasoning_mode_steps.py
@@ -6,7 +6,7 @@ from pytest_bdd import scenario, given, when, then, parsers
 
 from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
-from autoresearch.errors import ConfigError
+from autoresearch.errors import ConfigError, NotFoundError
 from autoresearch.orchestration import ReasoningMode
 from autoresearch.orchestration.orchestrator import Orchestrator
 
@@ -36,6 +36,38 @@ def test_dialectical_real_query():
     "Unsupported reasoning mode fails gracefully",
 )
 def test_unsupported_mode():
+    pass
+
+
+@scenario(
+    "../features/reasoning_mode.feature",
+    "Direct mode agent failure triggers fallback",
+)
+def test_direct_failure():
+    pass
+
+
+@scenario(
+    "../features/reasoning_mode.feature",
+    "Chain-of-thought mode agent failure triggers fallback",
+)
+def test_cot_failure():
+    pass
+
+
+@scenario(
+    "../features/reasoning_mode.feature",
+    "Dialectical mode agent failure triggers fallback",
+)
+def test_dialectical_failure():
+    pass
+
+
+@scenario(
+    "../features/reasoning_mode.feature",
+    "Loop overflow triggers recovery",
+)
+def test_loop_overflow():
     pass
 
 
@@ -130,6 +162,156 @@ def run_orchestrator_invalid(query: str, mode: str, config: ConfigModel):
     return {"error": None, "record": record, "logs": logs, "state": state}
 
 
+def _run_orchestrator_with_failure(query: str, config: ConfigModel, *, overflow: bool = False):
+    record: list[str] = []
+    logs: list[str] = []
+    state = {"active": True}
+    recovery_info: dict = {}
+
+    original_handle = Orchestrator._handle_agent_error
+
+    def spy_handle(agent_name: str, e: Exception, state_obj, metrics):
+        info = original_handle(agent_name, e, state_obj, metrics)
+        info["recovery_applied"] = state_obj.metadata.get("recovery_applied")
+        recovery_info.update(info)
+        logs.append(str(e))
+        logs.append(f"recovery for {agent_name}")
+        return info
+
+    if config.reasoning_mode == ReasoningMode.CHAIN_OF_THOUGHT:
+        from autoresearch.orchestration.state import QueryState
+        from autoresearch.orchestration.metrics import OrchestrationMetrics
+
+        call_count = 0
+
+        class FailingSynthesizer:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+            def can_execute(self, *args, **kwargs) -> bool:
+                return True
+
+            def execute(self, state_obj, cfg):
+                nonlocal call_count
+                call_count += 1
+                record.append(self.name)
+                if overflow and call_count > cfg.loops:
+                    raise NotFoundError("loop overflow")
+                raise NotFoundError("missing resource")
+
+        def cot_run(self, q, cfg, agent_factory=None):
+            state_obj = QueryState(query=q)
+            metrics = OrchestrationMetrics()
+            agent = FailingSynthesizer("Synthesizer")
+            loops = cfg.loops + 1 if overflow else cfg.loops
+            for _ in range(loops):
+                try:
+                    agent.execute(state_obj, cfg)
+                except Exception as e:  # noqa: PERF203 - test instrumentation
+                    info = spy_handle("Synthesizer", e, state_obj, metrics)
+                    state_obj.add_error(info)
+            return state_obj.synthesize()
+
+        with patch(
+            "autoresearch.orchestration.orchestrator.Orchestrator._handle_agent_error",
+            side_effect=spy_handle,
+        ), patch(
+            "autoresearch.orchestration.reasoning.ChainOfThoughtStrategy.run_query",
+            cot_run,
+        ):
+            try:
+                Orchestrator.run_query(query, config)
+                error = None
+            except Exception as exc:  # pragma: no cover - not expected
+                error = exc
+            finally:
+                state["active"] = False
+
+        return {
+            "error": error,
+            "record": record,
+            "logs": logs,
+            "state": state,
+            "recovery_info": recovery_info,
+        }
+
+    params: dict = {}
+
+    original_parse = Orchestrator._parse_config
+
+    def spy_parse(cfg: ConfigModel):
+        out = original_parse(cfg)
+        if overflow:
+            out["loops"] = cfg.loops + 1
+        params.update(out)
+        return out
+
+    call_count = 0
+
+    class FailingAgent:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def can_execute(self, *args, **kwargs) -> bool:
+            return True
+
+        def execute(self, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            record.append(self.name)
+            if overflow:
+                if call_count > config.loops:
+                    raise NotFoundError("loop overflow")
+                return {}
+            raise NotFoundError("missing resource")
+
+    def get_agent(name: str, llm_adapter=None):
+        return FailingAgent(name)
+
+    with patch(
+        "autoresearch.orchestration.orchestrator.AgentFactory.get",
+        side_effect=get_agent,
+    ), patch(
+        "autoresearch.orchestration.orchestrator.Orchestrator._handle_agent_error",
+        side_effect=spy_handle,
+    ), patch(
+        "autoresearch.orchestration.orchestrator.Orchestrator._parse_config",
+        side_effect=spy_parse,
+    ):
+        try:
+            Orchestrator.run_query(query, config)
+            error = None
+        except Exception as exc:
+            error = exc
+        finally:
+            state["active"] = False
+
+    return {
+        "error": error,
+        "record": record,
+        "logs": logs,
+        "state": state,
+        "recovery_info": recovery_info,
+        "config_params": params,
+    }
+
+
+@when(
+    parsers.parse('I run the orchestrator on query "{query}" with a failing agent'),
+    target_fixture="run_result",
+)
+def run_orchestrator_failure(query: str, config: ConfigModel):
+    return _run_orchestrator_with_failure(query, config)
+
+
+@when(
+    parsers.parse('I run the orchestrator on query "{query}" exceeding loop limit'),
+    target_fixture="run_result",
+)
+def run_orchestrator_overflow(query: str, config: ConfigModel):
+    return _run_orchestrator_with_failure(query, config, overflow=True)
+
+
 @then(parsers.parse('the loops used should be {count:d}'))
 def assert_loops(run_result: dict, count: int) -> None:
     assert run_result["config_params"].get("loops") == count
@@ -162,3 +344,9 @@ def assert_invalid_mode(error_result: dict) -> None:
 @then("no agents should execute")
 def assert_no_agents(error_result: dict) -> None:
     assert error_result["record"] == []
+
+
+@then(parsers.parse('the fallback agent should be "{agent}"'))
+def assert_fallback_agent(run_result: dict, agent: str) -> None:
+    info = run_result.get("recovery_info", {})
+    assert info.get("agent") == agent


### PR DESCRIPTION
## Summary
- add behavior tests for reasoning-mode fallback and loop overflow recovery
- assert fallback agent, recovery logs, and state

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: incomplete run)*
- `uv run pytest tests/behavior` *(fails: fixture 'dummy_query_response' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f7ac862c8333a9a13907f09ec9e6