### PR TITLE
Raise stored exceptions in BDD steps

### DIFF
--- a/tests/behavior/steps/orchestrator_agents_integration_extended_steps.py
+++ b/tests/behavior/steps/orchestrator_agents_integration_extended_steps.py
@@ -22,6 +22,8 @@ def system_configured_with_multiple_agents(extended_test_context):
         agents=["Synthesizer", "Contrarian", "FactChecker"],
         reasoning_mode="dialectical",
         loops=1,
+        llm_backend="dummy",
+        default_model="dummy-model",
     )
     extended_test_context["agents"] = ["Synthesizer", "Contrarian", "FactChecker"]
 
@@ -96,6 +98,8 @@ def system_configured_for_multiple_loops(extended_test_context):
         agents=["Synthesizer", "Contrarian", "FactChecker"],
         reasoning_mode="dialectical",
         loops=3,  # Run 3 loops
+        llm_backend="dummy",
+        default_model="dummy-model",
     )
     extended_test_context["agents"] = ["Synthesizer", "Contrarian", "FactChecker"]
 
@@ -179,11 +183,9 @@ def run_query_with_multiple_loops(extended_test_context, monkeypatch):
 @then("each loop should execute the agents in the correct sequence")
 def each_loop_executes_agents_in_correct_sequence(extended_test_context):
     """Verify that each loop executes the agents in the correct sequence."""
-    # Skip this assertion if there was an exception during execution
+    # Surface any error captured during execution
     if "exception" in extended_test_context:
-        pytest.skip(
-            f"Test skipped due to exception: {extended_test_context['exception']}"
-        )
+        raise extended_test_context["exception"]
 
     # Verify that we have the expected number of loops
     assert len(extended_test_context["loop_executions"]) == 3, (
@@ -201,11 +203,9 @@ def each_loop_executes_agents_in_correct_sequence(extended_test_context):
 @then("the state should be preserved between loops")
 def state_preserved_between_loops(extended_test_context):
     """Verify that the state is preserved between loops."""
-    # Skip this assertion if there was an exception during execution
+    # Surface any error captured during execution
     if "exception" in extended_test_context:
-        pytest.skip(
-            f"Test skipped due to exception: {extended_test_context['exception']}"
-        )
+        raise extended_test_context["exception"]
 
     # Verify that the state from the last agent in loop 1 is passed to the first agent in loop 2
     last_agent_loop1 = extended_test_context["loop_executions"][1][-1]
@@ -224,11 +224,9 @@ def state_preserved_between_loops(extended_test_context):
 @then("the final result should include contributions from all loops")
 def result_includes_all_loop_contributions(extended_test_context):
     """Verify that the final result includes contributions from all loops."""
-    # Skip this assertion if there was an exception during execution
+    # Surface any error captured during execution
     if "exception" in extended_test_context:
-        pytest.skip(
-            f"Test skipped due to exception: {extended_test_context['exception']}"
-        )
+        raise extended_test_context["exception"]
 
     # The result should include all agents from all loops
     result_str = str(extended_test_context["result"])
@@ -247,6 +245,8 @@ def system_configured_with_direct_reasoning_mode(extended_test_context):
         agents=["Synthesizer", "Contrarian", "FactChecker"],
         reasoning_mode="direct",  # Use direct reasoning mode
         loops=1,
+        llm_backend="dummy",
+        default_model="dummy-model",
     )
     extended_test_context["agents"] = ["Synthesizer", "Contrarian", "FactChecker"]
     extended_test_context["primary_agent"] = (
@@ -322,11 +322,9 @@ def run_query_with_direct_reasoning_mode(extended_test_context, monkeypatch):
 @then("only the primary agent should be executed")
 def only_primary_agent_executed(extended_test_context):
     """Verify that only the primary agent was executed."""
-    # Skip this assertion if there was an exception during execution
+    # Surface any error captured during execution
     if "exception" in extended_test_context:
-        pytest.skip(
-            f"Test skipped due to exception: {extended_test_context['exception']}"
-        )
+        raise extended_test_context["exception"]
 
     # In direct mode, only the primary agent (Synthesizer) should be executed
     assert len(extended_test_context["executed_agents"]) == 1, (
@@ -343,11 +341,9 @@ def only_primary_agent_executed(extended_test_context):
 @then("the final result should include only the primary agent's contribution")
 def result_includes_only_primary_agent_contribution(extended_test_context):
     """Verify that the final result includes only the primary agent's contribution."""
-    # Skip this assertion if there was an exception during execution
+    # Surface any error captured during execution
     if "exception" in extended_test_context:
-        pytest.skip(
-            f"Test skipped due to exception: {extended_test_context['exception']}"
-        )
+        raise extended_test_context["exception"]
 
     # The result should include only the primary agent
     result_str = str(extended_test_context["result"])
@@ -392,6 +388,8 @@ def agent_that_modifies_state(extended_test_context, monkeypatch):
         agents=extended_test_context["agents"],
         reasoning_mode="dialectical",
         loops=3,  # Run 3 loops
+        llm_backend="dummy",
+        default_model="dummy-model",
     )
 
     # Store the agent for later use
@@ -401,11 +399,9 @@ def agent_that_modifies_state(extended_test_context, monkeypatch):
 @then("the state modifications should be preserved between loops")
 def state_modifications_preserved_between_loops(extended_test_context):
     """Verify that state modifications are preserved between loops."""
-    # Skip this assertion if there was an exception during execution
+    # Surface any error captured during execution
     if "exception" in extended_test_context:
-        pytest.skip(
-            f"Test skipped due to exception: {extended_test_context['exception']}"
-        )
+        raise extended_test_context["exception"]
 
     # Verify that the counter was incremented in each loop
     for loop in range(1, 4):  # Loops 1, 2, 3
@@ -421,11 +417,9 @@ def state_modifications_preserved_between_loops(extended_test_context):
 @then("the final result should reflect the cumulative state changes")
 def result_reflects_cumulative_state_changes(extended_test_context):
     """Verify that the final result reflects the cumulative state changes."""
-    # Skip this assertion if there was an exception during execution
+    # Surface any error captured during execution
     if "exception" in extended_test_context:
-        pytest.skip(
-            f"Test skipped due to exception: {extended_test_context['exception']}"
-        )
+        raise extended_test_context["exception"]
 
     # The result should include the final counter value
     result_str = str(extended_test_context["result"])

--- a/tests/behavior/steps/orchestrator_agents_integration_steps.py
+++ b/tests/behavior/steps/orchestrator_agents_integration_steps.py
@@ -86,6 +86,8 @@ def system_configured_with_multiple_agents(test_context):
         agents=["Synthesizer", "Contrarian", "FactChecker"],
         reasoning_mode="dialectical",
         loops=1,
+        llm_backend="dummy",
+        default_model="dummy-model",
     )
     test_context["agents"] = ["Synthesizer", "Contrarian", "FactChecker"]
 
@@ -156,9 +158,9 @@ def run_query_with_dialectical_reasoning(test_context, mock_agent_factory, monke
 @then("the agents should be executed in the correct sequence")
 def agents_executed_in_correct_sequence(test_context):
     """Verify that agents were executed in the correct sequence."""
-    # Skip this assertion if there was an exception during execution
+    # Surface any error captured during execution
     if "exception" in test_context:
-        pytest.skip(f"Test skipped due to exception: {test_context['exception']}")
+        raise test_context["exception"]
 
     expected_sequence = test_context["agents"]
     assert test_context["executed_agents"] == expected_sequence
@@ -167,9 +169,9 @@ def agents_executed_in_correct_sequence(test_context):
 @then("each agent should receive the state from previous agents")
 def agents_receive_state_from_previous(test_context):
     """Verify that each agent received the state from previous agents."""
-    # Skip this assertion if there was an exception during execution
+    # Surface any error captured during execution
     if "exception" in test_context:
-        pytest.skip(f"Test skipped due to exception: {test_context['exception']}")
+        raise test_context["exception"]
 
     for i, agent_name in enumerate(test_context["executed_agents"]):
         if i > 0:
@@ -180,9 +182,9 @@ def agents_receive_state_from_previous(test_context):
 @then("the final result should include contributions from all agents")
 def result_includes_all_agent_contributions(test_context):
     """Verify that the final result includes contributions from all agents."""
-    # Skip this assertion if there was an exception during execution
+    # Surface any error captured during execution
     if "exception" in test_context:
-        pytest.skip(f"Test skipped due to exception: {test_context['exception']}")
+        raise test_context["exception"]
 
     for agent_name in test_context["agents"]:
         assert agent_name in str(test_context["result"])
@@ -206,6 +208,8 @@ def agent_that_raises_error(mock_agent_factory, test_context):
         reasoning_mode="direct",
         loops=1,
         max_errors=1,
+        llm_backend="dummy",
+        default_model="dummy-model",
     )
 
 
@@ -291,7 +295,11 @@ def agent_with_specific_execution_conditions(mock_agent_factory, test_context):
     mock_agent_factory.get.side_effect = get_agent
 
     test_context["config"] = ConfigModel(
-        agents=["ConditionalAgent", "Synthesizer"], reasoning_mode="direct", loops=1
+        agents=["ConditionalAgent", "Synthesizer"],
+        reasoning_mode="direct",
+        loops=1,
+        llm_backend="dummy",
+        default_model="dummy-model",
     )
 
 
@@ -328,9 +336,9 @@ def run_query_not_meeting_conditions(test_context, mock_agent_factory, monkeypat
 @then("that agent should not be executed")
 def agent_not_executed(test_context):
     """Verify that the conditional agent was not executed."""
-    # Skip this assertion if there was an exception during execution
+    # Surface any error captured during execution
     if "exception" in test_context:
-        pytest.skip(f"Test skipped due to exception: {test_context['exception']}")
+        raise test_context["exception"]
 
     assert "ConditionalAgent" not in test_context["executed_agents"]
 
@@ -338,9 +346,9 @@ def agent_not_executed(test_context):
 @then("the orchestrator should continue with other agents")
 def orchestrator_continues_with_other_agents_after_skip(test_context):
     """Verify that the orchestrator continued with other agents after skipping one."""
-    # Skip this assertion if there was an exception during execution
+    # Surface any error captured during execution
     if "exception" in test_context:
-        pytest.skip(f"Test skipped due to exception: {test_context['exception']}")
+        raise test_context["exception"]
 
     assert "Synthesizer" in test_context["executed_agents"]
 
@@ -348,8 +356,8 @@ def orchestrator_continues_with_other_agents_after_skip(test_context):
 @then("the final result should not include contributions from the skipped agent")
 def result_excludes_skipped_agent_contributions(test_context):
     """Verify that the final result doesn't include contributions from the skipped agent."""
-    # Skip this assertion if there was an exception during execution
+    # Surface any error captured during execution
     if "exception" in test_context:
-        pytest.skip(f"Test skipped due to exception: {test_context['exception']}")
+        raise test_context["exception"]
 
     assert "ConditionalAgent" not in str(test_context["result"])

--- a/tests/behavior/steps/test_cleanup_steps.py
+++ b/tests/behavior/steps/test_cleanup_steps.py
@@ -45,6 +45,8 @@ def system_configured_with_multiple_agents(cleanup_context, config_model):
     config.agents = ["Synthesizer", "Contrarian", "FactChecker"]
     config.reasoning_mode = "dialectical"
     config.loops = 1
+    config.llm_backend = "dummy"
+    config.default_model = "dummy-model"
 
     # Track initial state
     cleanup_context["initial_env_vars"] = os.environ.copy()
@@ -99,9 +101,9 @@ def run_query_with_dialectical_reasoning(config, cleanup_context, monkeypatch):
 @then("all monkeypatches should be properly cleaned up")
 def monkeypatches_properly_cleaned_up(cleanup_context):
     """Verify that all monkeypatches are properly cleaned up."""
-    # Skip this check if there was an error during execution
+    # Surface any error captured during execution
     if "error" in cleanup_context:
-        pytest.skip(f"Test skipped due to error: {cleanup_context['error']}")
+        raise cleanup_context["error"]
 
     # Check that monkeypatched functions are restored
     for path, original_value in cleanup_context["monkeypatches"]:
@@ -124,9 +126,9 @@ def monkeypatches_properly_cleaned_up(cleanup_context):
 @then("all mocks should be properly cleaned up")
 def mocks_properly_cleaned_up(cleanup_context):
     """Verify that all mocks are properly cleaned up."""
-    # Skip this check if there was an error during execution
+    # Surface any error captured during execution
     if "error" in cleanup_context:
-        pytest.skip(f"Test skipped due to error: {cleanup_context['error']}")
+        raise cleanup_context["error"]
 
     # Check that mocked objects are no longer in use
     for mock in cleanup_context["mocks"]:


### PR DESCRIPTION
## Summary
- raise stored errors in BDD step assertions instead of skipping
- configure BDD scenarios to use dummy LLM backend and model

## Testing
- `task behavior` *(fails: tests/behavior/steps/api_documentation_steps.py::test_retrieve_openapi_schema - ValueError: tuple.index(x): x not in tuple)*
- `task verify` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689ccabd83308333bba3bb2d113d6d89