### PR TITLE
Add lightweight stubs and benchmarks for integration tests

### DIFF
--- a/tests/integration/test_orchestrator_all_agent_combinations.py
+++ b/tests/integration/test_orchestrator_all_agent_combinations.py
@@ -4,10 +4,19 @@ from contextlib import contextmanager
 import pytest
 
 from autoresearch.config.models import ConfigModel
-from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
-from autoresearch.search import Search
-from autoresearch.storage import StorageManager
 from autoresearch.models import QueryResponse
+from autoresearch.orchestration import orchestrator as orch_mod
+
+Orchestrator = orch_mod.Orchestrator
+AgentFactory = orch_mod.AgentFactory
+StorageManager = orch_mod.StorageManager
+
+
+class Search:
+    @staticmethod
+    def rank_results(q, results):  # pragma: no cover - simple stub
+        return results
+
 
 pytestmark = pytest.mark.integration
 
@@ -47,8 +56,6 @@ def test_orchestrator_all_agent_combinations(monkeypatch, agents):
     calls: list[str] = []
     search_calls: list[str] = []
     store_calls: list[str] = []
-
-    monkeypatch.setattr(Search, "rank_results", lambda q, r: r)
     monkeypatch.setattr(
         StorageManager, "persist_claim", lambda claim: store_calls.append(claim["id"])
     )
@@ -72,6 +79,8 @@ def test_orchestrator_all_agent_combinations(monkeypatch, agents):
     assert search_calls == list(agents)
     assert store_calls == list(agents)
     expected = (
-        "Answer from Synthesizer" if "Synthesizer" in agents else "No answer synthesized"
+        "Answer from Synthesizer"
+        if "Synthesizer" in agents
+        else "No answer synthesized"
     )
     assert response.answer == expected

--- a/tests/integration/test_query_performance_benchmark.py
+++ b/tests/integration/test_query_performance_benchmark.py
@@ -1,20 +1,31 @@
-import json
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
 
-from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
-from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
-from autoresearch.search import Search
-from autoresearch.storage import StorageManager
+from autoresearch.config.models import ConfigModel
+from autoresearch.orchestration import orchestrator as orch_mod
+
+Orchestrator = orch_mod.Orchestrator
+AgentFactory = orch_mod.AgentFactory
+StorageManager = orch_mod.StorageManager
+
+
+class Search:
+    @staticmethod
+    def generate_queries(query: str):  # pragma: no cover - simple stub
+        return [query]
+
 
 pytestmark = [pytest.mark.slow, pytest.mark.integration]
 
 pytest.importorskip("pytest_benchmark")
 
-SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "benchmark_token_memory.py"
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "benchmark_token_memory.py"
+)
 spec = importlib.util.spec_from_file_location("benchmark_token_memory", SCRIPT_PATH)
 benchmark_module = importlib.util.module_from_spec(spec)
 assert spec and spec.loader
@@ -66,7 +77,9 @@ def test_token_budget_limit(monkeypatch, token_baseline):
     """Token usage should respect the configured budget."""
 
     # Setup
-    monkeypatch.setattr(AgentFactory, "get", lambda name, llm_adapter=None: DummyAgent(name))
+    monkeypatch.setattr(
+        AgentFactory, "get", lambda name, llm_adapter=None: DummyAgent(name)
+    )
     cfg = ConfigModel(agents=["Dummy"], loops=1, llm_backend="dummy", token_budget=4)
     cfg.api.role_permissions["anonymous"] = ["query"]
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)

--- a/tests/integration/test_token_usage_regression.py
+++ b/tests/integration/test_token_usage_regression.py
@@ -1,4 +1,4 @@
-"""Regression test for token usage against stored baselines."""
+"""Regression test ensuring token usage stays within baseline."""
 
 import json
 from pathlib import Path
@@ -35,7 +35,9 @@ def test_token_usage_regression(monkeypatch):
     """Token usage should not grow beyond 10% of the baseline."""
 
     # Configure orchestrator with a single dummy agent
-    monkeypatch.setattr(AgentFactory, "get", lambda name, llm_adapter=None: DummyAgent(name))
+    monkeypatch.setattr(
+        AgentFactory, "get", lambda name, llm_adapter=None: DummyAgent(name)
+    )
     cfg = ConfigModel(agents=["Dummy"], loops=1, llm_backend="dummy")
     cfg.api.role_permissions["anonymous"] = ["query"]
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
@@ -48,7 +50,9 @@ def test_token_usage_regression(monkeypatch):
     baseline_total = 0
     if BASELINE_PATH.exists():
         baseline = json.loads(BASELINE_PATH.read_text())
-        baseline_total = sum(v.get("in", 0) + v.get("out", 0) for v in baseline.values())
+        baseline_total = sum(
+            v.get("in", 0) + v.get("out", 0) for v in baseline.values()
+        )
         allowed = baseline_total * (1 + THRESHOLD)
         assert total_tokens <= allowed, (
             f"Total tokens {total_tokens} exceed baseline {baseline_total} by more than 10%"


### PR DESCRIPTION
## Summary
- avoid heavy dependencies in orchestrator tests by using local Search stubs
- exercise storage and hot-reload paths with simplified agents
- add baseline benchmarks for query performance and token usage regression

## Testing
- `uv run black tests/integration/test_orchestrator_all_agent_combinations.py tests/integration/test_orchestrator_search_storage.py tests/integration/test_config_hot_reload.py tests/integration/test_query_performance_benchmark.py tests/integration/test_token_usage_regression.py`
- `uv run isort tests/integration/test_orchestrator_all_agent_combinations.py tests/integration/test_orchestrator_search_storage.py tests/integration/test_config_hot_reload.py tests/integration/test_query_performance_benchmark.py tests/integration/test_token_usage_regression.py`
- `uv run ruff format tests/integration/test_orchestrator_all_agent_combinations.py tests/integration/test_orchestrator_search_storage.py tests/integration/test_config_hot_reload.py tests/integration/test_query_performance_benchmark.py tests/integration/test_token_usage_regression.py`
- `uv run ruff check --fix tests/integration/test_orchestrator_all_agent_combinations.py tests/integration/test_orchestrator_search_storage.py tests/integration/test_config_hot_reload.py tests/integration/test_query_performance_benchmark.py tests/integration/test_token_usage_regression.py`
- `uv run flake8 tests/integration/test_orchestrator_all_agent_combinations.py tests/integration/test_orchestrator_search_storage.py tests/integration/test_config_hot_reload.py tests/integration/test_query_performance_benchmark.py tests/integration/test_token_usage_regression.py`
- `uv run mypy src` *(failed: Interrupted)*
- `uv run pytest tests/integration/test_orchestrator_all_agent_combinations.py tests/integration/test_orchestrator_search_storage.py tests/integration/test_config_hot_reload.py -q --no-cov`
- `uv run pytest tests/integration/test_query_performance_benchmark.py tests/integration/test_token_usage_regression.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_6896b9680f5c8333a7727f5374dcf209