### PR TITLE
Document failing tests after orchestrator refactor

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,12 +1,11 @@
 # Autoresearch Project - Task Progress
 
 This document tracks the progress of tasks for the Autoresearch project,
-organized by phases from the code complete plan. As of **August 14, 2025**, unit
-tests `tests/unit/test_main_config_commands.py::test_config_init_command_force`
-and `tests/unit/test_eviction.py::test_lru_eviction_order` fail, so coverage is
-not generated and integration and behavior suites remain pending. Issues #27 and
-#28 track these blockers. The **0.1.0** release is still targeted for
-**November 15, 2025**.
+organized by phases from the code complete plan. As of **August 15, 2025**, `task
+verify` reports **13 failing unit tests** and overall coverage of **66%**, well
+below the 90% requirement. Integration and behavior suites remain pending.
+Issues #27 and #28 track these blockers. The **0.1.0** release is still
+targeted for **November 15, 2025**.
 
 ## Phase 1: Core System Completion (Weeks 1-2)
 
@@ -232,11 +231,8 @@ Coverage could not be generated because `task coverage` fails in
 
 ### Latest Test Results
 
-- `task coverage` failed in
-  `tests/unit/test_main_config_commands.py::test_config_init_command_force`.
-- `task verify` failed in
-  `tests/unit/test_eviction.py::test_lru_eviction_order`; these issues are
-  tracked in #27 and #28.
+- `task verify` reports 13 failing unit tests and total coverage of 66%.
+  See #28 for a detailed list of failing tests.
 - `flake8` reports no style errors.
 - `uv run mypy src` completes in ~7s after excluding site packages;
   issue [#22](issues/archive/0022-investigate-mypy-hang.md) closed.

--- a/issues/0028-unit-tests-after-orchestrator-refactor.md
+++ b/issues/0028-unit-tests-after-orchestrator-refactor.md
@@ -10,6 +10,21 @@ leave tests in an inconsistent state.
 - Fixtures and helper utilities may need redesign to use fresh Orchestrator
   instances per test.
 
+## Current Failures
+- `tests/unit/test_api_error_handling.py::test_query_endpoint_runtime_error`
+- `tests/unit/test_api_error_handling.py::test_query_endpoint_invalid_response`
+- `tests/unit/test_cli_help.py::test_search_loops_option`
+- `tests/unit/test_cli_visualize.py::test_search_visualize_option`
+- `tests/unit/test_main_cli.py::test_search_reasoning_mode_option[direct]`
+- `tests/unit/test_main_cli.py::test_search_reasoning_mode_option[dialectical]`
+- `tests/unit/test_main_cli.py::test_search_primus_start_option`
+- `tests/unit/test_mcp_interface.py::test_client_server_roundtrip`
+- `tests/unit/test_metrics.py::test_metrics_collection_and_endpoint`
+- `tests/unit/test_orchestrator_errors.py::test_parallel_query_error_claims`
+- `tests/unit/test_orchestrator_errors.py::test_parallel_query_timeout_claims`
+- `tests/unit/test_parallel_module.py::test_execute_parallel_query_basic`
+- `tests/unit/test_parallel_module.py::test_execute_parallel_query_agent_error`
+
 ## Acceptance Criteria
 - Unit tests are updated to accommodate the instance-level `_cb_manager`.
 - Any hanging or failing tests are fixed.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,6 @@ from autoresearch.storage import (  # noqa: E402
     teardown as storage_teardown,
 )  # noqa: E402
 from autoresearch.extensions import VSSExtensionLoader  # noqa: E402
-from autoresearch.orchestration.orchestrator import Orchestrator  # noqa: E402
 import duckdb  # noqa: E402
 
 _orig_option = typer.Option


### PR DESCRIPTION
## Summary
- remove unused orchestrator import from test fixtures
- document current unit test failures in issue tracker and progress doc

## Testing
- `task verify` *(fails: 13 unit tests, 66% coverage)*

------
https://chatgpt.com/codex/tasks/task_e_689ea9a8fbb883339d18a521077800d2