### PR TITLE
Clarify virtualenv usage and dev extras in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 ## Verification steps
 - Always run tests with `uv run` or inside the activated `.venv`; all tests
   must run inside this environment.
+- Verify the environment by running `which pytest` and ensure it resolves
+  to `.venv/bin/pytest`.
 - Run `task verify` before committing; it performs linting, type checking,
   and all tests with coverage (see [`Taskfile.yml`](Taskfile.yml)).
 - Use `rg` for repository searches instead of `grep -R` or `ls -R`.
@@ -43,9 +45,9 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   - Run the unit suite: `uv run pytest -q`.
   - Execute BDD tests in `tests/behavior`: `uv run pytest tests/behavior`.
   - Run the entire suite with coverage: `uv run pytest --cov=src`.
-- Full test runs, including integration and behavior tests, require optional
-  extras; install them with `uv pip install -e '.[full,parsers,git,llm,dev]'`
-  before running.
+- Before running any tests, install the development extras with
+  `uv pip install -e '.[full,parsers,git,llm,dev]'`. These extras are required
+  for full test runs, including integration and behavior tests.
 - See [tests/behavior/README.md](tests/behavior/README.md) for markers
   such as `requires_ui` and `requires_vss` to select specific scenarios.
 


### PR DESCRIPTION
## Summary
- Emphasize activating the `.venv` or using `uv run` and verifying `which pytest` resolves to the virtualenv.
- Note that development extras must be installed with `uv pip install -e '.[full,parsers,git,llm,dev]'` before running tests.

## Testing
- `which pytest`
- `uv pip install -e '.[full,parsers,git,llm,dev]'`
- `pytest -q` *(incomplete: interrupted after prolonged run)*

------
https://chatgpt.com/codex/tasks/task_e_68993f92d2b883339798d34d22b459a2