### PR TITLE
Sync package version with project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "autoresearch"
-version = "0.1.0-alpha.1" # keep in sync with autoresearch.__version__
+version = "0.1.0a1" # keep in sync with autoresearch.__version__
 description = "Local-first research assistant coordinating agents for evidence-backed answers."
 authors = [
     {name = "Caitlyn O'Hanna",email = "caitlyn.ohanna@gmail.com"}

--- a/src/autoresearch/__init__.py
+++ b/src/autoresearch/__init__.py
@@ -10,6 +10,7 @@ interfaces and a modular architecture.
 # creation.
 import importlib
 import sys
+from importlib.metadata import version as _version
 
 try:  # pragma: no cover - best effort patch
     module = importlib.import_module("pydantic.root_model")
@@ -17,19 +18,19 @@ try:  # pragma: no cover - best effort patch
 except Exception:  # pragma: no cover
     pass
 
-__version__ = "0.1.0"
+__version__ = _version("autoresearch")
 
 try:  # pragma: no cover - optional distributed extras
     from .distributed import (
+        InMemoryBroker,
         ProcessExecutor,
         RayExecutor,
-        StorageCoordinator,
-        ResultAggregator,
-        InMemoryBroker,
         RedisBroker,
-        start_storage_coordinator,
-        start_result_aggregator,
+        ResultAggregator,
+        StorageCoordinator,
         publish_claim,
+        start_result_aggregator,
+        start_storage_coordinator,
     )
 except Exception as exc:  # pragma: no cover - missing optional deps
     ProcessExecutor = None  # type: ignore

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,5 +1,7 @@
+import importlib.metadata
 import tomllib
 from pathlib import Path
+
 import autoresearch
 
 
@@ -7,3 +9,7 @@ def test_init_version_matches_pyproject():
     pyproject = Path(__file__).parents[2] / "pyproject.toml"
     data = tomllib.loads(pyproject.read_text())
     assert autoresearch.__version__ == data["project"]["version"]
+
+
+def test_init_version_matches_metadata():
+    assert autoresearch.__version__ == importlib.metadata.version("autoresearch")


### PR DESCRIPTION
## Summary
- derive `__version__` from installed package metadata
- align project version with normalized metadata version
- verify runtime version matches both `pyproject.toml` and `importlib.metadata`

## Testing
- `uv run ruff check --fix src/autoresearch/__init__.py tests/unit/test_version.py`
- `uv run flake8 src/autoresearch/__init__.py tests/unit/test_version.py`
- `uv run mypy src/autoresearch/__init__.py --follow-imports=skip --ignore-missing-imports`
- `uv run pytest tests/unit/test_version.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689807073e6c8333b493b3120e22bc5f