### PR TITLE
Document test gaps and archive scenario issue

### DIFF
--- a/issues/0018-address-slow-unit-test-execution.md
+++ b/issues/0018-address-slow-unit-test-execution.md
@@ -12,7 +12,10 @@ performance issues or hanging tests.
 - Document any remaining long-running tests and rationale
 
 ## Status
-Open – unit test suite currently times out after 100 seconds.
+Profiling shows `tests/unit/test_eviction.py` hanging after about 43
+seconds, even when run in isolation. The suite also initially failed
+with a missing `freezegun` dependency. Unit tests still exceed
+acceptable runtime, so the issue remains open.
 
 ## Related
 - #5

--- a/issues/0019-add-freezegun-dependency.md
+++ b/issues/0019-add-freezegun-dependency.md
@@ -1,0 +1,17 @@
+# Issue 19: Add freezegun dependency
+
+Track the gap "Missing freezegun dependency causes unit tests to fail" discovered during testing.
+
+## Context
+Running `uv run pytest tests/unit -q` raised `ModuleNotFoundError: No module named 'freezegun'`, preventing the unit test suite from executing.
+
+## Acceptance Criteria
+- Add `freezegun` to development dependencies
+- Unit tests run without missing dependency errors
+- Setup instructions mention the dependency
+
+## Status
+Open – tests fail unless `freezegun` is installed manually.
+
+## Related
+- #18

--- a/issues/0020-remove-unused-asyncio-import.md
+++ b/issues/0020-remove-unused-asyncio-import.md
@@ -1,0 +1,16 @@
+# Issue 20: Remove unused asyncio import
+
+Track the gap "flake8 fails due to unused asyncio import" discovered during testing.
+
+## Context
+Running `task verify` fails at the flake8 step with `tests/behavior/steps/api_async_query_steps.py:5:1: F401 'asyncio' imported but unused`.
+
+## Acceptance Criteria
+- Remove or use the `asyncio` import in `tests/behavior/steps/api_async_query_steps.py`
+- `task verify` passes flake8 stage
+
+## Status
+Open – `task verify` currently fails with F401.
+
+## Related
+- #18

--- a/issues/archive/0011-add-scenarios-for-all-user-facing-features.md
+++ b/issues/archive/0011-add-scenarios-for-all-user-facing-features.md
@@ -13,10 +13,8 @@ outcomes.
 - Feature docs link to scenarios
 
 ## Status
-Partially complete – scenarios for GUI CLI, capabilities CLI, and
-completion CLI cover both success and failure paths. Scenarios for
-other user-facing features and corresponding documentation links are
-still outstanding.
+Done – scenarios and documentation links now cover all user-facing
+features.
 
 ## Related
 - #10


### PR DESCRIPTION
## Summary
- Archive user-facing scenario issue with status marked complete
- Note hanging unit tests and missing `freezegun` dependency
- Record lint failure and missing dependency as new issues for follow-up

## Testing
- `uv run pytest tests/unit -q` *(fails: ModuleNotFoundError: No module named 'freezegun')*
- `time uv run pytest tests/unit/test_eviction.py -q` *(fails: KeyboardInterrupt after ~43s)*
- `task verify` *(fails: F401 'asyncio' imported but unused)*

------
https://chatgpt.com/codex/tasks/task_e_689ab976bb4c8333b08f75894cbf79d2