### PR TITLE
Align tests with instance-based Orchestrator

### DIFF
--- a/tests/unit/test_api_error_handling.py
+++ b/tests/unit/test_api_error_handling.py
@@ -27,7 +27,7 @@ def _setup(monkeypatch):
 def test_query_endpoint_runtime_error(monkeypatch):
     _setup(monkeypatch)
 
-    def raise_error(q, c):
+    def raise_error(self, q, c, callbacks=None):
         raise RuntimeError("fail")
 
     monkeypatch.setattr(Orchestrator, "run_query", raise_error)
@@ -41,7 +41,9 @@ def test_query_endpoint_runtime_error(monkeypatch):
 
 def test_query_endpoint_invalid_response(monkeypatch):
     _setup(monkeypatch)
-    monkeypatch.setattr(Orchestrator, "run_query", lambda q, c: {"foo": "bar"})
+    monkeypatch.setattr(
+        Orchestrator, "run_query", lambda self, q, c, callbacks=None: {"foo": "bar"}
+    )
     client = TestClient(app)
     resp = client.post("/query", json={"query": "q"})
     assert resp.status_code == 200

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -125,7 +125,7 @@ def test_search_loops_option(monkeypatch):
 
     captured = {}
 
-    def _run(query, config, callbacks=None):
+    def _run(self, query, config, callbacks=None):
         captured["loops"] = config.loops
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 

--- a/tests/unit/test_cli_visualize.py
+++ b/tests/unit/test_cli_visualize.py
@@ -26,7 +26,7 @@ def test_summary_table_render():
 def test_search_visualize_option(monkeypatch):
     runner = CliRunner()
 
-    def _mock_run(query, config, callbacks=None):
+    def _mock_run(self, query, config, callbacks=None):
         return QueryResponse(answer='a', citations=[], reasoning=[], metrics={'m': 1})
 
     monkeypatch.setattr(Orchestrator, 'run_query', _mock_run)

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -15,7 +15,7 @@ from autoresearch.models import QueryResponse  # noqa: E402
 from autoresearch.orchestration.orchestrator import Orchestrator  # noqa: E402
 
 
-def _mock_run_query(query, config, callbacks=None):
+def _mock_run_query(self, query, config, callbacks=None):
     return QueryResponse(answer="a", citations=[], reasoning=[], metrics={})
 
 
@@ -44,7 +44,7 @@ def test_search_reasoning_mode_option(monkeypatch, mode, config_loader):
 
     captured = {}
 
-    def _run(query, config, callbacks=None):
+    def _run(self, query, config, callbacks=None):
         captured["mode"] = config.reasoning_mode
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
@@ -62,7 +62,7 @@ def test_search_primus_start_option(monkeypatch, config_loader):
 
     captured = {}
 
-    def _run(query, config, callbacks=None):
+    def _run(self, query, config, callbacks=None):
         captured["start"] = config.primus_start
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 

--- a/tests/unit/test_mcp_interface.py
+++ b/tests/unit/test_mcp_interface.py
@@ -4,7 +4,7 @@ from autoresearch.models import QueryResponse
 from autoresearch.config.models import ConfigModel
 
 
-def _mock_run_query(query, config):
+def _mock_run_query(self, query, config, callbacks=None):
     return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
 

--- a/tests/unit/test_orchestrator_errors.py
+++ b/tests/unit/test_orchestrator_errors.py
@@ -145,7 +145,7 @@ def test_orchestrator_raises_after_error(monkeypatch, test_config, failing_agent
 
     # Execute and Verify
     with pytest.raises(OrchestrationError) as excinfo:
-        Orchestrator.run_query("test query", test_config)
+        Orchestrator().run_query("test query", test_config)
 
     # Verify the error contains the agent errors
     assert excinfo.value.context.get("errors") is not None
@@ -164,7 +164,7 @@ def test_invalid_agent_name_raises(test_config):
 
     # Execute and Verify
     with pytest.raises(OrchestrationError) as excinfo:
-        Orchestrator.run_query("test query", test_config)
+        Orchestrator().run_query("test query", test_config)
 
     # Verify the error contains the agent errors
     assert excinfo.value.context.get("errors") is not None
@@ -190,7 +190,7 @@ def test_callback_error_propagates(test_config):
 
     # Execute and Verify
     with pytest.raises(RuntimeError):
-        Orchestrator.run_query(
+        Orchestrator().run_query(
             "test query",
             test_config,
             callbacks={"on_cycle_start": bad_callback},
@@ -233,7 +233,7 @@ def test_agent_error_is_wrapped(monkeypatch, test_config, error_type, error_mess
 
     # Execute and Verify
     with pytest.raises(OrchestrationError) as excinfo:
-        Orchestrator.run_query("test query", test_config)
+        Orchestrator().run_query("test query", test_config)
 
     # Verify the error contains agent errors
     assert excinfo.value.context.get("errors") is not None
@@ -251,7 +251,7 @@ def test_parallel_query_error_claims(monkeypatch):
 
     cfg = ConfigModel(agents=[], loops=1)
 
-    def mock_run_query(query, config):
+    def mock_run_query(self, query, config, callbacks=None):
         if config.agents == ["A"]:
             return QueryResponse(
                 answer="a",
@@ -284,7 +284,7 @@ def test_parallel_query_timeout_claims(monkeypatch):
     original_sleep = time.sleep
     monkeypatch.setattr(time, "sleep", lambda s: None)
 
-    def mock_run_query(query, config):
+    def mock_run_query(self, query, config, callbacks=None):
         if config.agents == ["slow"]:
             original_sleep(0.002)
             return QueryResponse(

--- a/tests/unit/test_parallel_module.py
+++ b/tests/unit/test_parallel_module.py
@@ -47,7 +47,7 @@ def test_calculate_result_confidence():
 def test_execute_parallel_query_basic(monkeypatch):
     cfg = ConfigModel.model_construct(agents=[], loops=1)
 
-    def mock_run_query(query, config):
+    def mock_run_query(self, query, config, callbacks=None):
         return QueryResponse(
             answer=config.agents[0],
             citations=[],
@@ -74,7 +74,7 @@ def test_execute_parallel_query_basic(monkeypatch):
 def test_execute_parallel_query_agent_error(monkeypatch, caplog):
     cfg = ConfigModel.model_construct(agents=[], loops=1)
 
-    def mock_run_query(query, config):
+    def mock_run_query(self, query, config, callbacks=None):
         raise AgentError("boom", agent_name="A")
 
     synthesizer = MagicMock()


### PR DESCRIPTION
## Summary
- ensure patched `Orchestrator.run_query` test helpers accept `self` and optional `callbacks`
- update tests to invoke `Orchestrator().run_query` where required

## Testing
- `uv run pytest tests/unit/test_api_error_handling.py tests/unit/test_cli_help.py::test_search_loops_option tests/unit/test_cli_visualize.py::test_search_visualize_option tests/unit/test_main_cli.py tests/unit/test_mcp_interface.py::test_client_server_roundtrip tests/unit/test_orchestrator_errors.py tests/unit/test_parallel_module.py -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_689eb1a4a65883338392b43bb8489b06