### PR TITLE
Adjust storage delegate test stub

### DIFF
--- a/tests/behavior/steps/api_misc_steps.py
+++ b/tests/behavior/steps/api_misc_steps.py
@@ -4,8 +4,6 @@ from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel, APIConfig
 
 
-
-
 @given("the API server is running")
 def api_server_running(test_context, api_client, monkeypatch):
     cfg = ConfigModel(api=APIConfig())

--- a/tests/unit/test_storage_delegate.py
+++ b/tests/unit/test_storage_delegate.py
@@ -12,8 +12,9 @@ class DummyStorage(StorageManager):
     called = False
 
     @staticmethod
-    def setup(db_path=None):
+    def setup(db_path=None, context=None, *args, **kwargs):
         DummyStorage.called = True
+        return context
 
 
 def test_set_and_get_delegate():


### PR DESCRIPTION
## Summary
- update DummyStorage.setup in test_storage_delegate to accept context arguments
- tidy API misc step definitions to satisfy style checks

## Testing
- `task verify` *(fails: Required test coverage of 90% not reached; test failures)*
- `uv run pytest tests/unit/test_storage_delegate.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_689e29e29dcc83338f70bce427d569e2