### PR TITLE
Speed up mypy type checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Update release plan to align milestones with the 2025 development timeline.
 - Add rich configuration context fixtures with sample data for tests. [#17](issues/0017-create-more-comprehensive-test-contexts.md)
+- Optimize mypy configuration to skip site packages, preventing hangs during
+  verification. [#22](issues/0022-investigate-mypy-hang.md).
 
 ## [0.1.0-alpha.1] - 2025-08-09
 - Verified source and wheel builds succeed; TestPyPI upload failed with 403 Forbidden.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -229,10 +229,10 @@ completed.
 ### Latest Test Results
 
 - `flake8` reports no style errors.
-- `uv run mypy src` hangs without output; see issue [#22](issues/0022-investigate-mypy-hang.md).
-- Targeted `pytest` runs for backup and metrics modules pass, but a full
-  `pytest tests/unit` run was interrupted after several minutes without
-  additional failures observed.
+- `uv run mypy src` completes in ~7s after excluding site packages;
+  issue [#22](issues/0022-investigate-mypy-hang.md) closed.
+- Unit tests begin executing, but the full suite remains long-running and
+  was interrupted after partial progress (~21%).
 
 ### Performance Baselines
 

--- a/issues/0022-investigate-mypy-hang.md
+++ b/issues/0022-investigate-mypy-hang.md
@@ -11,7 +11,11 @@ Running `uv run mypy src` appears to hang without producing output even after se
 - Document any configuration changes needed.
 
 ## Status
-Open
+Closed – Added `no_site_packages` and disabled `import-untyped` errors in
+`pyproject.toml`, preventing mypy from traversing third-party packages.
+`uv run mypy src` now completes in around seven seconds without errors.
+
+This resolves the hang observed during verification.
 
 ## Related
 - #1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,8 @@ markers = [
 [tool.mypy]
 python_version = "3.12"
 ignore_missing_imports = true
+no_site_packages = true
+disable_error_code = ["import-untyped"]
 plugins = ["pydantic.mypy"]
 check_untyped_defs = true
 


### PR DESCRIPTION
## Summary
- skip site packages in mypy config and silence import-untyped errors
- document and close the "mypy hang" issue
- note faster mypy run in task progress and changelog

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit -q` *(partial run, interrupted around 21%)*

------
https://chatgpt.com/codex/tasks/task_e_689b68dfc8d88333bfb423c6de240480