### PR TITLE
Clarify test coverage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 - Keep `AGENTS.md` files current and commit updates alongside related code changes.
 - When instructions affect environment setup or tooling, update `scripts/codex_setup.sh` to match.
 - Changes to tooling must be reflected in both this document and `scripts/codex_setup.sh` so documentation and setup stay in sync.
+- Changes under `tests/` must keep this document and `scripts/codex_setup.sh` in sync to reflect new test requirements.
 
 ## Binary artifacts
 - Do not commit binary files such as `.duckdb_extension` modules.
@@ -50,6 +51,7 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   to `.venv/bin/pytest`.
 - Run `task verify` before committing; it performs linting, type checking,
   and all tests with coverage (see [`Taskfile.yml`](Taskfile.yml)).
+- Generate explicit coverage reports with `task coverage`.
 - Use `rg` for repository searches instead of `grep -R` or `ls -R`.
   Example: `rg <pattern>`.
 - If `task` is unavailable, run these commands individually:
@@ -62,6 +64,8 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   - Run the unit suite: `uv run pytest -q`.
   - Execute BDD tests in `tests/behavior`: `uv run pytest tests/behavior`.
   - Run the entire suite with coverage: `uv run pytest --cov=src`.
+  - Execute any targeted suites in `tests/targeted` and fold them into the
+    main test directories once validated.
 - Before running any tests, install the development extras with
   `uv pip install -e '.[full,parsers,git,llm,dev]'`. These extras are required
   for full test runs, including integration and behavior tests.

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -6,7 +6,8 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 set -x
 
 # NOTE: Keep this script in sync with AGENTS.md.
-# When tooling or helper scripts change, update both this file and AGENTS.md.
+# When tooling, helper scripts, or test directories change, update both this
+# file and AGENTS.md so new test requirements are captured here.
 
 # Pre-flight: ensure uv is installed
 if ! command -v uv >/dev/null 2>&1; then

--- a/tests/targeted/README.md
+++ b/tests/targeted/README.md
@@ -1,0 +1,12 @@
+# Targeted tests
+
+Temporary tests to reproduce specific issues live here. Execute them with:
+
+```bash
+uv run pytest tests/targeted -q
+```
+
+After the underlying problem is resolved, merge these tests into the
+appropriate suite under `tests/unit`, `tests/integration`, or `tests/behavior`
+so they run as part of `task coverage`.
+


### PR DESCRIPTION
## Summary
- instruct contributors to run `task coverage` and execute or merge any `tests/targeted` suites
- note that changes under `tests/` must sync `AGENTS.md` and `scripts/codex_setup.sh`
- document targeted test usage in `tests/targeted/README.md` and align setup script comments

## Testing
- `task coverage` *(fails: Ontology reasoning interrupted, StorageError in tests/unit/test_eviction.py)*
- `uv run pytest tests/targeted -q` *(fails: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_689d18fe4738833386ead3257e06fc8e