### PR TITLE
Refactor request logging

### DIFF
--- a/src/autoresearch/api/__init__.py
+++ b/src/autoresearch/api/__init__.py
@@ -8,38 +8,30 @@ from .errors import handle_rate_limit
 app = routing.app
 SLOWAPI_STUB = routing.SLOWAPI_STUB
 RateLimitExceeded = routing.RateLimitExceeded
-reset_request_log = routing.reset_request_log
 dynamic_limit = routing.dynamic_limit
 config_loader = routing.config_loader
 capabilities_endpoint = routing.capabilities_endpoint
 get_remote_address = routing.get_remote_address
-log_request = routing.log_request
 limiter = routing.limiter
 parse = routing.parse
 query_endpoint = routing.query_endpoint
+create_request_logger = routing.create_request_logger
+get_request_logger = routing.get_request_logger
+RequestLogger = routing.RequestLogger
 
 app.add_exception_handler(RateLimitExceeded, handle_rate_limit)
 
 __all__ = [
     "app",
     "SLOWAPI_STUB",
-    "reset_request_log",
     "dynamic_limit",
     "config_loader",
     "capabilities_endpoint",
     "get_remote_address",
-    "log_request",
-    "REQUEST_LOG",
-    "REQUEST_LOG_LOCK",
     "limiter",
     "parse",
     "query_endpoint",
+    "create_request_logger",
+    "get_request_logger",
+    "RequestLogger",
 ]
-
-
-def __getattr__(name: str):
-    if name == "REQUEST_LOG":
-        return routing.REQUEST_LOG
-    if name == "REQUEST_LOG_LOCK":
-        return routing.REQUEST_LOG_LOCK
-    raise AttributeError(name)

--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -10,7 +10,7 @@ if str(ROOT) not in sys.path:
 import os  # noqa: E402
 import pytest  # noqa: E402
 
-from autoresearch.api import reset_request_log  # noqa: E402
+from autoresearch.api import get_request_logger  # noqa: E402
 from tests.conftest import reset_limiter_state, VSS_AVAILABLE  # noqa: E402
 from autoresearch.orchestration.state import QueryState  # noqa: E402
 from autoresearch.config.models import ConfigModel  # noqa: E402
@@ -56,7 +56,7 @@ def pytest_runtest_setup(item):
 @pytest.fixture(autouse=True)
 def reset_api_request_log():
     """Clear API request log before each scenario."""
-    reset_request_log()
+    get_request_logger().reset()
     reset_limiter_state()
 
 

--- a/tests/behavior/steps/api_auth_steps.py
+++ b/tests/behavior/steps/api_auth_steps.py
@@ -4,7 +4,7 @@ from pytest_bdd import scenario, given, when, then, parsers
 from . import api_orchestrator_integration_steps  # noqa: F401
 from autoresearch.config.models import ConfigModel, APIConfig
 from autoresearch.config.loader import ConfigLoader
-from autoresearch.api import config_loader, reset_request_log
+from autoresearch.api import config_loader, get_request_logger
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.models import QueryResponse
 
@@ -45,7 +45,7 @@ def require_bearer_token(monkeypatch, token):
     )
 
 
-@given(parsers.parse('the API rate limit is {limit:d} request per minute'))
+@given(parsers.parse("the API rate limit is {limit:d} request per minute"))
 def set_rate_limit(monkeypatch, limit):
     cfg = ConfigModel(api=APIConfig(rate_limit=limit))
     ConfigLoader.reset_instance()
@@ -58,7 +58,7 @@ def set_rate_limit(monkeypatch, limit):
             answer="ok", citations=[], reasoning=[], metrics={}
         ),
     )
-    reset_request_log()
+    get_request_logger().reset()
 
 
 @when(parsers.parse('I send a query "{query}" with header "{header}" set to "{value}"'))
@@ -75,7 +75,7 @@ def send_two_queries(api_client_factory, test_context):
     test_context["resp2"] = client.post("/query", json={"query": "q"})
 
 
-@then(parsers.parse('the response status should be {status:d}'))
+@then(parsers.parse("the response status should be {status:d}"))
 def check_status(test_context, status):
     resp = test_context["response"]
     assert resp.status_code == status
@@ -86,7 +86,7 @@ def check_status(test_context, status):
         assert "detail" in data
 
 
-@then(parsers.parse('the first response status should be {status:d}'))
+@then(parsers.parse("the first response status should be {status:d}"))
 def check_first_status(test_context, status):
     resp = test_context["resp1"]
     assert resp.status_code == status
@@ -95,7 +95,7 @@ def check_first_status(test_context, status):
     assert "error" not in data
 
 
-@then(parsers.parse('the second response status should be {status:d}'))
+@then(parsers.parse("the second response status should be {status:d}"))
 def check_second_status(test_context, status):
     resp = test_context["resp2"]
     assert resp.status_code == status

--- a/tests/integration/test_cli_http.py
+++ b/tests/integration/test_cli_http.py
@@ -247,11 +247,12 @@ def test_http_throttling(monkeypatch):
 
         set_delegate(None)
         DummyStorage.persisted = []
-        api_mod.reset_request_log()
+        api_mod.get_request_logger().reset()
 
 
 def test_stream_endpoint(monkeypatch):
     """Streaming endpoint should yield multiple updates."""
+
     def dummy_run_query(query, config, callbacks=None, **kwargs):
         state = QueryState(query=query)
         for i in range(2):
@@ -276,7 +277,9 @@ def test_webhook_notification(monkeypatch):
     monkeypatch.setattr(
         Orchestrator,
         "run_query",
-        lambda q, c, callbacks=None, **k: QueryResponse(answer="ok", citations=[], reasoning=[], metrics={}),
+        lambda q, c, callbacks=None, **k: QueryResponse(
+            answer="ok", citations=[], reasoning=[], metrics={}
+        ),
     )
     client = TestClient(api_app)
 
@@ -293,7 +296,9 @@ def test_batch_query(monkeypatch):
     monkeypatch.setattr(
         Orchestrator,
         "run_query",
-        lambda q, c, callbacks=None, **k: QueryResponse(answer=q, citations=[], reasoning=[], metrics={}),
+        lambda q, c, callbacks=None, **k: QueryResponse(
+            answer=q, citations=[], reasoning=[], metrics={}
+        ),
     )
     client = TestClient(api_app)
 


### PR DESCRIPTION
## Summary
- encapsulate API request logging in a thread-safe RequestLogger and expose dependency helpers
- inject per-app RequestLogger into rate limit middleware
- update tests to use the new logger abstraction

## Testing
- `ruff format src/autoresearch/api/routing.py src/autoresearch/api/__init__.py tests/conftest.py tests/behavior/conftest.py tests/behavior/steps/api_auth_steps.py tests/integration/test_cli_http.py tests/unit/test_api.py`
- `ruff check --fix src/autoresearch/api/routing.py src/autoresearch/api/__init__.py tests/conftest.py tests/behavior/conftest.py tests/behavior/steps/api_auth_steps.py tests/integration/test_cli_http.py tests/unit/test_api.py`
- `flake8 src/autoresearch/api/__init__.py src/autoresearch/api/routing.py tests/conftest.py tests/behavior/conftest.py tests/behavior/steps/api_auth_steps.py tests/integration/test_cli_http.py tests/unit/test_api.py`
- `mypy src/autoresearch/api/__init__.py src/autoresearch/api/routing.py`
- `pytest tests/unit/test_api.py tests/integration/test_cli_http.py tests/behavior -q` *(failed: tests/integration/test_cli_http.py::test_http_no_query_field expected 400, got 422)*
- `pytest tests/unit/test_api.py -q` *(failed: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_6897e9022da48333983a41221998fb74