### PR TITLE
Add advanced eviction policies

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -55,7 +55,10 @@ regular storage APIs.
 The storage system supports automatic eviction of claims when the memory usage exceeds the configured budget:
 
 1. **LRU (Least Recently Used)** - Evicts the least recently accessed claims
-2. **Low Score** - Evicts claims with the lowest relevance scores
+2. **Score** - Evicts claims with the lowest relevance scores
+3. **Hybrid** - Combines recency and confidence score for balanced eviction
+4. **Adaptive** - Dynamically chooses the best policy based on usage patterns
+5. **Priority** - Evicts nodes using configurable priority tiers
 
 The eviction process is triggered automatically by the `_enforce_ram_budget()` method when the memory usage exceeds the configured budget.
 

--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -72,17 +72,13 @@ class SearchConfig(BaseModel):
     citation_count_factor: float = Field(default=0.4, ge=0.0, le=1.0)
     use_feedback: bool = Field(default=False)
     feedback_weight: float = Field(default=0.3, ge=0.0, le=1.0)
-    context_aware: ContextAwareSearchConfig = Field(
-        default_factory=ContextAwareSearchConfig
-    )
+    context_aware: ContextAwareSearchConfig = Field(default_factory=ContextAwareSearchConfig)
     local_file: LocalFileConfig = Field(default_factory=LocalFileConfig)
     local_git: LocalGitConfig = Field(default_factory=LocalGitConfig)
     max_workers: int = Field(default=4, ge=1)
     http_pool_size: int = Field(default=10, ge=1)
 
-    _normalize_ranking_weights = model_validator(mode="after")(
-        normalize_ranking_weights
-    )
+    _normalize_ranking_weights = model_validator(mode="after")(normalize_ranking_weights)
 
 
 class StorageConfig(BaseModel):
@@ -171,9 +167,7 @@ class DistributedConfig(BaseModel):
     address: str | None = Field(default=None, description="Ray cluster address")
     num_cpus: int = Field(default=1, ge=1)
     message_broker: str = Field(default="memory")
-    broker_url: str | None = Field(
-        default=None, description="URL for the message broker"
-    )
+    broker_url: str | None = Field(default=None, description="URL for the message broker")
 
 
 class AnalysisConfig(BaseModel):
@@ -248,7 +242,13 @@ class ConfigModel(BaseModel):
         default_factory=dict,
         description="Named coalitions of agents for message broadcasting",
     )
-    graph_eviction_policy: str = Field(default="LRU")
+    graph_eviction_policy: str = Field(
+        default="LRU",
+        description=(
+            "Policy for evicting nodes from the knowledge graph. Supported "
+            'policies: "LRU", "score", "hybrid", "priority", "adaptive"'
+        ),
+    )
     default_model: str = Field(default="mistral")
     active_profile: Optional[str] = None
     distributed: bool = Field(
@@ -260,9 +260,7 @@ class ConfigModel(BaseModel):
     _validate_reasoning_mode = field_validator("reasoning_mode", mode="before")(
         validate_reasoning_mode
     )
-    _validate_token_budget = field_validator("token_budget", mode="before")(
-        validate_token_budget
-    )
+    _validate_token_budget = field_validator("token_budget", mode="before")(validate_token_budget)
     _validate_eviction_policy = field_validator("graph_eviction_policy", mode="before")(
         validate_eviction_policy
     )

--- a/src/autoresearch/config/validators.py
+++ b/src/autoresearch/config/validators.py
@@ -13,9 +13,7 @@ def validate_rdf_backend(cls, v: str) -> str:
     """Validate the RDF backend configuration."""
     valid_backends = ["sqlite", "berkeleydb", "memory"]
     if v not in valid_backends:
-        raise ConfigError(
-            "Invalid RDF backend", valid_backends=valid_backends, provided=v
-        )
+        raise ConfigError("Invalid RDF backend", valid_backends=valid_backends, provided=v)
     return v
 
 
@@ -34,9 +32,7 @@ def normalize_ranking_weights(self: "SearchConfig") -> "SearchConfig":
             suggestion="Check the default weight values",
         )
     if abs(defaults_total - 1.0) > 0.001:
-        default_weights = {
-            name: value / defaults_total for name, value in default_weights.items()
-        }
+        default_weights = {name: value / defaults_total for name, value in default_weights.items()}
 
     weight_fields = set(default_weights.keys())
     provided = self.model_fields_set & weight_fields
@@ -122,7 +118,13 @@ def validate_token_budget(cls, v: int | str | None) -> int | None:
 
 def validate_eviction_policy(cls, v: str | object) -> str:
     """Validate the graph eviction policy configuration."""
-    valid_policies = {"lru": "LRU", "score": "score"}
+    valid_policies = {
+        "lru": "LRU",
+        "score": "score",
+        "hybrid": "hybrid",
+        "priority": "priority",
+        "adaptive": "adaptive",
+    }
     if not isinstance(v, str):
         v = getattr(v, "value", v)
     v = str(v)

--- a/tests/unit/test_config_validators_additional.py
+++ b/tests/unit/test_config_validators_additional.py
@@ -31,7 +31,10 @@ def test_token_budget_invalid(budget):
         ConfigModel(token_budget=budget)
 
 
-@pytest.mark.parametrize("policy", ["LRU", "score"])
+@pytest.mark.parametrize(
+    "policy",
+    ["LRU", "score", "hybrid", "priority", "adaptive"],
+)
 def test_eviction_policy_valid(policy):
     cfg = ConfigModel(graph_eviction_policy=policy)
     assert cfg.graph_eviction_policy == policy

--- a/tests/unit/test_storage_eviction.py
+++ b/tests/unit/test_storage_eviction.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from unittest.mock import MagicMock, patch
 
+from autoresearch.config.models import ConfigModel
 from autoresearch.orchestration.metrics import EVICTION_COUNTER
 from autoresearch.storage import StorageManager
 
@@ -91,15 +92,14 @@ def test_enforce_ram_budget_lru_policy():
         with patch.object(StorageManager.state, "lru", mock_lru):
             with patch(
                 "autoresearch.storage.StorageManager._current_ram_mb",
-                side_effect=[100, 100, 100, 50, 50],
+                side_effect=[100, 100, 50, 50],
             ):
-                with patch("autoresearch.config.loader.ConfigLoader.config") as mock_config:
-                    mock_config.graph_eviction_policy = "lru"
-                    mock_config.eviction_batch_size = 10
-
-                # Execute
-                start = EVICTION_COUNTER._value.get()
-                StorageManager._enforce_ram_budget(75)
+                with patch(
+                    "autoresearch.config.loader.ConfigLoader.config",
+                    new=ConfigModel(graph_eviction_policy="lru"),
+                ):
+                    start = EVICTION_COUNTER._value.get()
+                    StorageManager._enforce_ram_budget(75)
 
                 # Verify
                 assert mock_graph.remove_node.call_count == 2
@@ -135,16 +135,14 @@ def test_enforce_ram_budget_score_policy():
         with patch.object(StorageManager.state, "lru", mock_lru):
             with patch(
                 "autoresearch.storage.StorageManager._current_ram_mb",
-                side_effect=[100, 100, 100, 50, 50],
+                side_effect=[100, 100, 50, 50],
             ):
-                with patch("autoresearch.config.loader.ConfigLoader.config") as mock_config:
-                    mock_config.graph_eviction_policy = "score"
-                    mock_config.eviction_batch_size = 10
-                    mock_config.eviction_safety_margin = 0.1
-
-                # Execute
-                start = EVICTION_COUNTER._value.get()
-                StorageManager._enforce_ram_budget(75)
+                with patch(
+                    "autoresearch.config.loader.ConfigLoader.config",
+                    new=ConfigModel(graph_eviction_policy="score"),
+                ):
+                    start = EVICTION_COUNTER._value.get()
+                    StorageManager._enforce_ram_budget(75)
 
                 # Verify
                 assert mock_graph.remove_node.call_count == 2
@@ -154,6 +152,113 @@ def test_enforce_ram_budget_score_policy():
 
                 # Verify that remaining nodes exclude evicted ones
                 assert "0" not in nodes_dict and "1" not in nodes_dict
+
+
+def test_enforce_ram_budget_hybrid_policy():
+    """Test that _enforce_ram_budget evicts nodes using the hybrid policy."""
+    mock_graph = MagicMock()
+    mock_graph.has_node.return_value = True
+    mock_graph.nodes = {
+        "a": {"confidence": 0.9},
+        "b": {"confidence": 0.2},
+        "c": {"confidence": 0.1},
+    }
+    mock_lru = OrderedDict([("a", 1), ("b", 2), ("c", 3)])
+
+    def mock_remove_node(node_id):
+        mock_graph.nodes.pop(node_id, None)
+
+    mock_graph.remove_node.side_effect = mock_remove_node
+
+    with patch.object(StorageManager.context, "graph", mock_graph):
+        with patch.object(StorageManager.state, "lru", mock_lru):
+            with patch(
+                "autoresearch.storage.StorageManager._current_ram_mb",
+                side_effect=[100, 100, 50, 50],
+            ):
+                with patch(
+                    "autoresearch.config.loader.ConfigLoader.config",
+                    new=ConfigModel(graph_eviction_policy="hybrid"),
+                ):
+                    start = EVICTION_COUNTER._value.get()
+                    StorageManager._enforce_ram_budget(75)
+
+                    assert mock_graph.remove_node.call_count == 2
+                    assert "c" not in mock_graph.nodes
+                    assert "b" not in mock_graph.nodes
+                    assert EVICTION_COUNTER._value.get() == start + 2
+
+
+def test_enforce_ram_budget_adaptive_policy():
+    """Test that _enforce_ram_budget uses score policy when variance is high."""
+    mock_graph = MagicMock()
+    mock_graph.has_node.return_value = True
+    mock_graph.nodes = {"a": {"confidence": 0.1}, "b": {"confidence": 0.9}}
+    mock_lru = OrderedDict([("a", 1), ("b", 2)])
+
+    def mock_remove_node(node_id):
+        mock_graph.nodes.pop(node_id, None)
+
+    mock_graph.remove_node.side_effect = mock_remove_node
+
+    with (
+        patch.object(StorageManager, "_access_frequency", {"a": 10, "b": 1}),
+        patch.object(StorageManager, "_last_adaptive_policy", "lru"),
+    ):
+        with patch.object(StorageManager.context, "graph", mock_graph):
+            with patch.object(StorageManager.state, "lru", mock_lru):
+                with patch(
+                    "autoresearch.storage.StorageManager._current_ram_mb",
+                    side_effect=[100, 100, 50, 50],
+                ):
+                    with patch(
+                        "autoresearch.storage.StorageManager._pop_low_score",
+                        return_value="a",
+                    ) as pls:
+                        with patch(
+                            "autoresearch.config.loader.ConfigLoader.config",
+                            new=ConfigModel(graph_eviction_policy="adaptive"),
+                        ):
+                            StorageManager._enforce_ram_budget(75)
+
+                            pls.assert_called()
+                            mock_graph.remove_node.assert_called_with("a")
+                            assert getattr(StorageManager, "_last_adaptive_policy") == "score"
+
+
+def test_enforce_ram_budget_priority_policy():
+    """Test that _enforce_ram_budget evicts nodes using priority tiers."""
+    mock_graph = MagicMock()
+    mock_graph.has_node.return_value = True
+    mock_graph.nodes = {
+        "sys": {"type": "system", "confidence": 0.9},
+        "user": {"type": "user", "confidence": 0.5},
+        "res": {"type": "research", "confidence": 0.5},
+    }
+    mock_lru = OrderedDict([(k, i) for i, k in enumerate(["sys", "user", "res"])])
+
+    def mock_remove_node(node_id):
+        mock_graph.nodes.pop(node_id, None)
+
+    mock_graph.remove_node.side_effect = mock_remove_node
+
+    with patch.object(StorageManager.context, "graph", mock_graph):
+        with patch.object(StorageManager.state, "lru", mock_lru):
+            with patch(
+                "autoresearch.storage.StorageManager._current_ram_mb",
+                side_effect=[100, 100, 50, 50],
+            ):
+                with patch(
+                    "autoresearch.config.loader.ConfigLoader.config",
+                    new=ConfigModel(graph_eviction_policy="priority"),
+                ):
+                    start = EVICTION_COUNTER._value.get()
+                    StorageManager._enforce_ram_budget(75)
+
+                    assert mock_graph.remove_node.call_count == 2
+                    assert "res" not in mock_graph.nodes
+                    assert "user" not in mock_graph.nodes
+                    assert EVICTION_COUNTER._value.get() == start + 2
 
 
 def test_enforce_ram_budget_zero_budget():


### PR DESCRIPTION
## Summary
- allow "hybrid", "priority", and "adaptive" eviction policies alongside existing options
- clarify eviction policy configuration and document all supported strategies
- add unit tests exercising each eviction policy path

## Testing
- `uv run ruff check src/autoresearch/config/validators.py src/autoresearch/config/models.py tests/unit/test_config_validators_additional.py tests/unit/test_storage_eviction.py`
- `uv run black src/autoresearch/config/validators.py src/autoresearch/config/models.py tests/unit/test_config_validators_additional.py tests/unit/test_storage_eviction.py`
- `uv run mypy src/autoresearch/config/validators.py src/autoresearch/config/models.py`
- `uv run pytest tests/unit/test_storage_eviction.py::test_enforce_ram_budget_lru_policy tests/unit/test_storage_eviction.py::test_enforce_ram_budget_score_policy -q -p no:cov -o addopts=`
- `uv run pytest tests/unit/test_config_validators_additional.py tests/unit/test_storage_eviction.py::test_enforce_ram_budget_hybrid_policy tests/unit/test_storage_eviction.py::test_enforce_ram_budget_adaptive_policy tests/unit/test_storage_eviction.py::test_enforce_ram_budget_priority_policy -q -p no:cov -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_689e669231e48333952594a047df25bc