### PR TITLE
Document venv practices and track test hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Add rich configuration context fixtures with sample data for tests. [#17](issues/0017-create-more-comprehensive-test-contexts.md)
 - Optimize mypy configuration to skip site packages, preventing hangs during
   verification. [#22](issues/0022-investigate-mypy-hang.md).
+- Document virtual environment best practices in the developer guide.
 
 ## [0.1.0-alpha.1] - 2025-08-09
 - Verified source and wheel builds succeed; TestPyPI upload failed with 403 Forbidden.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -231,8 +231,8 @@ completed.
 - `flake8` reports no style errors.
 - `uv run mypy src` completes in ~7s after excluding site packages;
   issue [#22](issues/0022-investigate-mypy-hang.md) closed.
-- Unit tests begin executing, but the full suite remains long-running and
-  was interrupted after partial progress (~21%).
+- Unit tests begin executing but stall around 42% and were manually
+  interrupted. See [#23](issues/0023-unit-test-hang.md).
 
 ### Performance Baselines
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -20,7 +20,15 @@ The project uses **uv** for dependency management. All commands below rely on
 
 Several unit and integration tests require `gitpython` and the DuckDB VSS
 extension. Include the `git` extra when setting up the environment, for example:
-`uv pip install -e '.[full,parsers,git,llm,dev]'`.
+ `uv pip install -e '.[full,parsers,git,llm,dev]'`.
+
+### Virtual environment best practices
+
+- Keep the `.venv` isolated by avoiding global package installs.
+- Always activate the environment or prefix commands with `uv run`.
+- Regenerate the lock file with `uv lock` when dependencies change and
+  reinstall using `uv pip install -e '.[full,parsers,git,llm,dev]'`.
+- Use `task verify` to run linting and tests inside the active environment.
 
 ## Code Style
 

--- a/issues/0023-unit-test-hang.md
+++ b/issues/0023-unit-test-hang.md
@@ -1,0 +1,18 @@
+# Issue 23: Unit test suite hangs during verification
+
+Running `task verify` triggers `uv run pytest tests/unit --cov=src --cov-report=term-missing --cov-append`.
+The test suite progresses to about 42% and then stalls indefinitely. Manual interruption shows the process still running.
+
+## Context
+`task verify` is part of the standard development workflow. The hang prevents complete verification and suggests a problematic test or dependency.
+
+## Acceptance Criteria
+- Identify the test or dependency causing the hang.
+- Ensure `task verify` completes within a reasonable time (under 5 minutes).
+- Update documentation or configuration as needed to prevent recurrence.
+
+## Status
+Open
+
+## Related
+- #22


### PR DESCRIPTION
## Summary
- document virtual environment best practices in the developer guide
- note stalled unit test suite in task progress and changelog
- record hanging unit tests as issue #23

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `task verify` *(hangs around 42% during unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b6ff2fe9c83338c4d2651078736c2