### PR TITLE
Add message broker and analysis behavior tests

### DIFF
--- a/tests/behavior/features/data_analysis.feature
+++ b/tests/behavior/features/data_analysis.feature
@@ -1,0 +1,15 @@
+# Documentation: docs/installation.md
+Feature: Data analysis utilities
+  As a user
+  I want to summarize metrics with Polars
+  So that I can analyze agent performance
+
+  Scenario: Generate metrics dataframe when Polars enabled
+    Given sample metrics
+    When I generate metrics dataframe with Polars enabled
+    Then a Polars dataframe should be returned
+
+  Scenario: Fail to generate metrics dataframe when Polars disabled
+    Given sample metrics
+    When I generate metrics dataframe with Polars disabled
+    Then the operation should fail with polars disabled error

--- a/tests/behavior/features/message_broker_config.feature
+++ b/tests/behavior/features/message_broker_config.feature
@@ -1,0 +1,16 @@
+# Documentation: docs/message_brokers.md
+# Documentation: docs/configuration.md
+Feature: Message broker selection
+  As a developer
+  I want to configure message broker backends
+  So that distributed workers coordinate correctly
+
+  Scenario: Use default in-memory message broker
+    Given the message broker name "memory"
+    When I obtain a message broker instance
+    Then an in-memory broker should be returned
+
+  Scenario: Unsupported message broker raises error
+    Given the message broker name "unknown"
+    When I obtain a message broker instance
+    Then a message broker error should be raised

--- a/tests/behavior/steps/data_analysis_steps.py
+++ b/tests/behavior/steps/data_analysis_steps.py
@@ -1,0 +1,40 @@
+from pytest_bdd import given, when, then
+from autoresearch.data_analysis import metrics_dataframe
+import polars as pl
+
+
+@given("sample metrics")
+def sample_metrics(bdd_context) -> None:
+    bdd_context["metrics"] = {"agent_timings": {"A": [1.0, 2.0]}}
+
+
+@when("I generate metrics dataframe with Polars enabled")
+def generate_df_enabled(bdd_context) -> None:
+    metrics = bdd_context["metrics"]
+    bdd_context["result"] = metrics_dataframe(metrics, polars_enabled=True)
+    bdd_context["error"] = None
+
+
+@when("I generate metrics dataframe with Polars disabled")
+def generate_df_disabled(bdd_context) -> None:
+    metrics = bdd_context["metrics"]
+    try:
+        metrics_dataframe(metrics, polars_enabled=False)
+        bdd_context["result"] = None
+        bdd_context["error"] = None
+    except Exception as e:
+        bdd_context["result"] = None
+        bdd_context["error"] = e
+
+
+@then("a Polars dataframe should be returned")
+def assert_polars_dataframe(bdd_context) -> None:
+    assert isinstance(bdd_context["result"], pl.DataFrame)
+
+
+@then("the operation should fail with polars disabled error")
+def assert_polars_disabled_error(bdd_context) -> None:
+    assert bdd_context["result"] is None
+    err = bdd_context.get("error")
+    assert err is not None
+    assert "Polars analysis is disabled" in str(err)

--- a/tests/behavior/steps/message_broker_steps.py
+++ b/tests/behavior/steps/message_broker_steps.py
@@ -1,0 +1,32 @@
+from pytest_bdd import given, when, then
+from autoresearch.distributed import get_message_broker, InMemoryBroker
+
+
+@given('the message broker name "{name}"')
+def given_broker_name(bdd_context, name: str) -> None:
+    bdd_context["broker_name"] = name
+
+
+@when("I obtain a message broker instance")
+def obtain_broker_instance(bdd_context) -> None:
+    name = bdd_context["broker_name"]
+    try:
+        broker = get_message_broker(name)
+        bdd_context["broker"] = broker
+        bdd_context["broker_error"] = None
+    except Exception as e:  # pragma: no cover - error path
+        bdd_context["broker"] = None
+        bdd_context["broker_error"] = e
+
+
+@then("an in-memory broker should be returned")
+def assert_in_memory_broker(bdd_context) -> None:
+    assert isinstance(bdd_context["broker"], InMemoryBroker)
+
+
+@then("a message broker error should be raised")
+def assert_broker_error(bdd_context) -> None:
+    assert bdd_context["broker"] is None
+    err = bdd_context.get("broker_error")
+    assert err is not None
+    assert "Unsupported message broker" in str(err)


### PR DESCRIPTION
## Summary
- add BDD scenarios for message broker selection and Polars-based analysis utilities
- align async query steps with current API responses

## Testing
- `uv run pytest tests/behavior` *(fails: tests/behavior/steps/api_documentation_steps.py::test_retrieve_openapi_schema - ValueError: tuple.index(x): x not in tuple)*

------
https://chatgpt.com/codex/tasks/task_e_689aac7869788333aa72a24c397f0799