### PR TITLE
Add MCP interface behavior tests

### DIFF
--- a/tests/behavior/features/mcp_interface.feature
+++ b/tests/behavior/features/mcp_interface.feature
@@ -1,0 +1,17 @@
+Feature: MCP interface
+  Tests interactions with the MCP client and server.
+
+  Background:
+    Given a mock MCP server is available
+
+  Scenario: Successful query exchange
+    When I send a MCP query "hello"
+    Then I should receive a MCP response with answer "42"
+
+  Scenario: Malformed request handling
+    When I send a malformed MCP request
+    Then the MCP client should receive an error response
+
+  Scenario: Connection failure recovery
+    When a connection interruption occurs and the client retries
+    Then the client should eventually receive a MCP response with answer "42"

--- a/tests/behavior/steps/mcp_interface_steps.py
+++ b/tests/behavior/steps/mcp_interface_steps.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastmcp import Client, FastMCP
+from pytest_bdd import given, scenario, then, when
+
+import tests.stubs.fastmcp  # noqa: F401
+from autoresearch import mcp_interface
+
+pytest_plugins = ["tests.behavior.steps.common_steps"]
+
+
+@pytest.fixture
+def mock_server():
+    """Provide a mock MCP server for scenarios and ensure cleanup."""
+    server = FastMCP("Mock")
+
+    @server.tool
+    async def research(query: str) -> dict:
+        if query == "bad":
+            raise ValueError("malformed request")
+        return {"answer": "42"}
+
+    yield server
+
+    server.tools.clear()
+
+
+@given("a mock MCP server is available", target_fixture="server")
+def given_server(mock_server: FastMCP) -> FastMCP:
+    return mock_server
+
+
+@when('I send a MCP query "{query}"')
+def send_mcp_query(server: FastMCP, bdd_context: dict, query: str) -> None:
+    response = mcp_interface.query(query, transport=server)
+    bdd_context["response"] = response
+
+
+@then('I should receive a MCP response with answer "{answer}"')
+def check_mcp_response(bdd_context: dict, answer: str) -> None:
+    assert bdd_context["response"]["answer"] == answer
+
+
+@when("I send a malformed MCP request")
+def send_malformed_request(server: FastMCP, bdd_context: dict) -> None:
+    with pytest.raises(Exception) as exc:
+        mcp_interface.query("bad", transport=server)
+    bdd_context["error"] = str(exc.value)
+
+
+@then("the MCP client should receive an error response")
+def check_malformed_error(bdd_context: dict) -> None:
+    assert "malformed" in bdd_context["error"].lower()
+
+
+@when("a connection interruption occurs and the client retries")
+def retry_after_connection_failure(server: FastMCP, bdd_context: dict) -> None:
+    class FlakyClient(Client):
+        def __init__(self, target):  # pragma: no cover - simple init
+            super().__init__(target)
+            self.failed = False
+
+        async def __aenter__(self):  # pragma: no cover - context manager
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):  # pragma: no cover - context
+            pass
+
+        async def call_tool(self, name, params):
+            if not self.failed:
+                self.failed = True
+                raise ConnectionError("temporary outage")
+            if hasattr(self.target, "call_tool"):
+                return await self.target.call_tool(name, params)
+            return {}
+
+    with patch("autoresearch.mcp_interface.Client", FlakyClient):
+        with pytest.raises(ConnectionError):
+            mcp_interface.query("hello", transport=server)
+        result = mcp_interface.query("hello", transport=server)
+    bdd_context["response"] = result
+
+
+@then('the client should eventually receive a MCP response with answer "{answer}"')
+def check_recovered_response(bdd_context: dict, answer: str) -> None:
+    assert bdd_context["response"]["answer"] == answer
+
+
+@scenario("../features/mcp_interface.feature", "Successful query exchange")
+def test_mcp_success():
+    pass
+
+
+@scenario("../features/mcp_interface.feature", "Malformed request handling")
+def test_mcp_malformed():
+    pass
+
+
+@scenario("../features/mcp_interface.feature", "Connection failure recovery")
+def test_mcp_recovery():
+    pass


### PR DESCRIPTION
## Summary
- add BDD scenarios for MCP interface covering success, malformed requests, and connection recovery
- implement step definitions with a mock FastMCP server and retry logic

## Testing
- `uv run black tests/behavior/steps/mcp_interface_steps.py`
- `uv run isort tests/behavior/steps/mcp_interface_steps.py`
- `uv run ruff check --fix tests/behavior/steps/mcp_interface_steps.py`
- `uv run flake8 tests/behavior/steps/mcp_interface_steps.py`
- `uv run mypy tests/behavior/steps/mcp_interface_steps.py` *(fails: Module has no attribute errors for stub modules)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest tests/behavior/features/mcp_interface.feature -q -p pytest_bdd.plugin -p pytest_cov` *(fails: heavy dependency import; KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689698f4cc888333bc0c661475a51f9f