### PR TITLE
Patch run_query for parallel tests

### DIFF
--- a/tests/unit/test_orchestrator_errors.py
+++ b/tests/unit/test_orchestrator_errors.py
@@ -272,7 +272,16 @@ def test_parallel_query_error_claims(monkeypatch):
     synthesizer = MagicMock()
     synthesizer.execute.return_value = {"answer": "final"}
 
-    monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
+    orchestrator = Orchestrator()
+    monkeypatch.setattr(
+        orchestrator,
+        "run_query",
+        mock_run_query.__get__(orchestrator, Orchestrator),
+    )
+    monkeypatch.setattr(
+        "autoresearch.orchestration.orchestrator.Orchestrator",
+        lambda: orchestrator,
+    )
     monkeypatch.setattr(
         "autoresearch.orchestration.orchestrator.AgentFactory.get",
         lambda name: synthesizer,
@@ -319,7 +328,16 @@ def test_parallel_query_timeout_claims(monkeypatch):
     synthesizer = MagicMock()
     synthesizer.execute.return_value = {"answer": "final"}
 
-    monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
+    orchestrator = Orchestrator()
+    monkeypatch.setattr(
+        orchestrator,
+        "run_query",
+        mock_run_query.__get__(orchestrator, Orchestrator),
+    )
+    monkeypatch.setattr(
+        "autoresearch.orchestration.orchestrator.Orchestrator",
+        lambda: orchestrator,
+    )
     monkeypatch.setattr(
         "autoresearch.orchestration.orchestrator.AgentFactory.get",
         lambda name: synthesizer,


### PR DESCRIPTION
## Summary
- Bind `run_query` mocks to `Orchestrator` instances in parallel query error/timeout tests.
- Ensure `execute_cycle_async` receives the instance circuit breaker manager.

## Testing
- `uv run pytest tests/unit/test_orchestrator_errors.py -k 'parallel_query_error_claims or parallel_query_timeout_claims' --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689febf065e88333b2c64f62a82a8e4b