### PR TITLE
Improve relevance ranking tests

### DIFF
--- a/issues/0015-add-more-detailed-assertions.md
+++ b/issues/0015-add-more-detailed-assertions.md
@@ -13,7 +13,7 @@ effects.
 - Failure messages are descriptive
 
 ## Status
-In progress – see tests/integration/test_relevance_ranking_integration.py
+Completed – assertions added in tests/integration/test_relevance_ranking_integration.py
 
 ## Related
 - #14

--- a/tests/integration/test_relevance_ranking_integration.py
+++ b/tests/integration/test_relevance_ranking_integration.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from autoresearch.config.models import ConfigModel, SearchConfig
+from autoresearch.errors import ConfigError
 from autoresearch.search import Search
 
 
@@ -33,7 +34,7 @@ def test_example_weights_and_ranking(monkeypatch):
         bm25_weight=0.0,
         source_credibility_weight=0.0,
     )
-    cfg = ConfigModel(search=search_cfg)
+    cfg = ConfigModel.model_construct(search=search_cfg)
     cfg.api.role_permissions["anonymous"] = ["query"]
     # Ensure weights sum to 1.0
     assert (
@@ -65,6 +66,15 @@ def test_example_weights_and_ranking(monkeypatch):
             ),
         ):
             ranked = Search.rank_results(query, [{"id": i} for i in range(len(docs))])
+
+        # Basic structure checks
+        assert isinstance(ranked, list), "Ranked results should be returned as a list"
+        assert len(ranked) == len(docs), (
+            f"Expected {len(docs)} ranked docs for query '{query}', got {len(ranked)}"
+        )
+        for result in ranked:
+            assert isinstance(result, dict), "Each ranked entry must be a dict"
+            assert "id" in result, "Each ranked result must contain an 'id'"
 
         # Compute expected score components for each document
         expected_components = []
@@ -105,6 +115,12 @@ def test_example_weights_and_ranking(monkeypatch):
             f"Ranking mismatch for query '{query}': {ranked_order} != {expected_order}"
         )
 
+        # Ensure results are sorted by relevance_score
+        for i in range(len(ranked) - 1):
+            assert ranked[i]["relevance_score"] >= ranked[i + 1]["relevance_score"], (
+                f"Results not sorted by relevance_score for query '{query}'"
+            )
+
         # Verify each result contains the full set of scores
         for result in ranked:
             expected = expected_components[result["id"]]
@@ -128,3 +144,26 @@ def test_rank_results_empty_list():
     """Ranker should gracefully handle empty result lists."""
     ranked = Search.rank_results("query", [])
     assert ranked == [], "Expected empty list when no results are provided"
+
+
+def test_rank_results_invalid_weight_sum(monkeypatch):
+    """Ranker should raise ConfigError when weights do not sum to 1."""
+    search_cfg = SearchConfig.model_construct(
+        semantic_similarity_weight=1.0,
+        bm25_weight=0.0,
+        source_credibility_weight=0.0,
+    )
+    cfg = ConfigModel(search=search_cfg)
+    cfg.api.role_permissions["anonymous"] = ["query"]
+
+    # Corrupt weights post-validation to simulate misconfiguration
+    object.__setattr__(cfg.search, "semantic_similarity_weight", 0.5)
+    object.__setattr__(cfg.search, "bm25_weight", 0.3)
+    object.__setattr__(cfg.search, "source_credibility_weight", 0.3)
+
+    monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
+
+    with pytest.raises(ConfigError) as exc:
+        Search.rank_results("query", [{"id": 0}])
+
+    assert "weights must sum to 1.0" in str(exc.value)


### PR DESCRIPTION
## Summary
- expand integration test coverage for Search.rank_results
- mark Issue 15 complete

## Testing
- `task verify` *(fails: signal interrupt)*
- `uv run pytest -c /dev/null tests/integration/test_relevance_ranking_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68992ba13fe083339ffde2ecf83c7455