### PR TITLE
Add ontology reasoning limits and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ backend = "sqlite"
 path = "rdf_store"
 # Ontology reasoning engine (owlrl or module:function)
 ontology_reasoner = "owlrl"
+# Maximum triples allowed for reasoning (None for no limit)
+ontology_reasoner_max_triples = 100000
 ```
 
 ### Agent Configuration

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -169,6 +169,7 @@ The RDF store supports optional ontology-based reasoning using the
 ```toml
 [storage]
 ontology_reasoner = "owlrl"           # or "my_module:run_reasoner"
+ontology_reasoner_max_triples = 100000 # skip reasoning for larger graphs
 ```
 
 Behavior tests use the lightweight `rdfs` reasoner by default to keep test

--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -89,6 +89,8 @@ class StorageConfig(BaseModel):
     Attributes:
         ontology_reasoner_timeout: Timeout for ontology reasoning in seconds.
             Defaults to ``None`` meaning no timeout.
+        ontology_reasoner_max_triples: Skip reasoning when triple count exceeds
+            this value. Defaults to ``None`` meaning no limit.
     """
 
     duckdb_path: str = Field(default="autoresearch.duckdb")
@@ -108,6 +110,11 @@ class StorageConfig(BaseModel):
     ontology_reasoner_timeout: float | None = Field(
         default=None,
         description="Reasoner timeout in seconds. None disables the timeout.",
+    )
+    ontology_reasoner_max_triples: int | None = Field(
+        default=None,
+        ge=1,
+        description="Skip reasoning when triple count exceeds this limit.",
     )
     max_connections: int = Field(default=1, ge=1)
     use_kuzu: bool = Field(default=False)

--- a/tests/unit/test_kg_reasoning.py
+++ b/tests/unit/test_kg_reasoning.py
@@ -10,22 +10,37 @@ import time
 from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.errors import StorageError
-from autoresearch.kg_reasoning import run_ontology_reasoner, query_with_reasoning
+from autoresearch.kg_reasoning import (
+    run_ontology_reasoner,
+    query_with_reasoning,
+    register_reasoner,
+)
 
 
-def _mock_config(reasoner: str, timeout: float | None = None) -> ConfigModel:
+def _mock_config(
+    reasoner: str,
+    timeout: float | None = None,
+    max_triples: int | None = None,
+) -> ConfigModel:
     return ConfigModel.model_construct(
         storage=StorageConfig(
-            ontology_reasoner=reasoner, ontology_reasoner_timeout=timeout
+            ontology_reasoner=reasoner,
+            ontology_reasoner_timeout=timeout,
+            ontology_reasoner_max_triples=max_triples,
         )
     )
 
 
-def _patch_config(monkeypatch, reasoner: str, timeout: float | None = None) -> None:
+def _patch_config(
+    monkeypatch,
+    reasoner: str,
+    timeout: float | None = None,
+    max_triples: int | None = None,
+) -> None:
     monkeypatch.setattr(
         ConfigLoader,
         "load_config",
-        lambda self: _mock_config(reasoner, timeout),
+        lambda self: _mock_config(reasoner, timeout, max_triples),
     )
     ConfigLoader()._config = None
 
@@ -113,3 +128,40 @@ def test_run_ontology_reasoner_keyboard_interrupt(monkeypatch):
     with pytest.raises(StorageError) as excinfo:
         run_ontology_reasoner(g)
     assert "interrupted" in str(excinfo.value).lower()
+
+
+def test_run_ontology_reasoner_skips_when_limit_exceeded(monkeypatch, caplog):
+    called = {}
+
+    @register_reasoner("dummy_limit")
+    def _dummy(store):  # pragma: no cover - executed only if limit ignored
+        called["hit"] = True
+
+    g = rdflib.Graph()
+    g.add(
+        (
+            rdflib.URIRef("urn:s"),
+            rdflib.URIRef("urn:p"),
+            rdflib.URIRef("urn:o"),
+        )
+    )
+    g.add(
+        (
+            rdflib.URIRef("urn:s2"),
+            rdflib.URIRef("urn:p"),
+            rdflib.URIRef("urn:o"),
+        )
+    )
+
+    _patch_config(monkeypatch, "dummy_limit", max_triples=1)
+
+    with caplog.at_level("WARNING"):
+        run_ontology_reasoner(g)
+
+    assert "Skipping ontology reasoning" in caplog.text
+    assert "hit" not in called
+
+    # cleanup plugin registry
+    import autoresearch.kg_reasoning as kr
+
+    kr._REASONER_PLUGINS.pop("dummy_limit", None)


### PR DESCRIPTION
## Summary
- log ontology reasoning start and completion details
- support configurable `ontology_reasoner_max_triples` to skip reasoning for large graphs
- document new reasoning limit configuration

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- Unit tests attempted but did not complete due to environment limitations

------
https://chatgpt.com/codex/tasks/task_e_68968b6b24e08333a4d1445b7478e165