### PR TITLE
Shorten blocking steps

### DIFF
--- a/tests/behavior/steps/gui_cli_steps.py
+++ b/tests/behavior/steps/gui_cli_steps.py
@@ -1,34 +1,47 @@
-from pytest_bdd import scenario, when, then
+import subprocess
+
+from pytest_bdd import scenario, then, when
+
 from autoresearch.main import app as cli_app
 
 
-@when('I run `autoresearch gui --port 8502 --no-browser`')
-def run_gui_no_browser(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
-    monkeypatch.setattr('subprocess.run', lambda *a, **k: None)
+@when("I run `autoresearch gui --port 8502 --no-browser`")
+def run_gui_no_browser(
+    cli_runner, bdd_context, monkeypatch, temp_config, isolate_network
+):
+    calls: list = []
+
+    def fake_run(*a, **k):
+        calls.append((a, k))
+        return subprocess.CompletedProcess(a, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
     result = cli_runner.invoke(
-        cli_app, ['gui', '--port', '8502', '--no-browser'], catch_exceptions=False
+        cli_app, ["gui", "--port", "8502", "--no-browser"], catch_exceptions=False
     )
-    bdd_context['result'] = result
+    bdd_context.update({"result": result, "run_calls": calls})
 
 
-@when('I run `autoresearch gui --help`')
+@when("I run `autoresearch gui --help`")
 def run_gui_help(cli_runner, bdd_context, temp_config, isolate_network):
-    result = cli_runner.invoke(cli_app, ['gui', '--help'], catch_exceptions=False)
-    bdd_context['result'] = result
+    result = cli_runner.invoke(cli_app, ["gui", "--help"], catch_exceptions=False)
+    bdd_context["result"] = result
 
 
-@then('the CLI should exit successfully')
+@then("the CLI should exit successfully")
 def cli_success(bdd_context):
-    result = bdd_context['result']
+    result = bdd_context["result"]
     assert result.exit_code == 0
-    assert result.stderr == ''
+    assert result.stderr == ""
+    if "run_calls" in bdd_context:
+        assert len(bdd_context["run_calls"]) == 1
 
 
-@scenario('../features/gui_cli.feature', 'Launch GUI without opening a browser')
+@scenario("../features/gui_cli.feature", "Launch GUI without opening a browser")
 def test_gui_no_browser():
     pass
 
 
-@scenario('../features/gui_cli.feature', 'Display help for GUI command')
+@scenario("../features/gui_cli.feature", "Display help for GUI command")
 def test_gui_help():
     pass

--- a/tests/behavior/steps/monitor_cli_steps.py
+++ b/tests/behavior/steps/monitor_cli_steps.py
@@ -4,12 +4,13 @@
 from __future__ import annotations
 
 import time
-from pytest_bdd import scenario, when, then
+
+from pytest_bdd import scenario, then, when
 
 from .common_steps import cli_app
 
 
-@when('I run `autoresearch monitor`')
+@when("I run `autoresearch monitor`")
 def run_monitor(
     monkeypatch,
     bdd_context,
@@ -23,11 +24,12 @@ def run_monitor(
         "autoresearch.monitor._collect_system_metrics",
         lambda: {"cpu_percent": 10.0, "memory_percent": 5.0},
     )
+    monkeypatch.setattr("autoresearch.monitor.time.sleep", lambda *_: None)
     result = cli_runner.invoke(cli_app, ["monitor"])
     bdd_context["monitor_result"] = result
 
 
-@when('I run `autoresearch monitor -w`')
+@when("I run `autoresearch monitor -w`")
 def run_monitor_watch(
     monkeypatch,
     bdd_context,
@@ -47,13 +49,13 @@ def run_monitor_watch(
         sleep_calls.append(interval)
         raise KeyboardInterrupt()
 
-    monkeypatch.setattr(time, "sleep", fake_sleep)
+    monkeypatch.setattr("autoresearch.monitor.time.sleep", fake_sleep)
     result = cli_runner.invoke(cli_app, ["monitor", "-w"])
     bdd_context["monitor_result"] = result
     bdd_context["sleep_calls"] = sleep_calls
 
 
-@when('I run `autoresearch monitor` with metrics backend unavailable')
+@when("I run `autoresearch monitor` with metrics backend unavailable")
 def run_monitor_backend_unavailable(
     monkeypatch,
     bdd_context,
@@ -67,6 +69,7 @@ def run_monitor_backend_unavailable(
         raise RuntimeError("metrics backend unavailable")
 
     monkeypatch.setattr("autoresearch.monitor._collect_system_metrics", fail)
+    monkeypatch.setattr("autoresearch.monitor.time.sleep", lambda *_: None)
     result = cli_runner.invoke(cli_app, ["monitor"])
     bdd_context["monitor_result"] = result
 
@@ -118,4 +121,3 @@ def test_monitor_watch():
 def test_monitor_backend_unavailable():
     """Scenario: Metrics backend unavailable."""
     pass
-


### PR DESCRIPTION
## Summary
- Ensure monitor CLI patches module sleep to avoid blocking
- Run serve-a2a in a background thread and verify clean shutdown
- Mock GUI subprocess and rework async query steps for fast cancellation

## Testing
- `uv run black tests/behavior/steps/monitor_cli_steps.py tests/behavior/steps/serve_cli_steps.py tests/behavior/steps/gui_cli_steps.py tests/behavior/steps/api_async_query_steps.py`
- `uv run isort tests/behavior/steps/monitor_cli_steps.py tests/behavior/steps/serve_cli_steps.py tests/behavior/steps/gui_cli_steps.py tests/behavior/steps/api_async_query_steps.py`
- `uv run ruff format tests/behavior/steps/monitor_cli_steps.py tests/behavior/steps/serve_cli_steps.py tests/behavior/steps/gui_cli_steps.py tests/behavior/steps/api_async_query_steps.py`
- `uv run ruff check --fix tests/behavior/steps/monitor_cli_steps.py tests/behavior/steps/serve_cli_steps.py tests/behavior/steps/gui_cli_steps.py tests/behavior/steps/api_async_query_steps.py`
- `uv run flake8 tests/behavior/steps/monitor_cli_steps.py tests/behavior/steps/serve_cli_steps.py tests/behavior/steps/gui_cli_steps.py tests/behavior/steps/api_async_query_steps.py`
- `uv run mypy src`
- `uv run pytest tests/behavior` *(fails: api_documentation_steps::test_retrieve_openapi_schema)*

------
https://chatgpt.com/codex/tasks/task_e_68962579000883338c40686a4ee2fd76