### PR TITLE
Disable vector extension in monitor CLI test

### DIFF
--- a/tests/unit/test_monitor_cli.py
+++ b/tests/unit/test_monitor_cli.py
@@ -1,6 +1,6 @@
 from typer.testing import CliRunner
 from autoresearch.main import app
-from autoresearch.config.models import ConfigModel
+from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.models import QueryResponse
@@ -26,7 +26,11 @@ def test_monitor_prompts_and_passes_callbacks(monkeypatch):
     monkeypatch.setattr(
         ConfigLoader,
         "load_config",
-        lambda self: ConfigModel(loops=1, output_format="json"),
+        lambda self: ConfigModel(
+            loops=1,
+            output_format="json",
+            storage=StorageConfig(vector_extension=False),
+        ),
     )
     responses = iter(["test", "", "q"])
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- ensure monitor CLI test avoids network dependency by disabling vector extension

## Testing
- `uv run pytest tests/unit/test_monitor_cli.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689c21aa5f9c8333a9fee81d90ffd2b5