### PR TITLE
Default behavior tests to RDFS reasoner

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -171,6 +171,10 @@ The RDF store supports optional ontology-based reasoning using the
 ontology_reasoner = "owlrl"           # or "my_module:run_reasoner"
 ```
 
+Behavior tests use the lightweight `rdfs` reasoner by default to keep test
+execution fast. Production deployments can select the more expressive `owlrl`
+engine (or another custom reasoner) when full OWL‑RL reasoning is required.
+
 The following tutorial walks through a typical ontology workflow.
 
 1. **Load an ontology file** to add schema triples:

--- a/tests/behavior/steps/ontology_reasoning_steps.py
+++ b/tests/behavior/steps/ontology_reasoning_steps.py
@@ -1,13 +1,16 @@
-from pytest_bdd import scenario, given, when, then
 import rdflib
+from pytest_bdd import given, scenario, then, when
 
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.storage import StorageManager, teardown
-from autoresearch.config.models import ConfigModel, StorageConfig
-from autoresearch.config.loader import ConfigLoader
 
 
-@scenario("../features/ontology_reasoning.feature", "Infer subclass relations through orchestrator")
+@scenario(
+    "../features/ontology_reasoning.feature",
+    "Infer subclass relations through orchestrator",
+)
 def test_infer_subclass_relations():
     """Infer subclass relations through orchestrator."""
     pass
@@ -16,7 +19,13 @@ def test_infer_subclass_relations():
 @given("the storage system is configured for in-memory RDF")
 def configure_in_memory_rdf(tmp_path, monkeypatch):
     teardown(remove_db=True)
-    cfg = ConfigModel(storage=StorageConfig(rdf_backend="memory", rdf_path=str(tmp_path / "rdf")))
+    cfg = ConfigModel(
+        storage=StorageConfig(
+            rdf_backend="memory",
+            rdf_path=str(tmp_path / "rdf"),
+            ontology_reasoner="rdfs",
+        )
+    )
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader()._config = None
     StorageManager.setup()
@@ -52,7 +61,9 @@ def infer_via_orchestrator():
     Orchestrator.infer_relations()
 
 
-@then("querying the ontology for the superclass via the orchestrator should include the instance")
+@then(
+    "querying the ontology for the superclass via the orchestrator should include the instance"
+)
 def check_query_via_orchestrator():
     res = Orchestrator.query_ontology(
         "ASK { <http://example.com/x> a <http://example.com/B> }"


### PR DESCRIPTION
## Summary
- Configure in-memory RDF fixture to use the fast `rdfs` ontology reasoner
- Note in storage docs that behavior tests default to `rdfs`, while production may opt for `owlrl`

## Testing
- `uv run pytest tests/behavior/steps/ontology_reasoning_steps.py::test_infer_subclass_relations -q --cov=src --cov-fail-under=0`
- `task verify` *(fails: interrupt)*
- `task test:behavior` *(fails: ValueError in api_documentation_steps)*

------
https://chatgpt.com/codex/tasks/task_e_68967f1ca12c8333975699bfd7d35b3c