### PR TITLE
docs: add formatting and lint checks to verification steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   - After running `scripts/codex_setup.sh`, verify `pytest-cov`, `tomli_w`, `hypothesis`, and `duckdb-extension-vss` are present using `uv pip list`.
 
 ## Verification steps
+- Format code with `uv run black .`.
+- Sort imports with `uv run isort .`.
+- Format with `uv run ruff format src tests`.
+- Lint with `uv run ruff check --fix src tests`.
 - Check code style with `uv run flake8 src tests`.
 - Verify type hints with `uv run mypy src`.
 - Run the unit suite: `uv run pytest -q`.


### PR DESCRIPTION
## Summary
- document running `black`, `isort`, and `ruff` before existing lint and test commands in AGENTS guidelines

## Testing
- `uv run black --check .` *(fails: would reformat many files)*
- `uv run isort --check-only .` *(fails: imports incorrectly sorted)*
- `uv run ruff format --check src tests` *(fails: many files would be reformatted)*
- `uv run ruff check src tests` *(fails: found import order issues)*
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(terminated: KeyboardInterrupt during import)
- `uv run pytest tests/behavior` *(terminated: KeyboardInterrupt during import)
- `task coverage` *(terminated: KeyboardInterrupt during import)*

------
https://chatgpt.com/codex/tasks/task_e_689580768b108333adbf67fb02fa7f72