### PR TITLE
Handle optional deps lazily

### DIFF
--- a/tests/unit/test_search_context.py
+++ b/tests/unit/test_search_context.py
@@ -1,0 +1,72 @@
+import importlib
+import sys
+import types
+
+
+def test_optional_dependencies_not_imported_on_module_load(monkeypatch):
+    for name in ("spacy", "bertopic", "sentence_transformers"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    module = importlib.reload(importlib.import_module("autoresearch.search.context"))
+    assert not module.SPACY_AVAILABLE
+    assert not module.BERTOPIC_AVAILABLE
+    assert not module.SENTENCE_TRANSFORMERS_AVAILABLE
+    assert "spacy" not in sys.modules
+    assert "bertopic" not in sys.modules
+    assert "sentence_transformers" not in sys.modules
+
+
+def test_spacy_loaded_when_needed(monkeypatch):
+    for name in ("spacy", "spacy.cli"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    module = importlib.reload(importlib.import_module("autoresearch.search.context"))
+    assert not module.SPACY_AVAILABLE
+
+    dummy_cli = types.ModuleType("cli")
+    dummy_cli.download = lambda model: None
+    dummy_spacy = types.ModuleType("spacy")
+    dummy_spacy.load = lambda model: "nlp"
+    dummy_spacy.cli = dummy_cli
+    monkeypatch.setitem(sys.modules, "spacy", dummy_spacy)
+    monkeypatch.setitem(sys.modules, "spacy.cli", dummy_cli)
+
+    ctx = module.SearchContext.new_for_tests()
+    assert module.SPACY_AVAILABLE
+    assert ctx.nlp == "nlp"
+
+
+def test_topic_model_imports_when_built(monkeypatch):
+    for name in ("spacy", "spacy.cli", "bertopic", "sentence_transformers"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    module = importlib.reload(importlib.import_module("autoresearch.search.context"))
+    monkeypatch.setattr(module.SearchContext, "_initialize_nlp", lambda self: None)
+
+    dummy_bertopic = types.ModuleType("bertopic")
+
+    class DummyBERTopic:
+        def fit_transform(self, docs):
+            return [0 for _ in docs], []
+
+    dummy_bertopic.BERTopic = DummyBERTopic
+    monkeypatch.setitem(sys.modules, "bertopic", dummy_bertopic)
+
+    dummy_st = types.ModuleType("sentence_transformers")
+
+    class DummySentenceTransformer:
+        pass
+
+    dummy_st.SentenceTransformer = DummySentenceTransformer
+    monkeypatch.setitem(sys.modules, "sentence_transformers", dummy_st)
+
+    ctx = module.SearchContext.new_for_tests()
+    ctx.search_history = [
+        {"query": "foo", "results": [{"title": "bar", "snippet": "baz"}]}
+    ]
+
+    assert not module.BERTOPIC_AVAILABLE
+    assert not module.SENTENCE_TRANSFORMERS_AVAILABLE
+
+    ctx.build_topic_model()
+
+    assert module.BERTOPIC_AVAILABLE
+    assert module.SENTENCE_TRANSFORMERS_AVAILABLE
+    assert isinstance(ctx.topic_model, DummyBERTopic)


### PR DESCRIPTION
## Summary
- load spaCy, BERTopic, and sentence-transformers only when needed and expose availability flags
- add tests ensuring optional dependencies are lazily imported

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `pytest tests/unit/test_search_context.py tests/unit/test_context_aware_search.py::test_search_context_singleton`

------
https://chatgpt.com/codex/tasks/task_e_689ba48fecb48333a29d860302c8e1c5