### PR TITLE
Document optional test markers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,11 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   `task test:slow` or `uv run pytest -m requires_nlp`. Skip them with
   `-m 'not requires_nlp'` if the extras are unavailable.
   - See [tests/behavior/README.md](tests/behavior/README.md) for markers
-    such as `requires_ui`, `requires_vss`, and `requires_nlp` to select specific scenarios.
+    such as `requires_ui`, `requires_vss`, `requires_git`, and `requires_nlp` to select specific scenarios.
+  - Tag tests that rely on optional extras with the appropriate marker
+    (`requires_ui`, `requires_vss`, `requires_git`, or `requires_nlp`). When
+    introducing new markers, update this document and `scripts/codex_setup.sh`
+    so setup remains in sync.
 
 ### Cleanup
 - Run `task clean` to remove `__pycache__` and `.mypy_cache` directories.

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -78,6 +78,9 @@ if ! uv pip show duckdb-extension-vss >/dev/null 2>&1; then
 fi
 
 # Confirm required extras are installed
+# Tests marked `requires_ui`, `requires_vss`, `requires_git`, and `requires_nlp`
+# depend on these packages. Update this list and AGENTS.md when adding new
+# markers or optional test extras.
 echo "Verifying required extras..."
 missing=0
 missing_pkgs=""


### PR DESCRIPTION
## Summary
- remind contributors to mark tests requiring optional extras with `requires_ui`, `requires_vss`, `requires_git`, and `requires_nlp`
- note that new markers require updates to `scripts/codex_setup.sh`
- document marker responsibility in `codex_setup.sh` to keep setup in sync

## Testing
- `task verify` *(fails: hung around 39% of tests, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_689d6d4266b483338f05f14f76be7a56