### PR TITLE
Expand error recovery test coverage

### DIFF
--- a/tests/behavior/features/error_recovery.feature
+++ b/tests/behavior/features/error_recovery.feature
@@ -73,6 +73,20 @@ Feature: Error Recovery
     And the logs should include "recovery"
     And the response should list an error of type "AgentError"
 
+  Scenario: Recovery after agent timeout
+    Given an agent that times out during execution
+    And reasoning mode is "dialectical"
+    When I run the orchestrator on query "recover test"
+    Then the reasoning mode selected should be "dialectical"
+    And the loops used should be 1
+    And the agent groups should be "Slowpoke"
+    And the agents executed should be "Slowpoke"
+    And a recovery strategy "retry_with_backoff" should be recorded
+    And recovery should be applied
+    And the system state should be restored
+    And the logs should include "recovery"
+    And the response should list a timeout error
+
   Scenario: Recovery after agent failure with fallback
     Given an agent that fails triggering fallback
     When I run the orchestrator on query "recover test"

--- a/tests/behavior/steps/api_documentation_steps.py
+++ b/tests/behavior/steps/api_documentation_steps.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from pytest_bdd import given, when, then, scenario, parsers
+from fastapi.openapi.docs import get_swagger_ui_html
+from pytest_bdd import given, parsers, scenario, then, when
 
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import APIConfig, ConfigModel
-from fastapi.openapi.docs import get_swagger_ui_html
+
+pytest_plugins = ["tests.behavior.steps.common_steps"]
 
 
 @given("the API server is running")
@@ -30,7 +32,9 @@ def api_server_running(
     if not any(r.path == "/docs" for r in api_app.router.routes):
         api_app.router.add_api_route(
             "/docs",
-            lambda: get_swagger_ui_html(openapi_url="/openapi.json", title="Swagger UI"),
+            lambda: get_swagger_ui_html(
+                openapi_url="/openapi.json", title="Swagger UI"
+            ),
             include_in_schema=False,
         )
 

--- a/tests/behavior/steps/error_recovery_steps.py
+++ b/tests/behavior/steps/error_recovery_steps.py
@@ -66,6 +66,14 @@ def test_error_recovery_network_outage():
 
 @scenario(
     "../features/error_recovery.feature",
+    "Recovery after agent timeout",
+)
+def test_error_recovery_timeout():
+    pass
+
+
+@scenario(
+    "../features/error_recovery.feature",
     "Unsupported reasoning mode during recovery fails gracefully",
 )
 def test_error_recovery_unsupported_mode():
@@ -386,7 +394,11 @@ def assert_recovery_applied(run_result: dict) -> None:
 def assert_timeout_error(run_result: dict) -> None:
     errors = run_result["response"].metadata.get("errors", [])
     _assert_error_schema(errors)
-    assert any(e.get("error_type") == "TimeoutError" for e in errors), errors
+    assert any(
+        e.get("error_type") == "TimeoutError"
+        and "simulated timeout" in e.get("message", "")
+        for e in errors
+    ), errors
 
 
 @then("the response should list an agent execution error")

--- a/tests/behavior/steps/gui_cli_steps.py
+++ b/tests/behavior/steps/gui_cli_steps.py
@@ -32,6 +32,7 @@ def run_gui_help(cli_runner, bdd_context, temp_config, isolate_network):
 def cli_success(bdd_context):
     result = bdd_context["result"]
     assert result.exit_code == 0
+    assert result.stdout != ""
     assert result.stderr == ""
     if "run_calls" in bdd_context:
         assert len(bdd_context["run_calls"]) == 1


### PR DESCRIPTION
## Summary
- exercise timeout recovery path in behavior specs
- verify timeout details when checking recovery metrics
- load common step fixtures for API docs tests and assert CLI output

## Testing
- `uv run black tests/behavior/steps/error_recovery_steps.py tests/behavior/steps/gui_cli_steps.py tests/behavior/steps/api_documentation_steps.py`
- `uv run isort tests/behavior/steps/error_recovery_steps.py tests/behavior/steps/gui_cli_steps.py tests/behavior/steps/api_documentation_steps.py`
- `uv run ruff format tests/behavior/steps/error_recovery_steps.py tests/behavior/steps/gui_cli_steps.py tests/behavior/steps/api_documentation_steps.py`
- `uv run ruff check --fix tests/behavior/steps/error_recovery_steps.py tests/behavior/steps/gui_cli_steps.py tests/behavior/steps/api_documentation_steps.py`
- `uv run flake8 tests/behavior/steps/error_recovery_steps.py tests/behavior/steps/gui_cli_steps.py tests/behavior/steps/api_documentation_steps.py`
- `uv run mypy src`
- `uv run pytest tests/behavior` *(fails: ValueError: tuple.index(x): x not in tuple)*

------
https://chatgpt.com/codex/tasks/task_e_6897bdb825608333806930a6a9fb8301