### PR TITLE
Add BDD scenarios for messaging and reasoning

### DIFF
--- a/tests/behavior/features/agent_messages.feature
+++ b/tests/behavior/features/agent_messages.feature
@@ -8,3 +8,8 @@ Feature: Agent message exchange
     Given a coalition with a sender and two receivers
     When the sender broadcasts to the coalition
     Then both receivers should process the broadcast
+
+  Scenario: Messaging disabled prevents communication
+    Given two communicating agents without messaging
+    When I execute a query
+    Then the receiver should have no messages

--- a/tests/behavior/features/error_recovery.feature
+++ b/tests/behavior/features/error_recovery.feature
@@ -108,3 +108,8 @@ Feature: Error Recovery
     And no agents should execute
     And the system state should be restored
     And the logs should include "unsupported reasoning mode"
+
+  Scenario: Successful run does not trigger recovery
+    Given a reliable agent
+    When I run the orchestrator on query "recover test"
+    Then no recovery should be recorded

--- a/tests/behavior/features/reasoning_mode.feature
+++ b/tests/behavior/features/reasoning_mode.feature
@@ -7,6 +7,14 @@ Feature: Reasoning Mode Selection
   Background:
     Given loops is set to 2 in configuration
 
+  Scenario: Default reasoning mode is dialectical
+    Given loops is set to 1 in configuration
+    When I run the orchestrator on query "mode test"
+    Then the loops used should be 1
+    And the reasoning mode selected should be "dialectical"
+    And the agent groups should be "Synthesizer; Contrarian; FactChecker"
+    And the agents executed should be "Synthesizer, Contrarian, FactChecker"
+
   Scenario: Direct mode runs Synthesizer only
     Given reasoning mode is "direct"
     When I run the orchestrator on query "mode test"

--- a/tests/behavior/steps/reasoning_mode_steps.py
+++ b/tests/behavior/steps/reasoning_mode_steps.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from pytest_bdd import scenario, given, when, then, parsers
+from pytest_bdd import given, parsers, scenario, then, when
 
-from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel
 from autoresearch.errors import ConfigError, NotFoundError
 from autoresearch.orchestration import ReasoningMode
 from autoresearch.orchestration.orchestrator import Orchestrator
@@ -13,6 +13,11 @@ from autoresearch.orchestration.orchestrator import Orchestrator
 
 @scenario("../features/reasoning_mode.feature", "Direct mode runs Synthesizer only")
 def test_direct_mode():
+    pass
+
+
+@scenario("../features/reasoning_mode.feature", "Default reasoning mode is dialectical")
+def test_default_mode():
     pass
 
 
@@ -105,8 +110,8 @@ def set_primus_start(config: ConfigModel, index: int):
 def run_orchestrator(
     query: str,
     config: ConfigModel,
-    _isolate_network,
-    _restore_environment,
+    isolate_network,
+    restore_environment,
 ):
     record: list[str] = []
     params: dict = {}
@@ -163,8 +168,8 @@ def run_orchestrator_invalid(
     query: str,
     mode: str,
     config: ConfigModel,
-    _isolate_network,
-    _restore_environment,
+    isolate_network,
+    restore_environment,
 ):
     record: list[str] = []
     logs: list[str] = []
@@ -188,8 +193,8 @@ def run_orchestrator_invalid(
 def _run_orchestrator_with_failure(
     query: str,
     config: ConfigModel,
-    _isolate_network,
-    _restore_environment,
+    isolate_network,
+    restore_environment,
     *,
     overflow: bool = False,
 ):
@@ -209,8 +214,8 @@ def _run_orchestrator_with_failure(
         return info
 
     if config.reasoning_mode == ReasoningMode.CHAIN_OF_THOUGHT:
-        from autoresearch.orchestration.state import QueryState
         from autoresearch.orchestration.metrics import OrchestrationMetrics
+        from autoresearch.orchestration.state import QueryState
 
         call_count = 0
 
@@ -340,11 +345,11 @@ def _run_orchestrator_with_failure(
 def run_orchestrator_failure(
     query: str,
     config: ConfigModel,
-    _isolate_network,
-    _restore_environment,
+    isolate_network,
+    restore_environment,
 ):
     return _run_orchestrator_with_failure(
-        query, config, _isolate_network, _restore_environment
+        query, config, isolate_network, restore_environment
     )
 
 
@@ -355,11 +360,11 @@ def run_orchestrator_failure(
 def run_orchestrator_overflow(
     query: str,
     config: ConfigModel,
-    _isolate_network,
-    _restore_environment,
+    isolate_network,
+    restore_environment,
 ):
     return _run_orchestrator_with_failure(
-        query, config, _isolate_network, _restore_environment, overflow=True
+        query, config, isolate_network, restore_environment, overflow=True
     )
 
 


### PR DESCRIPTION
## Summary
- add scenario for agent messaging when communication is disabled
- cover default dialectical reasoning mode
- verify error-free runs record no recovery

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest --no-cov steps/agent_messages_steps.py::test_messaging_disabled steps/reasoning_mode_steps.py::test_default_mode steps/error_recovery_steps.py::test_error_recovery_none`

------
https://chatgpt.com/codex/tasks/task_e_68991fd16b188333be3eb8981872056e