### PR TITLE
Fix API test configuration hooks

### DIFF
--- a/tests/unit/test_api_error_handling.py
+++ b/tests/unit/test_api_error_handling.py
@@ -11,7 +11,7 @@ from autoresearch.orchestration.orchestrator import Orchestrator
 def _setup(monkeypatch):
     cfg = ConfigModel.model_construct(api=APIConfig())
     cfg.api.role_permissions["anonymous"] = ["query"]
-    monkeypatch.setattr("autoresearch.api.get_config", lambda: cfg)
+    monkeypatch.setattr("autoresearch.api.routing.get_config", lambda: cfg)
     dummy_loader = types.SimpleNamespace(
         config=cfg, watching=lambda *a, **k: contextlib.nullcontext()
     )

--- a/tests/unit/test_failure_paths.py
+++ b/tests/unit/test_failure_paths.py
@@ -60,7 +60,7 @@ def test_query_endpoint_validation_error(monkeypatch):
     """/query returns 422 when required fields are missing."""
     cfg = ConfigModel(api=APIConfig())
     cfg.api.role_permissions["anonymous"] = ["query"]
-    monkeypatch.setattr("autoresearch.api.get_config", lambda: cfg)
+    monkeypatch.setattr("autoresearch.api.routing.get_config", lambda: cfg)
     client = TestClient(app)
     resp = client.post("/query", json={})
     assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- fix FastAPI tests by monkeypatching routing.get_config
- adjust failure path tests to use routing.get_config

## Testing
- `uv run pytest tests/unit/test_api_error_handling.py::test_query_endpoint_runtime_error tests/unit/test_failure_paths.py::test_query_endpoint_validation_error -q`
- `uv run pytest tests/unit/test_api_error_handling.py::test_query_endpoint_runtime_error tests/unit/test_failure_paths.py::test_query_endpoint_validation_error -q`


------
https://chatgpt.com/codex/tasks/task_e_6897cfe5abe48333ae953430ef2c3772