### PR TITLE
Include targeted tests in default suite

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -4,11 +4,12 @@ This document provides guidelines for writing tests in the Autoresearch project.
 
 ## Test Organization
 
-Tests are organized into three categories:
+Tests are organized into four categories:
 
 1. **Unit Tests** (`tests/unit/`): Test individual components in isolation
 2. **Integration Tests** (`tests/integration/`): Test interactions between components
 3. **Behavior Tests** (`tests/behavior/`): BDD-style tests using Gherkin syntax
+4. **Targeted Tests** (`tests/targeted/`): Edge cases and extra scenarios included in the standard test run
 
 ## Running tests
 
@@ -25,7 +26,7 @@ task test:integration  # integration tests excluding slow tests
 task test:behavior     # behavior-driven tests
 task test:fast         # unit, integration, and behavior tests (no slow)
 task test:slow         # only tests marked as slow
-task test:all          # entire suite including slow tests
+task test:all          # entire suite including slow tests and targeted tests
 ```
 You can also invoke the slow suite directly with:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ autoresearch = "autoresearch.main:app"
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--maxfail=1 --disable-warnings -q --cov=autoresearch.orchestration.orchestrator --cov=autoresearch.storage --cov=autoresearch.storage_backends --cov=autoresearch.search.core --cov=autoresearch.streamlit_ui --cov-report=xml --cov-report=term-missing --cov-fail-under=90 -m 'not slow and not requires_ui and not requires_vss'"
-testpaths = ["tests/unit", "tests/integration", "tests/behavior"]
+testpaths = ["tests/unit", "tests/integration", "tests/behavior", "tests/targeted"]
 python_files = ["test_*.py", "*_steps.py"]
 markers = [
     "behavior: mark behavior (BDD) tests",

--- a/tests/targeted/test_orchestrator_edgecases2.py
+++ b/tests/targeted/test_orchestrator_edgecases2.py
@@ -23,7 +23,7 @@ def test_adaptive_token_budget():
 
 
 def test_categorize_error_cases():
-    assert Orchestrator._categorize_error(TimeoutError()) == "transient"
+    assert Orchestrator._categorize_error(TimeoutError("timeout")) == "transient"
     nf = NotFoundError("x", resource_type="a", resource_id="b")
     assert Orchestrator._categorize_error(nf) == "recoverable"
     assert Orchestrator._categorize_error(AgentError("configuration bad")) == "recoverable"

--- a/tests/targeted/test_storage_edgecases2.py
+++ b/tests/targeted/test_storage_edgecases2.py
@@ -9,10 +9,14 @@ def test_current_ram_fallback(monkeypatch):
     def fake_import(name, *a, **k):
         if name == "psutil":
             raise ImportError
+        if name == "resource":
+            return types.SimpleNamespace(
+                RUSAGE_SELF=0,
+                getrusage=lambda x: types.SimpleNamespace(ru_maxrss=1024 * 1024),
+            )
         return orig_import(name, *a, **k)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
-    monkeypatch.setattr(storage, "resource", types.SimpleNamespace(getrusage=lambda x: types.SimpleNamespace(ru_maxrss=1024*1024)))
     mb = storage.StorageManager._current_ram_mb()
     assert mb == 1024.0
 

--- a/tests/targeted/test_streamlit_extra.py
+++ b/tests/targeted/test_streamlit_extra.py
@@ -1,19 +1,18 @@
 import types
 
-from autoresearch import streamlit_app  # noqa: E402
+from autoresearch import streamlit_app, streamlit_ui  # noqa: E402
 
 
 def test_apply_accessibility(monkeypatch):
     calls = []
-    fake_st = types.SimpleNamespace(markdown=lambda *a, **k: calls.append(a))
-    fake_st.session_state = {'high_contrast': True}
-    monkeypatch.setattr(streamlit_app, 'st', fake_st)
+    fake_st = types.SimpleNamespace(markdown=lambda *a, **k: calls.append(a), session_state={'high_contrast': True})
+    monkeypatch.setattr(streamlit_ui, 'st', fake_st)
     streamlit_app.apply_accessibility_settings()
     assert len(calls) == 2
 
 
 def test_display_query_input_has_accessibility(monkeypatch):
-    calls = {"markdown": [], "button": []}
+    calls = {"markdown": [], "form_submit_button": []}
 
     class Dummy:
         def __enter__(self):
@@ -27,12 +26,18 @@ def test_display_query_input_has_accessibility(monkeypatch):
         text_area=lambda *a, **k: "",
         selectbox=lambda *a, **k: None,
         slider=lambda *a, **k: 0,
-        button=lambda *a, **k: calls["button"].append(k) or False,
+        button=lambda *a, **k: False,
         columns=lambda *a, **k: (Dummy(), Dummy()),
         container=lambda: Dummy(),
-        session_state={"config": types.SimpleNamespace(reasoning_mode=streamlit_app.ReasoningMode.DIALECTICAL, loops=2)}
+        form=lambda *a, **k: Dummy(),
+        form_submit_button=lambda *a, **k: calls["form_submit_button"].append(k) or False,
+        session_state=types.SimpleNamespace(
+            config=types.SimpleNamespace(
+                reasoning_mode=streamlit_app.ReasoningMode.DIALECTICAL, loops=2
+            )
+        ),
     )
     monkeypatch.setattr(streamlit_app, "st", fake_st)
     streamlit_app.display_query_input()
     assert any("aria-label='Query input area'" in args[0] for args, _ in calls["markdown"])
-    assert any("run your query" in kw.get("help", "") for kw in calls["button"])
+    assert any("run your query" in kw.get("help", "") for kw in calls["form_submit_button"])

--- a/tests/targeted/test_streamlit_theme.py
+++ b/tests/targeted/test_streamlit_theme.py
@@ -1,11 +1,11 @@
 import types
-from autoresearch import streamlit_app
+from autoresearch import streamlit_app, streamlit_ui
 
 
 def test_apply_theme_settings(monkeypatch):
     calls = []
     fake_st = types.SimpleNamespace(markdown=lambda *a, **k: calls.append(a), session_state={"dark_mode": True})
-    monkeypatch.setattr(streamlit_app, "st", fake_st)
+    monkeypatch.setattr(streamlit_ui, "st", fake_st)
     streamlit_app.apply_theme_settings()
     assert calls
     fake_st.session_state["dark_mode"] = False


### PR DESCRIPTION
## Summary
- run targeted tests with standard pytest by adding tests/targeted to testpaths
- document targeted tests in testing guidelines
- update targeted tests for orchestrator, storage, and Streamlit changes

## Testing
- `uv run pytest tests/targeted -q --cov-fail-under=0`
- `task test:all` *(fails: exit status 143)*

------
https://chatgpt.com/codex/tasks/task_e_689ca0c60be483338a919fd6869a2049