### PR TITLE
Add BDD coverage for config API and placeholder metrics CLI

### DIFF
--- a/tests/behavior/README.md
+++ b/tests/behavior/README.md
@@ -53,3 +53,10 @@ uv run pytest tests/behavior/features/config_cli.feature::Update_reasoning_confi
 uv run pytest tests/behavior/features/reasoning_mode_cli.feature
 uv run pytest tests/behavior/features/error_recovery.feature
 ```
+
+## New features
+
+- `api_config.feature` exercises the configuration endpoints exposed by the
+  HTTP API.
+- `visualize_metrics_cli.feature` documents the planned
+  `visualize-metrics` CLI command until implementation lands.

--- a/tests/behavior/features/api_config.feature
+++ b/tests/behavior/features/api_config.feature
@@ -1,0 +1,23 @@
+Feature: Config API
+  Background:
+    Given the API server is running with config permissions
+
+  Scenario: Retrieve current configuration
+    When I request the config endpoint
+    Then the response status should be 200
+    And the response body should contain "reasoning_mode"
+
+  Scenario: Update loops via the config endpoint
+    When I update loops to 2 via the config endpoint
+    Then the response status should be 200
+    And the response body should show loops 2
+
+  Scenario: Replace configuration via the config endpoint
+    When I replace the configuration via the config endpoint
+    Then the response status should be 200
+    And the response body should contain "reasoning_mode"
+
+  Scenario: Reload configuration
+    When I reload the configuration
+    Then the response status should be 200
+    And the response body should contain "reasoning_mode"

--- a/tests/behavior/features/visualize_metrics_cli.feature
+++ b/tests/behavior/features/visualize_metrics_cli.feature
@@ -1,0 +1,4 @@
+Feature: Visualize metrics CLI
+  Scenario: Attempt to visualize metrics before implementation
+    When I run `autoresearch visualize-metrics metrics.json metrics.png`
+    Then the CLI should report the command is missing

--- a/tests/behavior/steps/api_config_steps.py
+++ b/tests/behavior/steps/api_config_steps.py
@@ -1,0 +1,75 @@
+from pytest_bdd import given, when, then, scenario
+from autoresearch.config.models import ConfigModel, APIConfig
+from autoresearch.config.loader import ConfigLoader
+
+
+@given("the API server is running with config permissions")
+def api_server_with_permissions(test_context, api_client, monkeypatch):
+    cfg = ConfigModel(api=APIConfig())
+    cfg.api.role_permissions["anonymous"].append("capabilities")
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    test_context["client"] = api_client
+
+
+@when("I request the config endpoint")
+def request_config(test_context):
+    client = test_context["client"]
+    test_context["response"] = client.get("/config")
+
+
+@when("I update loops to 2 via the config endpoint")
+def update_config(test_context):
+    client = test_context["client"]
+    test_context["response"] = client.put("/config", json={"loops": 2})
+
+
+@when("I replace the configuration via the config endpoint")
+def replace_config(test_context):
+    client = test_context["client"]
+    current = client.get("/config").json()
+    test_context["response"] = client.post("/config", json=current)
+
+
+@when("I reload the configuration")
+def reload_config(test_context):
+    client = test_context["client"]
+    test_context["response"] = client.delete("/config")
+
+
+@then("the response status should be 200")
+def response_ok(test_context):
+    resp = test_context["response"]
+    assert resp.status_code == 200
+    assert "error" not in resp.json()
+
+
+@then('the response body should contain "reasoning_mode"')
+def body_has_reasoning_mode(test_context):
+    data = test_context["response"].json()
+    assert "reasoning_mode" in data
+
+
+@then("the response body should show loops 2")
+def body_shows_loops(test_context):
+    data = test_context["response"].json()
+    assert data.get("loops") == 2
+
+
+@scenario("../features/api_config.feature", "Retrieve current configuration")
+def test_get_config():
+    pass
+
+
+@scenario("../features/api_config.feature", "Update loops via the config endpoint")
+def test_update_config():
+    pass
+
+
+@scenario("../features/api_config.feature", "Replace configuration via the config endpoint")
+def test_replace_config():
+    pass
+
+
+@scenario("../features/api_config.feature", "Reload configuration")
+def test_reload_config():
+    pass

--- a/tests/behavior/steps/visualize_metrics_cli_steps.py
+++ b/tests/behavior/steps/visualize_metrics_cli_steps.py
@@ -1,0 +1,24 @@
+from pytest_bdd import scenario, when, then
+from autoresearch.main import app as cli_app
+
+
+@when('I run `autoresearch visualize-metrics metrics.json metrics.png`')
+def run_visualize_metrics(cli_runner, bdd_context, temp_config, isolate_network):
+    result = cli_runner.invoke(
+        cli_app,
+        ['visualize-metrics', 'metrics.json', 'metrics.png'],
+        catch_exceptions=False,
+    )
+    bdd_context['result'] = result
+
+
+@then('the CLI should report the command is missing')
+def cli_reports_missing(bdd_context):
+    result = bdd_context['result']
+    assert result.exit_code != 0
+    assert 'No such command' in result.output
+
+
+@scenario('../features/visualize_metrics_cli.feature', 'Attempt to visualize metrics before implementation')
+def test_visualize_metrics_cli():
+    pass


### PR DESCRIPTION
## Summary
- add feature files for config API endpoints and planned `visualize-metrics` CLI command
- implement matching step modules
- document new scenarios in behavior test README

## Testing
- `task verify` *(fails: interrupted)*
- `uv run pytest tests/behavior -k 'api_config or visualize_metrics_cli' -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_6896348df2f88333b1950fc45dc7b2ec