### PR TITLE
Refactor circuit breaker management

### DIFF
--- a/src/autoresearch/orchestration/circuit_breaker.py
+++ b/src/autoresearch/orchestration/circuit_breaker.py
@@ -1,8 +1,16 @@
-"""Circuit breaker utilities for agent orchestration."""
+"""Circuit breaker utilities for agent orchestration.
+
+This module previously relied on module level globals to track circuit breaker
+state and configuration. That made it difficult to isolate tests and reuse the
+logic in different orchestration contexts. The new ``CircuitBreakerManager``
+class encapsulates this state and exposes methods for updating and querying the
+breaker for a given agent.
+"""
+
 from __future__ import annotations
 
-from typing import TypedDict
 import time
+from typing import TypedDict
 
 from ..logging_utils import get_logger
 
@@ -16,81 +24,100 @@ class CircuitBreakerState(TypedDict):
     recovery_attempts: int
 
 
-# Global circuit breaker state for all agents
-_circuit_breakers: dict[str, CircuitBreakerState] = {}
+class CircuitBreakerManager:
+    """Manage circuit breaker state for multiple agents."""
 
-# Default configuration values; these are adjusted by the orchestrator
-_circuit_breaker_threshold: int = 3
-_circuit_breaker_cooldown: int = 30
+    def __init__(self, threshold: int = 3, cooldown: int = 30) -> None:
+        self.threshold = threshold
+        self.cooldown = cooldown
+        self.circuit_breakers: dict[str, CircuitBreakerState] = {}
 
+    # ------------------------------------------------------------------
+    # State management helpers
+    # ------------------------------------------------------------------
+    def update_circuit_breaker(self, agent_name: str, error_category: str) -> None:
+        """Update the circuit breaker state for ``agent_name``.
 
-def update_circuit_breaker(agent_name: str, error_category: str) -> None:
-    """Update the circuit breaker state for an agent."""
-    log = get_logger(__name__)
+        ``error_category`` should be one of ``critical``, ``recoverable`` or
+        ``transient``. Critical and recoverable errors increment the failure
+        count by one while transient errors increment by 0.5.
+        """
 
-    if agent_name not in _circuit_breakers:
-        _circuit_breakers[agent_name] = {
-            "failure_count": 0.0,
-            "last_failure_time": 0.0,
-            "state": "closed",
-            "recovery_attempts": 0,
-        }
+        log = get_logger(__name__)
 
-    breaker = _circuit_breakers[agent_name]
-    current_time = time.time()
+        if agent_name not in self.circuit_breakers:
+            self.circuit_breakers[agent_name] = {
+                "failure_count": 0.0,
+                "last_failure_time": 0.0,
+                "state": "closed",
+                "recovery_attempts": 0,
+            }
 
-    if error_category in ["critical", "recoverable"]:
-        breaker["failure_count"] += 1
-        breaker["last_failure_time"] = current_time
-        if (
-            breaker["failure_count"] >= _circuit_breaker_threshold
-            and breaker["state"] == "closed"
-        ):
-            breaker["state"] = "open"
-            log.warning(
-                f"Circuit breaker for agent {agent_name} is now OPEN due to repeated failures",
-                extra={"agent": agent_name, "circuit_state": "open", "failure_count": breaker["failure_count"]},
+        breaker = self.circuit_breakers[agent_name]
+        current_time = time.time()
+
+        if error_category in ["critical", "recoverable"]:
+            breaker["failure_count"] += 1
+            breaker["last_failure_time"] = current_time
+            if (
+                breaker["failure_count"] >= self.threshold
+                and breaker["state"] == "closed"
+            ):
+                breaker["state"] = "open"
+                log.warning(
+                    f"Circuit breaker for agent {agent_name} is now OPEN due to repeated failures",
+                    extra={
+                        "agent": agent_name,
+                        "circuit_state": "open",
+                        "failure_count": breaker["failure_count"],
+                    },
+                )
+        elif error_category == "transient":
+            breaker["failure_count"] += 0.5
+            breaker["last_failure_time"] = current_time
+
+        if breaker["state"] == "open":
+            if current_time - breaker["last_failure_time"] > self.cooldown:
+                breaker["state"] = "half-open"
+                breaker["recovery_attempts"] += 1
+                log.info(
+                    f"Circuit breaker for agent {agent_name} is now HALF-OPEN, attempting recovery",
+                    extra={
+                        "agent": agent_name,
+                        "circuit_state": "half-open",
+                        "recovery_attempts": breaker["recovery_attempts"],
+                    },
+                )
+
+    def handle_agent_success(self, agent_name: str) -> None:
+        """Reset or downgrade the circuit breaker state on success."""
+
+        breaker = self.circuit_breakers.get(agent_name)
+        if not breaker:
+            return
+
+        if breaker["state"] == "half-open":
+            breaker["state"] = "closed"
+            breaker["failure_count"] = 0.0
+            breaker["last_failure_time"] = 0.0
+            get_logger(__name__).info(
+                f"Circuit breaker for agent {agent_name} CLOSED after successful recovery",
+                extra={"agent": agent_name, "circuit_state": "closed"},
             )
-    elif error_category == "transient":
-        breaker["failure_count"] += 0.5
-        breaker["last_failure_time"] = current_time
+        elif breaker["failure_count"] > 0:
+            breaker["failure_count"] = max(0.0, breaker["failure_count"] - 1)
 
-    if breaker["state"] == "open":
-        cooling_period = _circuit_breaker_cooldown
-        if current_time - breaker["last_failure_time"] > cooling_period:
-            breaker["state"] = "half-open"
-            breaker["recovery_attempts"] += 1
-            log.info(
-                f"Circuit breaker for agent {agent_name} is now HALF-OPEN, attempting recovery",
-                extra={"agent": agent_name, "circuit_state": "half-open", "recovery_attempts": breaker["recovery_attempts"]},
-            )
+    def get_circuit_breaker_state(self, agent_name: str) -> CircuitBreakerState:
+        """Return a copy of the current state for ``agent_name``."""
 
-
-def handle_agent_success(agent_name: str) -> None:
-    """Reset or downgrade the circuit breaker state on success."""
-    breaker = _circuit_breakers.get(agent_name)
-    if not breaker:
-        return
-
-    if breaker["state"] == "half-open":
-        breaker["state"] = "closed"
-        breaker["failure_count"] = 0.0
-        breaker["last_failure_time"] = 0.0
-        get_logger(__name__).info(
-            f"Circuit breaker for agent {agent_name} CLOSED after successful recovery",
-            extra={"agent": agent_name, "circuit_state": "closed"},
-        )
-    elif breaker["failure_count"] > 0:
-        breaker["failure_count"] = max(0.0, breaker["failure_count"] - 1)
+        if agent_name not in self.circuit_breakers:
+            return {
+                "state": "closed",
+                "failure_count": 0.0,
+                "last_failure_time": 0.0,
+                "recovery_attempts": 0,
+            }
+        return self.circuit_breakers[agent_name].copy()
 
 
-def get_circuit_breaker_state(agent_name: str) -> CircuitBreakerState:
-    """Get the current circuit breaker state for an agent."""
-    if agent_name not in _circuit_breakers:
-        return {
-            "state": "closed",
-            "failure_count": 0.0,
-            "last_failure_time": 0.0,
-            "recovery_attempts": 0,
-        }
-    return _circuit_breakers[agent_name].copy()
+__all__ = ["CircuitBreakerManager", "CircuitBreakerState"]

--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -2,15 +2,15 @@
 Metrics collection for orchestration system.
 """
 
-from typing import Dict, Any, List, Tuple
-import os
 import json
-from pathlib import Path
+import os
 import time
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
 
 from prometheus_client import Counter, Histogram
 
-from .circuit_breaker import CircuitBreakerState, get_circuit_breaker_state
+from .circuit_breaker import CircuitBreakerState
 
 QUERY_COUNTER = Counter(
     "autoresearch_queries_total", "Total number of queries processed"
@@ -132,9 +132,11 @@ class OrchestrationMetrics:
         self.error_counts[agent_name] += 1
         ERROR_COUNTER.inc()
 
-    def record_circuit_breaker(self, agent_name: str) -> None:
-        """Record the circuit breaker state for an agent."""
-        self.circuit_breakers[agent_name] = get_circuit_breaker_state(agent_name)
+    def record_circuit_breaker(
+        self, agent_name: str, state: CircuitBreakerState
+    ) -> None:
+        """Record the circuit breaker ``state`` for ``agent_name``."""
+        self.circuit_breakers[agent_name] = state
 
     def _log_release_tokens(self) -> None:
         """Persist token counts for this release."""
@@ -274,6 +276,7 @@ class OrchestrationMetrics:
             return prompt
 
         from ..llm.token_counting import compress_prompt
+
         return compress_prompt(prompt, token_budget)
 
     def suggest_token_budget(self, current_budget: int, *, margin: float = 0.1) -> int:

--- a/tests/unit/test_agent_communication.py
+++ b/tests/unit/test_agent_communication.py
@@ -1,9 +1,9 @@
 from autoresearch.agents.base import Agent, AgentRole
-from autoresearch.agents.registry import AgentFactory, AgentRegistry
-from autoresearch.orchestration.state import QueryState
 from autoresearch.agents.messages import MessageProtocol
-from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.agents.registry import AgentFactory, AgentRegistry
 from autoresearch.config.models import ConfigModel
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.state import QueryState
 
 
 class SimpleAgent(Agent):
@@ -60,7 +60,17 @@ def test_orchestrator_handles_coalitions(monkeypatch, tmp_path):
         agent = SimpleAgent(name=name)
         return agent
 
-    def fake_execute(agent_name, state, config, metrics, callbacks, agent_factory, storage_manager, loop):
+    def fake_execute(
+        agent_name,
+        state,
+        config,
+        metrics,
+        callbacks,
+        agent_factory,
+        storage_manager,
+        loop,
+        cb_manager,
+    ):
         executed.append(agent_name)
 
     monkeypatch.setattr(AgentFactory, "get", staticmethod(fake_get))
@@ -85,8 +95,12 @@ def test_message_protocols():
 
     alice.broadcast(state, "hey team", "team")
 
-    msgs_bob = bob.get_messages(state, from_agent="Alice", coalition="team", protocol=MessageProtocol.BROADCAST)
-    msgs_charlie = charlie.get_messages(state, from_agent="Alice", coalition="team", protocol=MessageProtocol.BROADCAST)
+    msgs_bob = bob.get_messages(
+        state, from_agent="Alice", coalition="team", protocol=MessageProtocol.BROADCAST
+    )
+    msgs_charlie = charlie.get_messages(
+        state, from_agent="Alice", coalition="team", protocol=MessageProtocol.BROADCAST
+    )
 
     assert len(msgs_bob) >= 1 and len(msgs_charlie) >= 1
     assert msgs_bob[0].content == "hey team"

--- a/tests/unit/test_circuit_breaker_module.py
+++ b/tests/unit/test_circuit_breaker_module.py
@@ -1,38 +1,39 @@
 import types
-from autoresearch.orchestration import circuit_breaker
+
+from autoresearch.orchestration.circuit_breaker import CircuitBreakerManager
 
 
 def test_state_transitions(monkeypatch):
-    circuit_breaker._circuit_breakers.clear()
+    manager = CircuitBreakerManager()
     t = {"v": 0}
     monkeypatch.setattr(
         "autoresearch.orchestration.circuit_breaker.time",
         types.SimpleNamespace(time=lambda: t.setdefault("v", t["v"] + 10)),
     )
     for _ in range(3):
-        circuit_breaker.update_circuit_breaker("A", "recoverable")
-    state = circuit_breaker.get_circuit_breaker_state("A")
+        manager.update_circuit_breaker("A", "recoverable")
+    state = manager.get_circuit_breaker_state("A")
     assert state["state"] == "open"
     t["v"] += 40
-    circuit_breaker._circuit_breakers["A"]["last_failure_time"] = 0
-    circuit_breaker.update_circuit_breaker("A", "noop")
-    state = circuit_breaker.get_circuit_breaker_state("A")
+    manager.circuit_breakers["A"]["last_failure_time"] = 0
+    manager.update_circuit_breaker("A", "noop")
+    state = manager.get_circuit_breaker_state("A")
     assert state["state"] == "half-open"
 
 
 def test_recovery(monkeypatch):
-    circuit_breaker._circuit_breakers.clear()
+    manager = CircuitBreakerManager()
     t = {"v": 0}
     monkeypatch.setattr(
         "autoresearch.orchestration.circuit_breaker.time",
         types.SimpleNamespace(time=lambda: t.setdefault("v", t["v"] + 10)),
     )
     for _ in range(3):
-        circuit_breaker.update_circuit_breaker("B", "recoverable")
+        manager.update_circuit_breaker("B", "recoverable")
     t["v"] += 40
-    circuit_breaker._circuit_breakers["B"]["last_failure_time"] = 0
-    circuit_breaker.update_circuit_breaker("B", "noop")
-    circuit_breaker.handle_agent_success("B")
-    state = circuit_breaker.get_circuit_breaker_state("B")
+    manager.circuit_breakers["B"]["last_failure_time"] = 0
+    manager.update_circuit_breaker("B", "noop")
+    manager.handle_agent_success("B")
+    state = manager.get_circuit_breaker_state("B")
     assert state["state"] == "closed"
     assert state["failure_count"] == 0


### PR DESCRIPTION
## Summary
- encapsulate breaker state in new `CircuitBreakerManager`
- pass a manager through orchestrator instead of module globals
- update metrics and tests for manager-based API

## Testing
- `task verify` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6896c44097748333835c98f3628b303d