### PR TITLE
Use Orchestrator instance in MCP server

### DIFF
--- a/src/autoresearch/mcp_interface.py
+++ b/src/autoresearch/mcp_interface.py
@@ -19,12 +19,14 @@ _config_loader: ConfigLoader = ConfigLoader()
 def create_server(host: str = "127.0.0.1", port: int = 8080) -> FastMCP:
     """Create a FastMCP server exposing the research tool."""
     config = _config_loader.load_config()
+    orchestrator = Orchestrator()
     server: FastMCP = FastMCP("Autoresearch", host=host, port=port)
+    setattr(server, "orchestrator", orchestrator)
 
     @server.tool
     async def research(query: str) -> dict[str, Any]:
         try:
-            result = Orchestrator().run_query(query, config)
+            result = server.orchestrator.run_query(query, config)
             return {
                 "answer": result.answer,
                 "citations": [

--- a/tests/unit/test_mcp_interface.py
+++ b/tests/unit/test_mcp_interface.py
@@ -1,5 +1,6 @@
 from autoresearch import mcp_interface
-from autoresearch.orchestration.orchestrator import Orchestrator
+from types import MethodType
+
 from autoresearch.config.models import ConfigModel
 
 
@@ -9,9 +10,13 @@ def _mock_load_config():
 
 def test_client_server_roundtrip(monkeypatch, mock_run_query):
     monkeypatch.setattr(mcp_interface._config_loader, "load_config", _mock_load_config)
-    monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
 
     server = mcp_interface.create_server()
+    monkeypatch.setattr(
+        server.orchestrator,
+        "run_query",
+        MethodType(mock_run_query, server.orchestrator),
+    )
 
     result = mcp_interface.query("hello", transport=server)
 


### PR DESCRIPTION
## Summary
- reuse a single `Orchestrator` instance when building MCP server and expose it for patching
- adjust unit test to patch `run_query` on the server instance

## Testing
- `uv run ruff format src/autoresearch/mcp_interface.py tests/unit/test_mcp_interface.py`
- `uv run ruff check --fix src/autoresearch/mcp_interface.py tests/unit/test_mcp_interface.py`
- `uv run flake8 src/autoresearch/mcp_interface.py tests/unit/test_mcp_interface.py`
- `uv run mypy src` *(fails: Error importing plugin "pydantic.mypy" - No module named 'pydantic')*
- `uv run --with fastapi python -m pytest -q -o addopts= tests/unit/test_mcp_interface.py::test_client_server_roundtrip`


------
https://chatgpt.com/codex/tasks/task_e_689febe803948333b14c90953070eaa3