### PR TITLE
docs: add cleanup instructions to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,10 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   - Execute BDD tests in `tests/behavior`: `uv run pytest tests/behavior`.
   - Run the entire suite with coverage: `uv run pytest --cov=src`.
 
+### Cleanup
+- Run `task clean` to remove `__pycache__` and `.mypy_cache` directories.
+- Manually remove test artifacts such as `kg.duckdb` and `rdf_store` if present.
+
 ## GitHub Actions workflows
 - All GitHub Actions workflows are disabled until further notice.
 - Store workflow files in `.github/workflows.disabled`; `.github/workflows` must remain empty.


### PR DESCRIPTION
## Summary
- add cleanup guidance after verification steps

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit --cov=src --cov-report=term-missing --cov-append` *(terminated early)*
- `task clean`


------
https://chatgpt.com/codex/tasks/task_e_6896148afb10833395c1c3ef826b8767