### PR TITLE
Skip heavy search context in tests

### DIFF
--- a/tests/unit/test_context_aware_search.py
+++ b/tests/unit/test_context_aware_search.py
@@ -6,6 +6,8 @@ from unittest.mock import patch, MagicMock
 from autoresearch.search import Search, SearchContext
 from autoresearch.config.models import SearchConfig, ContextAwareSearchConfig
 
+pytestmark = [pytest.mark.slow, pytest.mark.requires_nlp]
+
 
 @pytest.fixture
 def reset_search_context():

--- a/tests/unit/test_eviction.py
+++ b/tests/unit/test_eviction.py
@@ -11,6 +11,7 @@ from freezegun import freeze_time
 def test_ram_eviction(storage_manager, monkeypatch):
     StorageManager.clear_all()
     config = ConfigModel(ram_budget_mb=1)
+    config.search.context_aware.enabled = False
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: config)
     # reload config property
     ConfigLoader()._config = None
@@ -25,6 +26,7 @@ def test_ram_eviction(storage_manager, monkeypatch):
 def test_score_eviction(storage_manager, monkeypatch):
     StorageManager.clear_all()
     config = ConfigModel(ram_budget_mb=1, graph_eviction_policy="score")
+    config.search.context_aware.enabled = False
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: config)
     ConfigLoader()._config = None
     monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 0)
@@ -53,6 +55,7 @@ def test_lru_eviction_order(storage_manager, monkeypatch):
 
     storage.StorageManager.state.lru.clear()
     config = ConfigModel(ram_budget_mb=1)
+    config.search.context_aware.enabled = False
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: config)
     ConfigLoader()._config = None
     monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 0)

--- a/tests/unit/test_search_backends_unit.py
+++ b/tests/unit/test_search_backends_unit.py
@@ -8,6 +8,7 @@ from autoresearch.errors import SearchError
 
 def test_register_backend_and_lookup(monkeypatch):
     Search.backends = {}
+    original_defaults = dict(Search._default_backends)
 
     @Search.register_backend("dummy")
     def dummy_backend(query: str, max_results: int = 5):
@@ -24,6 +25,9 @@ def test_register_backend_and_lookup(monkeypatch):
 
     results = Search.external_lookup("x", max_results=1)
     assert results == [{"title": "t", "url": "u", "backend": "dummy"}]
+
+    Search.reset()
+    Search._default_backends = original_defaults
 
 
 def test_external_lookup_unknown_backend(monkeypatch):

--- a/tests/unit/test_search_context.py
+++ b/tests/unit/test_search_context.py
@@ -2,6 +2,10 @@ import importlib
 import sys
 import types
 
+import pytest
+
+pytestmark = pytest.mark.requires_nlp
+
 
 def test_optional_dependencies_not_imported_on_module_load(monkeypatch):
     for name in ("spacy", "bertopic", "sentence_transformers"):

--- a/tests/unit/test_search_context_extract_entities_no_spacy.py
+++ b/tests/unit/test_search_context_extract_entities_no_spacy.py
@@ -1,7 +1,12 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from autoresearch.search.context import SearchContext
+
+
+pytestmark = pytest.mark.requires_nlp
 
 
 def make_config():

--- a/tests/unit/test_search_context_history_trim.py
+++ b/tests/unit/test_search_context_history_trim.py
@@ -1,7 +1,12 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from autoresearch.search.context import SearchContext
+
+
+pytestmark = pytest.mark.requires_nlp
 
 
 def make_config(max_history):


### PR DESCRIPTION
## Summary
- disable context-aware search in eviction tests to prevent heavy imports
- mark search-context tests with `requires_nlp`/`slow` for optional NLP extras
- reset registered search backends in tests to avoid leaking heavy defaults

## Testing
- `task verify` *(fails: Coverage failure: total of 45 is less than fail-under=90)*


------
https://chatgpt.com/codex/tasks/task_e_689c0702f384833394bcc89f4e8b5175