### PR TITLE
Add health endpoint and async query ID support

### DIFF
--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -80,7 +80,9 @@ class SearchConfig(BaseModel):
     max_workers: int = Field(default=4, ge=1)
     http_pool_size: int = Field(default=10, ge=1)
 
-    _normalize_ranking_weights = model_validator(mode="after")(normalize_ranking_weights)
+    _normalize_ranking_weights = model_validator(mode="after")(
+        normalize_ranking_weights
+    )
 
 
 class StorageConfig(BaseModel):
@@ -147,7 +149,7 @@ class APIConfig(BaseModel):
         default_factory=lambda: {
             "anonymous": ["query"],
             "user": ["query"],
-            "admin": ["query", "metrics", "capabilities"],
+            "admin": ["query", "metrics", "capabilities", "config", "health"],
         },
         description="Mapping of roles to allowed actions",
     )
@@ -169,7 +171,9 @@ class DistributedConfig(BaseModel):
     address: str | None = Field(default=None, description="Ray cluster address")
     num_cpus: int = Field(default=1, ge=1)
     message_broker: str = Field(default="memory")
-    broker_url: str | None = Field(default=None, description="URL for the message broker")
+    broker_url: str | None = Field(
+        default=None, description="URL for the message broker"
+    )
 
 
 class AnalysisConfig(BaseModel):
@@ -253,15 +257,15 @@ class ConfigModel(BaseModel):
     )
     distributed_config: DistributedConfig = Field(default_factory=DistributedConfig)
 
-    _validate_reasoning_mode = field_validator(
-        "reasoning_mode", mode="before"
-    )(validate_reasoning_mode)
-    _validate_token_budget = field_validator(
-        "token_budget", mode="before"
-    )(validate_token_budget)
-    _validate_eviction_policy = field_validator(
-        "graph_eviction_policy", mode="before"
-    )(validate_eviction_policy)
+    _validate_reasoning_mode = field_validator("reasoning_mode", mode="before")(
+        validate_reasoning_mode
+    )
+    _validate_token_budget = field_validator("token_budget", mode="before")(
+        validate_token_budget
+    )
+    _validate_eviction_policy = field_validator("graph_eviction_policy", mode="before")(
+        validate_eviction_policy
+    )
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ConfigModel":

--- a/tests/behavior/steps/api_config_steps.py
+++ b/tests/behavior/steps/api_config_steps.py
@@ -6,7 +6,7 @@ from autoresearch.config.loader import ConfigLoader
 @given("the API server is running with config permissions")
 def api_server_with_permissions(test_context, api_client, monkeypatch):
     cfg = ConfigModel(api=APIConfig())
-    cfg.api.role_permissions["anonymous"].append("capabilities")
+    cfg.api.role_permissions["anonymous"].append("config")
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     test_context["client"] = api_client
 
@@ -65,7 +65,9 @@ def test_update_config():
     pass
 
 
-@scenario("../features/api_config.feature", "Replace configuration via the config endpoint")
+@scenario(
+    "../features/api_config.feature", "Replace configuration via the config endpoint"
+)
 def test_replace_config():
     pass
 

--- a/tests/behavior/steps/api_misc_steps.py
+++ b/tests/behavior/steps/api_misc_steps.py
@@ -4,8 +4,13 @@ from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel, APIConfig
 
 
+
+
 @given("the API server is running")
-def api_server_running(test_context, api_client):
+def api_server_running(test_context, api_client, monkeypatch):
+    cfg = ConfigModel(api=APIConfig())
+    cfg.api.role_permissions["anonymous"].append("health")
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     test_context["client"] = api_client
 
 

--- a/tests/integration/test_api_additional.py
+++ b/tests/integration/test_api_additional.py
@@ -11,7 +11,13 @@ import time
 def _setup(monkeypatch):
     cfg = ConfigModel(_env_file=None, _cli_parse_args=[])
     # allow all permissions for anonymous for simplicity
-    cfg.api.role_permissions["anonymous"] = ["query", "metrics", "capabilities"]
+    cfg.api.role_permissions["anonymous"] = [
+        "query",
+        "metrics",
+        "capabilities",
+        "config",
+        "health",
+    ]
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     return cfg
 


### PR DESCRIPTION
## Summary
- expose /health and guard /metrics with permissions
- require explicit config permission for runtime config endpoints
- run asynchronous queries via background thread and return query_id

## Testing
- `uv run pytest --no-cov tests/integration/test_api_additional.py tests/integration/test_api_docs.py tests/integration/test_api_auth.py tests/integration/test_api_auth_failure.py -q`
- `uv run pytest --no-cov tests/behavior/steps/api_misc_steps.py tests/behavior/steps/api_config_steps.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e0e0a157483339f2b8ed9e0f834a6