### PR TITLE
Align mock run_query signatures in tests

### DIFF
--- a/tests/behavior/steps/agent_orchestration_steps.py
+++ b/tests/behavior/steps/agent_orchestration_steps.py
@@ -94,7 +94,8 @@ def run_orchestrator_on_query(query):
         "autoresearch.orchestration.orchestrator.Orchestrator._parse_config",
         side_effect=spy_parse,
     ):
-        Orchestrator.run_query(query, cfg)
+        orch = Orchestrator()
+        orch.run_query(query, cfg)
 
     return {"record": record, "config_params": config_params}
 
@@ -197,7 +198,15 @@ def run_two_queries(monkeypatch):
     original_run_query = Orchestrator.run_query
     query_data = {"primus_indices": []}
 
-    def mock_run_query(query, config, callbacks=None):
+    def mock_run_query(
+        self,
+        query,
+        config,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         query_data["primus_indices"].append(config.primus_start)
         config.primus_start = (config.primus_start + 1) % len(config.agents)
         return QueryResponse(
@@ -215,8 +224,9 @@ def run_two_queries(monkeypatch):
         primus_start=0,
     )
 
-    Orchestrator.run_query("Query 1", config)
-    Orchestrator.run_query("Query 2", config)
+    orch = Orchestrator()
+    orch.run_query("Query 1", config)
+    orch.run_query("Query 2", config)
 
     monkeypatch.setattr(Orchestrator, "run_query", original_run_query)
 

--- a/tests/behavior/steps/cli_options_steps.py
+++ b/tests/behavior/steps/cli_options_steps.py
@@ -42,7 +42,14 @@ def test_cli_primus_start(bdd_context):
 )
 def run_with_budget(query, loops, budget, monkeypatch, cli_runner, bdd_context):
     ConfigLoader.reset_instance()
-    def mock_run_query(q, cfg, callbacks=None):
+    def mock_run_query(
+        q,
+        cfg,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         bdd_context["cfg"] = cfg
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
@@ -69,7 +76,14 @@ def check_budget_config(bdd_context, loops, budget):
 @when(parsers.parse('I run `autoresearch search "{query}" --agents {agents}`'))
 def run_with_agents(query, agents, monkeypatch, cli_runner, bdd_context):
     ConfigLoader.reset_instance()
-    def mock_run_query(q, cfg, callbacks=None):
+    def mock_run_query(
+        q,
+        cfg,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         bdd_context["cfg"] = cfg
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
@@ -116,7 +130,14 @@ def run_parallel_cli(g1, g2, query, monkeypatch, cli_runner, bdd_context):
 def run_with_reasoning(query, mode, monkeypatch, cli_runner, bdd_context):
     ConfigLoader.reset_instance()
 
-    def mock_run_query(q, cfg, callbacks=None):
+    def mock_run_query(
+        q,
+        cfg,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         bdd_context["cfg"] = cfg
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
@@ -140,7 +161,14 @@ def check_reasoning_mode(bdd_context, mode):
 def run_with_primus(query, index, monkeypatch, cli_runner, bdd_context):
     ConfigLoader.reset_instance()
 
-    def mock_run_query(q, cfg, callbacks=None):
+    def mock_run_query(
+        q,
+        cfg,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         bdd_context["cfg"] = cfg
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 

--- a/tests/behavior/steps/reasoning_parameters_steps.py
+++ b/tests/behavior/steps/reasoning_parameters_steps.py
@@ -20,7 +20,14 @@ def test_adaptive_budget_flags(bdd_context):
 def run_breaker_cli(query, threshold, cooldown, monkeypatch, cli_runner, bdd_context):
     ConfigLoader.reset_instance()
 
-    def mock_run_query(q, cfg, callbacks=None):
+    def mock_run_query(
+        q,
+        cfg,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         bdd_context["cfg"] = cfg
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
@@ -56,7 +63,14 @@ def check_breaker_config(bdd_context, threshold, cooldown):
 def run_adaptive_cli(query, factor, buffer, monkeypatch, cli_runner, bdd_context):
     ConfigLoader.reset_instance()
 
-    def mock_run_query(q, cfg, callbacks=None):
+    def mock_run_query(
+        q,
+        cfg,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         bdd_context["cfg"] = cfg
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -607,7 +607,15 @@ def api_client_factory() -> Callable[[dict[str, str] | None], TestClient]:
 def mock_run_query():
     """Return a simple Orchestrator.run_query stub for tests."""
 
-    def _mock_run_query(self, query, config, callbacks=None):
+    def _mock_run_query(
+        self,
+        query,
+        config,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         return QueryResponse(
             answer="ok", citations=[], reasoning=[], metrics={"m": 1}
         )

--- a/tests/integration/test_orchestrator_agents.py
+++ b/tests/integration/test_orchestrator_agents.py
@@ -65,7 +65,8 @@ def test_run_query_with_coalitions(monkeypatch):
         coalitions={"Team": ["FactChecker", "Contrarian"]},
     )
 
-    response = Orchestrator.run_query("q", cfg)
+    orch = Orchestrator()
+    response = orch.run_query("q", cfg)
 
     assert response.answer == "FactChecker, Contrarian, Synthesizer"
     assert calls == ["FactChecker", "Contrarian", "Synthesizer"]
@@ -83,7 +84,14 @@ def test_run_query_with_coalitions(monkeypatch):
 def test_run_parallel_query_aggregates_results(monkeypatch):
     cfg = ConfigModel(agents=[], loops=1)
 
-    def mock_run_query(query, config):
+    def mock_run_query(
+        query,
+        config,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         if config.agents == ["A"]:
             return QueryResponse(
                 answer="a", citations=[], reasoning=["claim A"], metrics={}

--- a/tests/unit/test_config_watcher_cleanup.py
+++ b/tests/unit/test_config_watcher_cleanup.py
@@ -9,7 +9,15 @@ from autoresearch.api import app as api_app
 from autoresearch.orchestration.orchestrator import Orchestrator
 
 
-def _mock_run_query_error(query, config, *args, **kwargs):
+def _mock_run_query_error(
+    self,
+    query,
+    config,
+    callbacks=None,
+    *,
+    agent_factory=None,
+    storage_manager=None,
+):
     raise RuntimeError("boom")
 
 

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -40,7 +40,15 @@ def test_search_reasoning_mode_option(monkeypatch, mode, config_loader):
 
     captured = {}
 
-    def _run(self, query, config, callbacks=None):
+    def _run(
+        self,
+        query,
+        config,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         captured["mode"] = config.reasoning_mode
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
@@ -58,7 +66,15 @@ def test_search_primus_start_option(monkeypatch, config_loader):
 
     captured = {}
 
-    def _run(self, query, config, callbacks=None):
+    def _run(
+        self,
+        query,
+        config,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         captured["start"] = config.primus_start
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 

--- a/tests/unit/test_orchestrator_errors.py
+++ b/tests/unit/test_orchestrator_errors.py
@@ -251,7 +251,15 @@ def test_parallel_query_error_claims(monkeypatch):
 
     cfg = ConfigModel(agents=[], loops=1)
 
-    def mock_run_query(self, query, config, callbacks=None):
+    def mock_run_query(
+        self,
+        query,
+        config,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         if config.agents == ["A"]:
             return QueryResponse(
                 answer="a",
@@ -284,7 +292,15 @@ def test_parallel_query_timeout_claims(monkeypatch):
     original_sleep = time.sleep
     monkeypatch.setattr(time, "sleep", lambda s: None)
 
-    def mock_run_query(self, query, config, callbacks=None):
+    def mock_run_query(
+        self,
+        query,
+        config,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         if config.agents == ["slow"]:
             original_sleep(0.002)
             return QueryResponse(

--- a/tests/unit/test_parallel_module.py
+++ b/tests/unit/test_parallel_module.py
@@ -47,7 +47,15 @@ def test_calculate_result_confidence():
 def test_execute_parallel_query_basic(monkeypatch):
     cfg = ConfigModel.model_construct(agents=[], loops=1)
 
-    def mock_run_query(self, query, config, callbacks=None):
+    def mock_run_query(
+        self,
+        query,
+        config,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         return QueryResponse(
             answer=config.agents[0],
             citations=[],
@@ -74,7 +82,15 @@ def test_execute_parallel_query_basic(monkeypatch):
 def test_execute_parallel_query_agent_error(monkeypatch, caplog):
     cfg = ConfigModel.model_construct(agents=[], loops=1)
 
-    def mock_run_query(self, query, config, callbacks=None):
+    def mock_run_query(
+        self,
+        query,
+        config,
+        callbacks=None,
+        *,
+        agent_factory=None,
+        storage_manager=None,
+    ):
         raise AgentError("boom", agent_name="A")
 
     synthesizer = MagicMock()


### PR DESCRIPTION
## Summary
- Expand test run_query stubs to accept agent_factory and storage_manager
- Mirror production signature across unit and behavior mock_run_query helpers
- Invoke Orchestrator.run_query on instances instead of the class

## Testing
- `python -m pytest tests/unit -q` *(fails: Coverage failure, total 67% < 90%)*

------
https://chatgpt.com/codex/tasks/task_e_689f7dc2b8a88333a7c9efff1b315717