### PR TITLE
Clarify test execution requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   - After running `scripts/codex_setup.sh`, verify `pytest-cov`, `tomli_w`, `hypothesis`, and `duckdb-extension-vss` are present using `uv pip list`.
 
 ## Verification steps
+- Always run tests with `uv run` or inside the activated `.venv`; running
+  them outside may lead to missing package errors.
 - Use `task verify` to run linting, type checking, and all tests with coverage (see [`Taskfile.yml`](Taskfile.yml)).
 - If `task` is unavailable, run these commands individually:
   - Format code with `uv run black .`.


### PR DESCRIPTION
## Summary
- Emphasize running tests via `uv run` or inside the `.venv` to avoid missing packages

## Testing
- `task verify` *(interrupted: Signal received: "interrupt")*

------
https://chatgpt.com/codex/tasks/task_e_6896b077e6b4833392ee6d21913df4f5