### PR TITLE
test: expand recovery and async reasoning scenarios

### DIFF
--- a/tests/behavior/features/api_async_query.feature
+++ b/tests/behavior/features/api_async_query.feature
@@ -12,3 +12,24 @@ Feature: Asynchronous query API
     Given an async query has been submitted
     When I cancel the async query
     Then the response should indicate cancellation
+
+  Scenario: Async query timeout triggers retry with backoff
+    When a failing async query is submitted that times out
+    Then a recovery strategy "retry_with_backoff" should be recorded
+    And error category "transient" should be recorded
+    And the system state should be restored
+    And the logs should include "retry_with_backoff"
+
+  Scenario: Async query agent crash fails gracefully
+    When a failing async query is submitted that crashes
+    Then a recovery strategy "fail_gracefully" should be recorded
+    And error category "critical" should be recorded
+    And the system state should be restored
+    And the logs should include "fail_gracefully"
+
+  Scenario: Async query uses fallback agent after failure
+    When a failing async query is submitted that triggers fallback
+    Then a recovery strategy "fallback_agent" should be recorded
+    And error category "recoverable" should be recorded
+    And the system state should be restored
+    And the logs should include "fallback_agent"

--- a/tests/behavior/features/error_recovery.feature
+++ b/tests/behavior/features/error_recovery.feature
@@ -73,6 +73,20 @@ Feature: Error Recovery
     And the logs should include "recovery"
     And the response should list an error of type "AgentError"
 
+  Scenario: Recovery after agent failure with fallback
+    Given an agent that fails triggering fallback
+    When I run the orchestrator on query "recover test"
+    Then the reasoning mode selected should be "dialectical"
+    And the loops used should be 1
+    And the agent groups should be "Faulty"
+    And the agents executed should be "Faulty"
+    And a recovery strategy "fallback_agent" should be recorded
+    And error category "recoverable" should be recorded
+    And recovery should be applied
+    And the system state should be restored
+    And the logs should include "recovery"
+    And the response should list an agent execution error
+
   Scenario: Unsupported reasoning mode during recovery fails gracefully
     Given an agent that raises a transient error
     When I run the orchestrator on query "recover test" with unsupported reasoning mode "quantum"

--- a/tests/behavior/features/error_recovery_extended.feature
+++ b/tests/behavior/features/error_recovery_extended.feature
@@ -51,6 +51,21 @@ Feature: Extended Error Recovery
     And the logs should include "recovery"
     And the response should list a timeout error
 
+  Scenario: Recovery after network outage with fallback agent
+    Given an agent facing a persistent network outage
+    And reasoning mode is "chain-of-thought"
+    When I run the orchestrator on query "Explain the theory of relativity"
+    Then the reasoning mode selected should be "chain-of-thought"
+    And the loops used should be 1
+    And the agent groups should be "Offline"
+    And the agents executed should be "Offline"
+    And a recovery strategy "fallback_agent" should be recorded
+    And error category "recoverable" should be recorded
+    And recovery should be applied
+    And the system state should be restored
+    And the logs should include "recovery"
+    And the response should list an error of type "AgentError"
+
   Scenario: Unsupported reasoning mode during extended recovery fails gracefully
     Given an agent that times out during execution
     When I run the orchestrator on query "Explain the theory of relativity" with unsupported reasoning mode "quantum"

--- a/tests/behavior/features/reasoning_mode_api.feature
+++ b/tests/behavior/features/reasoning_mode_api.feature
@@ -65,3 +65,39 @@ Feature: Reasoning mode via API
     And no agents should execute
     And the system state should be restored
     And the logs should include "unsupported reasoning mode"
+
+  Scenario: Direct mode via async API
+    Given loops is set to 2 in configuration
+    When I send an async query "mode test" with reasoning mode "direct" to the API
+    Then the response status should be 200
+    And the loops used should be 1
+    And the reasoning mode selected should be "direct"
+    And the agent groups should be "Synthesizer"
+    And the agents executed should be "Synthesizer"
+    And the reasoning steps should be "Synthesizer-1"
+    And the metrics should record 1 cycles
+    And the metrics should list agents "Synthesizer"
+
+  Scenario: Chain-of-thought mode via async API
+    Given loops is set to 2 in configuration
+    When I send an async query "mode test" with reasoning mode "chain-of-thought" to the API
+    Then the response status should be 200
+    And the loops used should be 2
+    And the reasoning mode selected should be "chain-of-thought"
+    And the agent groups should be "Synthesizer; Contrarian; FactChecker"
+    And the agents executed should be "Synthesizer, Synthesizer"
+    And the reasoning steps should be "Synthesizer-1; Synthesizer-2"
+    And the metrics should record 2 cycles
+    And the metrics should list agents "Synthesizer"
+
+  Scenario: Dialectical mode via async API
+    Given loops is set to 1 in configuration
+    When I send an async query "mode test" with reasoning mode "dialectical" to the API
+    Then the response status should be 200
+    And the loops used should be 1
+    And the reasoning mode selected should be "dialectical"
+    And the agent groups should be "Synthesizer; Contrarian; FactChecker"
+    And the agents executed should be "Synthesizer, Contrarian, FactChecker"
+    And the reasoning steps should be "Synthesizer-1; Contrarian-2; FactChecker-3"
+    And the metrics should record 1 cycles
+    And the metrics should list agents "Synthesizer, Contrarian, FactChecker"

--- a/tests/behavior/features/reasoning_mode_cli.feature
+++ b/tests/behavior/features/reasoning_mode_cli.feature
@@ -61,3 +61,11 @@ Feature: Reasoning mode via CLI
     And no agents should execute
     And the system state should be restored
     And the logs should include "unsupported reasoning mode"
+
+  Scenario: Invalid reasoning mode via SPARQL CLI
+    Given loops is set to 2 in configuration
+    When I run `autoresearch sparql "mode test" --mode invalid`
+    Then the CLI should exit with an error
+    And no agents should execute
+    And the system state should be restored
+    And the logs should include "unsupported reasoning mode"

--- a/tests/behavior/steps/error_recovery_extended_steps.py
+++ b/tests/behavior/steps/error_recovery_extended_steps.py
@@ -42,3 +42,12 @@ def test_error_recovery_timeout_direct() -> None:
 def test_error_recovery_extended_unsupported() -> None:
     """Unsupported reasoning modes surface an error without executing agents."""
     return
+
+
+@scenario(
+    "../features/error_recovery_extended.feature",
+    "Recovery after network outage with fallback agent",
+)
+def test_error_recovery_network_fallback() -> None:
+    """Fallback agent handles network outages."""
+    return


### PR DESCRIPTION
## Summary
- cover reasoning mode selection for async API queries
- add CLI SPARQL mode validation and async recovery paths
- exercise fallback and retry strategies in error recovery suites

## Testing
- `uv run black tests/behavior/steps/reasoning_mode_api_steps.py tests/behavior/steps/reasoning_mode_cli_steps.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/error_recovery_steps.py tests/behavior/steps/error_recovery_extended_steps.py`
- `uv run isort tests/behavior/steps/reasoning_mode_api_steps.py tests/behavior/steps/reasoning_mode_cli_steps.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/error_recovery_steps.py tests/behavior/steps/error_recovery_extended_steps.py`
- `uv run ruff format tests/behavior/steps/reasoning_mode_api_steps.py tests/behavior/steps/reasoning_mode_cli_steps.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/error_recovery_steps.py tests/behavior/steps/error_recovery_extended_steps.py`
- `uv run ruff check --fix tests/behavior/steps/reasoning_mode_api_steps.py tests/behavior/steps/reasoning_mode_cli_steps.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/error_recovery_steps.py tests/behavior/steps/error_recovery_extended_steps.py`
- `uv run flake8 tests/behavior/steps/reasoning_mode_api_steps.py tests/behavior/steps/reasoning_mode_cli_steps.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/error_recovery_steps.py tests/behavior/steps/error_recovery_extended_steps.py`
- `uv run mypy src`
- `uv run pytest tests/behavior -q` *(failed: Network access disabled during tests)*

------
https://chatgpt.com/codex/tasks/task_e_6895926544f88333a317cb6680e18f0f