### PR TITLE
Ensure request log returns integer counts

### DIFF
--- a/src/autoresearch/api/routing.py
+++ b/src/autoresearch/api/routing.py
@@ -118,20 +118,30 @@ class RequestLogger:
         self._lock = threading.Lock()
 
     def log(self, ip: str) -> int:
-        """Record a request from ``ip`` and return the new count."""
+        """Record a request from ``ip`` and return the new count.
+
+        This method is thread-safe.
+        """
         with self._lock:
             self._log[ip] = self._log.get(ip, 0) + 1
             return self._log[ip]
 
     def reset(self) -> None:
-        """Clear all recorded requests."""
+        """Clear all recorded requests.
+
+        This method is thread-safe.
+        """
         with self._lock:
             self._log.clear()
 
-    def get(self, ip: str) -> int | None:
-        """Return the number of requests from ``ip``."""
+    def get(self, ip: str) -> int:
+        """Return the number of requests from ``ip``.
+
+        Returns ``0`` if the IP has not been logged yet. This method is
+        thread-safe.
+        """
         with self._lock:
-            return self._log.get(ip)
+            return self._log.get(ip, 0)
 
     def snapshot(self) -> dict[str, int]:
         """Return a copy of the current log state."""

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -120,8 +120,10 @@ def test_request_log_thread_safety(monkeypatch):
 
     api_mod.get_request_logger().reset()
 
+    results: list[int] = []
+
     def make_request() -> None:
-        api_mod.get_request_logger().log("1")
+        results.append(api_mod.get_request_logger().log("1"))
 
     threads = [threading.Thread(target=make_request) for _ in range(20)]
     for t in threads:
@@ -129,4 +131,12 @@ def test_request_log_thread_safety(monkeypatch):
     for t in threads:
         t.join()
 
-    assert api_mod.get_request_logger().get("1") == 20
+    assert all(isinstance(r, int) for r in results)
+
+    count = api_mod.get_request_logger().get("1")
+    assert isinstance(count, int)
+    assert count == 20
+
+    missing = api_mod.get_request_logger().get("2")
+    assert isinstance(missing, int)
+    assert missing == 0


### PR DESCRIPTION
## Summary
- return 0 from RequestLogger.get when IP not logged
- document thread-safe request log methods and rely on shared app state
- tighten request log thread safety test to assert integer counts

## Testing
- `uv run ruff format src/autoresearch/api/routing.py tests/unit/test_api.py`
- `uv run ruff check --fix src/autoresearch/api/routing.py tests/unit/test_api.py`
- `uv run flake8 src/autoresearch/api/routing.py tests/unit/test_api.py`
- `uv run mypy --follow-imports=skip src/autoresearch/api/routing.py`
- `uv run pytest tests/unit/test_api.py::test_request_log_thread_safety --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689817b08d0c8333a834a30ac835646b