### PR TITLE
Refactor run_query_async to instance method

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -43,11 +43,11 @@ The orchestration workflow is illustrated by the PlantUML description in `docs/d
 
 ## Deployment Considerations
 
-The orchestrator can run agents either sequentially or concurrently.  When
-integrated into an asynchronous application you can use
-`Orchestrator.run_query_async` which executes agents using `asyncio`.  Passing
-`concurrent=True` will dispatch each agent within a cycle to background
-threads, allowing I/O bound agents to overlap.
+The orchestrator can run agents either sequentially or concurrently. When
+integrated into an asynchronous application, use `run_query_async` on an
+`Orchestrator` instance to execute agents using `asyncio`. Passing
+`concurrent=True` dispatches each agent within a cycle to background threads,
+allowing I/O bound agents to overlap.
 
 For large scale deployments, set `distributed=true` and configure the
 `[distributed]` section to enable multi-process orchestration via Ray. When

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -236,7 +236,6 @@ class Orchestrator:
 
         return state.synthesize()
 
-    @staticmethod
     async def run_query_async(
         self,
         query: str,

--- a/tests/behavior/steps/conftest.py
+++ b/tests/behavior/steps/conftest.py
@@ -7,23 +7,9 @@ from autoresearch.orchestration.orchestrator import Orchestrator
 def orchestrator_runner(monkeypatch):
     """Ensure step definitions use a fresh Orchestrator per invocation."""
     orig_run_query = Orchestrator.run_query
-    orig_run_query_async = Orchestrator.run_query_async
 
     def run_query_wrapper(query, config, callbacks=None, **kwargs):
         return orig_run_query(Orchestrator(), query, config, callbacks, **kwargs)
 
-    async def run_query_async_wrapper(query, config, callbacks=None, **kwargs):
-        return await orig_run_query_async(
-            Orchestrator(), query, config, callbacks, **kwargs
-        )
-
     monkeypatch.setattr(Orchestrator, "run_query", staticmethod(run_query_wrapper))
-    monkeypatch.setattr(
-        Orchestrator,
-        "run_query_async",
-        staticmethod(run_query_async_wrapper),
-    )
     monkeypatch.setattr(Orchestrator, "_orig_run_query", orig_run_query, raising=False)
-    monkeypatch.setattr(
-        Orchestrator, "_orig_run_query_async", orig_run_query_async, raising=False
-    )

--- a/tests/behavior/steps/reasoning_mode_api_steps.py
+++ b/tests/behavior/steps/reasoning_mode_api_steps.py
@@ -190,8 +190,8 @@ def send_async_query(test_context: dict, query: str, mode: str, config: ConfigMo
         params.update(out)
         return out
 
-    async def run_async(q: str, cfg: ConfigModel):
-        return Orchestrator.run_query(q, cfg)
+    async def run_async(self, q: str, cfg: ConfigModel, callbacks=None, **kwargs):
+        return self.run_query(q, cfg)
 
     with (
         patch(

--- a/tests/integration/test_api_additional.py
+++ b/tests/integration/test_api_additional.py
@@ -1,11 +1,13 @@
-from autoresearch.api import app as api_app
-from autoresearch.config.models import ConfigModel
-from autoresearch.config.loader import ConfigLoader
-from autoresearch.orchestration.orchestrator import Orchestrator
-from autoresearch.models import QueryResponse
-from fastapi.testclient import TestClient
 import asyncio
 import time
+
+from fastapi.testclient import TestClient
+
+from autoresearch.api import app as api_app
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import Orchestrator
 
 
 def _setup(monkeypatch):
@@ -45,7 +47,7 @@ def test_config_endpoints(monkeypatch):
 def test_async_query_status(monkeypatch):
     _setup(monkeypatch)
 
-    async def dummy_async(query, config, callbacks=None, **k):
+    async def dummy_async(self, query, config, callbacks=None, **k):
         await asyncio.sleep(0.01)
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
@@ -75,7 +77,7 @@ def test_async_query_status(monkeypatch):
 def test_async_query_cancel(monkeypatch):
     _setup(monkeypatch)
 
-    async def long_async(query, config, callbacks=None, **k):
+    async def long_async(self, query, config, callbacks=None, **k):
         await asyncio.sleep(0.1)
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,23 +7,9 @@ from autoresearch.orchestration.orchestrator import Orchestrator
 def orchestrator_runner(monkeypatch):
     """Provide fresh orchestrator instances for class-level calls in unit tests."""
     orig_run_query = Orchestrator.run_query
-    orig_run_query_async = Orchestrator.run_query_async
 
     def run_query_wrapper(query, config, callbacks=None, **kwargs):
         return orig_run_query(Orchestrator(), query, config, callbacks, **kwargs)
 
-    async def run_query_async_wrapper(query, config, callbacks=None, **kwargs):
-        return await orig_run_query_async(
-            Orchestrator(), query, config, callbacks, **kwargs
-        )
-
     monkeypatch.setattr(Orchestrator, "run_query", staticmethod(run_query_wrapper))
-    monkeypatch.setattr(
-        Orchestrator,
-        "run_query_async",
-        staticmethod(run_query_async_wrapper),
-    )
     monkeypatch.setattr(Orchestrator, "_orig_run_query", orig_run_query, raising=False)
-    monkeypatch.setattr(
-        Orchestrator, "_orig_run_query_async", orig_run_query_async, raising=False
-    )

--- a/tests/unit/test_orchestrator_order.py
+++ b/tests/unit/test_orchestrator_order.py
@@ -1,9 +1,9 @@
-from unittest.mock import patch
 import asyncio
+from unittest.mock import patch
 
-from autoresearch.orchestration.orchestrator import Orchestrator
-from autoresearch.orchestration import ReasoningMode
 from autoresearch.config.models import ConfigModel
+from autoresearch.orchestration import ReasoningMode
+from autoresearch.orchestration.orchestrator import Orchestrator
 
 
 class DummyAgent:
@@ -46,7 +46,8 @@ def test_async_custom_agents_concurrent():
         "autoresearch.orchestration.orchestrator.AgentFactory.get",
         side_effect=get_agent,
     ):
-        asyncio.run(Orchestrator.run_query_async("q", cfg, concurrent=True))
+        orchestrator = Orchestrator()
+        asyncio.run(orchestrator.run_query_async("q", cfg, concurrent=True))
 
     assert sorted(record) == ["A1", "A2", "A3"]
 


### PR DESCRIPTION
## Summary
- convert `Orchestrator.run_query_async` from static to instance method
- update tests, fixtures and docs to instantiate `Orchestrator`

## Testing
- `uv run ruff check --fix src/autoresearch/orchestration/orchestrator.py tests/behavior/steps/conftest.py tests/behavior/steps/reasoning_mode_api_steps.py tests/integration/test_api_additional.py tests/unit/conftest.py tests/unit/test_orchestrator_order.py`
- `uv run flake8 src tests` *(fails: No such file or directory)*
- `uv run mypy src` *(fails: No module named 'pydantic')*
- `uv run pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_689fb545b9e8833393edbff3b1c32e65