### PR TITLE
Document failing tests and update release status

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,18 @@ Autoresearch is currently in the **Development** phase preparing for the
 upcoming **0.1.0** release. The version is defined in
 `autoresearch.__version__` and mirrored in `pyproject.toml`, but it has
 **not** been published yet. The first official release was originally
-planned for **July 20, 2025**, but the schedule slipped. Integration and
-behavior tests still fail and total coverage remains below the **90%**
-target. Packaging checks and documentation continue, so the milestone is
-now targeted for **November 15, 2025**. Remaining blockers include failing
-tests, incomplete coverage, and packaging scripts that need additional
-configuration. See [docs/release_plan.md](docs/release_plan.md) for the
-full milestone schedule and outstanding tasks.
+planned for **July 20, 2025**, but the schedule slipped. Running `task
+coverage` on **August 14, 2025** fails in
+`tests/unit/test_main_config_commands.py::test_config_init_command_force`,
+so coverage is not generated and integration and behavior suites are
+skipped. `task verify` also fails in
+`tests/unit/test_eviction.py::test_lru_eviction_order`. Packaging checks
+and documentation continue, so the milestone is now targeted for
+**November 15, 2025**. Remaining blockers include these failing tests
+(issues #27 and #28), missing coverage, and packaging scripts that
+need additional configuration. See
+[docs/release_plan.md](docs/release_plan.md) for the full milestone
+schedule and outstanding tasks.
 
 ## Installation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,12 @@
 # Autoresearch Roadmap
 
 This roadmap summarizes planned features for upcoming releases. Dates and milestones align with the [release plan](docs/release_plan.md).
-Last updated **August 13, 2025**.
-Phase 2 testing tasks are complete: integration and behavior tests pass and total coverage has reached **92%**. Milestone dates are synchronized with the release plan and listed below.
+Last updated **August 14, 2025**.
+Phase 2 testing tasks remain open: `task coverage` fails in
+`tests/unit/test_main_config_commands.py::test_config_init_command_force`
+and coverage is not generated, while `task verify` fails in
+`tests/unit/test_eviction.py::test_lru_eviction_order`. Milestone dates are
+synchronized with the release plan and listed below.
 ## Milestones
 
 | Version | Target Date | Key Goals |
@@ -22,7 +26,12 @@ complete documentation. Key activities include:
 - Finalizing API reference and user guides.
 - Verifying packaging metadata and TestPyPI uploads.
 
-Integration and behavior tests now pass and total coverage exceeds the **90%** target. The release was originally planned for **July 20, 2025**, but the schedule slipped. With **Phase 2** complete, the **0.1.0** milestone remains targeted for **November 15, 2025** while packaging validation and documentation work continue. Remaining blockers include packaging scripts that need additional configuration.
+Unit tests still fail (`tests/unit/test_main_config_commands.py::test_config_init_command_force` and
+`tests/unit/test_eviction.py::test_lru_eviction_order`), so coverage is not
+generated and integration and behavior suites remain pending. The release was
+originally planned for **July 20, 2025**, but the schedule slipped. The
+**0.1.0** milestone remains targeted for **November 15, 2025** while these
+failures (tracked in issues #27 and #28) and packaging tasks are resolved.
 
 ## 0.1.1 – Bug fixes and documentation updates
 

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,6 +1,12 @@
 # Autoresearch Project - Task Progress
 
-This document tracks the progress of tasks for the Autoresearch project, organized by phases from the code complete plan.
+This document tracks the progress of tasks for the Autoresearch project,
+organized by phases from the code complete plan. As of **August 14, 2025**, unit
+tests `tests/unit/test_main_config_commands.py::test_config_init_command_force`
+and `tests/unit/test_eviction.py::test_lru_eviction_order` fail, so coverage is
+not generated and integration and behavior suites remain pending. Issues #27 and
+#28 track these blockers. The **0.1.0** release is still targeted for
+**November 15, 2025**.
 
 ## Phase 1: Core System Completion (Weeks 1-2)
 
@@ -221,15 +227,19 @@ Issues #10–#17 are marked **Done**, matching the checkboxes above.
 
 ### Coverage Report
 
-Overall coverage: statements **92%**, branches **88%**, functions **90%**,
-lines **92%**.
+Coverage could not be generated because `task coverage` fails in
+`tests/unit/test_main_config_commands.py::test_config_init_command_force`.
 
 ### Latest Test Results
 
+- `task coverage` failed in
+  `tests/unit/test_main_config_commands.py::test_config_init_command_force`.
+- `task verify` failed in
+  `tests/unit/test_eviction.py::test_lru_eviction_order`; these issues are
+  tracked in #27 and #28.
 - `flake8` reports no style errors.
-  - `uv run mypy src` completes in ~7s after excluding site packages;
-    issue [#22](issues/archive/0022-investigate-mypy-hang.md) closed.
-- Unit, integration, and behavior tests now run to completion after resolving the previous hang.
+- `uv run mypy src` completes in ~7s after excluding site packages;
+  issue [#22](issues/archive/0022-investigate-mypy-hang.md) closed.
 
 ### Performance Baselines
 

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -3,29 +3,35 @@
 This document outlines the upcoming release milestones for **Autoresearch**. Dates are aspirational and may shift as development progresses. The publishing workflow follows the steps in [deployment.md](deployment.md).
 
 The project kicked off in **May 2025** (see the initial commit dated `2025-05-18`).
-This schedule was last updated on **August 13, 2025** and reflects the fact that
+This schedule was last updated on **August 14, 2025** and reflects the fact that
 the codebase currently sits at the **unreleased 0.1.0** version defined in
 `autoresearch.__version__`.
-Phase 2 testing tasks are complete: integration and behavior tests pass and coverage sits at **92%**, so Phase 3 (stabilization/testing/documentation) and Phase 4 activities remain planned.
+Phase 2 testing tasks remain open: `task coverage` fails in
+`tests/unit/test_main_config_commands.py::test_config_init_command_force`
+and coverage is not generated, so Phase 3 (stabilization/testing/documentation)
+and Phase 4 activities remain planned.
 
 ## Milestones
 
 | Version | Target Date | Key Goals |
 | ------- | ----------- | --------- |
-| **0.1.0** | 2025-11-15 | Finalize packaging, docs and CI checks; Phase 2 complete (integration & behavior tests passing, 92% coverage) |
+| **0.1.0** | 2025-11-15 | Finalize packaging, docs and CI checks; resolve failing tests and generate coverage |
 | **0.1.1** | 2026-02-01 | Bug fixes and documentation updates |
 | **0.2.0** | 2026-04-15 | API stabilization, configuration hot-reload, improved search backends |
 | **0.3.0** | 2026-07-15 | Distributed execution support, monitoring utilities |
 | **1.0.0** | 2026-10-01 | Full feature set, performance tuning and stable interfaces |
 
 The **0.1.0** release was originally aimed for **July 20, 2025**, but the
-schedule slipped. Tests now pass and total coverage is **92%**. Packaging
-checks and documentation work continue, so the milestone remains targeted
-for **November 15, 2025** while packaging tasks are completed.
+schedule slipped. `task coverage` currently fails in
+`tests/unit/test_main_config_commands.py::test_config_init_command_force`,
+and `task verify` fails in `tests/unit/test_eviction.py::test_lru_eviction_order`,
+so coverage is not available. Packaging checks and documentation work
+continue, so the milestone remains targeted for **November 15, 2025** while
+these failures (issues #27 and #28) and packaging tasks are completed.
 
 The following tasks remain before publishing **0.1.0**:
 
-- [ ] Confirm Phase 2 results remain stable: integration & behavior tests continue passing with ≥90% coverage.
+- [ ] Resolve failing tests and re-run `task coverage` to reach ≥90% total coverage (issues #27 and #28).
 - [ ] Install optional dependencies with `uv pip install -e '.[full,parsers,git,llm,dev]'` so the full unit, integration and behavior suites run successfully.
 - [ ] Ensure new dependency pins are reflected in the lock file and docs. `slowapi` is locked to **0.1.9** and `fastapi` must be **0.115** or newer.
 - [ ] Verify `python -m build` and `scripts/publish_dev.py` create valid packages across platforms.
@@ -33,6 +39,8 @@ The following tasks remain before publishing **0.1.0**:
 
 ### Current Blockers
 
+- Unit tests failing (`tests/unit/test_main_config_commands.py::test_config_init_command_force`,
+  `tests/unit/test_eviction.py::test_lru_eviction_order`); see issues #27 and #28.
 - Packaging scripts require additional configuration before they run reliably.
 
 Resolving these issues will determine the new completion date for **0.1.0**.


### PR DESCRIPTION
## Summary
- note unit test failures in README, ROADMAP, release plan, and task progress
- clarify that coverage is unavailable and issues #27/#28 block release

## Testing
- `task coverage` *(fails: tests/unit/test_main_config_commands.py::test_config_init_command_force)*
- `task verify` *(fails: tests/unit/test_eviction.py::test_lru_eviction_order)*

------
https://chatgpt.com/codex/tasks/task_e_689d4c566a208333ac33959e87a6214b