### PR TITLE
Fix side effect timing in DuckDB storage tests

### DIFF
--- a/tests/unit/test_storage_backend_extra.py
+++ b/tests/unit/test_storage_backend_extra.py
@@ -1,7 +1,9 @@
-import pytest
 from unittest.mock import MagicMock, patch
-from autoresearch.storage_backends import DuckDBStorageBackend
+
+import pytest
+
 from autoresearch.errors import StorageError
+from autoresearch.storage_backends import DuckDBStorageBackend
 
 
 def test_connection_context_no_pool():
@@ -46,10 +48,10 @@ def test_persist_claim_calls_execute(mock_connect):
 @patch("autoresearch.storage_backends.duckdb.connect")
 def test_persist_claim_failure(mock_connect):
     conn = MagicMock()
-    conn.execute.side_effect = Exception("fail")
     mock_connect.return_value = conn
     backend = DuckDBStorageBackend()
     backend.setup(db_path=":memory:")
+    conn.execute.side_effect = Exception("fail")
     with pytest.raises(StorageError):
         backend.persist_claim({"id": "c1"})
 
@@ -68,10 +70,10 @@ def test_vector_search_no_vss(mock_connect):
 @patch("autoresearch.storage_backends.duckdb.connect")
 def test_vector_search_failure(mock_connect):
     conn = MagicMock()
-    conn.execute.side_effect = Exception("boom")
     mock_connect.return_value = conn
     backend = DuckDBStorageBackend()
     backend.setup(db_path=":memory:")
+    conn.execute.side_effect = Exception("boom")
     backend._has_vss = True
     with pytest.raises(StorageError):
         backend.vector_search([0.1, 0.2, 0.3])


### PR DESCRIPTION
## Summary
- ensure DuckDB storage tests set `conn.execute.side_effect` only after `backend.setup`

## Testing
- `uv run flake8 tests/unit/test_storage_backend_extra.py`
- `uv run mypy src`
- `uv run pytest tests/unit/test_storage_backend_extra.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689e0db975f48333bc4b1114595aeea4