### PR TITLE
Document ontology reasoner configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,35 +249,31 @@ output_format = null
 ### Storage Configuration
 
 ```toml
-[storage.duckdb]
-# Path to DuckDB database file
-path = "data/research.duckdb"
-
-# Enable vector extension for similarity search
-vector_extension = true
-
-# Path to the VSS extension file (optional, auto-detected if not specified)
-# vector_extension_path = "./extensions/vss/vss.duckdb_extension"
-
+[storage]
+duckdb_path = "data/research.duckdb"  # Path to DuckDB database file
+vector_extension = true               # Enable vector extension for similarity search
 # HNSW index parameters for vector search
 hnsw_m = 16
 hnsw_ef_construction = 200
 hnsw_metric = "l2"
-
 # For detailed information about DuckDB and VSS extension compatibility,
 # see docs/duckdb_compatibility.md
 
-[storage.rdf]
-# RDF backend (sqlite, berkeleydb, or memory)
-backend = "sqlite"
+rdf_backend = "sqlite"                # RDF backend (sqlite, berkeleydb, or memory)
+rdf_path = "rdf_store"                # Path to RDF store
 
-# Path to RDF store
-path = "rdf_store"
-# Ontology reasoning engine (owlrl or module:function)
-ontology_reasoner = "owlrl"
-# Maximum triples allowed for reasoning (None for no limit)
-ontology_reasoner_max_triples = 100000
+# Lightweight RDFS reasoning for tests
+ontology_reasoner = "rdfs"
+ontology_reasoner_timeout = 5         # seconds
+
+# Switch to OWL-RL in production and raise the timeout
+# ontology_reasoner = "owlrl"
+# ontology_reasoner_timeout = 30
+
+ontology_reasoner_max_triples = 100000 # Skip reasoning for larger graphs
 ```
+
+Use `rdfs` with a small `ontology_reasoner_timeout` in test environments, and switch to `owlrl` with a higher timeout for production workloads.
 
 ### Agent Configuration
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -164,17 +164,26 @@ This indicates that the RDFLib SQLAlchemy plugin is not properly registered. To 
 ## Ontology Reasoning and Visualization
 
 The RDF store supports optional ontology-based reasoning using the
-`owlrl` package or a custom engine. Configure the desired reasoner with
+`owlrl` package, the lightweight `rdfs` reasoner, or a custom engine.
+Configure the desired reasoner and timeout with
 
 ```toml
 [storage]
-ontology_reasoner = "owlrl"           # or "my_module:run_reasoner"
+# Use "rdfs" in tests for faster execution
+ontology_reasoner = "rdfs"
+ontology_reasoner_timeout = 5          # seconds
+
+# In production switch to OWL-RL and raise the timeout
+# ontology_reasoner = "owlrl"
+# ontology_reasoner_timeout = 30
+
 ontology_reasoner_max_triples = 100000 # skip reasoning for larger graphs
 ```
 
 Behavior tests use the lightweight `rdfs` reasoner by default to keep test
 execution fast. Production deployments can select the more expressive `owlrl`
-engine (or another custom reasoner) when full OWL‑RL reasoning is required.
+engine (or another custom reasoner) and increase
+`ontology_reasoner_timeout` when full OWL‑RL reasoning is required.
 
 The following tutorial walks through a typical ontology workflow.
 


### PR DESCRIPTION
## Summary
- Explain `storage.ontology_reasoner`, `ontology_reasoner_timeout`, and `ontology_reasoner_max_triples`
- Show how to use `rdfs` in tests vs `owlrl` in production and adjust timeouts

## Testing
- `uv run mkdocs build`
- `task verify` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689698b639608333adaf226dcbb740f9