### PR TITLE
Add CLI BDD step definitions

### DIFF
--- a/tests/behavior/steps/gui_cli_steps.py
+++ b/tests/behavior/steps/gui_cli_steps.py
@@ -1,0 +1,34 @@
+from pytest_bdd import scenario, when, then
+from autoresearch.main import app as cli_app
+
+
+@when('I run `autoresearch gui --port 8502 --no-browser`')
+def run_gui_no_browser(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+    monkeypatch.setattr('subprocess.run', lambda *a, **k: None)
+    result = cli_runner.invoke(
+        cli_app, ['gui', '--port', '8502', '--no-browser'], catch_exceptions=False
+    )
+    bdd_context['result'] = result
+
+
+@when('I run `autoresearch gui --help`')
+def run_gui_help(cli_runner, bdd_context, temp_config, isolate_network):
+    result = cli_runner.invoke(cli_app, ['gui', '--help'], catch_exceptions=False)
+    bdd_context['result'] = result
+
+
+@then('the CLI should exit successfully')
+def cli_success(bdd_context):
+    result = bdd_context['result']
+    assert result.exit_code == 0
+    assert result.stderr == ''
+
+
+@scenario('../features/gui_cli.feature', 'Launch GUI without opening a browser')
+def test_gui_no_browser():
+    pass
+
+
+@scenario('../features/gui_cli.feature', 'Display help for GUI command')
+def test_gui_help():
+    pass

--- a/tests/behavior/steps/interface_test_cli_steps.py
+++ b/tests/behavior/steps/interface_test_cli_steps.py
@@ -1,0 +1,96 @@
+from pytest_bdd import scenario, when, then
+from autoresearch.main import app as cli_app
+
+
+@when('I run `autoresearch test_mcp --host 127.0.0.1 --port 8080`')
+def run_test_mcp(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+
+    class DummyClient:
+        def __init__(self, host='127.0.0.1', port=8080):
+            pass
+
+        def run_test_suite(self):
+            return {'connection_test': {'status': 'success'}}
+    monkeypatch.setattr('autoresearch.main.app.MCPTestClient', DummyClient)
+    monkeypatch.setattr('autoresearch.main.app.format_test_results', lambda r, f: 'ok')
+    result = cli_runner.invoke(
+        cli_app,
+        ['test_mcp', '--host', '127.0.0.1', '--port', '8080'],
+        catch_exceptions=False,
+    )
+    bdd_context['result'] = result
+
+
+@when('I run `autoresearch test_mcp --port 9`')
+def run_test_mcp_fail(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+
+    class FailingClient:
+        def __init__(self, host='127.0.0.1', port=9):
+            raise RuntimeError('connection failed')
+    monkeypatch.setattr('autoresearch.main.app.MCPTestClient', FailingClient)
+    result = cli_runner.invoke(cli_app, ['test_mcp', '--port', '9'], catch_exceptions=False)
+    bdd_context['result'] = result
+
+
+@when('I run `autoresearch test_a2a --host 127.0.0.1 --port 8765`')
+def run_test_a2a(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+
+    class DummyClient:
+        def __init__(self, host='127.0.0.1', port=8765):
+            pass
+
+        def run_test_suite(self):
+            return {'connection_test': {'status': 'success'}}
+    monkeypatch.setattr('autoresearch.main.app.A2ATestClient', DummyClient)
+    monkeypatch.setattr('autoresearch.main.app.format_test_results', lambda r, f: 'ok')
+    result = cli_runner.invoke(
+        cli_app,
+        ['test_a2a', '--host', '127.0.0.1', '--port', '8765'],
+        catch_exceptions=False,
+    )
+    bdd_context['result'] = result
+
+
+@when('I run `autoresearch test_a2a --port 9`')
+def run_test_a2a_fail(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+
+    class FailingClient:
+        def __init__(self, host='127.0.0.1', port=9):
+            raise RuntimeError('connection failed')
+    monkeypatch.setattr('autoresearch.main.app.A2ATestClient', FailingClient)
+    result = cli_runner.invoke(cli_app, ['test_a2a', '--port', '9'], catch_exceptions=False)
+    bdd_context['result'] = result
+
+
+@then('the CLI should exit successfully')
+def cli_success(bdd_context):
+    result = bdd_context['result']
+    assert result.exit_code == 0
+    assert result.stderr == ''
+
+
+@then('the CLI should exit with an error')
+def cli_error(bdd_context):
+    result = bdd_context['result']
+    assert result.exit_code != 0
+    assert result.stderr != '' or result.exception is not None
+
+
+@scenario('../features/interface_test_cli.feature', 'Run MCP interface tests')
+def test_mcp_success():
+    pass
+
+
+@scenario('../features/interface_test_cli.feature', 'Fail to connect to MCP server')
+def test_mcp_failure():
+    pass
+
+
+@scenario('../features/interface_test_cli.feature', 'Run A2A interface tests')
+def test_a2a_success():
+    pass
+
+
+@scenario('../features/interface_test_cli.feature', 'Fail to connect to A2A server')
+def test_a2a_failure():
+    pass

--- a/tests/behavior/steps/search_cli_steps.py
+++ b/tests/behavior/steps/search_cli_steps.py
@@ -1,0 +1,44 @@
+from pytest_bdd import scenario, when, then
+from autoresearch.main import app as cli_app
+from autoresearch.orchestration.orchestrator import Orchestrator
+
+
+@when('I run `autoresearch search "What is artificial intelligence?" --reasoning-mode direct`')
+def run_search_direct(cli_runner, bdd_context, monkeypatch, dummy_query_response, temp_config, isolate_network):
+    monkeypatch.setattr(Orchestrator, 'run_query', lambda *a, **k: dummy_query_response)
+    result = cli_runner.invoke(
+        cli_app,
+        ['search', 'What is artificial intelligence?', '--reasoning-mode', 'direct'],
+        catch_exceptions=False,
+    )
+    bdd_context['result'] = result
+
+
+@when('I run `autoresearch search`')
+def run_search_missing(cli_runner, bdd_context, temp_config, isolate_network):
+    result = cli_runner.invoke(cli_app, ['search'], catch_exceptions=False)
+    bdd_context['result'] = result
+
+
+@then('the CLI should exit successfully')
+def cli_success(bdd_context):
+    result = bdd_context['result']
+    assert result.exit_code == 0
+    assert result.stderr == ''
+
+
+@then('the CLI should exit with an error')
+def cli_error(bdd_context):
+    result = bdd_context['result']
+    assert result.exit_code != 0
+    assert result.stderr != '' or result.exception is not None
+
+
+@scenario('../features/search_cli.feature', 'Run a basic search query')
+def test_search_direct():
+    pass
+
+
+@scenario('../features/search_cli.feature', 'Missing query argument')
+def test_search_missing():
+    pass

--- a/tests/behavior/steps/sparql_cli_steps.py
+++ b/tests/behavior/steps/sparql_cli_steps.py
@@ -1,0 +1,46 @@
+from pytest_bdd import scenario, when, then
+from autoresearch.main import app as cli_app
+
+
+@when('I run `autoresearch sparql "SELECT ?s WHERE { ?s a <http://example.com/B> }"`')
+def run_sparql_query(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+    monkeypatch.setattr('autoresearch.main.app._cli_sparql', lambda *a, **k: None)
+    result = cli_runner.invoke(
+        cli_app,
+        ['sparql', 'SELECT ?s WHERE { ?s a <http://example.com/B> }'],
+        catch_exceptions=False,
+    )
+    bdd_context['result'] = result
+
+
+@when('I run `autoresearch sparql "INVALID QUERY"`')
+def run_sparql_invalid(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+    def _raise(*a, **k):
+        raise ValueError('invalid')
+    monkeypatch.setattr('autoresearch.main.app._cli_sparql', _raise)
+    result = cli_runner.invoke(cli_app, ['sparql', 'INVALID QUERY'], catch_exceptions=False)
+    bdd_context['result'] = result
+
+
+@then('the CLI should exit successfully')
+def cli_success(bdd_context):
+    result = bdd_context['result']
+    assert result.exit_code == 0
+    assert result.stderr == ''
+
+
+@then('the CLI should exit with an error')
+def cli_error(bdd_context):
+    result = bdd_context['result']
+    assert result.exit_code != 0
+    assert result.stderr != '' or result.exception is not None
+
+
+@scenario('../features/sparql_cli.feature', 'Execute a SPARQL query with reasoning')
+def test_sparql_success():
+    pass
+
+
+@scenario('../features/sparql_cli.feature', 'Invalid SPARQL query')
+def test_sparql_invalid():
+    pass

--- a/tests/behavior/steps/visualization_cli_steps.py
+++ b/tests/behavior/steps/visualization_cli_steps.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+from pytest_bdd import scenario, when, then
+
+from autoresearch.main import app as cli_app
+
+
+@when('I run `autoresearch visualize "What is quantum computing?" graph.png`')
+def run_visualize_query(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+    def fake_visualize(query, output, layout='spring'):
+        Path(output).touch()
+    monkeypatch.setattr('autoresearch.main.app._cli_visualize_query', fake_visualize)
+    result = cli_runner.invoke(
+        cli_app,
+        ['visualize', 'What is quantum computing?', 'graph.png'],
+        catch_exceptions=False,
+    )
+    bdd_context['result'] = result
+
+
+@when('I run `autoresearch visualize-rdf rdf_graph.png`')
+def run_visualize_rdf(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+    monkeypatch.setattr('autoresearch.main.app._cli_visualize', lambda *a, **k: None)
+    result = cli_runner.invoke(cli_app, ['visualize-rdf', 'rdf_graph.png'], catch_exceptions=False)
+    bdd_context['result'] = result
+
+
+@when('I run `autoresearch visualize "What is quantum computing?"')
+def run_visualize_missing(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+    def _raise(*a, **k):
+        raise RuntimeError('missing output')
+    monkeypatch.setattr('autoresearch.main.app._cli_visualize_query', _raise)
+    result = cli_runner.invoke(cli_app, ['visualize', 'What is quantum computing?'], catch_exceptions=False)
+    bdd_context['result'] = result
+
+
+@then('the CLI should exit successfully')
+def cli_success(bdd_context):
+    result = bdd_context['result']
+    assert result.exit_code == 0
+    assert result.stderr == ''
+
+
+@then('the CLI should exit with an error')
+def cli_error(bdd_context):
+    result = bdd_context['result']
+    assert result.exit_code != 0
+    assert result.stderr != '' or result.exception is not None
+
+
+@then('the file "graph.png" should be created')
+def check_graph_created():
+    assert Path('graph.png').exists()
+
+
+@scenario('../features/visualization_cli.feature', 'Generate a query graph PNG')
+def test_visualize_query():
+    pass
+
+
+@scenario('../features/visualization_cli.feature', 'Render RDF graph to PNG')
+def test_visualize_rdf():
+    pass
+
+
+@scenario('../features/visualization_cli.feature', 'Missing output file for visualization')
+def test_visualize_missing():
+    pass


### PR DESCRIPTION
## Summary
- add BDD steps for GUI, interface tests, search, SPARQL, and visualization CLI commands
- mock external processes and record CLI outputs for exit-code assertions
- verify generated graph files in visualization scenarios

## Testing
- `flake8 src tests`
- `mypy src` *(fails: "ConfigModel has no attribute model_dump")*
- `pytest -q` *(fails: "No module named 'pytest_httpx'")*
- `pytest tests/behavior -q` *(fails: "No module named 'pytest_httpx'")*

------
https://chatgpt.com/codex/tasks/task_e_689569cc39f083339c3ecdc3153fe76d