### PR TITLE
Refactor orchestration helpers

### DIFF
--- a/docs/diagrams/orchestration.puml
+++ b/docs/diagrams/orchestration.puml
@@ -6,20 +6,28 @@ package "Orchestration" {
     + {static} run_query(query, config, callbacks, agent_factory, storage_manager): QueryResponse
     + {static} run_parallel_query(query, config, agent_groups): QueryResponse
     - {static} _parse_config(config): Dict
-    - {static} _get_agent(agent_name, agent_factory): Agent
-    - {static} _check_agent_can_execute(agent, agent_name, state, config): bool
-    - {static} _log_agent_execution(agent_name, state, loop): void
-    - {static} _call_agent_start_callback(agent_name, state, callbacks): void
-    - {static} _execute_agent_with_token_counting(agent, agent_name, state, config, metrics): Dict
-    - {static} _handle_agent_completion(agent_name, result, state, metrics, callbacks, duration, loop): void
-    - {static} _log_sources(agent_name, result): void
-    - {static} _persist_claims(agent_name, result, storage_manager): void
-    - {static} _handle_agent_error(agent_name, e, state, metrics): void
-    - {static} _execute_agent(agent_name, state, config, metrics, callbacks, agent_factory, storage_manager, loop): void
-    - {static} _execute_cycle(loop, loops, agents, primus_index, max_errors, state, config, metrics, callbacks, agent_factory, storage_manager, tracer): int
-    - {static} _execute_with_adapter(agent, state, config, adapter): Dict
-    - {static} _rotate_list(items, start_idx): List
-    - {static} _capture_token_usage(agent_name, metrics, config): Iterator
+  }
+
+  class OrchestrationUtils {
+    + {static} get_agent(agent_name, agent_factory): Agent
+    + {static} check_agent_can_execute(agent, agent_name, state, config): bool
+    + {static} log_agent_execution(agent_name, state, loop): void
+    + {static} call_agent_start_callback(agent_name, state, callbacks): void
+    + {static} execute_agent_with_token_counting(agent, agent_name, state, config, metrics): Dict
+    + {static} handle_agent_completion(agent_name, result, state, metrics, callbacks, duration, loop): void
+    + {static} log_sources(agent_name, result): void
+    + {static} persist_claims(agent_name, result, storage_manager): void
+    + {static} handle_agent_error(agent_name, e, state, metrics): void
+    + {static} execute_agent(agent_name, state, config, metrics, callbacks, agent_factory, storage_manager, loop): void
+    + {static} execute_cycle(loop, loops, agents, primus_index, max_errors, state, config, metrics, callbacks, agent_factory, storage_manager, tracer): int
+    + {static} execute_with_adapter(agent, state, config, adapter): Dict
+    + {static} rotate_list(items, start_idx): List
+    + {static} capture_token_usage(agent_name, metrics, config): Iterator
+    + {static} categorize_error(exc): str
+    + {static} apply_recovery_strategy(agent, category, exc, state): Dict
+    + {static} apply_adaptive_token_budget(config, query): void
+    + {static} get_memory_usage(): float
+    + {static} calculate_result_confidence(result): float
   }
 
   class QueryState {

--- a/src/autoresearch/orchestration/execution.py
+++ b/src/autoresearch/orchestration/execution.py
@@ -325,9 +325,7 @@ def _execute_cycle(
                         f"({max_errors}) reached"
                     )
                     break
-                from .orchestrator import Orchestrator
-
-                Orchestrator._execute_agent(  # type: ignore[attr-defined]
+                _execute_agent(
                     agent_name,
                     state,
                     config,
@@ -395,10 +393,8 @@ async def _execute_cycle_async(
         async def run_agent(name: str) -> None:
             if state.error_count >= max_errors:
                 return
-            from .orchestrator import Orchestrator
-
             await asyncio.to_thread(
-                Orchestrator._execute_agent,  # type: ignore[attr-defined]
+                _execute_agent,
                 name,
                 state,
                 config,

--- a/src/autoresearch/orchestration/orchestration_utils.py
+++ b/src/autoresearch/orchestration/orchestration_utils.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Utility helpers for orchestration components.
+
+This module groups functions that were previously attached dynamically to
+:class:`~autoresearch.orchestration.orchestrator.Orchestrator`.  Keeping them in a
+separate utility class makes the helpers easier to import directly in tests and
+other modules without relying on dynamic attribute assignment.
+"""
+
+from .budgeting import _apply_adaptive_token_budget
+from .execution import (
+    _call_agent_start_callback,
+    _check_agent_can_execute,
+    _deliver_messages,
+    _execute_agent,
+    _execute_agent_with_token_counting,
+    _execute_cycle,
+    _execute_cycle_async,
+    _get_agent,
+    _handle_agent_completion,
+    _log_agent_execution,
+    _log_sources,
+    _persist_claims,
+    _rotate_list,
+)
+from .error_handling import (
+    _apply_recovery_strategy,
+    _categorize_error,
+    _handle_agent_error,
+)
+from .token_utils import _capture_token_usage, _execute_with_adapter
+from .utils import calculate_result_confidence, get_memory_usage
+
+
+class OrchestrationUtils:
+    """Collection of static helpers used by the orchestrator."""
+
+    # execution helpers
+    get_agent = staticmethod(_get_agent)
+    check_agent_can_execute = staticmethod(_check_agent_can_execute)
+    deliver_messages = staticmethod(_deliver_messages)
+    log_agent_execution = staticmethod(_log_agent_execution)
+    call_agent_start_callback = staticmethod(_call_agent_start_callback)
+    execute_agent_with_token_counting = staticmethod(_execute_agent_with_token_counting)
+    handle_agent_completion = staticmethod(_handle_agent_completion)
+    log_sources = staticmethod(_log_sources)
+    persist_claims = staticmethod(_persist_claims)
+    handle_agent_error = staticmethod(_handle_agent_error)
+
+    # error handling helpers
+    categorize_error = staticmethod(_categorize_error)
+    apply_recovery_strategy = staticmethod(_apply_recovery_strategy)
+
+    # core execution flows
+    execute_agent = staticmethod(_execute_agent)
+    execute_cycle = staticmethod(_execute_cycle)
+    execute_cycle_async = staticmethod(_execute_cycle_async)
+    rotate_list = staticmethod(_rotate_list)
+    apply_adaptive_token_budget = staticmethod(_apply_adaptive_token_budget)
+
+    # utility functions
+    get_memory_usage = staticmethod(get_memory_usage)
+    calculate_result_confidence = staticmethod(calculate_result_confidence)
+    capture_token_usage = staticmethod(_capture_token_usage)
+    execute_with_adapter = staticmethod(_execute_with_adapter)

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -25,34 +25,11 @@ from ..logging_utils import get_logger
 from ..models import QueryResponse
 from ..storage import StorageManager
 from ..tracing import get_tracer, setup_tracing
-from .budgeting import _apply_adaptive_token_budget
 from .circuit_breaker import CircuitBreakerManager, CircuitBreakerState
-from .execution import (
-    _call_agent_start_callback,
-    _check_agent_can_execute,
-    _deliver_messages,
-    _execute_agent,
-    _execute_agent_with_token_counting,
-    _execute_cycle,
-    _execute_cycle_async,
-    _get_agent,
-    _handle_agent_completion,
-    _log_agent_execution,
-    _log_sources,
-    _persist_claims,
-    _rotate_list,
-)
-from .error_handling import (
-    _apply_recovery_strategy,
-    _categorize_error,
-    _handle_agent_error,
-)
 from .metrics import OrchestrationMetrics, record_query
+from .orchestration_utils import OrchestrationUtils
 from .reasoning import ChainOfThoughtStrategy, ReasoningMode
 from .state import QueryState
-from .token_utils import _capture_token_usage as capture_token_usage
-from .token_utils import _execute_with_adapter as execute_with_adapter
-from .utils import calculate_result_confidence, get_memory_usage
 
 log = get_logger(__name__)
 
@@ -152,7 +129,7 @@ class Orchestrator:
         )
         Orchestrator._cb_manager = cb_manager
 
-        Orchestrator._apply_adaptive_token_budget(config, query)  # type: ignore[attr-defined]
+        OrchestrationUtils.apply_adaptive_token_budget(config, query)
 
         token_budget = getattr(config, "token_budget", None)
         if (
@@ -205,7 +182,7 @@ class Orchestrator:
                 },
             )
 
-            primus_index = Orchestrator._execute_cycle(  # type: ignore[attr-defined]
+            primus_index = OrchestrationUtils.execute_cycle(
                 loop,
                 loops,
                 agents,
@@ -287,7 +264,7 @@ class Orchestrator:
         )
         Orchestrator._cb_manager = cb_manager
 
-        Orchestrator._apply_adaptive_token_budget(config, query)  # type: ignore[attr-defined]
+        OrchestrationUtils.apply_adaptive_token_budget(config, query)
 
         token_budget = getattr(config, "token_budget", None)
         if (
@@ -341,7 +318,7 @@ class Orchestrator:
                 },
             )
 
-            primus_index = await Orchestrator._execute_cycle_async(  # type: ignore[attr-defined]
+            primus_index = await OrchestrationUtils.execute_cycle_async(
                 loop,
                 loops,
                 agents,
@@ -416,47 +393,3 @@ class Orchestrator:
     def query_ontology(query: str) -> rdflib.query.Result:
         """Query the ontology graph via the storage manager."""
         return StorageManager.query_ontology(query)
-
-
-# Attach helper functions from submodules
-Orchestrator._get_agent = staticmethod(_get_agent)  # type: ignore[attr-defined]
-Orchestrator._check_agent_can_execute = staticmethod(  # type: ignore[attr-defined]
-    _check_agent_can_execute
-)
-Orchestrator._deliver_messages = staticmethod(_deliver_messages)  # type: ignore[attr-defined]
-Orchestrator._log_agent_execution = staticmethod(  # type: ignore[attr-defined]
-    _log_agent_execution
-)
-Orchestrator._call_agent_start_callback = staticmethod(  # type: ignore[attr-defined]
-    _call_agent_start_callback
-)
-Orchestrator._execute_agent_with_token_counting = staticmethod(  # type: ignore[attr-defined]
-    _execute_agent_with_token_counting
-)
-Orchestrator._handle_agent_completion = staticmethod(  # type: ignore[attr-defined]
-    _handle_agent_completion
-)
-Orchestrator._log_sources = staticmethod(_log_sources)  # type: ignore[attr-defined]
-Orchestrator._persist_claims = staticmethod(_persist_claims)  # type: ignore[attr-defined]
-Orchestrator._handle_agent_error = staticmethod(_handle_agent_error)  # type: ignore[attr-defined]
-Orchestrator._categorize_error = staticmethod(_categorize_error)  # type: ignore[attr-defined]
-Orchestrator._apply_recovery_strategy = staticmethod(  # type: ignore[attr-defined]
-    _apply_recovery_strategy
-)
-Orchestrator._execute_agent = staticmethod(_execute_agent)  # type: ignore[attr-defined]
-Orchestrator._execute_cycle = staticmethod(_execute_cycle)  # type: ignore[attr-defined]
-Orchestrator._execute_cycle_async = staticmethod(  # type: ignore[attr-defined]
-    _execute_cycle_async
-)
-Orchestrator._rotate_list = staticmethod(_rotate_list)  # type: ignore[attr-defined]
-Orchestrator._apply_adaptive_token_budget = staticmethod(  # type: ignore[attr-defined]
-    _apply_adaptive_token_budget
-)
-Orchestrator._get_memory_usage = staticmethod(get_memory_usage)  # type: ignore[attr-defined]
-Orchestrator._calculate_result_confidence = staticmethod(  # type: ignore[attr-defined]
-    calculate_result_confidence
-)
-Orchestrator._capture_token_usage = staticmethod(capture_token_usage)  # type: ignore[attr-defined]
-Orchestrator._execute_with_adapter = staticmethod(  # type: ignore[attr-defined]
-    execute_with_adapter
-)

--- a/tests/behavior/steps/api_async_query_steps.py
+++ b/tests/behavior/steps/api_async_query_steps.py
@@ -235,7 +235,7 @@ def failing_async_query(failure: str, api_client, monkeypatch):
             side_effect=run_async,
         ),
         patch(
-            "autoresearch.orchestration.orchestrator.Orchestrator._handle_agent_error",
+            "autoresearch.orchestration.orchestration_utils.OrchestrationUtils.handle_agent_error",
             side_effect=handle,
         ),
     ):

--- a/tests/behavior/steps/error_recovery_steps.py
+++ b/tests/behavior/steps/error_recovery_steps.py
@@ -11,6 +11,7 @@ from autoresearch.config.models import ConfigModel
 from autoresearch.errors import AgentError, StorageError, TimeoutError
 from autoresearch.orchestration import ReasoningMode
 from autoresearch.orchestration.orchestrator import AgentFactory, Orchestrator
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.storage import StorageManager
 
 pytest_plugins = ["tests.behavior.steps.common_steps"]
@@ -185,8 +186,8 @@ def failing_agent_fallback(monkeypatch, isolate_network, restore_environment):
         classmethod(lambda cls, name, llm_adapter=None: FailingAgent()),
     )
     monkeypatch.setattr(
-        Orchestrator,
-        "_handle_agent_error",
+        OrchestrationUtils,
+        "handle_agent_error",
         handle,
     )
     return cfg
@@ -289,7 +290,7 @@ def run_orchestrator(
     params: dict = {}
     logs: list[str] = []
     state = {"active": True}
-    original_handle = Orchestrator._handle_agent_error
+    original_handle = OrchestrationUtils.handle_agent_error
     original_get = AgentFactory.get
 
     def recording_get(name: str, llm_adapter=None):
@@ -324,7 +325,7 @@ def run_orchestrator(
             side_effect=recording_get,
         ),
         patch(
-            "autoresearch.orchestration.orchestrator.Orchestrator._handle_agent_error",
+            "autoresearch.orchestration.orchestration_utils.OrchestrationUtils.handle_agent_error",
             side_effect=spy_handle,
         ),
         patch(

--- a/tests/behavior/steps/orchestrator_agents_integration_extended_steps.py
+++ b/tests/behavior/steps/orchestrator_agents_integration_extended_steps.py
@@ -10,6 +10,7 @@ from pytest_bdd import scenario, given, when, then
 from unittest.mock import MagicMock, patch
 
 from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.config.models import ConfigModel
 from autoresearch.llm import DummyAdapter
 
@@ -108,7 +109,7 @@ def system_configured_for_multiple_loops(extended_test_context):
 def run_query_with_multiple_loops(extended_test_context, monkeypatch):
     """Run a query with multiple loops."""
     # Store original functions for cleanup verification
-    extended_test_context["original_execute_agent"] = Orchestrator._execute_agent
+    extended_test_context["original_execute_agent"] = OrchestrationUtils.execute_agent
 
     # Track executed agents by loop
     mock_agent_factory = MagicMock()
@@ -164,7 +165,7 @@ def run_query_with_multiple_loops(extended_test_context, monkeypatch):
         )
 
     # Use monkeypatch for automatic cleanup
-    monkeypatch.setattr(Orchestrator, "_execute_agent", execute_and_track_state)
+    monkeypatch.setattr(OrchestrationUtils, "execute_agent", execute_and_track_state)
 
     # Run the query
     with patch(
@@ -258,7 +259,7 @@ def system_configured_with_direct_reasoning_mode(extended_test_context):
 def run_query_with_direct_reasoning_mode(extended_test_context, monkeypatch):
     """Run a query with the direct reasoning mode."""
     # Store original functions for cleanup verification
-    extended_test_context["original_execute_agent"] = Orchestrator._execute_agent
+    extended_test_context["original_execute_agent"] = OrchestrationUtils.execute_agent
 
     # Track executed agents
     mock_agent_factory = MagicMock()
@@ -303,7 +304,7 @@ def run_query_with_direct_reasoning_mode(extended_test_context, monkeypatch):
         )
 
     # Use monkeypatch for automatic cleanup
-    monkeypatch.setattr(Orchestrator, "_execute_agent", execute_and_track_state)
+    monkeypatch.setattr(OrchestrationUtils, "execute_agent", execute_and_track_state)
 
     # Run the query
     with patch(

--- a/tests/behavior/steps/orchestrator_agents_integration_steps.py
+++ b/tests/behavior/steps/orchestrator_agents_integration_steps.py
@@ -10,6 +10,7 @@ from pytest_bdd import scenario, given, when, then
 from unittest.mock import MagicMock, patch
 
 from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.config.models import ConfigModel
 from autoresearch.llm import DummyAdapter
 
@@ -103,7 +104,7 @@ def system_using_dummy_llm_adapter(monkeypatch):
 def run_query_with_dialectical_reasoning(test_context, mock_agent_factory, monkeypatch):
     """Run a query with the dialectical reasoning mode."""
     # Store original functions for cleanup verification
-    test_context["original_execute_agent"] = Orchestrator._execute_agent
+    test_context["original_execute_agent"] = OrchestrationUtils.execute_agent
 
     # Track executed agents
     original_get = mock_agent_factory.get
@@ -139,7 +140,7 @@ def run_query_with_dialectical_reasoning(test_context, mock_agent_factory, monke
         )
 
     # Use monkeypatch for automatic cleanup
-    monkeypatch.setattr(Orchestrator, "_execute_agent", execute_and_track_state)
+    monkeypatch.setattr(OrchestrationUtils, "execute_agent", execute_and_track_state)
 
     # Run the query using a context manager for proper cleanup
     with patch(
@@ -217,7 +218,7 @@ def agent_that_raises_error(mock_agent_factory, test_context):
 def run_query_with_error_agent(test_context, mock_agent_factory, monkeypatch):
     """Run a query with the error-raising agent."""
     # Store original functions for cleanup verification
-    test_context["original_handle_error"] = Orchestrator._handle_agent_error
+    test_context["original_handle_error"] = OrchestrationUtils.handle_agent_error
 
     # Track errors
     def handle_and_track_error(self, error, agent_name, state, config):
@@ -227,7 +228,7 @@ def run_query_with_error_agent(test_context, mock_agent_factory, monkeypatch):
         )
 
     # Use monkeypatch for automatic cleanup
-    monkeypatch.setattr(Orchestrator, "_handle_agent_error", handle_and_track_error)
+    monkeypatch.setattr(OrchestrationUtils, "handle_agent_error", handle_and_track_error)
 
     # Run the query using a context manager for proper cleanup
     with patch(

--- a/tests/behavior/steps/reasoning_mode_steps.py
+++ b/tests/behavior/steps/reasoning_mode_steps.py
@@ -9,6 +9,7 @@ from autoresearch.config.models import ConfigModel
 from autoresearch.errors import ConfigError, NotFoundError
 from autoresearch.orchestration import ReasoningMode
 from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 
 
 @scenario("../features/reasoning_mode.feature", "Direct mode runs Synthesizer only")
@@ -203,7 +204,7 @@ def _run_orchestrator_with_failure(
     state = {"active": True}
     recovery_info: dict = {}
 
-    original_handle = Orchestrator._handle_agent_error
+    original_handle = OrchestrationUtils.handle_agent_error
 
     def spy_handle(agent_name: str, e: Exception, state_obj, metrics):
         info = original_handle(agent_name, e, state_obj, metrics)
@@ -249,7 +250,7 @@ def _run_orchestrator_with_failure(
 
         with (
             patch(
-                "autoresearch.orchestration.orchestrator.Orchestrator._handle_agent_error",
+                "autoresearch.orchestration.orchestration_utils.OrchestrationUtils.handle_agent_error",
                 side_effect=spy_handle,
             ),
             patch(
@@ -312,7 +313,7 @@ def _run_orchestrator_with_failure(
             side_effect=get_agent,
         ),
         patch(
-            "autoresearch.orchestration.orchestrator.Orchestrator._handle_agent_error",
+            "autoresearch.orchestration.orchestration_utils.OrchestrationUtils.handle_agent_error",
             side_effect=spy_handle,
         ),
         patch(

--- a/tests/unit/test_failure_paths.py
+++ b/tests/unit/test_failure_paths.py
@@ -2,7 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from autoresearch.agents.prompts import PromptTemplate, PromptTemplateRegistry
-from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.config.models import ConfigModel, APIConfig
 from autoresearch.orchestration.state import QueryState
 from autoresearch.search import Search
@@ -34,7 +34,7 @@ def test_check_agent_can_execute_false():
     cfg = ConfigModel()
     state = QueryState(query="q")
     agent = DummyAgent()
-    assert not Orchestrator._check_agent_can_execute(agent, "Dummy", state, cfg)
+    assert not OrchestrationUtils.check_agent_can_execute(agent, "Dummy", state, cfg)
 
 
 def test_external_lookup_unknown_backend(monkeypatch):

--- a/tests/unit/test_more_coverage.py
+++ b/tests/unit/test_more_coverage.py
@@ -1,9 +1,9 @@
 from queue import Queue
 from unittest.mock import MagicMock
 
-from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch import search as search_module
 from autoresearch.orchestration import execution as exec_mod
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.search import Search, close_http_session, get_http_session
 from autoresearch.storage import StorageManager
 from autoresearch.storage_backends import DuckDBStorageBackend
@@ -14,7 +14,7 @@ def test_log_sources(monkeypatch):
     msgs = []
     monkeypatch.setattr(exec_mod, "log", MagicMock())
     exec_mod.log.info = lambda msg, **k: msgs.append(msg)
-    Orchestrator._log_sources("A", {"sources": [{"title": "T"}]})
+    OrchestrationUtils.log_sources("A", {"sources": [{"title": "T"}]})
     assert any("provided 1 sources" in m for m in msgs)
 
 
@@ -22,7 +22,7 @@ def test_log_sources_missing(monkeypatch):
     msgs = []
     monkeypatch.setattr(exec_mod, "log", MagicMock())
     exec_mod.log.warning = lambda msg, **k: msgs.append(msg)
-    Orchestrator._log_sources("A", {})
+    OrchestrationUtils.log_sources("A", {})
     assert any("provided no sources" in m for m in msgs)
 
 
@@ -30,7 +30,7 @@ def test_persist_claims(monkeypatch):
     calls = []
     monkeypatch.setattr(StorageManager, "persist_claim", lambda c: calls.append(c["id"]))
     result = {"claims": [{"id": "c1"}, {"id": "c2"}]}
-    Orchestrator._persist_claims("A", result, StorageManager)
+    OrchestrationUtils.persist_claims("A", result, StorageManager)
     assert calls == ["c1", "c2"]
 
 
@@ -40,7 +40,7 @@ def test_persist_claims_invalid(monkeypatch):
     monkeypatch.setattr(exec_mod, "log", MagicMock())
     exec_mod.log.warning = lambda msg, **k: msgs.append(msg)
     result = {"claims": ["bad", {"foo": 1}]}
-    Orchestrator._persist_claims("A", result, StorageManager)
+    OrchestrationUtils.persist_claims("A", result, StorageManager)
     assert any("Skipping invalid claim format" in m for m in msgs)
 
 

--- a/tests/unit/test_orchestrator_budget_and_errors.py
+++ b/tests/unit/test_orchestrator_budget_and_errors.py
@@ -1,11 +1,12 @@
 import pytest
 from autoresearch.config.models import ConfigModel
-from autoresearch.orchestration.orchestrator import Orchestrator, TimeoutError, NotFoundError, AgentError
+from autoresearch.orchestration.orchestrator import TimeoutError, NotFoundError, AgentError
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 
 
 def test_adaptive_budget_scales_with_loops():
     cfg = ConfigModel(token_budget=100, loops=3)
-    Orchestrator._apply_adaptive_token_budget(cfg, "one two")
+    OrchestrationUtils.apply_adaptive_token_budget(cfg, "one two")
     assert cfg.token_budget <= 100
     assert cfg.token_budget >= len("one two".split())
 
@@ -19,4 +20,4 @@ def test_adaptive_budget_scales_with_loops():
     ],
 )
 def test_error_categorization(exc, expected):
-    assert Orchestrator._categorize_error(exc) == expected
+    assert OrchestrationUtils.categorize_error(exc) == expected

--- a/tests/unit/test_orchestrator_edgecases.py
+++ b/tests/unit/test_orchestrator_edgecases.py
@@ -1,5 +1,6 @@
 import pytest
 from autoresearch.orchestration.orchestrator import Orchestrator, ReasoningMode
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.config.models import ConfigModel
 from autoresearch.errors import NotFoundError
 
@@ -12,7 +13,7 @@ class DummyFactory:
 
 def test_get_agent_not_found():
     with pytest.raises(NotFoundError):
-        Orchestrator._get_agent("X", DummyFactory)
+        OrchestrationUtils.get_agent("X", DummyFactory)
 
 
 def test_parse_config_direct_mode():

--- a/tests/unit/test_orchestrator_errors.py
+++ b/tests/unit/test_orchestrator_errors.py
@@ -16,6 +16,7 @@ from autoresearch.models import QueryResponse
 from autoresearch.orchestration.circuit_breaker import CircuitBreakerManager
 from autoresearch.orchestration.metrics import OrchestrationMetrics
 from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.orchestration.state import QueryState
 
 
@@ -55,7 +56,7 @@ def test_execute_agent_records_errors_and_circuit_breaker(
         lambda name: failing_agent,
     )
 
-    Orchestrator._execute_agent(
+    OrchestrationUtils.execute_agent(
         "FailingAgent",
         state,
         test_config,
@@ -103,7 +104,7 @@ def test_retry_with_backoff_on_transient_error(monkeypatch, test_config):
     object.__setattr__(test_config, "retry_attempts", 2)
     object.__setattr__(test_config, "retry_backoff", 0)
 
-    Orchestrator._execute_agent(
+    OrchestrationUtils.execute_agent(
         "RetryAgent",
         state,
         test_config,

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 from autoresearch.config.models import ConfigModel
 from autoresearch.errors import NotFoundError, StorageError
-from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.orchestration.state import QueryState
 
 
@@ -24,26 +24,26 @@ class DummyFactory:
 
 
 def test_get_agent_success():
-    agent = Orchestrator._get_agent("Dummy", DummyFactory)
+    agent = OrchestrationUtils.get_agent("Dummy", DummyFactory)
     assert isinstance(agent, DummyAgent)
 
 
 def test_get_agent_not_found():
     with pytest.raises(NotFoundError) as excinfo:
-        Orchestrator._get_agent("Missing", DummyFactory)
+        OrchestrationUtils.get_agent("Missing", DummyFactory)
     assert isinstance(excinfo.value.__cause__, ValueError)
 
     state = QueryState(query="q")
     cfg = ConfigModel.model_construct(enable_agent_messages=True)
     state.add_message({"to": "Dummy", "content": "hi"})
-    Orchestrator._deliver_messages("Dummy", state, cfg)
+    OrchestrationUtils.deliver_messages("Dummy", state, cfg)
     assert "Dummy" in state.metadata.get("delivered_messages", {})
 
 
 def test_call_agent_start_callback():
     state = QueryState(query="q")
     calls = []
-    Orchestrator._call_agent_start_callback(
+    OrchestrationUtils.call_agent_start_callback(
         "Dummy", state, {"on_agent_start": lambda a, s: calls.append(a)}
     )
     assert calls == ["Dummy"]
@@ -55,6 +55,6 @@ def test_persist_claims_logs_storage_error(caplog):
     result = {"claims": [{"id": "c1"}]}
 
     with caplog.at_level("WARNING"):
-        Orchestrator._persist_claims("Agent", result, storage)
+        OrchestrationUtils.persist_claims("Agent", result, storage)
 
     assert "Error persisting claims for agent Agent" in caplog.text

--- a/tests/unit/test_orchestrator_memory.py
+++ b/tests/unit/test_orchestrator_memory.py
@@ -1,7 +1,7 @@
 import builtins
 import sys
 import types
-from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 
 
 def test_get_memory_usage_psutil(monkeypatch):
@@ -9,7 +9,7 @@ def test_get_memory_usage_psutil(monkeypatch):
         Process=lambda: types.SimpleNamespace(memory_info=lambda: types.SimpleNamespace(rss=42 * 1024 * 1024))
     )
     monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
-    assert Orchestrator._get_memory_usage() == 42.0
+    assert OrchestrationUtils.get_memory_usage() == 42.0
 
 
 def test_get_memory_usage_fallback(monkeypatch):
@@ -29,4 +29,4 @@ def test_get_memory_usage_fallback(monkeypatch):
         RUSAGE_SELF=0,
     )
     monkeypatch.setitem(sys.modules, "resource", fake_resource)
-    assert Orchestrator._get_memory_usage() == 2.0
+    assert OrchestrationUtils.get_memory_usage() == 2.0

--- a/tests/unit/test_orchestrator_utils.py
+++ b/tests/unit/test_orchestrator_utils.py
@@ -2,19 +2,19 @@ import pytest
 from hypothesis import given, strategies as st
 
 from autoresearch.orchestration.orchestrator import (
-    Orchestrator,
     AgentError,
     NotFoundError,
     TimeoutError,
     OrchestrationError,
 )
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.models import QueryResponse
 from autoresearch.orchestration.state import QueryState
 
 
 @given(st.lists(st.integers()), st.integers())
 def test_rotate_list_property(items, idx):
-    rotated = Orchestrator._rotate_list(items, idx)
+    rotated = OrchestrationUtils.rotate_list(items, idx)
     if not items:
         assert rotated == []
     else:
@@ -35,7 +35,7 @@ def test_rotate_list_property(items, idx):
     ],
 )
 def test_categorize_error(exc, expected):
-    assert Orchestrator._categorize_error(exc) == expected
+    assert OrchestrationUtils.categorize_error(exc) == expected
 
 
 @given(
@@ -53,27 +53,27 @@ def test_calculate_result_confidence(num_citations, reasoning_len, error_count):
             "errors": ["e"] * error_count,
         },
     )
-    score = Orchestrator._calculate_result_confidence(resp)
+    score = OrchestrationUtils.calculate_result_confidence(resp)
     assert 0.1 <= score <= 1.0
 
 
 def test_apply_recovery_strategy():
     state = QueryState(query="q")
-    info = Orchestrator._apply_recovery_strategy(
+    info = OrchestrationUtils.apply_recovery_strategy(
         "A", "transient", Exception("e"), state
     )
     assert info["recovery_strategy"] == "retry_with_backoff"
     assert "fallback" in state.results
 
     state = QueryState(query="q")
-    info = Orchestrator._apply_recovery_strategy(
+    info = OrchestrationUtils.apply_recovery_strategy(
         "A", "recoverable", Exception("e"), state
     )
     assert info["recovery_strategy"] == "fallback_agent"
     assert "fallback" in state.results
 
     state = QueryState(query="q")
-    info = Orchestrator._apply_recovery_strategy(
+    info = OrchestrationUtils.apply_recovery_strategy(
         "A", "critical", Exception("e"), state
     )
     assert info["recovery_strategy"] == "fail_gracefully"

--- a/tests/unit/test_token_budget.py
+++ b/tests/unit/test_token_budget.py
@@ -1,7 +1,7 @@
 from hypothesis import given, strategies as st
 
 from autoresearch.config.models import ConfigModel
-from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.orchestration.metrics import OrchestrationMetrics
 
 
@@ -11,7 +11,7 @@ from autoresearch.orchestration.metrics import OrchestrationMetrics
 )
 def test_budget_within_bounds(initial_budget, query):
     cfg = ConfigModel(token_budget=initial_budget)
-    Orchestrator._apply_adaptive_token_budget(cfg, query)
+    OrchestrationUtils.apply_adaptive_token_budget(cfg, query)
     q_tokens = len(query.split())
     max_budget = max(initial_budget // cfg.loops, q_tokens * 20)
     assert cfg.token_budget >= q_tokens
@@ -21,7 +21,7 @@ def test_budget_within_bounds(initial_budget, query):
 @given(st.text(min_size=1))
 def test_budget_none_unmodified(query):
     cfg = ConfigModel(token_budget=None)
-    Orchestrator._apply_adaptive_token_budget(cfg, query)
+    OrchestrationUtils.apply_adaptive_token_budget(cfg, query)
     assert cfg.token_budget is None
 
 
@@ -33,7 +33,7 @@ def test_budget_none_unmodified(query):
 def test_budget_scaling_exact(initial_budget, loops, q_tokens):
     query = " ".join("x" for _ in range(q_tokens))
     cfg = ConfigModel(token_budget=initial_budget, loops=loops)
-    Orchestrator._apply_adaptive_token_budget(cfg, query)
+    OrchestrationUtils.apply_adaptive_token_budget(cfg, query)
 
     budget = initial_budget
     if loops > 1:

--- a/tests/unit/test_token_usage.py
+++ b/tests/unit/test_token_usage.py
@@ -8,7 +8,7 @@ recorded when using LLM adapters.
 from unittest.mock import MagicMock
 from typing import Any
 
-from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.orchestration.metrics import OrchestrationMetrics
 from autoresearch.config.models import ConfigModel
 from autoresearch.llm.token_counting import compress_prompt
@@ -32,7 +32,7 @@ def test_capture_token_usage_counts_correctly(monkeypatch, flexible_llm_adapter)
     monkeypatch.setattr(llm, "get_pooled_adapter", lambda name: flexible_llm_adapter)
 
     # Execute
-    with Orchestrator._capture_token_usage("agent", metrics, mock_config) as (
+    with OrchestrationUtils.capture_token_usage("agent", metrics, mock_config) as (
         token_counter,
         wrapped_adapter,
     ):
@@ -55,7 +55,7 @@ def test_token_budget_truncates_prompt(monkeypatch, flexible_llm_adapter):
 
     monkeypatch.setattr(llm, "get_llm_adapter", lambda name: flexible_llm_adapter)
 
-    with Orchestrator._capture_token_usage("agent", metrics, mock_config) as (
+    with OrchestrationUtils.capture_token_usage("agent", metrics, mock_config) as (
         token_counter,
         wrapped_adapter,
     ):
@@ -82,7 +82,7 @@ def test_prompt_passed_to_adapter_is_compressed(monkeypatch, flexible_llm_adapte
     flexible_llm_adapter.generate = spy_generate
     monkeypatch.setattr(llm, "get_pooled_adapter", lambda name: flexible_llm_adapter)
 
-    with Orchestrator._capture_token_usage("agent", metrics, mock_config) as (
+    with OrchestrationUtils.capture_token_usage("agent", metrics, mock_config) as (
         _,
         wrapped_adapter,
     ):


### PR DESCRIPTION
## Summary
- Introduce `OrchestrationUtils` utility class to house orchestration helper functions
- Update orchestrator to use `OrchestrationUtils` instead of dynamically attached helpers
- Adjust tests and docs to import new utility class

## Testing
- `task verify` *(fails: Required test coverage of 90% not reached and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689d746935648333a906c2de5d280b7f