### PR TITLE
Reset global state between tests

### DIFF
--- a/issues/0016-implement-better-test-isolation.md
+++ b/issues/0016-implement-better-test-isolation.md
@@ -12,7 +12,12 @@ Ensure tests run independently without shared state or side effects.
 - Shared resources isolated
 
 ## Status
-In progress – see tests/conftest.py
+In progress – fixtures added, but parallel test run shows multiple failures
+
+## Next steps
+- Investigate failing unit tests uncovered by parallel execution
+- Address outstanding failures before closing #16
+- Review isolation status after fixes
 
 ## Related
 - #14

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,6 +179,8 @@ def reset_registries():
     AgentRegistry._registry = agent_reg
     AgentFactory._registry = agent_fact
     LLMFactory._registry = llm_reg
+    AgentFactory.set_delegate(None)
+    set_storage_delegate(None)
 
 
 @pytest.fixture
@@ -223,6 +225,16 @@ def reset_rate_limiting():
     reset_limiter_state()
     reset_request_log()
     yield
+    reset_limiter_state()
+    reset_request_log()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_storage():
+    """Remove any persistent storage state between tests."""
+    storage_teardown(remove_db=True)
+    yield
+    storage_teardown(remove_db=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- reset rate limiter and request log after tests
- clean up storage state between tests
- document remaining isolation work

## Testing
- `uv run ruff format tests/conftest.py`
- `uv run ruff check --fix tests/conftest.py`
- `uv run flake8 tests/conftest.py`
- `uv run pytest tests/unit -n auto -p no:cov -o addopts=''` *(fails: 44 failed, 328 passed, 42 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6898e37de3788333a43aff077d5dc339