### PR TITLE
chore: standardize disabled workflows

### DIFF
--- a/.github/workflows.disabled/ci.yml
+++ b/.github/workflows.disabled/ci.yml
@@ -1,3 +1,4 @@
+# NOTE: This workflow is disabled. Move to .github/workflows to enable.
 name: CI (Python 3.12)
 
 on:
@@ -24,57 +25,57 @@ jobs:
             platform: macos-arm64
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Verify Python version
-      run: |
-        python - <<'EOF'
-        import sys
-        major, minor = sys.version_info[:2]
-        assert (major == 3 and minor >= 12), f"Python 3.12 or newer required, got {major}.{minor}"
-        EOF
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Verify Python version
+        run: |
+          python - <<'EOF'
+          import sys
+          major, minor = sys.version_info[:2]
+          assert (major == 3 and minor >= 12), f"Python 3.12 or newer required, got {major}.{minor}"
+          EOF
       - name: Install uv
         run: python -m pip install uv
       - name: Install dependencies
         run: uv pip sync uv.lock
-    - name: Lint with flake8
-      if: matrix.os == 'ubuntu-latest' && matrix.test-mode == 'offline'
-      run: |
-        uv run flake8 src tests
-    - name: Type check with mypy
-      if: matrix.os == 'ubuntu-latest' && matrix.test-mode == 'offline'
-      run: |
-        uv run mypy --strict src
-    - name: Set up offline environment for tests
-      if: matrix.test-mode == 'offline'
-      run: |
-        cp .env.offline .env
-        echo "Using offline environment for tests"
-        cat .env
-    - name: Set up online environment for tests
-      if: matrix.test-mode == 'online'
-      run: |
-        echo "Using online environment for tests"
-        echo "AUTORESEARCH_STRICT_EXTENSIONS=false" > .env
-    - name: Test with pytest
-      run: |
-        uv run pytest tests/
-    - name: Token usage regression
-      if: matrix.os == 'ubuntu-latest' && matrix.test-mode == 'offline'
-      run: |
-        uv run python scripts/check_token_regression.py --threshold 5
-    - name: Deployment checks
-      run: |
-        uv run python scripts/deploy.py
-    - name: Upload coverage report
-      if: matrix.os == 'ubuntu-latest' && matrix.test-mode == 'offline'
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
-        fail_ci_if_error: false
+      - name: Lint with flake8
+        if: matrix.os == 'ubuntu-latest' && matrix.test-mode == 'offline'
+        run: |
+          uv run flake8 src tests
+      - name: Type check with mypy
+        if: matrix.os == 'ubuntu-latest' && matrix.test-mode == 'offline'
+        run: |
+          uv run mypy --strict src
+      - name: Set up offline environment for tests
+        if: matrix.test-mode == 'offline'
+        run: |
+          cp .env.offline .env
+          echo "Using offline environment for tests"
+          cat .env
+      - name: Set up online environment for tests
+        if: matrix.test-mode == 'online'
+        run: |
+          echo "Using online environment for tests"
+          echo "AUTORESEARCH_STRICT_EXTENSIONS=false" > .env
+      - name: Test with pytest
+        run: |
+          uv run pytest tests/
+      - name: Token usage regression
+        if: matrix.os == 'ubuntu-latest' && matrix.test-mode == 'offline'
+        run: |
+          uv run python scripts/check_token_regression.py --threshold 5
+      - name: Deployment checks
+        run: |
+          uv run python scripts/deploy.py
+      - name: Upload coverage report
+        if: matrix.os == 'ubuntu-latest' && matrix.test-mode == 'offline'
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: false
 
   build:
     runs-on: ubuntu-latest
@@ -82,9 +83,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Verify Python version
@@ -100,8 +101,8 @@ jobs:
           pip install uv build
           uv pip sync uv.lock
           python -m build
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: dist
-        path: dist/
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/.github/workflows.disabled/simple_ci.yml
+++ b/.github/workflows.disabled/simple_ci.yml
@@ -1,3 +1,4 @@
+# NOTE: This workflow is disabled. Move to .github/workflows to enable.
 name: CI (Python 3.12)
 on:
   push:
@@ -22,10 +23,10 @@ jobs:
         run: python -m pip install uv
       - name: Install dependencies
         run: uv pip sync uv.lock
-      - name: Lint
+      - name: Lint with flake8
         run: uv run flake8 src tests
-      - name: Type check
-        run: uv run mypy src
+      - name: Type check with mypy
+        run: uv run mypy --strict src
       - name: Test
         run: uv run pytest -q
       - name: Token usage regression

--- a/.github/workflows.disabled/wheels.yml
+++ b/.github/workflows.disabled/wheels.yml
@@ -1,3 +1,4 @@
+# NOTE: This workflow is disabled. Move to .github/workflows to enable.
 name: Build wheels (Python 3.12)
 
 on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,16 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 - Execute BDD tests in `tests/behavior`: `uv run pytest tests/behavior`.
 - Run the entire suite with coverage using `task coverage`. If `task` is unavailable, run `uv run pytest --cov=src` instead.
 
+## GitHub Actions workflows
+- All GitHub Actions workflows are disabled until further notice.
+- Store workflow files in `.github/workflows.disabled`; `.github/workflows` must remain empty.
+- Each workflow file must start with `# NOTE: This workflow is disabled. Move to .github/workflows to enable.`
+- Standardize on these actions versions:
+  - `actions/checkout@v4`
+  - `actions/setup-python@v5`
+  - `actions/upload-artifact@v4`
+- Verify Python 3.12+ within each workflow as shown in existing examples.
+
 ## Commit etiquette
 - Keep commits focused and write clear messages detailing your reasoning.
 - Remove temporary files and keep the repository tidy.


### PR DESCRIPTION
## Summary
- clarify that all GitHub Actions workflows must remain disabled
- align existing workflow templates on consistent action versions and a common header

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(logs truncated, please run locally)*

------
https://chatgpt.com/codex/tasks/task_e_68950bedd6b48333bab195b77b9fe297