### PR TITLE
Document NLP extras and vector path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   - Codex environments run `scripts/codex_setup.sh`, which delegates to `scripts/setup.sh` and installs all dev dependencies and extras so tools like `flake8`, `mypy`, and `pytest` are available and real rate limits are enforced. The setup script also installs [Go Task](https://taskfile.dev) system-wide so `task` commands work out of the box. After setup, verify `/usr/local/bin/task` exists; if missing, reinstall Go Task using `curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin`.
   - Confirm dev tools are installed with `uv pip list | grep flake8`.
   - After running `scripts/codex_setup.sh`, verify `pytest-cov`, `tomli_w`, `hypothesis`, `freezegun`, and `duckdb-extension-vss` are present using `uv pip list`.
+  - `VECTOR_EXTENSION_PATH` selects the DuckDB vector search extension. A stub
+    lives at `extensions/vss_stub.duckdb_extension` and is used in tests when
+    this variable is unset. Point it to a real `vss.duckdb_extension` to enable
+    the actual extension.
   - If `CODEX_ENVIRONMENT_SETUP_FAILED` exists, inspect
     `codex_setup.log` for setup details.
 
@@ -56,6 +60,11 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 - Before running any tests, install the development extras with
   `uv pip install -e '.[full,parsers,git,llm,dev]'`. These extras are required
   for full test runs, including integration and behavior tests.
+- Install optional NLP extras with `uv pip install -e '.[nlp]'` when running
+  tests that depend on topic modeling or transformer features. These tests use
+  the `requires_nlp` marker and are typically marked `slow`; run them with
+  `task test:slow` or `uv run pytest -m requires_nlp`. Skip them with
+  `-m 'not requires_nlp'` if the extras are unavailable.
 - See [tests/behavior/README.md](tests/behavior/README.md) for markers
   such as `requires_ui` and `requires_vss` to select specific scenarios.
 

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -80,7 +80,7 @@ fi
 echo "Verifying required extras..."
 missing=0
 missing_pkgs=""
-for pkg in pytest pytest-bdd pytest-httpx pytest-cov hypothesis tomli_w freezegun duckdb-extension-vss a2a-sdk GitPython pdfminer-six python-docx sentence-transformers transformers; do
+for pkg in pytest pytest-bdd pytest-httpx pytest-cov hypothesis tomli_w freezegun duckdb-extension-vss a2a-sdk GitPython pdfminer-six python-docx sentence-transformers transformers spacy bertopic; do
     if ! uv pip show "$pkg" >/dev/null 2>&1; then
         echo "Missing required package: $pkg" >&2
         missing=1
@@ -91,7 +91,13 @@ if [ "$missing" -ne 0 ]; then
     echo "ERROR: Missing dev packages: $missing_pkgs" >&2
     exit 1
 fi
-uv pip list | grep -E 'pytest(-bdd|-httpx)?|pytest-cov|hypothesis|tomli_w|freezegun|duckdb-extension-vss|a2a-sdk|GitPython|pdfminer-six|python-docx|sentence-transformers|transformers'
+uv pip list | grep -E 'pytest(-bdd|-httpx)?|pytest-cov|hypothesis|tomli_w|freezegun|duckdb-extension-vss|a2a-sdk|GitPython|pdfminer-six|python-docx|sentence-transformers|transformers|spacy|bertopic'
+
+# Ensure VECTOR_EXTENSION_PATH is configured
+if ! grep -q "VECTOR_EXTENSION_PATH" .env; then
+    echo "VECTOR_EXTENSION_PATH not set in .env" >&2
+    exit 1
+fi
 
 # Helper for retrying flaky network operations
 retry() {


### PR DESCRIPTION
## Summary
- document optional NLP extras and `requires_nlp` marker
- explain `VECTOR_EXTENSION_PATH` and bundled VSS stub
- verify NLP packages and vector extension path in setup script

## Testing
- `task verify` *(fails: interrupted)*
- `task test:slow` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689ba49758208333b326ee47533c3cde