### PR TITLE
Use dict for request logging

### DIFF
--- a/src/autoresearch/api/__init__.py
+++ b/src/autoresearch/api/__init__.py
@@ -2,21 +2,20 @@
 
 from __future__ import annotations
 
-from .routing import (
-    app,
-    SLOWAPI_STUB,
-    RateLimitExceeded,
-    reset_request_log,
-    dynamic_limit,
-    config_loader,
-    capabilities_endpoint,
-    get_remote_address,
-    REQUEST_LOG,
-    REQUEST_LOG_LOCK,
-    limiter,
-    parse,
-)
+from . import routing
 from .errors import handle_rate_limit
+
+app = routing.app
+SLOWAPI_STUB = routing.SLOWAPI_STUB
+RateLimitExceeded = routing.RateLimitExceeded
+reset_request_log = routing.reset_request_log
+dynamic_limit = routing.dynamic_limit
+config_loader = routing.config_loader
+capabilities_endpoint = routing.capabilities_endpoint
+get_remote_address = routing.get_remote_address
+log_request = routing.log_request
+limiter = routing.limiter
+parse = routing.parse
 
 app.add_exception_handler(RateLimitExceeded, handle_rate_limit)
 
@@ -28,8 +27,17 @@ __all__ = [
     "config_loader",
     "capabilities_endpoint",
     "get_remote_address",
+    "log_request",
     "REQUEST_LOG",
     "REQUEST_LOG_LOCK",
     "limiter",
     "parse",
 ]
+
+
+def __getattr__(name: str):
+    if name == "REQUEST_LOG":
+        return routing.REQUEST_LOG
+    if name == "REQUEST_LOG_LOCK":
+        return routing.REQUEST_LOG_LOCK
+    raise AttributeError(name)


### PR DESCRIPTION
## Summary
- replace Counter-based REQUEST_LOG with a plain dict and helper in log_request
- expose REQUEST_LOG dynamically in api package to keep references in sync

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit/test_api.py::test_request_log_thread_safety -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_6897a706d7088333abddbff79c731cd2