### PR TITLE
Refactor API into modular package

### DIFF
--- a/src/autoresearch/api/__init__.py
+++ b/src/autoresearch/api/__init__.py
@@ -1,0 +1,35 @@
+"""FastAPI app aggregator for Autoresearch."""
+
+from __future__ import annotations
+
+from .routing import (
+    app,
+    SLOWAPI_STUB,
+    RateLimitExceeded,
+    reset_request_log,
+    dynamic_limit,
+    config_loader,
+    capabilities_endpoint,
+    get_remote_address,
+    REQUEST_LOG,
+    REQUEST_LOG_LOCK,
+    limiter,
+    parse,
+)
+from .errors import handle_rate_limit
+
+app.add_exception_handler(RateLimitExceeded, handle_rate_limit)
+
+__all__ = [
+    "app",
+    "SLOWAPI_STUB",
+    "reset_request_log",
+    "dynamic_limit",
+    "config_loader",
+    "capabilities_endpoint",
+    "get_remote_address",
+    "REQUEST_LOG",
+    "REQUEST_LOG_LOCK",
+    "limiter",
+    "parse",
+]

--- a/src/autoresearch/api/deps.py
+++ b/src/autoresearch/api/deps.py
@@ -1,0 +1,16 @@
+"""Common dependencies for Autoresearch API modules."""
+
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException, Request
+
+
+def require_permission(permission: str):
+    """Ensure the requesting client has a specific permission."""
+
+    async def checker(request: Request) -> None:
+        permissions: set[str] = getattr(request.state, "permissions", set())
+        if permission not in permissions:
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+
+    return Depends(checker)

--- a/src/autoresearch/api/errors.py
+++ b/src/autoresearch/api/errors.py
@@ -1,0 +1,16 @@
+"""Error handling helpers for the Autoresearch API."""
+
+from __future__ import annotations
+
+from fastapi import Request
+from fastapi.responses import PlainTextResponse, Response
+
+
+def handle_rate_limit(request: Request, exc: Exception) -> Response:
+    """Translate rate limit exceptions into HTTP responses."""
+    from .routing import _rate_limit_exceeded_handler  # type: ignore
+
+    result = _rate_limit_exceeded_handler(request, exc)
+    if isinstance(result, Response):
+        return result
+    return PlainTextResponse(str(result), status_code=429)

--- a/src/autoresearch/api/streaming.py
+++ b/src/autoresearch/api/streaming.py
@@ -1,0 +1,72 @@
+"""Streaming endpoints for the Autoresearch API."""
+
+from __future__ import annotations
+
+import asyncio
+from fastapi.responses import StreamingResponse
+
+from .deps import require_permission
+from ..config import get_config
+from ..error_utils import get_error_info, format_error_for_api
+from ..models import QueryRequest, QueryResponse
+from ..orchestration import ReasoningMode
+from ..orchestration.orchestrator import Orchestrator
+from .webhooks import notify_webhook
+
+
+async def query_stream_endpoint(
+    request: QueryRequest, _=require_permission("query")
+) -> StreamingResponse:
+    """Stream incremental query results as JSON lines."""
+    config = get_config()
+
+    if request.reasoning_mode is not None:
+        config.reasoning_mode = ReasoningMode(request.reasoning_mode.value)
+    if request.loops is not None:
+        config.loops = request.loops
+    if request.llm_backend is not None:
+        config.llm_backend = request.llm_backend
+
+    queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+    def on_cycle_end(loop_idx: int, state) -> None:
+        queue.put_nowait(state.synthesize().model_dump_json())
+
+    def run() -> None:
+        try:
+            result = Orchestrator.run_query(
+                request.query, config, callbacks={"on_cycle_end": on_cycle_end}
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            error_info = get_error_info(exc)
+            error_data = format_error_for_api(error_info)
+            reasoning = ["An error occurred during processing."]
+            if error_info.suggestions:
+                for suggestion in error_info.suggestions:
+                    reasoning.append(f"Suggestion: {suggestion}")
+            else:
+                reasoning.append("Please check the logs for details.")
+            result = QueryResponse(
+                answer=f"Error: {error_info.message}",
+                citations=[],
+                reasoning=reasoning,
+                metrics={"error": error_info.message, "error_details": error_data},
+            )
+        queue.put_nowait(result.model_dump_json())
+        timeout = getattr(config.api, "webhook_timeout", 5)
+        if request.webhook_url:
+            notify_webhook(request.webhook_url, result, timeout)
+        for url in getattr(config.api, "webhooks", []):
+            notify_webhook(url, result, timeout)
+        queue.put_nowait(None)
+
+    asyncio.get_running_loop().run_in_executor(None, run)
+
+    async def generator():
+        while True:
+            item = await queue.get()
+            if item is None:
+                break
+            yield item + "\n"
+
+    return StreamingResponse(generator(), media_type="application/json")

--- a/src/autoresearch/api/webhooks.py
+++ b/src/autoresearch/api/webhooks.py
@@ -1,0 +1,16 @@
+"""Webhook utilities for the Autoresearch API."""
+
+from __future__ import annotations
+
+import httpx
+
+from ..models import QueryResponse
+
+
+def notify_webhook(url: str, result: QueryResponse, timeout: float = 5) -> None:
+    """Send the final result to a webhook URL if configured."""
+    try:
+        httpx.post(url, json=result.model_dump(), timeout=timeout)
+    except Exception:
+        # pragma: no cover - ignore webhook errors
+        pass

--- a/tests/behavior/steps/api_streaming_steps.py
+++ b/tests/behavior/steps/api_streaming_steps.py
@@ -56,13 +56,17 @@ def send_query_with_webhook(url, monkeypatch, api_client, bdd_context):
     monkeypatch.setattr(
         Orchestrator,
         "run_query",
-        lambda q, c, callbacks=None, **k: QueryResponse(answer="ok", citations=[], reasoning=[], metrics={}),
+        lambda q, c, callbacks=None, **k: QueryResponse(
+            answer="ok", citations=[], reasoning=[], metrics={}
+        ),
     )
     with responses.RequestsMock() as rsps:
         rsps.post(url, status=200)
         monkeypatch.setattr(
-            "autoresearch.api._notify_webhook",
-            lambda u, r, timeout=5: requests.post(u, json=r.model_dump(), timeout=timeout),
+            "autoresearch.api.webhooks.notify_webhook",
+            lambda u, r, timeout=5: requests.post(
+                u, json=r.model_dump(), timeout=timeout
+            ),
         )
         resp = api_client.post("/query", json={"query": "hi", "webhook_url": url})
         bdd_context["api_status"] = resp.status_code
@@ -84,6 +88,9 @@ def test_streaming_query_responses():
     pass
 
 
-@scenario("../features/api_streaming_webhook.feature", "Webhook notifications on query completion")
+@scenario(
+    "../features/api_streaming_webhook.feature",
+    "Webhook notifications on query completion",
+)
 def test_webhook_notifications():
     pass

--- a/tests/unit/test_api_error_handling.py
+++ b/tests/unit/test_api_error_handling.py
@@ -12,11 +12,15 @@ def _setup(monkeypatch):
     cfg = ConfigModel.model_construct(api=APIConfig())
     cfg.api.role_permissions["anonymous"] = ["query"]
     monkeypatch.setattr("autoresearch.api.get_config", lambda: cfg)
-    dummy_loader = types.SimpleNamespace(config=cfg, watching=lambda *a, **k: contextlib.nullcontext())
+    dummy_loader = types.SimpleNamespace(
+        config=cfg, watching=lambda *a, **k: contextlib.nullcontext()
+    )
     monkeypatch.setattr("autoresearch.api.config_loader", dummy_loader)
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader.reset_instance()
-    monkeypatch.setattr("autoresearch.api._notify_webhook", lambda u, r, timeout=5: None)
+    monkeypatch.setattr(
+        "autoresearch.api.webhooks.notify_webhook", lambda u, r, timeout=5: None
+    )
     return cfg
 
 


### PR DESCRIPTION
## Summary
- modularize API into routing, streaming, webhook and error modules
- aggregate FastAPI app from split components
- adjust tests for new module layout

## Testing
- `uv run ruff format src/autoresearch/api/routing.py src/autoresearch/api/webhooks.py src/autoresearch/api/streaming.py src/autoresearch/api/errors.py src/autoresearch/api/__init__.py tests/behavior/steps/api_streaming_steps.py tests/unit/test_api_error_handling.py`
- `uv run ruff check --fix src/autoresearch/api/deps.py src/autoresearch/api/routing.py src/autoresearch/api/streaming.py src/autoresearch/api/webhooks.py src/autoresearch/api/errors.py src/autoresearch/api/__init__.py tests/behavior/steps/api_streaming_steps.py tests/unit/test_api_error_handling.py`
- `uv run flake8 src/autoresearch/api/__init__.py src/autoresearch/api/routing.py src/autoresearch/api/webhooks.py src/autoresearch/api/streaming.py src/autoresearch/api/errors.py src/autoresearch/api/deps.py tests/behavior/steps/api_streaming_steps.py tests/unit/test_api_error_handling.py`
- `uv run mypy src/autoresearch/api/__init__.py src/autoresearch/api/routing.py src/autoresearch/api/streaming.py src/autoresearch/api/webhooks.py src/autoresearch/api/errors.py src/autoresearch/api/deps.py` *(interrupted)*
- `uv run pytest -q tests/unit tests/integration` *(failed: module 'autoresearch.api' has no attribute 'REQUEST_LOG_LOCK')*

------
https://chatgpt.com/codex/tasks/task_e_68978995456c8333957b09b2f1b0d9ab