### PR TITLE
Add distributed shutdown test and tidy imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Update release plan to align milestones with the 2025 development timeline.
+- Fix relevance ranking integration test imports.
+- Add unit test covering RayExecutor shutdown path.
 
 ## [0.1.0-alpha.1] - 2025-08-09
 - Verified source and wheel builds succeed; TestPyPI upload failed with 403 Forbidden.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -224,8 +224,10 @@ not be generated.
 ### Latest Test Results
 
 - `flake8` reports no style errors.
-- `mypy` completes without type issues.
-- `pytest` fails due to a configuration validation error (ConfigError).
+- `mypy` run was interrupted during execution.
+- Unit tests: `tests/unit/test_ray_executor_shutdown.py` passes.
+- Integration tests: `tests/integration/test_relevance_ranking_integration.py` passes.
+- Behavior tests: `tests/behavior` fail with `ModuleNotFoundError: autoresearch.api.models`.
 
 ### Performance Baselines
 

--- a/tests/integration/test_relevance_ranking_integration.py
+++ b/tests/integration/test_relevance_ranking_integration.py
@@ -1,15 +1,16 @@
-import csv
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+import csv
+
 from autoresearch.search import Search
 from autoresearch.config.models import ConfigModel, SearchConfig
 
 
-def load_data():
+def load_data() -> dict[str, list[dict[str, float]]]:
+    """Load search evaluation data from the examples directory."""
     path = Path(__file__).resolve().parents[2] / "examples" / "search_evaluation.csv"
-    data = {}
+    data: dict[str, list[dict[str, float]]] = {}
     with path.open() as f:
         reader = csv.DictReader(f)
         for row in reader:
@@ -25,6 +26,7 @@ def load_data():
 
 
 def test_example_weights_and_ranking(monkeypatch):
+    """Ensure weighting configuration influences ranking as expected."""
     data = load_data()
 
     search_cfg = SearchConfig.model_construct(

--- a/tests/unit/test_ray_executor_shutdown.py
+++ b/tests/unit/test_ray_executor_shutdown.py
@@ -1,0 +1,35 @@
+import sys
+import types
+
+
+def test_shutdown_without_start():
+    """RayExecutor.shutdown should handle cases with no brokers."""
+
+    # Provide lightweight stubs for heavy optional dependencies
+    sys.modules.setdefault("sentence_transformers", types.SimpleNamespace(SentenceTransformer=object))
+    sys.modules.setdefault("transformers", types.SimpleNamespace())
+    sys.modules.setdefault("torch", types.SimpleNamespace())
+
+    def _remote(func):
+        return types.SimpleNamespace(remote=lambda *a, **k: func(*a, **k))
+
+    sys.modules.setdefault(
+        "ray",
+        types.SimpleNamespace(
+            init=lambda *a, **k: None,
+            shutdown=lambda *a, **k: None,
+            remote=_remote,
+            get=lambda x: x,
+            put=lambda x: x,
+            ObjectRef=object,
+        ),
+    )
+
+    from autoresearch.distributed import RayExecutor
+    from autoresearch.config.models import ConfigModel, DistributedConfig
+
+    cfg = ConfigModel(distributed=False, distributed_config=DistributedConfig(enabled=False))
+    executor = RayExecutor(cfg)
+
+    # Should exit cleanly without raising exceptions
+    executor.shutdown()


### PR DESCRIPTION
## Summary
- fix relevance ranking integration test imports
- add RayExecutor shutdown coverage
- document current verification results

## Testing
- `uv run flake8 src tests`
- `uv run pytest --no-cov tests/unit/test_ray_executor_shutdown.py -q`
- `uv run pytest --no-cov tests/integration/test_relevance_ranking_integration.py -q`
- `uv run pytest --no-cov tests/behavior -q` *(fails: ModuleNotFoundError: autoresearch.api.models)*

------
https://chatgpt.com/codex/tasks/task_e_68979ddefe588333ad4b1a3a33f83da5