### PR TITLE
Expand relevance ranking checks

### DIFF
--- a/tests/integration/test_relevance_ranking_integration.py
+++ b/tests/integration/test_relevance_ranking_integration.py
@@ -2,8 +2,10 @@ import csv
 from pathlib import Path
 from unittest.mock import patch
 
-from autoresearch.search import Search
+import pytest
+
 from autoresearch.config.models import ConfigModel, SearchConfig
+from autoresearch.search import Search
 
 
 def load_data():
@@ -34,32 +36,95 @@ def test_example_weights_and_ranking(monkeypatch):
     cfg = ConfigModel(search=search_cfg)
     cfg.api.role_permissions["anonymous"] = ["query"]
     # Ensure weights sum to 1.0
-    assert abs(
-        cfg.search.semantic_similarity_weight
-        + cfg.search.bm25_weight
-        + cfg.search.source_credibility_weight
-        - 1.0
-    ) <= 0.001
+    assert (
+        abs(
+            cfg.search.semantic_similarity_weight
+            + cfg.search.bm25_weight
+            + cfg.search.source_credibility_weight
+            - 1.0
+        )
+        <= 0.001
+    ), "Search weights must sum to 1.0"
 
     monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
 
     for query, docs in data.items():
         with (
-            patch.object(Search, "calculate_bm25_scores", return_value=[d["bm25"] for d in docs]),
-            patch.object(Search, "calculate_semantic_similarity", return_value=[d["semantic"] for d in docs]),
-            patch.object(Search, "assess_source_credibility", return_value=[d["credibility"] for d in docs]),
+            patch.object(
+                Search, "calculate_bm25_scores", return_value=[d["bm25"] for d in docs]
+            ),
+            patch.object(
+                Search,
+                "calculate_semantic_similarity",
+                return_value=[d["semantic"] for d in docs],
+            ),
+            patch.object(
+                Search,
+                "assess_source_credibility",
+                return_value=[d["credibility"] for d in docs],
+            ),
         ):
             ranked = Search.rank_results(query, [{"id": i} for i in range(len(docs))])
-        expected_scores = [
-            cfg.search.bm25_weight * d["bm25"]
-            + cfg.search.semantic_similarity_weight * d["semantic"]
-            + cfg.search.source_credibility_weight * d["credibility"]
-            for d in docs
+
+        # Compute expected score components for each document
+        expected_components = []
+        for d in docs:
+            embedding_score = (d["semantic"] + 0.0) / 2
+            merged_score = (
+                cfg.search.bm25_weight * d["bm25"]
+                + cfg.search.semantic_similarity_weight * embedding_score
+            )
+            final_score = (
+                merged_score + cfg.search.source_credibility_weight * d["credibility"]
+            )
+            expected_components.append(
+                {
+                    "bm25_score": d["bm25"],
+                    "semantic_score": d["semantic"],
+                    "duckdb_score": 0.0,
+                    "embedding_score": embedding_score,
+                    "merged_score": merged_score,
+                    "credibility_score": d["credibility"],
+                    "relevance_score": final_score,
+                }
+            )
+
+        expected_scores = [c["relevance_score"] for c in expected_components]
+
+        # Verify ranking order
+        expected_order = [
+            idx
+            for _, idx in sorted(
+                zip(expected_scores, range(len(docs))),
+                key=lambda pair: pair[0],
+                reverse=True,
+            )
         ]
+        ranked_order = [r["id"] for r in ranked]
+        assert ranked_order == expected_order, (
+            f"Ranking mismatch for query '{query}': {ranked_order} != {expected_order}"
+        )
+
+        # Verify each result contains the full set of scores
+        for result in ranked:
+            expected = expected_components[result["id"]]
+            for key, value in expected.items():
+                assert key in result, f"Missing '{key}' in ranked result for '{query}'"
+                assert result[key] == pytest.approx(value), (
+                    f"{key} mismatch for doc {result['id']} in query '{query}'"
+                )
+
+        # Ensure the top result is one of the highest scoring documents
         max_score = max(expected_scores)
         top_indices = [
-            i
-            for i, s in enumerate(expected_scores)
-            if abs(s - max_score) <= 1e-9
+            i for i, s in enumerate(expected_scores) if abs(s - max_score) <= 1e-9
         ]
-        assert ranked[0]["id"] in top_indices
+        assert ranked[0]["id"] in top_indices, (
+            f"Top result id {ranked[0]['id']} not in expected top indices {top_indices}"
+        )
+
+
+def test_rank_results_empty_list():
+    """Ranker should gracefully handle empty result lists."""
+    ranked = Search.rank_results("query", [])
+    assert ranked == [], "Expected empty list when no results are provided"

--- a/tests/targeted/test_search_edgecases2.py
+++ b/tests/targeted/test_search_edgecases2.py
@@ -1,21 +1,25 @@
 import types
+
 import pytest
+
 from autoresearch import search
 from autoresearch.errors import ConfigError
 
 
 def test_bm25_fallback(monkeypatch):
-    monkeypatch.setattr(search, "BM25_AVAILABLE", False)
+    monkeypatch.setattr("autoresearch.search.core.BM25_AVAILABLE", False)
     scores = search.Search.calculate_bm25_scores("q", [{"title": "t"}])
-    assert scores == [1.0]
+    assert scores == [1.0], "BM25 fallback should return neutral score"
 
 
 def test_assess_source_credibility():
-    scores = search.Search.assess_source_credibility([
-        {"url": "https://wikipedia.org/Article"},
-        {"url": "https://unknown.domain"},
-    ])
-    assert scores[0] > scores[1]
+    scores = search.Search.assess_source_credibility(
+        [
+            {"url": "https://wikipedia.org/Article"},
+            {"url": "https://unknown.domain"},
+        ]
+    )
+    assert scores[0] > scores[1], "Known domains should have higher credibility scores"
 
 
 def test_rank_results_weight_error(monkeypatch):
@@ -29,5 +33,11 @@ def test_rank_results_weight_error(monkeypatch):
 
     cfg = types.SimpleNamespace(search=SCfg())
     monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
-    with pytest.raises(ConfigError):
+    with pytest.raises(ConfigError, match="sum to 1.0"):
         search.Search.rank_results("q", [{"title": "t", "url": "u"}])
+
+
+def test_rank_results_empty_input():
+    assert search.Search.rank_results("q", []) == [], (
+        "Expected empty list for empty search results"
+    )


### PR DESCRIPTION
## Summary
- validate full relevance score fields and ordering in integration test
- add descriptive assertions and edge case checks for ranking tests
- improve search edge case coverage and messaging

## Testing
- `uv run pytest tests/targeted/test_search_edgecases2.py -q --no-cov`
- `uv run pytest tests/integration/test_relevance_ranking_integration.py -q` *(fails: Coverage failure: total of 19 is less than fail-under=90)*
- `uv run pytest tests/integration/test_relevance_ranking_integration.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_6898d8c2c7c48333b5e35ab5a0264968