### PR TITLE
Ensure deterministic LRU eviction order

### DIFF
--- a/tests/unit/test_eviction.py
+++ b/tests/unit/test_eviction.py
@@ -1,4 +1,3 @@
-
 from datetime import timedelta
 
 from autoresearch.config.loader import ConfigLoader
@@ -10,6 +9,9 @@ from freezegun import freeze_time
 
 def test_ram_eviction(storage_manager, monkeypatch):
     StorageManager.clear_all()
+    monkeypatch.setattr(
+        "autoresearch.storage.run_ontology_reasoner", lambda *_, **__: None
+    )
     config = ConfigModel(ram_budget_mb=1)
     config.search.context_aware.enabled = False
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: config)
@@ -25,6 +27,9 @@ def test_ram_eviction(storage_manager, monkeypatch):
 
 def test_score_eviction(storage_manager, monkeypatch):
     StorageManager.clear_all()
+    monkeypatch.setattr(
+        "autoresearch.storage.run_ontology_reasoner", lambda *_, **__: None
+    )
     config = ConfigModel(ram_budget_mb=1, graph_eviction_policy="score")
     config.search.context_aware.enabled = False
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: config)
@@ -51,9 +56,9 @@ def test_score_eviction(storage_manager, monkeypatch):
 
 def test_lru_eviction_order(storage_manager, monkeypatch):
     StorageManager.clear_all()
-    from autoresearch import storage
-
-    storage.StorageManager.state.lru.clear()
+    monkeypatch.setattr(
+        "autoresearch.storage.run_ontology_reasoner", lambda *_, **__: None
+    )
     config = ConfigModel(ram_budget_mb=1)
     config.search.context_aware.enabled = False
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: config)
@@ -74,3 +79,47 @@ def test_lru_eviction_order(storage_manager, monkeypatch):
     graph = StorageManager.get_graph()
     assert "c1" not in graph.nodes
     assert "c2" in graph.nodes
+
+
+def test_lru_eviction_sequence(storage_manager, monkeypatch):
+    """Verify older nodes are evicted before newer ones with LRU policy."""
+    StorageManager.clear_all()
+    monkeypatch.setattr(
+        "autoresearch.storage.run_ontology_reasoner", lambda *_, **__: None
+    )
+    config = ConfigModel(ram_budget_mb=1)
+    config.search.context_aware.enabled = False
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: config)
+    ConfigLoader()._config = None
+
+    # Avoid eviction during setup
+    monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 0)
+
+    with freeze_time() as frozen_time:
+        StorageManager.persist_claim({"id": "c1", "type": "fact", "content": "a"})
+        frozen_time.tick(delta=timedelta(seconds=1))
+        StorageManager.persist_claim({"id": "c2", "type": "fact", "content": "b"})
+        frozen_time.tick(delta=timedelta(seconds=1))
+        StorageManager.persist_claim({"id": "c3", "type": "fact", "content": "c"})
+
+    def fake_ram_factory():
+        calls = {"n": 0}
+
+        def fake_ram():
+            calls["n"] += 1
+            return 1000 if calls["n"] == 1 else 0
+
+        return fake_ram
+
+    monkeypatch.setattr(StorageManager, "_current_ram_mb", fake_ram_factory())
+    StorageManager._enforce_ram_budget(1)
+    graph = StorageManager.get_graph()
+    assert "c1" not in graph.nodes
+    assert "c2" in graph.nodes
+    assert "c3" in graph.nodes
+
+    monkeypatch.setattr(StorageManager, "_current_ram_mb", fake_ram_factory())
+    StorageManager._enforce_ram_budget(1)
+    graph = StorageManager.get_graph()
+    assert "c2" not in graph.nodes
+    assert "c3" in graph.nodes


### PR DESCRIPTION
## Summary
- clear LRU cache in `StorageManager.clear_all`
- normalize graph eviction policy and handle LRU explicitly
- verify LRU eviction order in unit tests

## Testing
- `uv run ruff format src/autoresearch/storage.py tests/unit/test_eviction.py`
- `uv run ruff check --fix src/autoresearch/storage.py tests/unit/test_eviction.py`
- `uv run flake8 src/autoresearch/storage.py tests/unit/test_eviction.py`
- `uv run mypy src/autoresearch/storage.py`
- `uv run pytest tests/unit/test_eviction.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689e5e58a608833382748bdf0edb7c3e