### PR TITLE
Prefer ripgrep for repository searches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 - Always run tests with `uv run` or inside the activated `.venv`; all tests
   must run inside this environment.
 - Use `task verify` to run linting, type checking, and all tests with coverage (see [`Taskfile.yml`](Taskfile.yml)).
+- Use `rg` for repository searches instead of `grep -R` or `ls -R`.
+  Example: `rg <pattern>`.
 - If `task` is unavailable, run these commands individually:
   - Format code with `uv run black .`.
   - Sort imports with `uv run isort .`.


### PR DESCRIPTION
## Summary
- Encourage using ripgrep for repository searches in AGENTS guidelines

## Testing
- `task verify` *(fails: AttributeError: 'module' object at autoresearch.api has no attribute 'get_config')*


------
https://chatgpt.com/codex/tasks/task_e_6897bdc80e78833380dc2ad7f2413b6e