### PR TITLE
Clarify coverage guidance and fix lint issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,9 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   - Verify type hints with `uv run mypy src`.
   - Run the unit suite: `uv run pytest -q`.
   - Execute BDD tests in `tests/behavior`: `uv run pytest tests/behavior`.
-  - Run the entire suite with coverage: `uv run pytest --cov=src`.
+  - Run the entire suite with coverage: `task coverage` or
+    `uv run pytest --cov=src`. Ensure total coverage is at least 90%
+    and resolve any coverage failures before committing.
 
 ### Cleanup
 - Run `task clean` to remove `__pycache__` and `.mypy_cache` directories.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,6 +222,9 @@ and any `__pycache__` directories to keep your working tree clean.
 - All new code should have at least 90% test coverage
 - Critical components should have 100% test coverage
 - Tests should cover both normal operation and error cases
+- Run `task coverage` or `uv run pytest --cov=src` locally to verify
+  total coverage is at least 90%, and resolve any coverage failures
+  before committing
 
 Continuous integration invokes `task coverage`, which runs the entire suite with
 coverage reporting. This command must succeed to satisfy the 90% coverage gate.

--- a/src/autoresearch/config/loader.py
+++ b/src/autoresearch/config/loader.py
@@ -124,7 +124,7 @@ class ConfigLoader:
         for key, value in raw_env.items():
             key_lower = key.lower()
             if key_lower.startswith("autoresearch_"):
-                key_lower = key_lower[len("autoresearch_") :]
+                key_lower = key_lower[len("autoresearch_"):]
             parts = key_lower.split("__")
             d = env_settings
             for part in parts[:-1]:


### PR DESCRIPTION
## Summary
- document running `task coverage` or `uv run pytest --cov` with a 90% threshold
- require resolving coverage failures before commit
- fix flake8 whitespace error in config loader

## Testing
- `task verify` *(fails: interrupted during tests)*
- `task coverage` *(fails: interrupted during tests)*

------
https://chatgpt.com/codex/tasks/task_e_689767c7ec8c8333a8665e7577326148