### PR TITLE
Mark streamlit targeted tests as UI-dependent

### DIFF
--- a/tests/targeted/test_streamlit_extra.py
+++ b/tests/targeted/test_streamlit_extra.py
@@ -1,12 +1,17 @@
 import types
+import pytest
 
 from autoresearch import streamlit_app, streamlit_ui  # noqa: E402
+
+pytestmark = pytest.mark.requires_ui
 
 
 def test_apply_accessibility(monkeypatch):
     calls = []
-    fake_st = types.SimpleNamespace(markdown=lambda *a, **k: calls.append(a), session_state={'high_contrast': True})
-    monkeypatch.setattr(streamlit_ui, 'st', fake_st)
+    fake_st = types.SimpleNamespace(
+        markdown=lambda *a, **k: calls.append(a), session_state={"high_contrast": True}
+    )
+    monkeypatch.setattr(streamlit_ui, "st", fake_st)
     streamlit_app.apply_accessibility_settings()
     assert len(calls) == 2
 
@@ -30,7 +35,8 @@ def test_display_query_input_has_accessibility(monkeypatch):
         columns=lambda *a, **k: (Dummy(), Dummy()),
         container=lambda: Dummy(),
         form=lambda *a, **k: Dummy(),
-        form_submit_button=lambda *a, **k: calls["form_submit_button"].append(k) or False,
+        form_submit_button=lambda *a, **k: calls["form_submit_button"].append(k)
+        or False,
         session_state=types.SimpleNamespace(
             config=types.SimpleNamespace(
                 reasoning_mode=streamlit_app.ReasoningMode.DIALECTICAL, loops=2
@@ -39,5 +45,9 @@ def test_display_query_input_has_accessibility(monkeypatch):
     )
     monkeypatch.setattr(streamlit_app, "st", fake_st)
     streamlit_app.display_query_input()
-    assert any("aria-label='Query input area'" in args[0] for args, _ in calls["markdown"])
-    assert any("run your query" in kw.get("help", "") for kw in calls["form_submit_button"])
+    assert any(
+        "aria-label='Query input area'" in args[0] for args, _ in calls["markdown"]
+    )
+    assert any(
+        "run your query" in kw.get("help", "") for kw in calls["form_submit_button"]
+    )

--- a/tests/targeted/test_streamlit_theme.py
+++ b/tests/targeted/test_streamlit_theme.py
@@ -1,10 +1,15 @@
 import types
+import pytest
 from autoresearch import streamlit_app, streamlit_ui
+
+pytestmark = pytest.mark.requires_ui
 
 
 def test_apply_theme_settings(monkeypatch):
     calls = []
-    fake_st = types.SimpleNamespace(markdown=lambda *a, **k: calls.append(a), session_state={"dark_mode": True})
+    fake_st = types.SimpleNamespace(
+        markdown=lambda *a, **k: calls.append(a), session_state={"dark_mode": True}
+    )
     monkeypatch.setattr(streamlit_ui, "st", fake_st)
     streamlit_app.apply_theme_settings()
     assert calls


### PR DESCRIPTION
## Summary
- add pytest UI marker to streamlit targeted tests
- ensure tests import pytest

## Testing
- `python - <<'PY'
import streamlit
import pytest, sys
sys.exit(pytest.main(["tests/targeted/test_streamlit_extra.py","tests/targeted/test_streamlit_theme.py","-m","requires_ui","--no-cov","-q"]))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689d4736b7fc8333b24d66006a52c8a3