### PR TITLE
Add requires_nlp test marker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,8 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   the `requires_nlp` marker and are typically marked `slow`; run them with
   `task test:slow` or `uv run pytest -m requires_nlp`. Skip them with
   `-m 'not requires_nlp'` if the extras are unavailable.
-- See [tests/behavior/README.md](tests/behavior/README.md) for markers
-  such as `requires_ui` and `requires_vss` to select specific scenarios.
+  - See [tests/behavior/README.md](tests/behavior/README.md) for markers
+    such as `requires_ui`, `requires_vss`, and `requires_nlp` to select specific scenarios.
 
 ### Cleanup
 - Run `task clean` to remove `__pycache__` and `.mypy_cache` directories.

--- a/tests/behavior/README.md
+++ b/tests/behavior/README.md
@@ -6,18 +6,20 @@ setup.
 
 ## Installing extras
 
-Behavior tests rely on optional features such as the Streamlit UI and the DuckDB
-VSS extension. Install all extras with **uv** before running the scenarios:
+Behavior tests rely on optional features such as the Streamlit UI, the DuckDB
+VSS extension, and NLP components. Install all extras with **uv** before running
+the scenarios:
 
 ```bash
-uv pip install -e '.[full,parsers,git,llm,dev]'
+uv pip install -e '.[full,parsers,git,llm,dev,nlp]'
 ```
 
 ## Running extra tests
 
 Use pytest markers to execute these scenarios separately if you do not want to
 run the entire suite. `requires_ui` scenarios need the `ui` extra while
-`requires_vss` scenarios depend on the `vss` extra:
+`requires_vss` scenarios depend on the `vss` extra. NLP-dependent scenarios use
+the `requires_nlp` marker and require the `nlp` extra:
 
 ```bash
 # Scenarios that need the UI extra
@@ -25,6 +27,9 @@ uv run pytest tests/behavior -m requires_ui
 
 # Scenarios that need the VSS extra
 uv run pytest tests/behavior -m requires_vss
+
+# Scenarios that need NLP extras
+uv run pytest tests/behavior -m requires_nlp
 ```
 
 Scenarios with these markers are skipped when the corresponding extras are not

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,7 @@ typer.Option = _compat_option
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow")
+    config.addinivalue_line("markers", "requires_nlp: mark test requiring NLP extras")
 
 
 def reset_limiter_state() -> None:
@@ -87,11 +88,14 @@ def pytest_runtest_setup(item):
         pytest.skip("vss extra not installed")
     if item.get_closest_marker("requires_git") and not GITPYTHON_INSTALLED:
         pytest.skip("git extra not installed")
+    if item.get_closest_marker("requires_nlp") and not NLP_AVAILABLE:
+        pytest.skip("nlp extra not installed")
 
 
 GITPYTHON_INSTALLED = _module_available("git")
 POLARS_INSTALLED = _module_available("polars")
 UI_AVAILABLE = _module_available("streamlit")
+NLP_AVAILABLE = _module_available("sentence_transformers")
 
 
 def _check_vss() -> bool:
@@ -507,7 +511,7 @@ def realistic_claim_batch(claim_factory):
 @pytest.fixture
 def sample_eval_data():
     """Load the sample evaluation CSV for search weight tests."""
-
+    pytest.importorskip("sentence_transformers")
     from autoresearch.search import Search
 
     path = Path(__file__).resolve().parent / "data" / "eval" / "sample_eval.csv"

--- a/tests/integration/test_grid_search_optimization.py
+++ b/tests/integration/test_grid_search_optimization.py
@@ -1,4 +1,8 @@
+import pytest
+
 from autoresearch.search import Search
+
+pytestmark = pytest.mark.requires_nlp
 
 
 def test_optimize_weights_returns_better_score(sample_eval_data):

--- a/tests/integration/test_search_weights.py
+++ b/tests/integration/test_search_weights.py
@@ -2,11 +2,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import tomllib
 from autoresearch.search import Search
-import pytest
 
-pytestmark = pytest.mark.slow
+pytestmark = [pytest.mark.slow, pytest.mark.requires_nlp]
 
 
 def test_optimize_script_updates_weights(tmp_path, sample_eval_data):
@@ -18,7 +18,9 @@ def test_optimize_script_updates_weights(tmp_path, sample_eval_data):
 
     baseline = Search.evaluate_weights((0.5, 0.3, 0.2), sample_eval_data)
 
-    script = Path(__file__).resolve().parents[2] / "scripts" / "optimize_search_weights.py"
+    script = (
+        Path(__file__).resolve().parents[2] / "scripts" / "optimize_search_weights.py"
+    )
     subprocess.run(
         [sys.executable, str(script), str(dataset), str(cfg)],
         check=True,

--- a/tests/unit/test_optimize_weights_unit.py
+++ b/tests/unit/test_optimize_weights_unit.py
@@ -1,4 +1,8 @@
+import pytest
+
 from autoresearch.search import Search
+
+pytestmark = pytest.mark.requires_nlp
 
 
 def test_optimize_weights_improves_score(sample_eval_data):

--- a/tests/unit/test_property_weight_tuning.py
+++ b/tests/unit/test_property_weight_tuning.py
@@ -3,6 +3,8 @@ from hypothesis import given, strategies as st, settings, HealthCheck
 
 from autoresearch.search import Search
 
+pytestmark = pytest.mark.requires_nlp
+
 
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(step=st.floats(min_value=0.05, max_value=0.3))


### PR DESCRIPTION
## Summary
- add `requires_nlp` pytest marker and skip logic for missing NLP extras
- mark NLP-dependent tests and guard sample_eval_data fixture
- document `requires_nlp` marker in behavior test README and AGENTS instructions

## Testing
- `uv run ruff format tests/conftest.py tests/integration/test_grid_search_optimization.py tests/integration/test_search_weights.py tests/unit/test_optimize_weights_unit.py tests/unit/test_property_weight_tuning.py`
- `uv run ruff check --fix tests/conftest.py tests/integration/test_grid_search_optimization.py tests/integration/test_search_weights.py tests/unit/test_optimize_weights_unit.py tests/unit/test_property_weight_tuning.py`
- `uv run flake8 tests/conftest.py tests/integration/test_grid_search_optimization.py tests/integration/test_search_weights.py tests/unit/test_optimize_weights_unit.py tests/unit/test_property_weight_tuning.py`
- `uv run mypy src`
- `uv run pytest tests/unit/test_storage_validation.py::test_validate_claim_valid -q --no-cov`
- `uv run pytest tests/unit/test_optimize_weights_unit.py -q --no-cov`
- `uv run pytest tests/integration/test_grid_search_optimization.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689bb59983148333a78a56a624fa3ef4