### PR TITLE
Refactor API routing for dependency injection

### DIFF
--- a/src/autoresearch/api/__init__.py
+++ b/src/autoresearch/api/__init__.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from . import routing
-from .errors import handle_rate_limit
 
+create_app = routing.create_app
 app = routing.app
 SLOWAPI_STUB = routing.SLOWAPI_STUB
 RateLimitExceeded = routing.RateLimitExceeded
@@ -20,10 +20,9 @@ get_request_logger = routing.get_request_logger
 RequestLogger = routing.RequestLogger
 reset_request_log = routing.reset_request_log
 
-app.add_exception_handler(RateLimitExceeded, handle_rate_limit)
-
 __all__ = [
     "app",
+    "create_app",
     "SLOWAPI_STUB",
     "dynamic_limit",
     "config_loader",


### PR DESCRIPTION
## Summary
- refactor API routing into a factory with injectable ConfigLoader, limiter, and RequestLogger
- expose create_app and adapt request logging helpers
- update tests to build isolated app instances with factory

## Testing
- `uv run ruff format src/autoresearch/api/routing.py src/autoresearch/api/__init__.py tests/unit/test_api.py`
- `uv run ruff check --fix src/autoresearch/api/routing.py src/autoresearch/api/__init__.py tests/unit/test_api.py`
- `uv run mypy src/autoresearch/api`
- `uv run pytest tests/unit/test_api.py -q --no-cov`
- `uv run pytest tests/integration/test_api_additional.py tests/integration/test_api_auth.py tests/integration/test_api_auth_failure.py tests/integration/test_api_docs.py tests/integration/test_api_streaming.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689848a3a6508333a9c77910eb3b5efa