### PR TITLE
Refactor ConfigLoader for contextual instances

### DIFF
--- a/tests/integration/test_config_hot_reload.py
+++ b/tests/integration/test_config_hot_reload.py
@@ -74,7 +74,7 @@ def test_config_hot_reload(tmp_path, monkeypatch):
     )
     repo.index.add([str(cfg_file)])
     repo.index.commit("init config")
-    ConfigLoader.reset_instance()
+    loader = ConfigLoader.new_for_tests()
 
     def fake_load(self):
         data = tomllib.loads(cfg_file.read_text())
@@ -90,7 +90,6 @@ def test_config_hot_reload(tmp_path, monkeypatch):
         )
 
     monkeypatch.setattr(ConfigLoader, "load_config", fake_load, raising=False)
-    loader = ConfigLoader()
 
     calls: list[str] = []
     search_calls: list[str] = []

--- a/tests/unit/test_config_env_file.py
+++ b/tests/unit/test_config_env_file.py
@@ -5,7 +5,7 @@ def test_env_file_parsing(tmp_path):
     """ConfigLoader should populate ConfigModel from .env file."""
     env_path = tmp_path / ".env"
     env_path.write_text("\n".join(["loops=5", "storage__rdf_path=env.db"]))
-    loader = ConfigLoader(env_path=env_path)
+    loader = ConfigLoader.new_for_tests(env_path=env_path)
     cfg = loader.load_config()
     assert cfg.loops == 5
     assert cfg.storage.rdf_path == "env.db"

--- a/tests/unit/test_config_errors.py
+++ b/tests/unit/test_config_errors.py
@@ -8,14 +8,13 @@ from autoresearch.errors import ConfigError  # noqa: E402
 
 def test_load_config_file_error(tmp_path, monkeypatch):
     """Test that ConfigError is raised when the config file can't be loaded."""
-    ConfigLoader.reset_instance()
     monkeypatch.chdir(tmp_path)
 
     # Create an invalid TOML file
     config_path = tmp_path / "autoresearch.toml"
     config_path.write_text("invalid toml content")
 
-    loader = ConfigLoader()
+    loader = ConfigLoader.new_for_tests()
 
     # ConfigLoader should surface parse errors as ConfigError
     with pytest.raises(ConfigError, match="Error loading config file"):
@@ -24,8 +23,7 @@ def test_load_config_file_error(tmp_path, monkeypatch):
 
 def test_notify_observers_error():
     """Test that ConfigError is raised when an observer callback fails."""
-    ConfigLoader.reset_instance()
-    loader = ConfigLoader()
+    loader = ConfigLoader.new_for_tests()
 
     # Create a mock observer that raises an exception
     mock_observer = MagicMock(side_effect=ValueError("Observer error"))
@@ -38,31 +36,31 @@ def test_notify_observers_error():
 
 def test_watch_config_files_error(tmp_path, monkeypatch):
     """Test that ConfigError is raised when watching config files fails."""
-    ConfigLoader.reset_instance()
     monkeypatch.chdir(tmp_path)
 
     # Create a config file that exists
     config_path = tmp_path / "autoresearch.toml"
     config_path.write_text("[core]\nloops = 1\n")
 
-    loader = ConfigLoader()
+    loader = ConfigLoader.new_for_tests()
 
     # Mock the watch function to raise an exception and ensure it's reported
-    with patch("autoresearch.config.loader.watch", side_effect=ValueError("Watch error")):
+    with patch(
+        "autoresearch.config.loader.watch", side_effect=ValueError("Watch error")
+    ):
         with pytest.raises(ConfigError, match="Error in config watcher"):
             loader._watch_config_files()
 
 
 def test_watch_config_reload_error(tmp_path, monkeypatch):
     """Test that ConfigError is raised when reloading config fails."""
-    ConfigLoader.reset_instance()
     monkeypatch.chdir(tmp_path)
 
     # Create a config file that exists
     config_path = tmp_path / "autoresearch.toml"
     config_path.write_text("[core]\nloops = 1\n")
 
-    loader = ConfigLoader()
+    loader = ConfigLoader.new_for_tests()
 
     # Mock the watch function to return a change
     mock_watch = MagicMock()
@@ -70,7 +68,9 @@ def test_watch_config_reload_error(tmp_path, monkeypatch):
 
     # Mock load_config to raise an exception
     with patch("autoresearch.config.loader.watch", mock_watch):
-        with patch.object(loader, "load_config", side_effect=ValueError("Reload error")):
+        with patch.object(
+            loader, "load_config", side_effect=ValueError("Reload error")
+        ):
             with pytest.raises(ConfigError, match="Error in config watcher"):
                 loader._watch_config_files()
 
@@ -81,6 +81,8 @@ def test_reset_instance_error():
     # Create a temporary instance and simulate failure stopping its watcher
     with ConfigLoader.temporary_instance() as loader:
         ConfigLoader._instance = loader
-        with patch.object(loader, "stop_watching", side_effect=ValueError("Stop error")):
+        with patch.object(
+            loader, "stop_watching", side_effect=ValueError("Stop error")
+        ):
             with pytest.raises(ConfigError, match="Error stopping config watcher"):
                 ConfigLoader.reset_instance()

--- a/tests/unit/test_config_profiles.py
+++ b/tests/unit/test_config_profiles.py
@@ -50,9 +50,7 @@ def test_config_profiles_default():
         with patch("tomllib.load", return_value=mock_config):
             with patch("pathlib.Path.exists", return_value=True):
                 with patch("pathlib.Path.stat", mock_stat):
-                    # Reset the singleton to ensure we get a fresh instance
-                    ConfigLoader.reset_instance()
-                    config = ConfigLoader().load_config()
+                    config = ConfigLoader.new_for_tests().load_config()
 
                 # Should use the default (core) settings
                 assert config.llm_backend == "openai"
@@ -84,9 +82,7 @@ def test_config_profiles_switch():
         with patch("tomllib.load", return_value=mock_config):
             with patch("pathlib.Path.exists", return_value=True):
                 with patch("pathlib.Path.stat", mock_stat):
-                    # Reset the singleton to ensure we get a fresh instance
-                    ConfigLoader.reset_instance()
-                    config_loader = ConfigLoader()
+                    config_loader = ConfigLoader.new_for_tests()
 
                     # Switch to the offline profile
                     config_loader.set_active_profile("offline")
@@ -127,9 +123,7 @@ def test_config_profiles_invalid():
         with patch("tomllib.load", return_value=mock_config):
             with patch("pathlib.Path.exists", return_value=True):
                 with patch("pathlib.Path.stat", mock_stat):
-                    # Reset the singleton to ensure we get a fresh instance
-                    ConfigLoader.reset_instance()
-                    config_loader = ConfigLoader()
+                    config_loader = ConfigLoader.new_for_tests()
 
                     # Try to switch to a non-existent profile
                     with pytest.raises(ConfigError) as excinfo:
@@ -166,9 +160,7 @@ def test_config_profiles_merge():
         with patch("tomllib.load", return_value=mock_config):
             with patch("pathlib.Path.exists", return_value=True):
                 with patch("pathlib.Path.stat", mock_stat):
-                    # Reset the singleton to ensure we get a fresh instance
-                    ConfigLoader.reset_instance()
-                    config_loader = ConfigLoader()
+                    config_loader = ConfigLoader.new_for_tests()
 
                     # Switch to the minimal profile
                     config_loader.set_active_profile("minimal")

--- a/tests/unit/test_config_reload.py
+++ b/tests/unit/test_config_reload.py
@@ -10,7 +10,7 @@ def test_config_reload_on_change(tmp_path, monkeypatch):
 
     # Create a new ConfigLoader instance after changing the working directory
     # This ensures it will look for config files in the temporary directory
-    loader = ConfigLoader()
+    loader = ConfigLoader.new_for_tests()
     loader._config = loader.load_config()
 
     # Force update of watch paths to include the new config file


### PR DESCRIPTION
## Summary
- replace singleton ConfigLoader with context-driven loader
- ensure tests construct isolated loaders

## Testing
- `uv run ruff check --fix src/autoresearch/config/loader.py tests/unit/test_config_env_file.py tests/unit/test_config_errors.py tests/unit/test_config_profiles.py tests/unit/test_config_reload.py tests/integration/test_config_hot_reload.py tests/integration/test_config_hot_reload_components.py`
- `uv run flake8 src/autoresearch/config/loader.py tests/unit/test_config_env_file.py tests/unit/test_config_errors.py tests/unit/test_config_profiles.py tests/unit/test_config_reload.py tests/integration/test_config_hot_reload.py tests/integration/test_config_hot_reload_components.py`
- `uv run mypy src`
- `uv run pytest tests/unit/test_config_env_file.py tests/unit/test_config_errors.py tests/unit/test_config_loader_defaults.py tests/unit/test_config_profiles.py tests/unit/test_config_reload.py tests/unit/test_config_validation_errors.py tests/unit/test_config_validators_additional.py tests/unit/test_config_watcher_cleanup.py tests/integration/test_config_hot_reload.py tests/integration/test_config_hot_reload_components.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689767df8f648333b7d183a3ca02e2e8