### PR TITLE
Stub ontology reasoning in storage tests

### DIFF
--- a/tests/unit/test_storage_utils.py
+++ b/tests/unit/test_storage_utils.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from unittest.mock import patch
 
 import autoresearch.storage as storage
 from autoresearch.storage import StorageManager
@@ -16,8 +17,16 @@ def test_touch_node_updates_lru(monkeypatch):
 
 
 def test_clear_all(storage_manager):
-    StorageManager.persist_claim({"id": "n1", "type": "fact", "content": "c"})
-    StorageManager.clear_all()
+    with patch("autoresearch.storage.run_ontology_reasoner") as mock_reasoner:
+        mock_reasoner.return_value = None
+
+        StorageManager.persist_claim({"id": "n1", "type": "fact", "content": "c"})
+        StorageManager.clear_all()
+
+        # Expect reasoning to be invoked once during persistence
+        mock_reasoner.assert_called_once()
+
     assert StorageManager.get_graph().number_of_nodes() == 0
     conn = StorageManager.get_duckdb_conn()
-    assert conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0] == 0
+    # Verify the nodes table is empty after clearing
+    assert conn.execute("SELECT * FROM nodes").fetchall() == []


### PR DESCRIPTION
## Summary
- patch run_ontology_reasoner with a no-op in RDF persistence and clearing tests
- assert expected calls and adjust duckdb node checks

## Testing
- `uv run pytest tests/unit/test_storage_persistence.py::test_persist_to_rdf -q --no-cov`
- `uv run pytest tests/unit/test_storage_utils.py::test_clear_all -q --no-cov`
- `task verify` *(incomplete: hung during run)*

------
https://chatgpt.com/codex/tasks/task_e_689e0de07c7c83338076d829dfb1ac29