### PR TITLE
Refactor orchestrator circuit breaker management

### DIFF
--- a/scripts/benchmark_token_memory.py
+++ b/scripts/benchmark_token_memory.py
@@ -41,7 +41,7 @@ def run_benchmark() -> dict[str, float | dict[str, dict[str, int]]]:
 
     memory_before = StorageManager._current_ram_mb()
     start = time.perf_counter()
-    response = Orchestrator.run_query("benchmark query", cfg)
+    response = Orchestrator().run_query("benchmark query", cfg)
     duration = time.perf_counter() - start
     memory_after = StorageManager._current_ram_mb()
 

--- a/src/autoresearch/api/streaming.py
+++ b/src/autoresearch/api/streaming.py
@@ -34,7 +34,7 @@ async def query_stream_endpoint(
 
     def run() -> None:
         try:
-            result = Orchestrator.run_query(
+            result = Orchestrator().run_query(
                 request.query, config, callbacks={"on_cycle_end": on_cycle_end}
             )
         except Exception as exc:  # pragma: no cover - defensive

--- a/src/autoresearch/cli_utils.py
+++ b/src/autoresearch/cli_utils.py
@@ -274,7 +274,7 @@ def visualize_query_cli(query: str, output_path: str, *, layout: str = "spring")
         def on_cycle_end(loop: int, _state: Any) -> None:
             progress.update(task, advance=1)
 
-        result = Orchestrator.run_query(query, config, {"on_cycle_end": on_cycle_end})
+        result = Orchestrator().run_query(query, config, {"on_cycle_end": on_cycle_end})
 
     fmt = "json" if not sys.stdout.isatty() else "markdown"
     OutputFormatter.format(result, fmt)

--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -375,7 +375,7 @@ def search(
                     "[green]Processing query...",
                     total=loops,
                 )
-                result = Orchestrator.run_query(
+                result = Orchestrator().run_query(
                     query, config, callbacks={"on_cycle_end": on_cycle_end}
                 )
 

--- a/src/autoresearch/mcp_interface.py
+++ b/src/autoresearch/mcp_interface.py
@@ -24,7 +24,7 @@ def create_server(host: str = "127.0.0.1", port: int = 8080) -> FastMCP:
     @server.tool
     async def research(query: str) -> dict[str, Any]:
         try:
-            result = Orchestrator.run_query(query, config)
+            result = Orchestrator().run_query(query, config)
             return {
                 "answer": result.answer,
                 "citations": [

--- a/src/autoresearch/monitor/__init__.py
+++ b/src/autoresearch/monitor/__init__.py
@@ -249,7 +249,7 @@ def run() -> None:
                     progress.update(task, advance=1)
                     on_cycle_end(loop, state)
 
-                result = Orchestrator.run_query(
+                result = Orchestrator().run_query(
                     query, config, {"on_cycle_end": wrapped_on_cycle}
                 )
             fmt = config.output_format or (

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -37,7 +37,9 @@ log = get_logger(__name__)
 class Orchestrator:
     """Coordinates multi-agent dialectical cycles with rotating Primus."""
 
-    _cb_manager: CircuitBreakerManager | None = None
+    def __init__(self) -> None:
+        """Initialize orchestrator state for a single query."""
+        self._cb_manager: CircuitBreakerManager | None = None
 
     @staticmethod
     def _parse_config(config: ConfigModel) -> Dict[str, Any]:
@@ -90,19 +92,18 @@ class Orchestrator:
             "coalitions": coalitions,
         }
 
-    @staticmethod
-    def get_circuit_breaker_state(agent_name: str) -> CircuitBreakerState:
-        if Orchestrator._cb_manager is None:
+    def get_circuit_breaker_state(self, agent_name: str) -> CircuitBreakerState:
+        if self._cb_manager is None:
             return {
                 "state": "closed",
                 "failure_count": 0.0,
                 "last_failure_time": 0.0,
                 "recovery_attempts": 0,
             }
-        return Orchestrator._cb_manager.get_circuit_breaker_state(agent_name)
+        return self._cb_manager.get_circuit_breaker_state(agent_name)
 
-    @staticmethod
     def run_query(
+        self,
         query: str,
         config: ConfigModel,
         callbacks: Dict[str, Callable[..., None]] | None = None,
@@ -117,7 +118,7 @@ class Orchestrator:
         metrics = OrchestrationMetrics()
         callbacks = callbacks or {}
 
-        config_params = Orchestrator._parse_config(config)
+        config_params = self._parse_config(config)
         agents = config_params["agent_groups"]
         primus_index = config_params["primus_index"]
         loops = config_params["loops"]
@@ -127,7 +128,7 @@ class Orchestrator:
             config_params["circuit_breaker_threshold"],
             config_params["circuit_breaker_cooldown"],
         )
-        Orchestrator._cb_manager = cb_manager
+        self._cb_manager = cb_manager
 
         OrchestrationUtils.apply_adaptive_token_budget(config, query)
 
@@ -237,6 +238,7 @@ class Orchestrator:
 
     @staticmethod
     async def run_query_async(
+        self,
         query: str,
         config: ConfigModel,
         callbacks: Dict[str, Callable[..., None]] | None = None,
@@ -252,7 +254,7 @@ class Orchestrator:
         metrics = OrchestrationMetrics()
         callbacks = callbacks or {}
 
-        config_params = Orchestrator._parse_config(config)
+        config_params = self._parse_config(config)
         agents = config_params["agent_groups"]
         primus_index = config_params["primus_index"]
         loops = config_params["loops"]
@@ -262,7 +264,7 @@ class Orchestrator:
             config_params["circuit_breaker_threshold"],
             config_params["circuit_breaker_cooldown"],
         )
-        Orchestrator._cb_manager = cb_manager
+        self._cb_manager = cb_manager
 
         OrchestrationUtils.apply_adaptive_token_budget(config, query)
 

--- a/src/autoresearch/orchestration/parallel.py
+++ b/src/autoresearch/orchestration/parallel.py
@@ -59,7 +59,7 @@ def execute_parallel_query(
         group_config.token_budget = getattr(config, "token_budget", 4000)
 
         try:
-            return Orchestrator.run_query(query, group_config)
+            return Orchestrator().run_query(query, group_config)
         except (
             AgentError,
             TimeoutError,

--- a/src/autoresearch/streamlit_app.py
+++ b/src/autoresearch/streamlit_app.py
@@ -1353,7 +1353,7 @@ def display_query_history():
         with st.spinner("Processing query..."):
             try:
                 # Run the query
-                result = Orchestrator.run_query(
+                result = Orchestrator().run_query(
                     st.session_state.current_query,
                     st.session_state.config,
                 )
@@ -1439,7 +1439,7 @@ def display_query_history():
         with st.spinner(f"Rerunning query: {rerun_query[:50]}..."):
             try:
                 # Run the query
-                result = Orchestrator.run_query(rerun_query, st.session_state.config)
+                result = Orchestrator().run_query(rerun_query, st.session_state.config)
 
                 # Update token usage metrics
                 if (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,11 +243,29 @@ def cleanup_storage():
 
 
 @pytest.fixture(autouse=True)
-def reset_cb_manager():
-    """Ensure circuit breaker state does not leak between tests."""
-    Orchestrator._cb_manager = None
-    yield
-    Orchestrator._cb_manager = None
+def orchestrator_runner(monkeypatch):
+    """Provide fresh orchestrator instances for class-level calls."""
+    orig_run_query = Orchestrator.run_query
+    orig_run_query_async = Orchestrator.run_query_async
+
+    def run_query_wrapper(query, config, callbacks=None, **kwargs):
+        return orig_run_query(Orchestrator(), query, config, callbacks, **kwargs)
+
+    async def run_query_async_wrapper(query, config, callbacks=None, **kwargs):
+        return await orig_run_query_async(
+            Orchestrator(), query, config, callbacks, **kwargs
+        )
+
+    monkeypatch.setattr(Orchestrator, "run_query", staticmethod(run_query_wrapper))
+    monkeypatch.setattr(
+        Orchestrator,
+        "run_query_async",
+        staticmethod(run_query_async_wrapper),
+    )
+    monkeypatch.setattr(Orchestrator, "_orig_run_query", orig_run_query, raising=False)
+    monkeypatch.setattr(
+        Orchestrator, "_orig_run_query_async", orig_run_query_async, raising=False
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_orchestrator_agents.py
+++ b/tests/integration/test_orchestrator_agents.py
@@ -133,10 +133,11 @@ def test_circuit_breaker_opens(monkeypatch):
         agents=["Bad", "Synthesizer"], loops=1, circuit_breaker_threshold=1
     )
 
+    orch = Orchestrator()
     with pytest.raises(Exception):
-        Orchestrator.run_query("q", cfg)
+        Orchestrator._orig_run_query(orch, "q", cfg)
 
-    state = Orchestrator.get_circuit_breaker_state("Bad")
+    state = orch.get_circuit_breaker_state("Bad")
     assert state["state"] == "open"
 
 


### PR DESCRIPTION
## Summary
- make `Orchestrator` manage its circuit breaker per-instance
- instantiate the orchestrator when running queries in CLI, API, streaming, and tests
- add test helpers to provide fresh orchestrator instances

## Testing
- `task verify` *(fails: tests/unit/test_api_error_handling.py::test_query_endpoint_runtime_error, tests/unit/test_api_error_handling.py::test_query_endpoint_invalid_response, tests/unit/test_cli_help.py::test_search_loops_option, tests/unit/test_cli_visualize.py::test_search_visualize_option, tests/unit/test_main_cli.py::test_search_reasoning_mode_option[direct], tests/unit/test_main_cli.py::test_search_reasoning_mode_option[dialectical], tests/unit/test_main_cli.py::test_search_primus_start_option, tests/unit/test_mcp_interface.py::test_client_server_roundtrip, tests/unit/test_metrics.py::test_metrics_collection_and_endpoint, tests/unit/test_orchestrator_errors.py::test_parallel_query_error_claims, tests/unit/test_orchestrator_errors.py::test_parallel_query_timeout_claims, tests/unit/test_parallel_module.py::test_execute_parallel_query_basic, tests/unit/test_parallel_module.py::test_execute_parallel_query_agent_error)`

------
https://chatgpt.com/codex/tasks/task_e_689e6d92417c8333be58bb8f35ea69d0