### PR TITLE
Patch tests to use public orchestration hooks

### DIFF
--- a/tests/unit/test_agent_communication.py
+++ b/tests/unit/test_agent_communication.py
@@ -3,6 +3,7 @@ from autoresearch.agents.messages import MessageProtocol
 from autoresearch.agents.registry import AgentFactory, AgentRegistry
 from autoresearch.config.models import ConfigModel
 from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.orchestration.state import QueryState
 
 
@@ -60,21 +61,27 @@ def test_orchestrator_handles_coalitions(monkeypatch, tmp_path):
         agent = SimpleAgent(name=name)
         return agent
 
-    def fake_execute(
-        agent_name,
+    def fake_execute_cycle(
+        loop,
+        loops,
+        agents,
+        primus_index,
+        max_errors,
         state,
         config,
         metrics,
         callbacks,
         agent_factory,
         storage_manager,
-        loop,
+        tracer,
         cb_manager,
     ):
-        executed.append(agent_name)
+        for agent in agents[primus_index]:
+            executed.append(agent)
+        return primus_index
 
     monkeypatch.setattr(AgentFactory, "get", staticmethod(fake_get))
-    monkeypatch.setattr(Orchestrator, "_execute_agent", fake_execute)
+    monkeypatch.setattr(OrchestrationUtils, "execute_cycle", fake_execute_cycle)
     monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", str(tmp_path / "rel.json"))
     monkeypatch.setenv("AUTORESEARCH_QUERY_TOKENS", str(tmp_path / "qt.json"))
 

--- a/tests/unit/test_token_budget_heuristic.py
+++ b/tests/unit/test_token_budget_heuristic.py
@@ -1,18 +1,35 @@
 from autoresearch.config.models import ConfigModel
 from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 
 
 def test_token_budget_adjustment(monkeypatch):
     recorded = {}
 
-    def fake_execute_cycle(loop, loops, agents, primus_index, max_errors, state, config, metrics, callbacks, agent_factory, storage_manager, tracer):
-        recorded['budget'] = config.token_budget
+    def fake_execute_cycle(
+        loop,
+        loops,
+        agents,
+        primus_index,
+        max_errors,
+        state,
+        config,
+        metrics,
+        callbacks,
+        agent_factory,
+        storage_manager,
+        tracer,
+        cb_manager,
+    ):
+        recorded["budget"] = config.token_budget
         return primus_index
 
-    monkeypatch.setattr(Orchestrator, "_execute_cycle", fake_execute_cycle)
+    monkeypatch.setattr(OrchestrationUtils, "execute_cycle", fake_execute_cycle)
 
     base_cfg = ConfigModel(agents=["A"], loops=1, token_budget=90)
-    cfg = base_cfg.model_copy(update={"group_size": 2, "total_groups": 2, "total_agents": 3})
+    cfg = base_cfg.model_copy(
+        update={"group_size": 2, "total_groups": 2, "total_agents": 3}
+    )
 
     Orchestrator.run_query("q", cfg)
 


### PR DESCRIPTION
## Summary
- refactor coalition test to intercept `OrchestrationUtils.execute_cycle` instead of private `_execute_agent`
- adjust token budget heuristic test to patch `OrchestrationUtils.execute_cycle`

## Testing
- `uv run ruff format tests/unit/test_agent_communication.py tests/unit/test_token_budget_heuristic.py`
- `uv run ruff check --fix tests/unit/test_agent_communication.py tests/unit/test_token_budget_heuristic.py`
- `uv run flake8 tests/unit/test_agent_communication.py tests/unit/test_token_budget_heuristic.py`
- `uv run pytest tests/unit/test_agent_communication.py tests/unit/test_token_budget_heuristic.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689e005e04d48333b675ce8a8a6e6a1a