### PR TITLE
Add mock_run_query fixture for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ import tests.stubs  # noqa: F401,E402
 
 from autoresearch.config.loader import ConfigLoader  # noqa: E402
 from autoresearch.config.models import ConfigModel  # noqa: E402, F401
+from autoresearch.models import QueryResponse  # noqa: E402, F401
 
 
 from autoresearch.api import app as api_app, SLOWAPI_STUB, reset_request_log  # noqa: E402
@@ -600,3 +601,15 @@ def api_client_factory() -> Callable[[dict[str, str] | None], TestClient]:
         return client
 
     return _make
+
+
+@pytest.fixture
+def mock_run_query():
+    """Return a simple Orchestrator.run_query stub for tests."""
+
+    def _mock_run_query(self, query, config, callbacks=None):
+        return QueryResponse(
+            answer="ok", citations=[], reasoning=[], metrics={"m": 1}
+        )
+
+    return _mock_run_query

--- a/tests/unit/test_cli_visualize.py
+++ b/tests/unit/test_cli_visualize.py
@@ -3,7 +3,6 @@ from typer.testing import CliRunner
 
 from autoresearch.cli_utils import ascii_bar_graph, summary_table
 from autoresearch.orchestration.orchestrator import Orchestrator
-from autoresearch.models import QueryResponse
 
 
 def test_ascii_bar_graph_basic():
@@ -23,13 +22,10 @@ def test_summary_table_render():
     assert '1' in output
 
 
-def test_search_visualize_option(monkeypatch):
+def test_search_visualize_option(monkeypatch, mock_run_query):
     runner = CliRunner()
 
-    def _mock_run(self, query, config, callbacks=None):
-        return QueryResponse(answer='a', citations=[], reasoning=[], metrics={'m': 1})
-
-    monkeypatch.setattr(Orchestrator, 'run_query', _mock_run)
+    monkeypatch.setattr(Orchestrator, 'run_query', mock_run_query)
 
     import sys
     import types

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -15,23 +15,19 @@ from autoresearch.models import QueryResponse  # noqa: E402
 from autoresearch.orchestration.orchestrator import Orchestrator  # noqa: E402
 
 
-def _mock_run_query(self, query, config, callbacks=None):
-    return QueryResponse(answer="a", citations=[], reasoning=[], metrics={})
-
-
-def test_search_default_output_tty(monkeypatch):
+def test_search_default_output_tty(monkeypatch, mock_run_query):
     runner = CliRunner()
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    monkeypatch.setattr(Orchestrator, "run_query", _mock_run_query)
+    monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
     result = runner.invoke(app, ["search", "q"])
     assert result.exit_code == 0
     assert "# Answer" in result.stdout
 
 
-def test_search_default_output_json(monkeypatch):
+def test_search_default_output_json(monkeypatch, mock_run_query):
     runner = CliRunner()
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
-    monkeypatch.setattr(Orchestrator, "run_query", _mock_run_query)
+    monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     result = runner.invoke(app, ["search", "q"])
     assert result.exit_code == 0

--- a/tests/unit/test_mcp_interface.py
+++ b/tests/unit/test_mcp_interface.py
@@ -1,20 +1,15 @@
 from autoresearch import mcp_interface
 from autoresearch.orchestration.orchestrator import Orchestrator
-from autoresearch.models import QueryResponse
 from autoresearch.config.models import ConfigModel
-
-
-def _mock_run_query(self, query, config, callbacks=None):
-    return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
 
 def _mock_load_config():
     return ConfigModel()
 
 
-def test_client_server_roundtrip(monkeypatch):
+def test_client_server_roundtrip(monkeypatch, mock_run_query):
     monkeypatch.setattr(mcp_interface._config_loader, "load_config", _mock_load_config)
-    monkeypatch.setattr(Orchestrator, "run_query", _mock_run_query)
+    monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
 
     server = mcp_interface.create_server()
 


### PR DESCRIPTION
## Summary
- add reusable mock_run_query fixture returning QueryResponse
- simplify unit tests to use mock_run_query instead of local stubs

## Testing
- `task test:unit` *(fails: 21 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689ebbb0875483339cdcf0f8b9d16b05