### PR TITLE
Refactor orchestrator and API modules into subpackages

### DIFF
--- a/src/autoresearch/api/__init__.py
+++ b/src/autoresearch/api/__init__.py
@@ -3,22 +3,29 @@
 from __future__ import annotations
 
 from . import routing
+from .middleware import (
+    SLOWAPI_STUB,
+    RateLimitExceeded as _RateLimitExceeded,
+    dynamic_limit,
+    get_remote_address,
+    Limiter as _Limiter,
+    parse,
+)
+from .utils import (
+    RequestLogger,
+    create_request_logger,
+    get_request_logger,
+    reset_request_log,
+)
 
 create_app = routing.create_app
 app = routing.app
-SLOWAPI_STUB = routing.SLOWAPI_STUB
-RateLimitExceeded = routing.RateLimitExceeded
-dynamic_limit = routing.dynamic_limit
 config_loader = routing.config_loader
 capabilities_endpoint = routing.capabilities_endpoint
-get_remote_address = routing.get_remote_address
 limiter = routing.limiter
-parse = routing.parse
 query_endpoint = routing.query_endpoint
-create_request_logger = routing.create_request_logger
-get_request_logger = routing.get_request_logger
-RequestLogger = routing.RequestLogger
-reset_request_log = routing.reset_request_log
+RateLimitExceeded = _RateLimitExceeded
+Limiter = _Limiter
 
 __all__ = [
     "app",
@@ -30,6 +37,8 @@ __all__ = [
     "get_remote_address",
     "limiter",
     "parse",
+    "RateLimitExceeded",
+    "Limiter",
     "query_endpoint",
     "create_request_logger",
     "get_request_logger",

--- a/src/autoresearch/api/errors.py
+++ b/src/autoresearch/api/errors.py
@@ -8,7 +8,7 @@ from fastapi.responses import PlainTextResponse, Response
 
 def handle_rate_limit(request: Request, exc: Exception) -> Response:
     """Translate rate limit exceptions into HTTP responses."""
-    from .routing import _rate_limit_exceeded_handler  # type: ignore
+    from .middleware import _rate_limit_exceeded_handler  # type: ignore
 
     result = _rate_limit_exceeded_handler(request, exc)
     if isinstance(result, Response):

--- a/src/autoresearch/api/middleware.py
+++ b/src/autoresearch/api/middleware.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import importlib
+import types
+from typing import Any, Callable, cast
+
+from fastapi import Request, Response
+from fastapi.responses import PlainTextResponse, JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from limits.util import parse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from ..config import ConfigLoader, get_config
+from .errors import handle_rate_limit
+from .utils import RequestLogger
+
+# Lazily import SlowAPI and fall back to a minimal stub when unavailable
+Limiter: Any
+RateLimitExceeded: type[Exception]
+_rate_limit_exceeded_handler: Callable[..., Response]
+Limit: Any
+get_remote_address: Callable[[Request], str]
+
+try:  # pragma: no cover - optional dependency
+    _slowapi_module = importlib.import_module("slowapi")
+    SLOWAPI_STUB = getattr(_slowapi_module, "IS_STUB", False)
+    from slowapi import Limiter as SlowLimiter
+    from slowapi import _rate_limit_exceeded_handler as SlowHandler
+    from slowapi.errors import RateLimitExceeded as SlowRateLimitExceeded
+    from slowapi.util import get_remote_address as SlowGetRemoteAddress
+
+    if not SLOWAPI_STUB:
+        from slowapi.wrappers import Limit as SlowLimit
+
+    Limiter = SlowLimiter
+    RateLimitExceeded = SlowRateLimitExceeded
+    _rate_limit_exceeded_handler = SlowHandler
+    get_remote_address = SlowGetRemoteAddress
+    if not SLOWAPI_STUB:
+        Limit = SlowLimit
+    else:
+        Limit = type("Limit", (), {})
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    SLOWAPI_STUB = True
+
+    class _FallbackRateLimitExceeded(Exception):
+        """Fallback exception raised when the rate limit is exceeded."""
+
+    def _fallback_get_remote_address(request: Request) -> str:
+        return request.client.host if request.client else "unknown"
+
+    class _FallbackLimiter:  # pragma: no cover - simple stub
+        def __init__(self, *_, **__):
+            self.limiter = types.SimpleNamespace(hit=lambda *_a, **_k: True)
+
+        def _inject_headers(self, response: Response, *_a, **_k):
+            return response
+
+    def _fallback_rate_limit_exceeded_handler(*_a: Any, **_k: Any) -> Response:
+        return PlainTextResponse("rate limit exceeded", status_code=429)
+
+    class _FallbackLimit:  # pragma: no cover - simple stub
+        def __init__(self, *_, **__):
+            pass
+
+    RateLimitExceeded = _FallbackRateLimitExceeded
+    get_remote_address = _fallback_get_remote_address
+    Limiter = _FallbackLimiter
+    _rate_limit_exceeded_handler = _fallback_rate_limit_exceeded_handler
+    Limit = _FallbackLimit
+
+
+security = HTTPBearer(auto_error=False)
+
+
+def dynamic_limit() -> str:
+    limit = getattr(get_config().api, "rate_limit", 0)
+    return f"{limit}/minute" if limit > 0 else "1000000/minute"
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """API key and token authentication middleware."""
+
+    def _resolve_role(self, key: str | None, cfg) -> tuple[str, JSONResponse | None]:
+        if cfg.api_keys:
+            role = cfg.api_keys.get(key)
+            if not role:
+                return "anonymous", JSONResponse(
+                    {"detail": "Invalid API key"}, status_code=401
+                )
+            return role, None
+        if cfg.api_key:
+            if key != cfg.api_key:
+                return "anonymous", JSONResponse(
+                    {"detail": "Invalid API key"}, status_code=401
+                )
+            return "user", None
+        return "anonymous", None
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path in {"/docs", "/openapi.json"}:
+            return await call_next(request)
+        loader = cast(ConfigLoader, request.app.state.config_loader)
+        loader._config = loader.load_config()
+        cfg = loader._config.api
+        role, error = self._resolve_role(request.headers.get("X-API-Key"), cfg)
+        if error:
+            return error
+        request.state.role = role
+        request.state.permissions = set(cfg.role_permissions.get(role, []))
+        if cfg.bearer_token:
+            credentials: HTTPAuthorizationCredentials | None = await security(request)
+            token = credentials.credentials if credentials else None
+            if token != cfg.bearer_token:
+                return JSONResponse({"detail": "Invalid token"}, status_code=401)
+        return await call_next(request)
+
+
+class FallbackRateLimitMiddleware(BaseHTTPMiddleware):
+    """Simplified rate limiting used when SlowAPI is unavailable."""
+
+    def __init__(self, app, request_logger: RequestLogger, limiter: Limiter):
+        super().__init__(app)
+        self.request_logger = request_logger
+        self.limiter = limiter
+
+    async def dispatch(self, request: Request, call_next):
+        cfg_limit = getattr(get_config().api, "rate_limit", 0)
+        if cfg_limit:
+            ip = get_remote_address(request)
+            count = self.request_logger.log(ip)
+            limit_obj = parse(dynamic_limit())
+            request.state.view_rate_limit = (limit_obj, [ip])
+            if count > cfg_limit:
+                if SLOWAPI_STUB:
+                    return handle_rate_limit(
+                        request, RateLimitExceeded(cast("Limit", None))
+                    )
+                limit_wrapper = Limit(
+                    limit_obj,
+                    get_remote_address,
+                    None,
+                    False,
+                    None,
+                    None,
+                    None,
+                    1,
+                    False,
+                )
+                return handle_rate_limit(request, RateLimitExceeded(limit_wrapper))
+        response = await call_next(request)
+        if cfg_limit and not SLOWAPI_STUB:
+            response = self.limiter._inject_headers(
+                response, request.state.view_rate_limit
+            )
+        return response
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Rate limiting using SlowAPI's limiter with dynamic configuration."""
+
+    def __init__(self, app, request_logger: RequestLogger, limiter: Limiter):
+        super().__init__(app)
+        self.request_logger = request_logger
+        self.limiter = limiter
+
+    async def dispatch(self, request: Request, call_next):
+        cfg_limit = getattr(get_config().api, "rate_limit", 0)
+        if cfg_limit:
+            ip = get_remote_address(request)
+            count = self.request_logger.log(ip)
+            limit_obj = parse(dynamic_limit())
+            request.state.view_rate_limit = (limit_obj, [ip])
+            if not self.limiter.limiter.hit(limit_obj, ip) or count > cfg_limit:
+                limit_wrapper = Limit(
+                    limit_obj,
+                    get_remote_address,
+                    None,
+                    False,
+                    None,
+                    None,
+                    None,
+                    1,
+                    False,
+                )
+                return handle_rate_limit(request, RateLimitExceeded(limit_wrapper))
+            response = await call_next(request)
+            return self.limiter._inject_headers(response, request.state.view_rate_limit)
+        return await call_next(request)

--- a/src/autoresearch/api/utils.py
+++ b/src/autoresearch/api/utils.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections import Counter
+import threading
+from typing import cast
+
+from fastapi import FastAPI
+
+
+class RequestLogger:
+    """Thread-safe per-client request logger."""
+
+    def __init__(self) -> None:
+        self._log: Counter[str] = Counter()
+        self._lock = threading.Lock()
+
+    def log(self, ip: str) -> int:
+        with self._lock:
+            self._log[ip] += 1
+            return self._log[ip]
+
+    def reset(self) -> None:
+        with self._lock:
+            self._log.clear()
+
+    def get(self, ip: str) -> int:
+        with self._lock:
+            return self._log[ip]
+
+    def snapshot(self) -> dict[str, int]:
+        with self._lock:
+            return dict(self._log)
+
+
+def create_request_logger() -> RequestLogger:
+    """Factory for creating a new :class:`RequestLogger` instance."""
+    return RequestLogger()
+
+
+def get_request_logger(app: FastAPI | None = None) -> RequestLogger:
+    """Retrieve the application's request logger."""
+    if app is None:
+        app = cast(FastAPI | None, globals().get("app"))
+        if app is None:
+            return create_request_logger()
+    return cast(RequestLogger, app.state.request_logger)
+
+
+def reset_request_log(app: FastAPI | None = None) -> None:
+    """Clear the application's request log."""
+    get_request_logger(app).reset()

--- a/src/autoresearch/orchestration/budgeting.py
+++ b/src/autoresearch/orchestration/budgeting.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from ..config.models import ConfigModel
+
+
+def _apply_adaptive_token_budget(config: ConfigModel, query: str) -> None:
+    """Adjust ``config.token_budget`` based on query complexity and loops."""
+    budget = getattr(config, "token_budget", None)
+    if budget is None:
+        return
+
+    loops = getattr(config, "loops", 1)
+    if loops > 1:
+        budget = max(1, budget // loops)
+
+    query_tokens = len(query.split())
+    factor = getattr(config, "adaptive_max_factor", 20)
+    buffer = getattr(config, "adaptive_min_buffer", 10)
+    max_budget = query_tokens * factor
+    if budget > max_budget:
+        config.token_budget = max_budget
+    elif budget < query_tokens:
+        config.token_budget = query_tokens + buffer
+    else:
+        config.token_budget = budget

--- a/src/autoresearch/orchestration/error_handling.py
+++ b/src/autoresearch/orchestration/error_handling.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import time
+import traceback
+from typing import Dict
+
+from ..errors import AgentError, NotFoundError, OrchestrationError, TimeoutError
+from ..logging_utils import get_logger
+from .metrics import OrchestrationMetrics
+from .state import QueryState
+
+log = get_logger(__name__)
+
+
+def _categorize_error(e: Exception) -> str:
+    """Categorize an error for appropriate handling."""
+    if isinstance(e, TimeoutError):
+        return "transient"
+    if isinstance(e, NotFoundError):
+        return "recoverable"
+    if isinstance(e, AgentError):
+        error_str = str(e).lower()
+        if any(term in error_str for term in ["retry", "temporary", "timeout", "rate limit"]):
+            return "transient"
+        if any(term in error_str for term in ["configuration", "invalid input", "format"]):
+            return "recoverable"
+        return "critical"
+    if isinstance(e, OrchestrationError):
+        return "critical"
+    return "critical"
+
+
+def _apply_recovery_strategy(
+    agent_name: str, error_category: str, e: Exception, state: QueryState
+) -> dict:
+    """Apply an appropriate recovery strategy based on error category."""
+    if error_category == "transient":
+        recovery_strategy = "retry_with_backoff"
+        suggestion = "This error is likely temporary. The system will automatically retry with backoff."
+        fallback_result = {
+            "claims": [
+                f"Agent {agent_name} encountered a temporary error: {str(e)}"
+            ],
+            "results": {
+                "fallback": (
+                    f"The {agent_name} agent encountered a temporary issue. "
+                    "This is likely due to external factors and may resolve on retry."
+                )
+            },
+            "metadata": {
+                "recovery_applied": True,
+                "recovery_strategy": recovery_strategy,
+            },
+        }
+        state.update(fallback_result)
+        log.info(
+            f"Applied '{recovery_strategy}' recovery strategy for agent {agent_name}",
+            extra={"agent": agent_name, "recovery_strategy": recovery_strategy},
+        )
+    elif error_category == "recoverable":
+        recovery_strategy = "fallback_agent"
+        suggestion = "This error indicates a configuration or input issue. A fallback approach will be used."
+        fallback_result = {
+            "claims": [
+                f"Agent {agent_name} encountered a recoverable error: {str(e)}"
+            ],
+            "results": {
+                "fallback": (
+                    f"The {agent_name} agent encountered an issue that prevented it from completing normally. "
+                    "A simplified approach has been used instead."
+                )
+            },
+            "metadata": {
+                "recovery_applied": True,
+                "recovery_strategy": recovery_strategy,
+            },
+        }
+        state.update(fallback_result)
+        log.info(
+            f"Applied '{recovery_strategy}' recovery strategy for agent {agent_name}",
+            extra={"agent": agent_name, "recovery_strategy": recovery_strategy},
+        )
+    else:
+        recovery_strategy = "fail_gracefully"
+        suggestion = "This is a critical error that requires attention. Check the logs for details."
+        error_result = {
+            "claims": [
+                f"Agent {agent_name} encountered a critical error: {str(e)}"
+            ],
+            "results": {
+                "error": (
+                    f"The {agent_name} agent encountered a critical error that prevented completion. "
+                    "This requires investigation."
+                )
+            },
+            "metadata": {
+                "recovery_applied": True,
+                "recovery_strategy": recovery_strategy,
+                "critical_error": True,
+            },
+        }
+        state.update(error_result)
+        log.warning(
+            f"Applied '{recovery_strategy}' recovery strategy for agent {agent_name}",
+            extra={"agent": agent_name, "recovery_strategy": recovery_strategy},
+        )
+    return {"recovery_strategy": recovery_strategy, "suggestion": suggestion}
+
+
+def _handle_agent_error(
+    agent_name: str, e: Exception, state: QueryState, metrics: OrchestrationMetrics
+) -> Dict[str, object]:
+    """Handle agent errors with granular recovery strategies."""
+    error_category = _categorize_error(e)
+    error_info: Dict[str, object] = {
+        "agent": agent_name,
+        "error": str(e),
+        "error_type": type(e).__name__,
+        "error_category": error_category,
+        "traceback": traceback.format_exc(),
+        "timestamp": time.time(),
+    }
+    metrics.record_error(agent_name)
+    if error_category == "critical":
+        log.critical(
+            f"Critical error during agent {agent_name} execution: {str(e)}",
+            exc_info=True,
+            extra={"error_info": error_info},
+        )
+    elif error_category == "recoverable":
+        log.error(
+            f"Recoverable error during agent {agent_name} execution: {str(e)}",
+            exc_info=True,
+            extra={"error_info": error_info},
+        )
+    else:
+        log.warning(
+            f"Transient error during agent {agent_name} execution: {str(e)}",
+            exc_info=True,
+            extra={"error_info": error_info},
+        )
+    recovery_info = _apply_recovery_strategy(agent_name, error_category, e, state)
+    error_info.update(recovery_info)
+    return error_info

--- a/src/autoresearch/orchestration/execution.py
+++ b/src/autoresearch/orchestration/execution.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Callable, Dict, List
+
+import rdflib
+
+from ..agents.registry import AgentFactory
+from ..config.models import ConfigModel
+from ..errors import (
+    AgentError,
+    NotFoundError,
+    OrchestrationError,
+    StorageError,
+    TimeoutError,
+)
+from ..logging_utils import get_logger
+from ..storage import StorageManager
+from .circuit_breaker import CircuitBreakerManager
+from .error_handling import _handle_agent_error
+from .metrics import OrchestrationMetrics
+from .state import QueryState
+from .token_utils import _capture_token_usage as capture_token_usage
+from .token_utils import _execute_with_adapter as execute_with_adapter
+
+log = get_logger(__name__)
+
+
+def _get_agent(agent_name: str, agent_factory: type[AgentFactory]) -> Any:
+    """Get an agent instance from the factory."""
+    try:
+        return agent_factory.get(agent_name)
+    except Exception as e:  # pragma: no cover - defensive
+        raise NotFoundError(
+            f"Agent '{agent_name}' not found",
+            resource_type="agent",
+            resource_id=agent_name,
+            cause=e,
+        )
+
+
+def _check_agent_can_execute(
+    agent: Any, agent_name: str, state: QueryState, config: ConfigModel
+) -> bool:
+    """Check if an agent can execute."""
+    if not agent.can_execute(state, config):
+        log.info(f"Agent {agent_name} skipped execution (can_execute=False)")
+        return False
+    return True
+
+
+def _log_agent_execution(agent_name: str, state: QueryState, loop: int) -> None:
+    """Log agent execution start."""
+    log.info(
+        f"Executing agent: {agent_name} (loop {loop + 1}, cycle {state.cycle})",
+        extra={
+            "agent": agent_name,
+            "loop": loop + 1,
+            "cycle": state.cycle,
+            "query": state.query[:100] + "..." if len(state.query) > 100 else state.query,
+        },
+    )
+
+
+def _deliver_messages(agent_name: str, state: QueryState, config: ConfigModel) -> None:
+    """Record messages destined for the given agent."""
+    if not getattr(config, "enable_agent_messages", False):
+        return
+    msgs = state.get_messages(recipient=agent_name)
+    if not msgs:
+        return
+    delivered = state.metadata.setdefault("delivered_messages", {}).setdefault(
+        agent_name, []
+    )
+    delivered.extend(msgs)
+    log.debug(
+        f"Delivered {len(msgs)} messages to {agent_name}",
+        extra={"agent": agent_name, "message_count": len(msgs)},
+    )
+
+
+def _call_agent_start_callback(
+    agent_name: str, state: QueryState, callbacks: Dict[str, Callable[..., None]]
+) -> None:
+    """Call the on_agent_start callback if it exists."""
+    if callbacks.get("on_agent_start"):
+        log.debug(f"Calling on_agent_start callback for {agent_name}")
+        callbacks["on_agent_start"](agent_name, state)
+
+
+def _execute_agent_with_token_counting(
+    agent: Any,
+    agent_name: str,
+    state: QueryState,
+    config: ConfigModel,
+    metrics: OrchestrationMetrics,
+) -> Dict[str, Any]:
+    """Execute an agent with token counting."""
+    try:
+        log.debug(f"Starting token counting for {agent_name}")
+        with capture_token_usage(agent_name, metrics, config) as (
+            token_counter,
+            wrapped_adapter,
+        ):
+            log.debug(
+                f"Executing {agent_name}.execute() with token counting adapter"
+            )
+            result = execute_with_adapter(agent, state, config, wrapped_adapter)
+            log.debug(f"Finished {agent_name}.execute()")
+        return result
+    except TimeoutError:
+        log.error(f"Timeout during {agent_name} execution")
+        raise
+    except AgentError as e:
+        log.error(
+            f"Error during {agent_name} execution: {str(e)}",
+            exc_info=True,
+            extra={"agent": agent_name, "error": str(e)},
+        )
+        raise
+
+
+def _handle_agent_completion(
+    agent_name: str,
+    result: Dict[str, Any],
+    state: QueryState,
+    metrics: OrchestrationMetrics,
+    callbacks: Dict[str, Callable[..., None]],
+    duration: float,
+    loop: int,
+) -> None:
+    """Handle agent completion (timing, callbacks, logging)."""
+    metrics.record_agent_timing(agent_name, duration)
+    if callbacks.get("on_agent_end"):
+        log.debug(f"Calling on_agent_end callback for {agent_name}")
+        callbacks["on_agent_end"](agent_name, result, state)
+    log.info(
+        f"Agent {agent_name} completed turn (loop {loop + 1}, cycle {state.cycle}) in {duration:.2f}s",
+        extra={
+            "agent": agent_name,
+            "loop": loop + 1,
+            "cycle": state.cycle,
+            "duration": duration,
+            "has_claims": "claims" in result and bool(result["claims"]),
+            "has_sources": "sources" in result and bool(result["sources"]),
+            "result_keys": list(result.keys()),
+        },
+    )
+
+
+def _log_sources(agent_name: str, result: Dict[str, Any]) -> None:
+    """Log sources with context."""
+    if "sources" in result and result["sources"]:
+        source_count = len(result["sources"])
+        log.info(
+            f"Agent {agent_name} provided {source_count} sources",
+            extra={
+                "agent": agent_name,
+                "source_count": source_count,
+                "sources": [
+                    s.get("title", "Untitled") if isinstance(s, dict) else str(s)
+                    for s in result["sources"][:5]
+                ],
+            },
+        )
+    else:
+        log.warning(
+            f"Agent {agent_name} provided no sources",
+            extra={"agent": agent_name, "result_keys": list(result.keys())},
+        )
+
+
+def _persist_claims(
+    agent_name: str, result: Dict[str, Any], storage_manager: type[StorageManager]
+) -> None:
+    """Persist claims with error handling."""
+    try:
+        claims = result.get("claims", [])
+        if claims:
+            log.debug(
+                f"Persisting {len(claims)} claims for agent {agent_name}",
+                extra={"agent": agent_name, "claim_count": len(claims)},
+            )
+            for i, claim in enumerate(claims):
+                if isinstance(claim, dict) and "id" in claim:
+                    log.debug(
+                        f"Persisting claim {i + 1}/{len(claims)}: {claim.get('id')}"
+                    )
+                    storage_manager.persist_claim(claim)
+                else:
+                    log.warning(
+                        f"Skipping invalid claim format from agent {agent_name}",
+                        extra={
+                            "agent": agent_name,
+                            "claim_index": i,
+                            "claim_type": type(claim).__name__,
+                            "has_id": isinstance(claim, dict) and "id" in claim,
+                        },
+                    )
+    except (StorageError, rdflib.exceptions.Error, ValueError) as e:
+        log.warning(
+            f"Error persisting claims for agent {agent_name}: {str(e)}",
+            exc_info=True,
+            extra={"agent": agent_name, "error": str(e)},
+        )
+
+
+def _execute_agent(
+    agent_name: str,
+    state: QueryState,
+    config: ConfigModel,
+    metrics: OrchestrationMetrics,
+    callbacks: Dict[str, Callable[..., None]],
+    agent_factory: type[AgentFactory],
+    storage_manager: type[StorageManager],
+    loop: int,
+    cb_manager: CircuitBreakerManager,
+) -> None:
+    """Execute a single agent and update state with results."""
+    retries = getattr(config, "retry_attempts", 1)
+    backoff = getattr(config, "retry_backoff", 0.0)
+    breaker_state = cb_manager.get_circuit_breaker_state(agent_name)
+    if breaker_state.get("state") == "open":
+        error_info = {
+            "agent": agent_name,
+            "error": "Circuit breaker open",
+            "error_type": "CircuitBreakerOpen",
+            "error_category": "critical",
+            "traceback": "",
+            "timestamp": time.time(),
+        }
+        state.add_error(error_info)
+        metrics.record_error(agent_name)
+        metrics.record_circuit_breaker(agent_name, breaker_state)
+        return
+    for attempt in range(retries):
+        try:
+            agent = _get_agent(agent_name, agent_factory)
+            if not _check_agent_can_execute(agent, agent_name, state, config):
+                return
+            _deliver_messages(agent_name, state, config)
+            _log_agent_execution(agent_name, state, loop)
+            _call_agent_start_callback(agent_name, state, callbacks)
+            start_time = time.time()
+            result = _execute_agent_with_token_counting(
+                agent, agent_name, state, config, metrics
+            )
+            duration = time.time() - start_time
+            _handle_agent_completion(
+                agent_name, result, state, metrics, callbacks, duration, loop
+            )
+            state.update(result)
+            _log_sources(agent_name, result)
+            _persist_claims(agent_name, result, storage_manager)
+            cb_manager.handle_agent_success(agent_name)
+            metrics.record_circuit_breaker(
+                agent_name, cb_manager.get_circuit_breaker_state(agent_name)
+            )
+            return
+        except (
+            AgentError,
+            TimeoutError,
+            NotFoundError,
+            OrchestrationError,
+            ValueError,
+            RuntimeError,
+        ) as e:
+            error_info = _handle_agent_error(agent_name, e, state, metrics)
+            state.add_error(error_info)
+            category = str(error_info.get("error_category", "critical"))
+            cb_manager.update_circuit_breaker(agent_name, category)
+            metrics.record_circuit_breaker(
+                agent_name, cb_manager.get_circuit_breaker_state(agent_name)
+            )
+            if (
+                attempt < retries - 1
+                and error_info.get("error_category") == "transient"
+            ):
+                sleep_time = backoff * (2**attempt)
+                if sleep_time > 0:
+                    time.sleep(sleep_time)
+                continue
+            break
+
+
+def _rotate_list(items: List[Any], start_idx: int) -> List[Any]:
+    """Rotate a list so that start_idx becomes the first element."""
+    if not items:
+        return []
+    start_idx = start_idx % len(items)
+    return items[start_idx:] + items[:start_idx]
+
+
+def _execute_cycle(
+    loop: int,
+    loops: int,
+    agents: List[List[str]],
+    primus_index: int,
+    max_errors: int,
+    state: QueryState,
+    config: ConfigModel,
+    metrics: OrchestrationMetrics,
+    callbacks: Dict[str, Callable[..., None]],
+    agent_factory: type[AgentFactory],
+    storage_manager: type[StorageManager],
+    tracer: Any,
+    cb_manager: CircuitBreakerManager,
+) -> int:
+    """Execute a single dialectical cycle."""
+    with tracer.start_as_current_span(
+        "cycle",
+        attributes={"cycle": loop},
+    ):
+        log.info(f"Starting loop {loop + 1}/{loops}")
+        metrics.start_cycle()
+        if callbacks.get("on_cycle_start"):
+            callbacks["on_cycle_start"](loop, state)
+        order = _rotate_list(agents, primus_index)
+        for group in order:
+            for agent_name in group:
+                if state.error_count >= max_errors:
+                    log.warning(
+                        "Skipping remaining agents due to error threshold "
+                        f"({max_errors}) reached"
+                    )
+                    break
+                from .orchestrator import Orchestrator
+
+                Orchestrator._execute_agent(  # type: ignore[attr-defined]
+                    agent_name,
+                    state,
+                    config,
+                    metrics,
+                    callbacks,
+                    agent_factory,
+                    storage_manager,
+                    loop,
+                    cb_manager,
+                )
+            if state.error_count >= max_errors:
+                break
+        metrics.end_cycle()
+        state.metadata["execution_metrics"] = metrics.get_summary()
+        metrics.record_query_tokens(state.query)
+        token_budget = getattr(config, "token_budget", None)
+        if token_budget is not None:
+            config.token_budget = metrics.suggest_token_budget(token_budget)
+        state.prune_context()
+        if callbacks.get("on_cycle_end"):
+            callbacks["on_cycle_end"](loop, state)
+        if state.error_count >= max_errors:
+            log.error(
+                "Aborting dialectical process due to error "
+                f"threshold reached ({state.error_count}/{max_errors})"
+            )
+            state.results["error"] = (
+                f"Process aborted after {state.error_count} errors"
+            )
+            return primus_index
+        state.cycle += 1
+        primus_index = (primus_index + 1) % len(agents)
+        state.primus_index = primus_index
+        return primus_index
+
+
+async def _execute_cycle_async(
+    loop: int,
+    loops: int,
+    agents: List[List[str]],
+    primus_index: int,
+    max_errors: int,
+    state: QueryState,
+    config: ConfigModel,
+    metrics: OrchestrationMetrics,
+    callbacks: Dict[str, Callable[..., None]],
+    agent_factory: type[AgentFactory],
+    storage_manager: type[StorageManager],
+    tracer: Any,
+    *,
+    concurrent: bool = False,
+    cb_manager: CircuitBreakerManager,
+) -> int:
+    """Asynchronous version of ``_execute_cycle``."""
+    with tracer.start_as_current_span(
+        "cycle",
+        attributes={"cycle": loop},
+    ):
+        log.info(f"Starting loop {loop + 1}/{loops}")
+        metrics.start_cycle()
+        if callbacks.get("on_cycle_start"):
+            callbacks["on_cycle_start"](loop, state)
+        order = _rotate_list(agents, primus_index)
+
+        async def run_agent(name: str) -> None:
+            if state.error_count >= max_errors:
+                return
+            from .orchestrator import Orchestrator
+
+            await asyncio.to_thread(
+                Orchestrator._execute_agent,  # type: ignore[attr-defined]
+                name,
+                state,
+                config,
+                metrics,
+                callbacks,
+                agent_factory,
+                storage_manager,
+                loop,
+                cb_manager,
+            )
+
+        if concurrent:
+            for group in order:
+                await asyncio.gather(*(run_agent(a) for a in group))
+                if state.error_count >= max_errors:
+                    break
+        else:
+            for group in order:
+                for agent_name in group:
+                    if state.error_count >= max_errors:
+                        log.warning(
+                            "Skipping remaining agents due to error threshold "
+                            f"({max_errors}) reached"
+                        )
+                        break
+                    await run_agent(agent_name)
+                if state.error_count >= max_errors:
+                    break
+
+        metrics.end_cycle()
+        state.metadata["execution_metrics"] = metrics.get_summary()
+        token_budget = getattr(config, "token_budget", None)
+        if token_budget is not None:
+            config.token_budget = metrics.suggest_token_budget(token_budget)
+        state.prune_context()
+        if callbacks.get("on_cycle_end"):
+            callbacks["on_cycle_end"](loop, state)
+        if state.error_count >= max_errors:
+            log.error(
+                "Aborting dialectical process due to error "
+                f"threshold reached ({state.error_count}/{max_errors})"
+            )
+            state.results["error"] = (
+                f"Process aborted after {state.error_count} errors"
+            )
+            return primus_index
+        state.cycle += 1
+        primus_index = (primus_index + 1) % len(agents)
+        state.primus_index = primus_index
+        return primus_index

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -4,54 +4,49 @@ Orchestration system coordinating multi-agent dialectical cycles.
 Provides direct, dialectical, and chain-of-thought reasoning modes with
 state management, metrics, token tracking, and parallel execution. Behavior
 is exercised by unit and integration tests under ``tests/``.
-
-This module provides the core orchestration functionality for the Autoresearch system,
-coordinating the execution of multiple agents in a dialectical reasoning process.
-The orchestration system supports different reasoning modes:
-
-1. Direct: Uses only a single agent (typically the Synthesizer)
-2. Dialectical: Rotates through multiple agents in a thesis→antithesis→synthesis cycle
-3. Chain-of-thought: Loops a single agent (typically the Synthesizer) multiple times
-
-The Orchestrator class handles:
-- Executing agents in the correct order based on the reasoning mode
-- Managing state between agent executions
-- Collecting and reporting metrics
-- Error handling and recovery
-- Token usage tracking
-- Parallel execution of agent groups
-
-The system is designed to be extensible, allowing for custom agents, reasoning modes,
-and execution strategies.
 """
 
+from __future__ import annotations
+
 import asyncio
-import time
-import traceback
-from typing import (
-    Any,
-    Callable,
-    ContextManager,
-    Dict,
-    List,
-)
+from typing import Any, Callable, Dict, List
 
 import rdflib
 
 from ..agents.registry import AgentFactory, AgentRegistry
 from ..config.models import ConfigModel
-from ..errors import (
+from ..errors import (  # noqa: F401
     AgentError,
     NotFoundError,
     OrchestrationError,
-    StorageError,
     TimeoutError,
 )
 from ..logging_utils import get_logger
 from ..models import QueryResponse
 from ..storage import StorageManager
 from ..tracing import get_tracer, setup_tracing
+from .budgeting import _apply_adaptive_token_budget
 from .circuit_breaker import CircuitBreakerManager, CircuitBreakerState
+from .execution import (
+    _call_agent_start_callback,
+    _check_agent_can_execute,
+    _deliver_messages,
+    _execute_agent,
+    _execute_agent_with_token_counting,
+    _execute_cycle,
+    _execute_cycle_async,
+    _get_agent,
+    _handle_agent_completion,
+    _log_agent_execution,
+    _log_sources,
+    _persist_claims,
+    _rotate_list,
+)
+from .error_handling import (
+    _apply_recovery_strategy,
+    _categorize_error,
+    _handle_agent_error,
+)
 from .metrics import OrchestrationMetrics, record_query
 from .reasoning import ChainOfThoughtStrategy, ReasoningMode
 from .state import QueryState
@@ -65,17 +60,11 @@ log = get_logger(__name__)
 class Orchestrator:
     """Coordinates multi-agent dialectical cycles with rotating Primus."""
 
+    _cb_manager: CircuitBreakerManager | None = None
+
     @staticmethod
     def _parse_config(config: ConfigModel) -> Dict[str, Any]:
-        """Parse configuration and extract relevant parameters.
-
-        Args:
-            config: System configuration
-
-        Returns:
-            Dictionary with parsed configuration parameters
-        """
-        # Get enabled agents and reasoning mode from config
+        """Parse configuration and extract relevant parameters."""
         agents = getattr(
             config,
             "agents",
@@ -95,7 +84,6 @@ class Orchestrator:
             AgentRegistry.create_coalition(cname, members)
         enable_feedback = getattr(config, "enable_feedback", False)
 
-        # Adjust parameters based on reasoning mode
         agent_groups: List[List[str]] = []
         if mode == ReasoningMode.DIRECT:
             agents = ["Synthesizer"]
@@ -126,488 +114,6 @@ class Orchestrator:
         }
 
     @staticmethod
-    def _get_agent(agent_name: str, agent_factory: type[AgentFactory]) -> Any:
-        """Get an agent instance from the factory.
-
-        Args:
-            agent_name: Name of the agent to get
-            agent_factory: Factory for creating agent instances
-
-        Returns:
-            The agent instance
-
-        Raises:
-            NotFoundError: If agent cannot be found
-        """
-        try:
-            return agent_factory.get(agent_name)
-        except Exception as e:  # pragma: no cover - defensive
-            # Wrap factory errors in NotFoundError to provide consistent error handling
-            raise NotFoundError(
-                f"Agent '{agent_name}' not found",
-                resource_type="agent",
-                resource_id=agent_name,
-                cause=e,
-            )
-
-    @staticmethod
-    def _check_agent_can_execute(
-        agent: Any, agent_name: str, state: QueryState, config: ConfigModel
-    ) -> bool:
-        """Check if an agent can execute.
-
-        Args:
-            agent: The agent to check
-            agent_name: Name of the agent
-            state: Current query state
-            config: System configuration
-
-        Returns:
-            True if the agent can execute, False otherwise
-        """
-        if not agent.can_execute(state, config):
-            log.info(f"Agent {agent_name} skipped execution (can_execute=False)")
-            return False
-        return True
-
-    @staticmethod
-    def _log_agent_execution(agent_name: str, state: QueryState, loop: int) -> None:
-        """Log agent execution start.
-
-        Args:
-            agent_name: Name of the agent
-            state: Current query state
-            loop: Current loop number
-        """
-        log.info(
-            f"Executing agent: {agent_name} (loop {loop + 1}, cycle {state.cycle})",
-            extra={
-                "agent": agent_name,
-                "loop": loop + 1,
-                "cycle": state.cycle,
-                "query": state.query[:100] + "..."
-                if len(state.query) > 100
-                else state.query,
-            },
-        )
-
-    @staticmethod
-    def _deliver_messages(
-        agent_name: str, state: QueryState, config: ConfigModel
-    ) -> None:
-        """Record messages destined for the given agent."""
-
-        if not getattr(config, "enable_agent_messages", False):
-            return
-
-        msgs = state.get_messages(recipient=agent_name)
-        if not msgs:
-            return
-        delivered = state.metadata.setdefault("delivered_messages", {}).setdefault(
-            agent_name, []
-        )
-        delivered.extend(msgs)
-        log.debug(
-            f"Delivered {len(msgs)} messages to {agent_name}",
-            extra={"agent": agent_name, "message_count": len(msgs)},
-        )
-
-    @staticmethod
-    def _call_agent_start_callback(
-        agent_name: str, state: QueryState, callbacks: Dict[str, Callable[..., None]]
-    ) -> None:
-        """Call the on_agent_start callback if it exists.
-
-        Args:
-            agent_name: Name of the agent
-            state: Current query state
-            callbacks: Callbacks for monitoring execution
-        """
-        if callbacks.get("on_agent_start"):
-            log.debug(f"Calling on_agent_start callback for {agent_name}")
-            callbacks["on_agent_start"](agent_name, state)
-
-    @staticmethod
-    def _execute_agent_with_token_counting(
-        agent: Any,
-        agent_name: str,
-        state: QueryState,
-        config: ConfigModel,
-        metrics: OrchestrationMetrics,
-    ) -> Dict[str, Any]:
-        """Execute an agent with token counting.
-
-        Args:
-            agent: The agent to execute
-            agent_name: Name of the agent
-            state: Current query state
-            config: System configuration
-            metrics: Metrics collector
-
-        Returns:
-            The result of agent execution
-
-        Raises:
-            TimeoutError: If agent execution times out
-            AgentError: If agent execution fails
-        """
-        try:
-            log.debug(f"Starting token counting for {agent_name}")
-            with Orchestrator._capture_token_usage(agent_name, metrics, config) as (
-                token_counter,
-                wrapped_adapter,
-            ):
-                log.debug(
-                    f"Executing {agent_name}.execute() with token counting adapter"
-                )
-                # Inject the wrapped adapter into the agent's context
-                result = Orchestrator._execute_with_adapter(
-                    agent, state, config, wrapped_adapter
-                )
-                log.debug(f"Finished {agent_name}.execute()")
-            return result
-        except TimeoutError:
-            log.error(f"Timeout during {agent_name} execution")
-            raise
-        except AgentError as e:
-            log.error(
-                f"Error during {agent_name} execution: {str(e)}",
-                exc_info=True,
-                extra={"agent": agent_name, "error": str(e)},
-            )
-            raise
-
-    @staticmethod
-    def _handle_agent_completion(
-        agent_name: str,
-        result: Dict[str, Any],
-        state: QueryState,
-        metrics: OrchestrationMetrics,
-        callbacks: Dict[str, Callable[..., None]],
-        duration: float,
-        loop: int,
-    ) -> None:
-        """Handle agent completion (timing, callbacks, logging).
-
-        Args:
-            agent_name: Name of the agent
-            result: Result of agent execution
-            state: Current query state
-            metrics: Metrics collector
-            callbacks: Callbacks for monitoring execution
-            duration: Duration of agent execution
-            loop: Current loop number
-        """
-        # Record timing
-        metrics.record_agent_timing(agent_name, duration)
-
-        # Call on_agent_end callback
-        if callbacks.get("on_agent_end"):
-            log.debug(f"Calling on_agent_end callback for {agent_name}")
-            callbacks["on_agent_end"](
-                agent_name,
-                result,
-                state,
-            )
-
-        # Log completion with detailed context
-        log.info(
-            f"Agent {agent_name} completed turn "
-            f"(loop {loop + 1}, cycle {state.cycle}) "
-            f"in {duration:.2f}s",
-            extra={
-                "agent": agent_name,
-                "loop": loop + 1,
-                "cycle": state.cycle,
-                "duration": duration,
-                "has_claims": "claims" in result and bool(result["claims"]),
-                "has_sources": "sources" in result and bool(result["sources"]),
-                "result_keys": list(result.keys()),
-            },
-        )
-
-    @staticmethod
-    def _log_sources(agent_name: str, result: Dict[str, Any]) -> None:
-        """Log sources with context.
-
-        Args:
-            agent_name: Name of the agent
-            result: Result of agent execution
-        """
-        if "sources" in result and result["sources"]:
-            source_count = len(result["sources"])
-            log.info(
-                f"Agent {agent_name} provided {source_count} sources",
-                extra={
-                    "agent": agent_name,
-                    "source_count": source_count,
-                    "sources": [
-                        s.get("title", "Untitled") if isinstance(s, dict) else str(s)
-                        for s in result["sources"][:5]  # Log first 5 sources only
-                    ],
-                },
-            )
-        else:
-            log.warning(
-                f"Agent {agent_name} provided no sources",
-                extra={"agent": agent_name, "result_keys": list(result.keys())},
-            )
-
-    @staticmethod
-    def _persist_claims(
-        agent_name: str, result: Dict[str, Any], storage_manager: type[StorageManager]
-    ) -> None:
-        """Persist claims with error handling.
-
-        Args:
-            agent_name: Name of the agent
-            result: Result of agent execution
-            storage_manager: Storage manager for persisting claims
-        """
-        try:
-            claims = result.get("claims", [])
-            if claims:
-                log.debug(
-                    f"Persisting {len(claims)} claims for agent {agent_name}",
-                    extra={"agent": agent_name, "claim_count": len(claims)},
-                )
-                for i, claim in enumerate(claims):
-                    if isinstance(claim, dict) and "id" in claim:
-                        log.debug(
-                            f"Persisting claim {i + 1}/{len(claims)}: {claim.get('id')}"
-                        )
-                        storage_manager.persist_claim(claim)
-                    else:
-                        log.warning(
-                            f"Skipping invalid claim format from agent {agent_name}",
-                            extra={
-                                "agent": agent_name,
-                                "claim_index": i,
-                                "claim_type": type(claim).__name__,
-                                "has_id": isinstance(claim, dict) and "id" in claim,
-                            },
-                        )
-        except (StorageError, rdflib.exceptions.Error, ValueError) as e:
-            log.warning(
-                f"Error persisting claims for agent {agent_name}: {str(e)}",
-                exc_info=True,
-                extra={"agent": agent_name, "error": str(e)},
-            )
-            # Don't fail the whole process for storage errors
-
-    @staticmethod
-    def _handle_agent_error(
-        agent_name: str, e: Exception, state: QueryState, metrics: OrchestrationMetrics
-    ) -> dict:
-        """Handle agent errors with granular recovery strategies.
-
-        Args:
-            agent_name: Name of the agent
-            e: The exception that occurred
-            state: Current query state
-            metrics: Metrics collector
-
-        Returns:
-            Dictionary with error recovery information
-        """
-        log = get_logger(__name__)
-
-        # Categorize the error for appropriate handling
-        error_category = Orchestrator._categorize_error(e)
-
-        # Record detailed error information
-        error_info = {
-            "agent": agent_name,
-            "error": str(e),
-            "error_type": type(e).__name__,
-            "error_category": error_category,
-            "traceback": traceback.format_exc(),
-            "timestamp": time.time(),
-        }
-
-        # Record metrics
-        metrics.record_error(agent_name)
-
-        # Log the error with appropriate level based on category
-        if error_category == "critical":
-            log.critical(
-                f"Critical error during agent {agent_name} execution: {str(e)}",
-                exc_info=True,
-                extra={"error_info": error_info},
-            )
-        elif error_category == "recoverable":
-            log.error(
-                f"Recoverable error during agent {agent_name} execution: {str(e)}",
-                exc_info=True,
-                extra={"error_info": error_info},
-            )
-        else:  # "transient"
-            log.warning(
-                f"Transient error during agent {agent_name} execution: {str(e)}",
-                exc_info=True,
-                extra={"error_info": error_info},
-            )
-
-        # Apply recovery strategy based on error category
-        recovery_info = Orchestrator._apply_recovery_strategy(
-            agent_name, error_category, e, state
-        )
-
-        # Update error info with recovery details
-        error_info.update(recovery_info)
-
-        return error_info
-
-    @staticmethod
-    def _categorize_error(e: Exception) -> str:
-        """Categorize an error for appropriate handling.
-
-        Args:
-            e: The exception to categorize
-
-        Returns:
-            Error category: "transient", "recoverable", or "critical"
-        """
-        # Timeout errors are typically transient
-        if isinstance(e, TimeoutError):
-            return "transient"
-
-        # Not found errors are typically recoverable
-        if isinstance(e, NotFoundError):
-            return "recoverable"
-
-        # Agent errors might be recoverable depending on the specific error
-        if isinstance(e, AgentError):
-            # Check for specific error messages that indicate recoverable errors
-            error_str = str(e).lower()
-            if any(
-                term in error_str
-                for term in ["retry", "temporary", "timeout", "rate limit"]
-            ):
-                return "transient"
-            elif any(
-                term in error_str
-                for term in ["configuration", "invalid input", "format"]
-            ):
-                return "recoverable"
-            else:
-                return "critical"
-
-        # Orchestration errors are typically critical
-        if isinstance(e, OrchestrationError):
-            return "critical"
-
-        # Default to critical for unknown errors
-        return "critical"
-
-    @staticmethod
-    def _apply_recovery_strategy(
-        agent_name: str, error_category: str, e: Exception, state: QueryState
-    ) -> dict:
-        """Apply an appropriate recovery strategy based on error category.
-
-        Args:
-            agent_name: Name of the agent
-            error_category: Category of the error
-            e: The exception that occurred
-            state: Current query state
-
-        Returns:
-            Dictionary with recovery strategy information
-        """
-        log = get_logger(__name__)
-
-        if error_category == "transient":
-            # For transient errors, we can retry or use a fallback
-            recovery_strategy = "retry_with_backoff"
-            suggestion = "This error is likely temporary. The system will automatically retry with backoff."
-
-            # Add a placeholder result to avoid breaking the chain
-            fallback_result = {
-                "claims": [
-                    f"Agent {agent_name} encountered a temporary error: {str(e)}"
-                ],
-                "results": {
-                    "fallback": (
-                        f"The {agent_name} agent encountered a temporary issue. "
-                        "This is likely due to external factors and may resolve on retry."
-                    )
-                },
-                "metadata": {
-                    "recovery_applied": True,
-                    "recovery_strategy": recovery_strategy,
-                },
-            }
-            state.update(fallback_result)
-
-            log.info(
-                f"Applied '{recovery_strategy}' recovery strategy for agent {agent_name}",
-                extra={"agent": agent_name, "recovery_strategy": recovery_strategy},
-            )
-
-        elif error_category == "recoverable":
-            # For recoverable errors, we can use a fallback agent or simplified approach
-            recovery_strategy = "fallback_agent"
-            suggestion = "This error indicates a configuration or input issue. A fallback approach will be used."
-
-            # Add a simplified result to continue the process
-            fallback_result = {
-                "claims": [
-                    f"Agent {agent_name} encountered a recoverable error: {str(e)}"
-                ],
-                "results": {
-                    "fallback": (
-                        f"The {agent_name} agent encountered an issue that prevented it from completing normally. "
-                        "A simplified approach has been used instead."
-                    )
-                },
-                "metadata": {
-                    "recovery_applied": True,
-                    "recovery_strategy": recovery_strategy,
-                },
-            }
-            state.update(fallback_result)
-
-            log.info(
-                f"Applied '{recovery_strategy}' recovery strategy for agent {agent_name}",
-                extra={"agent": agent_name, "recovery_strategy": recovery_strategy},
-            )
-
-        else:  # "critical"
-            # For critical errors, we need to fail gracefully
-            recovery_strategy = "fail_gracefully"
-            suggestion = "This is a critical error that requires attention. Check the logs for details."
-
-            # Add error information to the state
-            error_result = {
-                "claims": [
-                    f"Agent {agent_name} encountered a critical error: {str(e)}"
-                ],
-                "results": {
-                    "error": (
-                        f"The {agent_name} agent encountered a critical error that prevented completion. "
-                        "This requires investigation."
-                    )
-                },
-                "metadata": {
-                    "recovery_applied": True,
-                    "recovery_strategy": recovery_strategy,
-                    "critical_error": True,
-                },
-            }
-            state.update(error_result)
-
-            log.warning(
-                f"Applied '{recovery_strategy}' recovery strategy for agent {agent_name}",
-                extra={"agent": agent_name, "recovery_strategy": recovery_strategy},
-            )
-
-        return {"recovery_strategy": recovery_strategy, "suggestion": suggestion}
-
-    # Circuit breaker configuration and state (delegated to circuit_breaker module)
-    _cb_manager: CircuitBreakerManager | None = None
-
-    @staticmethod
     def get_circuit_breaker_state(agent_name: str) -> CircuitBreakerState:
         if Orchestrator._cb_manager is None:
             return {
@@ -619,331 +125,6 @@ class Orchestrator:
         return Orchestrator._cb_manager.get_circuit_breaker_state(agent_name)
 
     @staticmethod
-    def _execute_agent(
-        agent_name: str,
-        state: QueryState,
-        config: ConfigModel,
-        metrics: OrchestrationMetrics,
-        callbacks: Dict[str, Callable[..., None]],
-        agent_factory: type[AgentFactory],
-        storage_manager: type[StorageManager],
-        loop: int,
-        cb_manager: CircuitBreakerManager,
-    ) -> None:
-        """Execute a single agent and update state with results.
-
-        Args:
-            agent_name: Name of the agent to execute
-            state: Current query state
-            config: System configuration
-            metrics: Metrics collector
-            callbacks: Callbacks for monitoring execution
-            agent_factory: Factory for creating agent instances
-            storage_manager: Storage manager for persisting claims
-            loop: Current loop number
-
-        Raises:
-            NotFoundError: If agent cannot be found
-            AgentError: If agent execution fails
-            TimeoutError: If agent execution times out
-        """
-        retries = getattr(config, "retry_attempts", 1)
-        backoff = getattr(config, "retry_backoff", 0.0)
-
-        breaker_state = cb_manager.get_circuit_breaker_state(agent_name)
-        if breaker_state.get("state") == "open":
-            error_info = {
-                "agent": agent_name,
-                "error": "Circuit breaker open",
-                "error_type": "CircuitBreakerOpen",
-                "error_category": "critical",
-                "traceback": "",
-                "timestamp": time.time(),
-            }
-            state.add_error(error_info)
-            metrics.record_error(agent_name)
-            metrics.record_circuit_breaker(agent_name, breaker_state)
-            return
-
-        for attempt in range(retries):
-            try:
-                # Get agent instance
-                agent = Orchestrator._get_agent(agent_name, agent_factory)
-
-                # Check if agent can execute
-                if not Orchestrator._check_agent_can_execute(
-                    agent, agent_name, state, config
-                ):
-                    return
-
-                # Deliver pending messages to this agent for the current cycle
-                Orchestrator._deliver_messages(agent_name, state, config)
-
-                # Log agent execution
-                Orchestrator._log_agent_execution(agent_name, state, loop)
-
-                # Call on_agent_start callback
-                Orchestrator._call_agent_start_callback(agent_name, state, callbacks)
-
-                # Execute agent and measure duration
-                start_time = time.time()
-                result = Orchestrator._execute_agent_with_token_counting(
-                    agent, agent_name, state, config, metrics
-                )
-                duration = time.time() - start_time
-
-                # Handle agent completion
-                Orchestrator._handle_agent_completion(
-                    agent_name, result, state, metrics, callbacks, duration, loop
-                )
-
-                # Update state with result
-                state.update(result)
-
-                # Log sources
-                Orchestrator._log_sources(agent_name, result)
-
-                # Persist claims
-                Orchestrator._persist_claims(agent_name, result, storage_manager)
-
-                # Successful execution resets circuit breaker state
-                cb_manager.handle_agent_success(agent_name)
-                metrics.record_circuit_breaker(
-                    agent_name, cb_manager.get_circuit_breaker_state(agent_name)
-                )
-                return
-            except (
-                AgentError,
-                TimeoutError,
-                NotFoundError,
-                OrchestrationError,
-                ValueError,
-                RuntimeError,
-            ) as e:
-                error_info = Orchestrator._handle_agent_error(
-                    agent_name, e, state, metrics
-                )
-                state.add_error(error_info)
-                category = str(error_info.get("error_category", "critical"))
-                cb_manager.update_circuit_breaker(agent_name, category)
-                metrics.record_circuit_breaker(
-                    agent_name, cb_manager.get_circuit_breaker_state(agent_name)
-                )
-
-                # Retry for transient errors if attempts remain
-                if (
-                    attempt < retries - 1
-                    and error_info.get("error_category") == "transient"
-                ):
-                    sleep_time = backoff * (2**attempt)
-                    if sleep_time > 0:
-                        time.sleep(sleep_time)
-                    continue
-                break
-
-    @staticmethod
-    def _execute_cycle(
-        loop: int,
-        loops: int,
-        agents: List[List[str]],
-        primus_index: int,
-        max_errors: int,
-        state: QueryState,
-        config: ConfigModel,
-        metrics: OrchestrationMetrics,
-        callbacks: Dict[str, Callable[..., None]],
-        agent_factory: type[AgentFactory],
-        storage_manager: type[StorageManager],
-        tracer: Any,
-        cb_manager: CircuitBreakerManager,
-    ) -> int:
-        """Execute a single dialectical cycle.
-
-        Args:
-            loop: Current loop number
-            loops: Total number of loops
-            agents: Groups of agent names
-            primus_index: Index of the primus agent
-            max_errors: Maximum number of errors before aborting
-            state: Current query state
-            config: System configuration
-            metrics: Metrics collector
-            callbacks: Callbacks for monitoring execution
-            agent_factory: Factory for creating agent instances
-            storage_manager: Storage manager for persisting claims
-            tracer: Tracer for distributed tracing
-
-        Returns:
-            Updated primus_index for the next cycle
-        """
-        with tracer.start_as_current_span(
-            "cycle",
-            attributes={"cycle": loop},
-        ):
-            log.info(f"Starting loop {loop + 1}/{loops}")
-            metrics.start_cycle()
-
-            # Call on_cycle_start callback
-            if callbacks.get("on_cycle_start"):
-                callbacks["on_cycle_start"](loop, state)
-
-            # Rotate agent order based on primus_index
-            order = Orchestrator._rotate_list(agents, primus_index)
-
-            # Execute each agent group in order
-            for group in order:
-                for agent_name in group:
-                    if state.error_count >= max_errors:
-                        log.warning(
-                            "Skipping remaining agents due to error threshold "
-                            f"({max_errors}) reached"
-                        )
-                        break
-
-                    Orchestrator._execute_agent(
-                        agent_name,
-                        state,
-                        config,
-                        metrics,
-                        callbacks,
-                        agent_factory,
-                        storage_manager,
-                        loop,
-                        cb_manager,
-                    )
-                if state.error_count >= max_errors:
-                    break
-
-            # End cycle and update metrics
-            metrics.end_cycle()
-            state.metadata["execution_metrics"] = metrics.get_summary()
-            metrics.record_query_tokens(state.query)
-            token_budget = getattr(config, "token_budget", None)
-            if token_budget is not None:
-                config.token_budget = metrics.suggest_token_budget(token_budget)
-
-            # Prune context to keep state size manageable
-            state.prune_context()
-
-            # Call on_cycle_end callback
-            if callbacks.get("on_cycle_end"):
-                callbacks["on_cycle_end"](loop, state)
-
-            # Check if we need to abort due to errors
-            if state.error_count >= max_errors:
-                log.error(
-                    "Aborting dialectical process due to error "
-                    f"threshold reached ({state.error_count}/{max_errors})"
-                )
-                state.results["error"] = (
-                    f"Process aborted after {state.error_count} errors"
-                )
-                return primus_index
-
-            # Increment cycle counter
-            state.cycle += 1
-
-            # Update primus_index for next cycle
-            primus_index = (primus_index + 1) % len(agents)
-            state.primus_index = primus_index
-
-            return primus_index
-
-    @staticmethod
-    async def _execute_cycle_async(
-        loop: int,
-        loops: int,
-        agents: List[List[str]],
-        primus_index: int,
-        max_errors: int,
-        state: QueryState,
-        config: ConfigModel,
-        metrics: OrchestrationMetrics,
-        callbacks: Dict[str, Callable[..., None]],
-        agent_factory: type[AgentFactory],
-        storage_manager: type[StorageManager],
-        tracer: Any,
-        *,
-        concurrent: bool = False,
-        cb_manager: CircuitBreakerManager,
-    ) -> int:
-        """Asynchronous version of ``_execute_cycle``."""
-        with tracer.start_as_current_span(
-            "cycle",
-            attributes={"cycle": loop},
-        ):
-            log.info(f"Starting loop {loop + 1}/{loops}")
-            metrics.start_cycle()
-
-            if callbacks.get("on_cycle_start"):
-                callbacks["on_cycle_start"](loop, state)
-
-            order = Orchestrator._rotate_list(agents, primus_index)
-
-            async def run_agent(name: str) -> None:
-                if state.error_count >= max_errors:
-                    return
-                await asyncio.to_thread(
-                    Orchestrator._execute_agent,
-                    name,
-                    state,
-                    config,
-                    metrics,
-                    callbacks,
-                    agent_factory,
-                    storage_manager,
-                    loop,
-                    cb_manager,
-                )
-
-            if concurrent:
-                for group in order:
-                    await asyncio.gather(*(run_agent(a) for a in group))
-                    if state.error_count >= max_errors:
-                        break
-            else:
-                for group in order:
-                    for agent_name in group:
-                        if state.error_count >= max_errors:
-                            log.warning(
-                                "Skipping remaining agents due to error threshold "
-                                f"({max_errors}) reached"
-                            )
-                            break
-                        await run_agent(agent_name)
-                    if state.error_count >= max_errors:
-                        break
-
-            metrics.end_cycle()
-            state.metadata["execution_metrics"] = metrics.get_summary()
-            token_budget = getattr(config, "token_budget", None)
-            if token_budget is not None:
-                config.token_budget = metrics.suggest_token_budget(token_budget)
-
-            # Prune context to keep state size manageable
-            state.prune_context()
-
-            if callbacks.get("on_cycle_end"):
-                callbacks["on_cycle_end"](loop, state)
-
-            if state.error_count >= max_errors:
-                log.error(
-                    "Aborting dialectical process due to error "
-                    f"threshold reached ({state.error_count}/{max_errors})"
-                )
-                state.results["error"] = (
-                    f"Process aborted after {state.error_count} errors"
-                )
-                return primus_index
-
-            state.cycle += 1
-
-            primus_index = (primus_index + 1) % len(agents)
-            state.primus_index = primus_index
-
-            return primus_index
-
-    @staticmethod
     def run_query(
         query: str,
         config: ConfigModel,
@@ -952,28 +133,13 @@ class Orchestrator:
         agent_factory: type[AgentFactory] = AgentFactory,
         storage_manager: type[StorageManager] = StorageManager,
     ) -> QueryResponse:
-        """Run a query through dialectical agent cycles.
-
-        Args:
-            query: The user's query string
-            config: System configuration
-            callbacks: Optional callbacks for monitoring execution
-                Supported callbacks: on_cycle_start, on_cycle_end,
-                on_agent_start, on_agent_end
-            agent_factory: Factory class used to retrieve agent instances
-            storage_manager: Storage manager class for persisting claims
-
-        Returns:
-            QueryResponse with answer, citations, reasoning, and metrics
-        """
-        # Setup tracing and metrics
+        """Run a query through dialectical agent cycles."""
         setup_tracing(getattr(config, "tracing_enabled", False))
         tracer = get_tracer(__name__)
         record_query()
         metrics = OrchestrationMetrics()
         callbacks = callbacks or {}
 
-        # Parse configuration
         config_params = Orchestrator._parse_config(config)
         agents = config_params["agent_groups"]
         primus_index = config_params["primus_index"]
@@ -986,10 +152,8 @@ class Orchestrator:
         )
         Orchestrator._cb_manager = cb_manager
 
-        # Adapt token budget based on query complexity and loops
-        Orchestrator._apply_adaptive_token_budget(config, query)
+        Orchestrator._apply_adaptive_token_budget(config, query)  # type: ignore[attr-defined]
 
-        # Scale token budget for parallel agent groups if metadata is present
         token_budget = getattr(config, "token_budget", None)
         if (
             token_budget is not None
@@ -1005,7 +169,6 @@ class Orchestrator:
                 group_tokens = max(1, token_budget * config.group_size // total_agents)
                 config.token_budget = group_tokens
 
-        # Handle chain-of-thought reasoning mode
         if mode == ReasoningMode.CHAIN_OF_THOUGHT:
             strategy = ChainOfThoughtStrategy()
             return strategy.run_query(
@@ -1014,14 +177,12 @@ class Orchestrator:
                 agent_factory=agent_factory,
             )
 
-        # Initialize query state
         state = QueryState(
             query=query,
             primus_index=primus_index,
             coalitions=config_params.get("coalitions", {}),
         )
 
-        # Execute dialectical cycles with detailed logging
         total_agents = sum(len(g) for g in agents)
         log.info(
             f"Starting dialectical process with {total_agents} agents in {len(agents)} groups and {loops} loops",
@@ -1044,7 +205,7 @@ class Orchestrator:
                 },
             )
 
-            primus_index = Orchestrator._execute_cycle(
+            primus_index = Orchestrator._execute_cycle(  # type: ignore[attr-defined]
                 loop,
                 loops,
                 agents,
@@ -1060,7 +221,6 @@ class Orchestrator:
                 cb_manager,
             )
 
-            # Break if we need to abort due to errors
             if "error" in state.results:
                 log.error(
                     f"Aborting dialectical process due to error: {state.results['error']}",
@@ -1082,11 +242,9 @@ class Orchestrator:
                 },
             )
 
-        # Add final metrics to state
         state.metadata["execution_metrics"] = metrics.get_summary()
         metrics.record_query_tokens(query)
 
-        # Raise error if process aborted or if there were any errors
         if "error" in state.results or state.error_count > 0:
             error_message = state.results.get(
                 "error", f"Process completed with {state.error_count} errors"
@@ -1098,7 +256,6 @@ class Orchestrator:
                 suggestion="Check the agent execution logs for details on the specific error and ensure all agents are properly configured",
             )
 
-        # Synthesize final response
         return state.synthesize()
 
     @staticmethod
@@ -1111,12 +268,7 @@ class Orchestrator:
         storage_manager: type[StorageManager] = StorageManager,
         concurrent: bool = False,
     ) -> QueryResponse:
-        """Asynchronous wrapper around :meth:`run_query`.
-
-        When ``concurrent`` is ``True`` agents within a cycle are executed
-        concurrently using ``asyncio`` threads.
-        """
-
+        """Asynchronous wrapper around :meth:`run_query`."""
         setup_tracing(getattr(config, "tracing_enabled", False))
         tracer = get_tracer(__name__)
         record_query()
@@ -1135,10 +287,8 @@ class Orchestrator:
         )
         Orchestrator._cb_manager = cb_manager
 
-        # Adapt token budget based on query complexity and loops
-        Orchestrator._apply_adaptive_token_budget(config, query)
+        Orchestrator._apply_adaptive_token_budget(config, query)  # type: ignore[attr-defined]
 
-        # Scale token budget for parallel agent groups if metadata is present
         token_budget = getattr(config, "token_budget", None)
         if (
             token_budget is not None
@@ -1191,7 +341,7 @@ class Orchestrator:
                 },
             )
 
-            primus_index = await Orchestrator._execute_cycle_async(
+            primus_index = await Orchestrator._execute_cycle_async(  # type: ignore[attr-defined]
                 loop,
                 loops,
                 agents,
@@ -1230,6 +380,7 @@ class Orchestrator:
             )
 
         state.metadata["execution_metrics"] = metrics.get_summary()
+        metrics.record_query_tokens(query)
 
         if "error" in state.results or state.error_count > 0:
             error_message = state.results.get(
@@ -1257,69 +408,6 @@ class Orchestrator:
         return parallel.execute_parallel_query(query, config, agent_groups, timeout)
 
     @staticmethod
-    def _execute_with_adapter(
-        agent: Any, state: QueryState, config: ConfigModel, adapter: Any
-    ) -> Dict[str, Any]:
-        """Execute an agent with a specific adapter."""
-        return execute_with_adapter(agent, state, config, adapter)
-
-    @staticmethod
-    def _rotate_list(items: List[Any], start_idx: int) -> List[Any]:
-        """Rotate a list so that start_idx becomes the first element.
-
-        This method is used to reorder the list of agents based on the primus_index,
-        ensuring that the primus agent is executed first in each cycle.
-
-        Args:
-            items: The list to rotate
-            start_idx: The index that should become the first element
-
-        Returns:
-            A new list with elements rotated so that items[start_idx] is the first element
-        """
-        if not items:
-            return []
-        start_idx = start_idx % len(items)  # Handle index out of bounds
-        return items[start_idx:] + items[:start_idx]
-
-    @staticmethod
-    def _apply_adaptive_token_budget(config: ConfigModel, query: str) -> None:
-        """Adjust ``config.token_budget`` based on query complexity and loops."""
-
-        budget = getattr(config, "token_budget", None)
-        if budget is None:
-            return
-
-        loops = getattr(config, "loops", 1)
-        if loops > 1:
-            budget = max(1, budget // loops)
-
-        query_tokens = len(query.split())
-        factor = getattr(config, "adaptive_max_factor", 20)
-        buffer = getattr(config, "adaptive_min_buffer", 10)
-        max_budget = query_tokens * factor
-        if budget > max_budget:
-            config.token_budget = max_budget
-        elif budget < query_tokens:
-            config.token_budget = query_tokens + buffer
-        else:
-            config.token_budget = budget
-
-    _get_memory_usage = staticmethod(get_memory_usage)
-    _calculate_result_confidence = staticmethod(calculate_result_confidence)
-
-    @staticmethod
-    def _capture_token_usage(
-        agent_name: str, metrics: OrchestrationMetrics, config: ConfigModel
-    ) -> ContextManager[tuple[dict[str, int], Any]]:
-        """Capture token usage for all LLM calls within the block."""
-        return capture_token_usage(agent_name, metrics, config)
-
-    # --------------------------------------------------------------
-    # Storage helper shortcuts
-    # --------------------------------------------------------------
-
-    @staticmethod
     def infer_relations() -> None:
         """Infer ontology relations via the storage manager."""
         StorageManager.infer_relations()
@@ -1328,3 +416,47 @@ class Orchestrator:
     def query_ontology(query: str) -> rdflib.query.Result:
         """Query the ontology graph via the storage manager."""
         return StorageManager.query_ontology(query)
+
+
+# Attach helper functions from submodules
+Orchestrator._get_agent = staticmethod(_get_agent)  # type: ignore[attr-defined]
+Orchestrator._check_agent_can_execute = staticmethod(  # type: ignore[attr-defined]
+    _check_agent_can_execute
+)
+Orchestrator._deliver_messages = staticmethod(_deliver_messages)  # type: ignore[attr-defined]
+Orchestrator._log_agent_execution = staticmethod(  # type: ignore[attr-defined]
+    _log_agent_execution
+)
+Orchestrator._call_agent_start_callback = staticmethod(  # type: ignore[attr-defined]
+    _call_agent_start_callback
+)
+Orchestrator._execute_agent_with_token_counting = staticmethod(  # type: ignore[attr-defined]
+    _execute_agent_with_token_counting
+)
+Orchestrator._handle_agent_completion = staticmethod(  # type: ignore[attr-defined]
+    _handle_agent_completion
+)
+Orchestrator._log_sources = staticmethod(_log_sources)  # type: ignore[attr-defined]
+Orchestrator._persist_claims = staticmethod(_persist_claims)  # type: ignore[attr-defined]
+Orchestrator._handle_agent_error = staticmethod(_handle_agent_error)  # type: ignore[attr-defined]
+Orchestrator._categorize_error = staticmethod(_categorize_error)  # type: ignore[attr-defined]
+Orchestrator._apply_recovery_strategy = staticmethod(  # type: ignore[attr-defined]
+    _apply_recovery_strategy
+)
+Orchestrator._execute_agent = staticmethod(_execute_agent)  # type: ignore[attr-defined]
+Orchestrator._execute_cycle = staticmethod(_execute_cycle)  # type: ignore[attr-defined]
+Orchestrator._execute_cycle_async = staticmethod(  # type: ignore[attr-defined]
+    _execute_cycle_async
+)
+Orchestrator._rotate_list = staticmethod(_rotate_list)  # type: ignore[attr-defined]
+Orchestrator._apply_adaptive_token_budget = staticmethod(  # type: ignore[attr-defined]
+    _apply_adaptive_token_budget
+)
+Orchestrator._get_memory_usage = staticmethod(get_memory_usage)  # type: ignore[attr-defined]
+Orchestrator._calculate_result_confidence = staticmethod(  # type: ignore[attr-defined]
+    calculate_result_confidence
+)
+Orchestrator._capture_token_usage = staticmethod(capture_token_usage)  # type: ignore[attr-defined]
+Orchestrator._execute_with_adapter = staticmethod(  # type: ignore[attr-defined]
+    execute_with_adapter
+)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -60,7 +60,7 @@ def test_fallback_no_limit(monkeypatch):
 
     api_mod.get_request_logger(app).reset()
     monkeypatch.setattr(
-        "autoresearch.api.routing.get_remote_address",
+        "autoresearch.api.middleware.get_remote_address",
         lambda req: req.headers.get("x-ip", "1"),
     )
     client = TestClient(app)
@@ -81,7 +81,7 @@ def test_fallback_multiple_ips(monkeypatch):
     def addr(req):
         return req.headers.get("x-ip", "1")
 
-    monkeypatch.setattr("autoresearch.api.routing.get_remote_address", addr)
+    monkeypatch.setattr("autoresearch.api.middleware.get_remote_address", addr)
     client = TestClient(app)
     limit_obj = api_mod.parse(api_mod.dynamic_limit())
 

--- a/tests/unit/test_storage_eviction.py
+++ b/tests/unit/test_storage_eviction.py
@@ -89,23 +89,23 @@ def test_enforce_ram_budget_lru_policy():
 
     with patch.object(StorageManager.context, "graph", mock_graph):
         with patch.object(StorageManager.state, "lru", mock_lru):
-                with patch(
-                    "autoresearch.storage.StorageManager._current_ram_mb",
-                    side_effect=[100, 100, 100, 50, 50],
-                ):
-                    with patch("autoresearch.config.loader.ConfigLoader.config") as mock_config:
-                        mock_config.graph_eviction_policy = "lru"
-                        mock_config.eviction_batch_size = 10
+            with patch(
+                "autoresearch.storage.StorageManager._current_ram_mb",
+                side_effect=[100, 100, 100, 50, 50],
+            ):
+                with patch("autoresearch.config.loader.ConfigLoader.config") as mock_config:
+                    mock_config.graph_eviction_policy = "lru"
+                    mock_config.eviction_batch_size = 10
 
-                    # Execute
-                    start = EVICTION_COUNTER._value.get()
-                    StorageManager._enforce_ram_budget(75)
+                # Execute
+                start = EVICTION_COUNTER._value.get()
+                StorageManager._enforce_ram_budget(75)
 
-                    # Verify
-                    assert mock_graph.remove_node.call_count == 2
-                    mock_graph.remove_node.assert_any_call("0")
-                    mock_graph.remove_node.assert_any_call("1")
-                    assert EVICTION_COUNTER._value.get() == start + 2
+                # Verify
+                assert mock_graph.remove_node.call_count == 2
+                mock_graph.remove_node.assert_any_call("0")
+                mock_graph.remove_node.assert_any_call("1")
+                assert EVICTION_COUNTER._value.get() == start + 2
 
 
 def test_enforce_ram_budget_score_policy():
@@ -137,23 +137,23 @@ def test_enforce_ram_budget_score_policy():
                 "autoresearch.storage.StorageManager._current_ram_mb",
                 side_effect=[100, 100, 100, 50, 50],
             ):
-                    with patch("autoresearch.config.loader.ConfigLoader.config") as mock_config:
-                        mock_config.graph_eviction_policy = "score"
-                        mock_config.eviction_batch_size = 10
-                        mock_config.eviction_safety_margin = 0.1
+                with patch("autoresearch.config.loader.ConfigLoader.config") as mock_config:
+                    mock_config.graph_eviction_policy = "score"
+                    mock_config.eviction_batch_size = 10
+                    mock_config.eviction_safety_margin = 0.1
 
-                    # Execute
-                    start = EVICTION_COUNTER._value.get()
-                    StorageManager._enforce_ram_budget(75)
+                # Execute
+                start = EVICTION_COUNTER._value.get()
+                StorageManager._enforce_ram_budget(75)
 
-                    # Verify
-                    assert mock_graph.remove_node.call_count == 2
-                    mock_graph.remove_node.assert_any_call("0")
-                    mock_graph.remove_node.assert_any_call("1")
-                    assert EVICTION_COUNTER._value.get() == start + 2
+                # Verify
+                assert mock_graph.remove_node.call_count == 2
+                mock_graph.remove_node.assert_any_call("0")
+                mock_graph.remove_node.assert_any_call("1")
+                assert EVICTION_COUNTER._value.get() == start + 2
 
-                    # Verify that remaining nodes exclude evicted ones
-                    assert "0" not in nodes_dict and "1" not in nodes_dict
+                # Verify that remaining nodes exclude evicted ones
+                assert "0" not in nodes_dict and "1" not in nodes_dict
 
 
 def test_enforce_ram_budget_zero_budget():


### PR DESCRIPTION
## Summary
- modularize orchestrator logic into execution, budgeting, and error handling helpers
- split monolithic API routing into dedicated routing, middleware, and utility modules
- adjust tests for new module paths

## Testing
- `task verify`

------
https://chatgpt.com/codex/tasks/task_e_689a269e977c8333ab3c72c765cd927b