### PR TITLE
Ensure fresh orchestrator per API request

### DIFF
--- a/src/autoresearch/__init__.py
+++ b/src/autoresearch/__init__.py
@@ -10,7 +10,7 @@ interfaces and a modular architecture.
 # creation.
 import importlib
 import sys
-from importlib.metadata import version as _version
+from importlib.metadata import PackageNotFoundError, version as _version
 from typing import TYPE_CHECKING, Any
 import warnings
 
@@ -20,7 +20,10 @@ try:  # pragma: no cover - best effort patch
 except Exception:  # pragma: no cover
     pass
 
-__version__ = _version("autoresearch")
+try:
+    __version__ = _version("autoresearch")
+except PackageNotFoundError:  # pragma: no cover - fallback for tests
+    __version__ = "0.0.0"
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checkers only
     from .distributed import (

--- a/src/autoresearch/api/deps.py
+++ b/src/autoresearch/api/deps.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from fastapi import Depends, HTTPException, Request
 
+from ..orchestration.orchestrator import Orchestrator
+
 
 def require_permission(permission: str):
     """Ensure the requesting client has a specific permission."""
@@ -14,3 +16,8 @@ def require_permission(permission: str):
             raise HTTPException(status_code=403, detail="Insufficient permissions")
 
     return Depends(checker)
+
+
+def create_orchestrator() -> Orchestrator:
+    """Create a new :class:`Orchestrator` instance."""
+    return Orchestrator()

--- a/src/autoresearch/api/streaming.py
+++ b/src/autoresearch/api/streaming.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 import asyncio
 from fastapi.responses import StreamingResponse
 
-from .deps import require_permission
+from .deps import require_permission, create_orchestrator
 from ..config import get_config
 from ..error_utils import get_error_info, format_error_for_api
 from ..models import QueryRequest, QueryResponse
 from ..orchestration import ReasoningMode
-from ..orchestration.orchestrator import Orchestrator
 from .webhooks import notify_webhook
 
 
@@ -34,7 +33,7 @@ async def query_stream_endpoint(
 
     def run() -> None:
         try:
-            result = Orchestrator().run_query(
+            result = create_orchestrator().run_query(
                 request.query, config, callbacks={"on_cycle_end": on_cycle_end}
             )
         except Exception as exc:  # pragma: no cover - defensive

--- a/tests/stubs/__init__.py
+++ b/tests/stubs/__init__.py
@@ -23,3 +23,13 @@ from . import spacy  # noqa: F401
 from . import streamlit  # noqa: F401
 from . import torch  # noqa: F401
 from . import transformers  # noqa: F401
+from . import watchfiles  # noqa: F401
+from . import networkx  # noqa: F401
+from . import rdflib  # noqa: F401
+from . import structlog  # noqa: F401
+from . import loguru  # noqa: F401
+from . import prometheus_client  # noqa: F401
+from . import opentelemetry  # noqa: F401
+from . import numpy  # noqa: F401
+from . import tinydb  # noqa: F401
+from . import limits  # noqa: F401

--- a/tests/stubs/limits.py
+++ b/tests/stubs/limits.py
@@ -1,0 +1,11 @@
+"""Minimal stub for the :mod:`limits` package."""
+
+import sys
+import types
+
+if "limits" not in sys.modules:
+    limits_stub = types.ModuleType("limits")
+    util_mod = types.ModuleType("limits.util")
+    util_mod.parse = lambda s: s
+    sys.modules["limits"] = limits_stub
+    sys.modules["limits.util"] = util_mod

--- a/tests/stubs/loguru.py
+++ b/tests/stubs/loguru.py
@@ -1,0 +1,14 @@
+"""Minimal stub for the :mod:`loguru` package."""
+
+import sys
+import types
+
+if "loguru" not in sys.modules:
+    loguru_stub = types.ModuleType("loguru")
+
+    class _Logger:
+        def __getattr__(self, _name):
+            return lambda *a, **k: None
+
+    loguru_stub.logger = _Logger()
+    sys.modules["loguru"] = loguru_stub

--- a/tests/stubs/networkx.py
+++ b/tests/stubs/networkx.py
@@ -1,0 +1,13 @@
+"""Minimal stub for the :mod:`networkx` package."""
+
+import sys
+import types
+
+if "networkx" not in sys.modules:
+    nx_stub = types.ModuleType("networkx")
+
+    class Graph:
+        pass
+
+    nx_stub.Graph = Graph
+    sys.modules["networkx"] = nx_stub

--- a/tests/stubs/numpy.py
+++ b/tests/stubs/numpy.py
@@ -1,0 +1,9 @@
+"""Minimal stub for the :mod:`numpy` package."""
+
+import sys
+import types
+
+if "numpy" not in sys.modules:
+    np_stub = types.ModuleType("numpy")
+    np_stub.array = lambda *a, **k: []
+    sys.modules["numpy"] = np_stub

--- a/tests/stubs/opentelemetry.py
+++ b/tests/stubs/opentelemetry.py
@@ -1,0 +1,62 @@
+"""Minimal stub for the :mod:`opentelemetry` package."""
+
+import sys
+import types
+
+if "opentelemetry" not in sys.modules:
+    otel = types.ModuleType("opentelemetry")
+
+    trace_mod = types.ModuleType("trace")
+
+    class _Tracer:
+        def start_as_current_span(self, *_a, **_k):
+            class _Span:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *exc):
+                    return False
+
+            return _Span()
+
+    trace_mod.get_tracer = lambda name=None: _Tracer()
+    trace_mod.set_tracer_provider = lambda provider: None
+    otel.trace = trace_mod
+    sys.modules["opentelemetry.trace"] = trace_mod
+
+    sdk_mod = types.ModuleType("sdk")
+    resources_mod = types.ModuleType("resources")
+    resources_mod.SERVICE_NAME = "service.name"
+
+    class Resource:
+        @staticmethod
+        def create(_data):
+            return Resource()
+
+    resources_mod.Resource = Resource
+    sys.modules["opentelemetry.sdk"] = sdk_mod
+    sys.modules["opentelemetry.sdk.resources"] = resources_mod
+
+    trace_sdk_mod = types.ModuleType("trace")
+
+    class TracerProvider:
+        pass
+
+    trace_sdk_mod.TracerProvider = TracerProvider
+    sys.modules["opentelemetry.sdk.trace"] = trace_sdk_mod
+
+    export_mod = types.ModuleType("export")
+
+    class BatchSpanProcessor:
+        def __init__(self, *a, **k):
+            pass
+
+    class ConsoleSpanExporter:
+        def __init__(self, *a, **k):
+            pass
+
+    export_mod.BatchSpanProcessor = BatchSpanProcessor
+    export_mod.ConsoleSpanExporter = ConsoleSpanExporter
+    sys.modules["opentelemetry.sdk.trace.export"] = export_mod
+
+    sys.modules["opentelemetry"] = otel

--- a/tests/stubs/prometheus_client.py
+++ b/tests/stubs/prometheus_client.py
@@ -1,0 +1,19 @@
+"""Minimal stub for the :mod:`prometheus_client` package."""
+
+import sys
+import types
+
+if "prometheus_client" not in sys.modules:
+    prom_stub = types.ModuleType("prometheus_client")
+
+    class Counter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class Histogram:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    prom_stub.Counter = Counter
+    prom_stub.Histogram = Histogram
+    sys.modules["prometheus_client"] = prom_stub

--- a/tests/stubs/rdflib.py
+++ b/tests/stubs/rdflib.py
@@ -1,0 +1,13 @@
+"""Minimal stub for the :mod:`rdflib` package."""
+
+import sys
+import types
+
+if "rdflib" not in sys.modules:
+    rdflib_stub = types.ModuleType("rdflib")
+
+    class Graph:
+        pass
+
+    rdflib_stub.Graph = Graph
+    sys.modules["rdflib"] = rdflib_stub

--- a/tests/stubs/structlog.py
+++ b/tests/stubs/structlog.py
@@ -1,0 +1,18 @@
+"""Minimal stub for the :mod:`structlog` package."""
+
+import sys
+import types
+
+if "structlog" not in sys.modules:
+    structlog_stub = types.ModuleType("structlog")
+
+    class BoundLogger:
+        def __getattr__(self, _name):
+            return lambda *a, **k: None
+
+    def get_logger(*_args, **_kwargs):
+        return BoundLogger()
+
+    structlog_stub.BoundLogger = BoundLogger
+    structlog_stub.get_logger = get_logger
+    sys.modules["structlog"] = structlog_stub

--- a/tests/stubs/tinydb.py
+++ b/tests/stubs/tinydb.py
@@ -1,0 +1,21 @@
+"""Minimal stub for the :mod:`tinydb` package."""
+
+import sys
+import types
+
+if "tinydb" not in sys.modules:
+    tinydb_stub = types.ModuleType("tinydb")
+
+    class TinyDB:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    class Query:
+        pass
+
+    tinydb_stub.TinyDB = TinyDB
+    tinydb_stub.Query = Query
+    sys.modules["tinydb"] = tinydb_stub

--- a/tests/stubs/watchfiles.py
+++ b/tests/stubs/watchfiles.py
@@ -1,0 +1,14 @@
+"""Minimal stub for the :mod:`watchfiles` package."""
+
+import sys
+import types
+
+if "watchfiles" not in sys.modules:
+    watchfiles_stub = types.ModuleType("watchfiles")
+
+    def watch(*_args, **_kwargs):
+        if False:
+            yield ("", "")
+
+    watchfiles_stub.watch = watch
+    sys.modules["watchfiles"] = watchfiles_stub

--- a/tests/unit/test_api_error_handling.py
+++ b/tests/unit/test_api_error_handling.py
@@ -27,10 +27,13 @@ def _setup(monkeypatch):
 def test_query_endpoint_runtime_error(monkeypatch):
     _setup(monkeypatch)
 
-    def raise_error(self, q, c, callbacks=None):
+    orch = Orchestrator()
+
+    def raise_error(q, c, callbacks=None):
         raise RuntimeError("fail")
 
-    monkeypatch.setattr(Orchestrator, "run_query", raise_error)
+    monkeypatch.setattr(orch, "run_query", raise_error)
+    monkeypatch.setattr("autoresearch.api.routing.create_orchestrator", lambda: orch)
     client = TestClient(app)
     resp = client.post("/query", json={"query": "q"})
     assert resp.status_code == 200
@@ -41,9 +44,9 @@ def test_query_endpoint_runtime_error(monkeypatch):
 
 def test_query_endpoint_invalid_response(monkeypatch):
     _setup(monkeypatch)
-    monkeypatch.setattr(
-        Orchestrator, "run_query", lambda self, q, c, callbacks=None: {"foo": "bar"}
-    )
+    orch = Orchestrator()
+    monkeypatch.setattr(orch, "run_query", lambda q, c, callbacks=None: {"foo": "bar"})
+    monkeypatch.setattr("autoresearch.api.routing.create_orchestrator", lambda: orch)
     client = TestClient(app)
     resp = client.post("/query", json={"query": "q"})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add `create_orchestrator` factory and use it in API routes for new instances
- patch unit tests to monkeypatch an orchestrator instance
- provide stubs for optional dependencies used in tests

## Testing
- `uv run ruff format src/autoresearch/api/deps.py src/autoresearch/api/routing.py src/autoresearch/api/streaming.py tests/unit/test_api_error_handling.py`
- `uv run ruff check --fix src/autoresearch/api/deps.py src/autoresearch/api/routing.py src/autoresearch/api/streaming.py tests/unit/test_api_error_handling.py`
- `uv run flake8 src/autoresearch/api/deps.py src/autoresearch/api/routing.py src/autoresearch/api/streaming.py tests/unit/test_api_error_handling.py`
- `uv run mypy src/autoresearch/api/deps.py src/autoresearch/api/routing.py src/autoresearch/api/streaming.py` *(fails: Error importing plugin "pydantic.mypy")*
- `pytest tests/unit/test_api_error_handling.py -q --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_689fdd5489e0833386aac6e3d0b5770c