### PR TITLE
docs: document task verify fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,15 +18,17 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   - After running `scripts/codex_setup.sh`, verify `pytest-cov`, `tomli_w`, `hypothesis`, and `duckdb-extension-vss` are present using `uv pip list`.
 
 ## Verification steps
-- Format code with `uv run black .`.
-- Sort imports with `uv run isort .`.
-- Format with `uv run ruff format src tests`.
-- Lint with `uv run ruff check --fix src tests`.
-- Check code style with `uv run flake8 src tests`.
-- Verify type hints with `uv run mypy src`.
-- Run the unit suite: `uv run pytest -q`.
-- Execute BDD tests in `tests/behavior`: `uv run pytest tests/behavior`.
-- Run the entire suite with coverage using `task coverage`. If `task` is unavailable, run `uv run pytest --cov=src` instead.
+- Use `task verify` to run linting, type checking, and all tests with coverage (see [`Taskfile.yml`](Taskfile.yml)).
+- If `task` is unavailable, run these commands individually:
+  - Format code with `uv run black .`.
+  - Sort imports with `uv run isort .`.
+  - Format with `uv run ruff format src tests`.
+  - Lint with `uv run ruff check --fix src tests`.
+  - Check code style with `uv run flake8 src tests`.
+  - Verify type hints with `uv run mypy src`.
+  - Run the unit suite: `uv run pytest -q`.
+  - Execute BDD tests in `tests/behavior`: `uv run pytest tests/behavior`.
+  - Run the entire suite with coverage: `uv run pytest --cov=src`.
 
 ## GitHub Actions workflows
 - All GitHub Actions workflows are disabled until further notice.


### PR DESCRIPTION
## Summary
- document `task verify` for linting, type checking, and tests with coverage, with fallbacks when `task` is unavailable

## Testing
- `uv run flake8 src tests`
- `timeout 100 uv run mypy src` *(fails: Interrupted)*
- `timeout 100 uv run pytest -q` *(timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68958d2344c48333981bef7f8a24472b