### PR TITLE
Track orchestrator refactor and test issues

### DIFF
--- a/issues/0027-orchestrator-instance-cb-manager.md
+++ b/issues/0027-orchestrator-instance-cb-manager.md
@@ -1,0 +1,25 @@
+# Issue 27: Refactor Orchestrator to instance-level circuit breaker
+
+The orchestrator currently uses a class-level `_cb_manager` that persists across
+queries and tests, leading to shared state and cross-test interference. A prior
+refactor attempt moved `_cb_manager` toward instance state but left methods and
+tests inconsistent, causing unit failures.
+
+## Context
+- `_cb_manager` lives on the `Orchestrator` class in
+  `src/autoresearch/orchestration/orchestrator.py`.
+- Shared state bleeds between queries and tests.
+- Refactoring requires allocating a new circuit breaker manager per query and
+  propagating this change through dependent modules and tests.
+
+## Acceptance Criteria
+- `_cb_manager` is an instance attribute initialized for each query.
+- Orchestrator methods and any downstream consumers are updated accordingly.
+- Tests are updated to assume instance-scoped circuit breaker state.
+- `task test:unit` completes successfully with no cross-test interference.
+
+## Status
+Open
+
+## Related
+- #28

--- a/issues/0028-unit-tests-after-orchestrator-refactor.md
+++ b/issues/0028-unit-tests-after-orchestrator-refactor.md
@@ -1,0 +1,22 @@
+# Issue 28: Remediate unit tests after Orchestrator refactor
+
+Unit tests fail following the attempted shift to an instance-based circuit
+breaker manager. The refactor introduced API changes and incomplete updates that
+leave tests in an inconsistent state.
+
+## Context
+- The in-progress refactor in issue #27 changed `_cb_manager` usage.
+- Existing tests expect class-level state, causing failures and potential hangs.
+- Fixtures and helper utilities may need redesign to use fresh Orchestrator
+  instances per test.
+
+## Acceptance Criteria
+- Unit tests are updated to accommodate the instance-level `_cb_manager`.
+- Any hanging or failing tests are fixed.
+- `task test:unit` passes reliably.
+
+## Status
+Open
+
+## Related
+- #27


### PR DESCRIPTION
## Summary
- add issue #27 to refactor orchestrator circuit breaker to instance scope
- add issue #28 to fix unit tests after orchestrator state changes

## Testing
- `task test:unit` *(failed: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689ca0f6b9dc83338a5dbc17719c482b