### PR TITLE
Streamline pytest coverage config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ autoresearch = "autoresearch.main:app"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--maxfail=1 --disable-warnings -q --cov=autoresearch.orchestration.orchestrator --cov=autoresearch.storage --cov=autoresearch.storage_backends --cov=autoresearch.search.core --cov=autoresearch.streamlit_ui --cov-report=xml --cov-report=term-missing --cov-fail-under=90 -m 'not slow and not requires_ui and not requires_vss'"
+addopts = "--cov=src --cov-report=term-missing --cov-fail-under=90 -m 'not slow and not requires_ui and not requires_vss'"
 testpaths = ["tests/unit", "tests/integration", "tests/behavior"]
 python_files = ["test_*.py", "*_steps.py"]
 markers = [


### PR DESCRIPTION
## Summary
- simplify pytest coverage options to use `--cov=src`
- remove redundant flags from default test options while keeping 90% threshold

## Testing
- `task verify` (fails: Required test coverage of 90% not reached; multiple failing tests)
- `task coverage` (interrupted)


------
https://chatgpt.com/codex/tasks/task_e_689d691267708333876111020442cf8e