### PR TITLE
Handle webhook request errors

### DIFF
--- a/src/autoresearch/api/webhooks.py
+++ b/src/autoresearch/api/webhooks.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import logging
+
 import httpx
 
 from ..models import QueryResponse
+
+
+log = logging.getLogger(__name__)
 
 
 def notify_webhook(url: str, result: QueryResponse, timeout: float = 5) -> None:
     """Send the final result to a webhook URL if configured."""
     try:
         httpx.post(url, json=result.model_dump(), timeout=timeout)
-    except Exception:
-        # pragma: no cover - ignore webhook errors
-        pass
+    except httpx.RequestError as exc:
+        log.warning("Webhook request to %s failed: %s", url, exc)

--- a/tests/unit/test_webhooks_logging.py
+++ b/tests/unit/test_webhooks_logging.py
@@ -1,0 +1,22 @@
+import logging
+
+import httpx
+
+from autoresearch.api.webhooks import notify_webhook
+from autoresearch.models import QueryResponse
+
+
+def test_notify_webhook_logs_request_error(monkeypatch, caplog):
+    def raise_error(*args, **kwargs):
+        raise httpx.RequestError("boom", request=httpx.Request("POST", "http://hook"))
+
+    monkeypatch.setattr(httpx, "post", raise_error)
+
+    payload = QueryResponse(answer="", citations=[], reasoning=[], metrics={})
+    with caplog.at_level(logging.WARNING):
+        notify_webhook("http://hook", payload)
+
+    assert any(
+        "http://hook" in record.getMessage() and "boom" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- catch `httpx.RequestError` in webhook helper and log failures
- test webhook failure logging

## Testing
- `uv run flake8 src/autoresearch/api/webhooks.py tests/unit/test_webhooks_logging.py`
- `uv run mypy src/autoresearch/api/webhooks.py --follow-imports=skip --ignore-missing-imports`
- `uv run pytest tests/unit/test_webhooks_logging.py -q --no-cov`
- `uv run pytest tests/integration -m "not slow" -q --no-cov` *(fails: assert 422 == 400)*
- `uv run pytest tests/behavior -q --no-cov` *(fails: Not all requests have been executed)*

------
https://chatgpt.com/codex/tasks/task_e_68982b80e11c83339fb8831d5c0dab28