### PR TITLE
Add importlib import for metrics test

### DIFF
--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib  # noqa: F401
 
 import duckdb
 from fastapi.testclient import TestClient


### PR DESCRIPTION
## Summary
- ensure metrics test explicitly imports importlib

## Testing
- `pytest tests/unit/test_metrics.py -q` *(fails: No package metadata found for autoresearch)*

------
https://chatgpt.com/codex/tasks/task_e_689eb1b9938883339af187de8d93c670