### PR TITLE
Patch visualize flag through CLI

### DIFF
--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -376,7 +376,10 @@ def search(
                     total=loops,
                 )
                 result = Orchestrator().run_query(
-                    query, config, callbacks={"on_cycle_end": on_cycle_end}
+                    query,
+                    config,
+                    callbacks={"on_cycle_end": on_cycle_end},
+                    visualize=visualize,
                 )
 
         fmt = output or (

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -110,6 +110,7 @@ class Orchestrator:
         *,
         agent_factory: type[AgentFactory] = AgentFactory,
         storage_manager: type[StorageManager] = StorageManager,
+        visualize: bool = False,
     ) -> QueryResponse:
         """Run a query through dialectical agent cycles."""
         setup_tracing(getattr(config, "tracing_enabled", False))
@@ -117,6 +118,9 @@ class Orchestrator:
         record_query()
         metrics = OrchestrationMetrics()
         callbacks = callbacks or {}
+
+        if visualize:
+            log.debug("Visualization requested for query")
 
         config_params = self._parse_config(config)
         agents = config_params["agent_groups"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -615,9 +615,8 @@ def mock_run_query():
         *,
         agent_factory=None,
         storage_manager=None,
+        visualize=False,
     ):
-        return QueryResponse(
-            answer="ok", citations=[], reasoning=[], metrics={"m": 1}
-        )
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={"m": 1})
 
     return _mock_run_query

--- a/tests/stubs/loguru.py
+++ b/tests/stubs/loguru.py
@@ -3,12 +3,33 @@
 import sys
 import types
 
-if "loguru" not in sys.modules:
+try:  # pragma: no cover - prefer real library if available
+    import loguru as _loguru  # type: ignore
+except Exception:  # pragma: no cover - fall back to stub
     loguru_stub = types.ModuleType("loguru")
 
+    class _Core:
+        handlers: dict[int, object] = {}
+
     class _Logger:
+        _core = _Core()
+
+        def add(self, *args, **kwargs) -> int:  # noqa: D401 - placeholder
+            handler_id = len(self._core.handlers) + 1
+            self._core.handlers[handler_id] = object()
+            return handler_id
+
+        def remove(self, *args, **kwargs) -> None:  # noqa: D401 - placeholder
+            if args:
+                self._core.handlers.pop(args[0], None)
+
+        def level(self, name: str):  # noqa: D401 - placeholder
+            return types.SimpleNamespace(name=name)
+
         def __getattr__(self, _name):
             return lambda *a, **k: None
 
     loguru_stub.logger = _Logger()
     sys.modules["loguru"] = loguru_stub
+else:  # pragma: no cover - real library available
+    sys.modules["loguru"] = _loguru

--- a/tests/stubs/prometheus_client.py
+++ b/tests/stubs/prometheus_client.py
@@ -14,6 +14,23 @@ if "prometheus_client" not in sys.modules:
         def __init__(self, *args, **kwargs):
             pass
 
+    class Gauge:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class CollectorRegistry:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    def start_http_server(*args, **kwargs):
+        pass
+
+    REGISTRY = CollectorRegistry()
+
     prom_stub.Counter = Counter
     prom_stub.Histogram = Histogram
+    prom_stub.Gauge = Gauge
+    prom_stub.CollectorRegistry = CollectorRegistry
+    prom_stub.REGISTRY = REGISTRY
+    prom_stub.start_http_server = start_http_server
     sys.modules["prometheus_client"] = prom_stub

--- a/tests/stubs/structlog.py
+++ b/tests/stubs/structlog.py
@@ -3,7 +3,9 @@
 import sys
 import types
 
-if "structlog" not in sys.modules:
+try:  # pragma: no cover - best effort to import real library
+    import structlog as _structlog  # type: ignore
+except Exception:  # pragma: no cover - fall back to stub
     structlog_stub = types.ModuleType("structlog")
 
     class BoundLogger:
@@ -13,6 +15,12 @@ if "structlog" not in sys.modules:
     def get_logger(*_args, **_kwargs):
         return BoundLogger()
 
+    def configure(*args, **kwargs):  # noqa: D401 - simple placeholder
+        """Stubbed configure function."""
+
     structlog_stub.BoundLogger = BoundLogger
     structlog_stub.get_logger = get_logger
+    structlog_stub.configure = configure
     sys.modules["structlog"] = structlog_stub
+else:  # pragma: no cover - real library available
+    sys.modules["structlog"] = _structlog

--- a/tests/unit/test_cli_visualize.py
+++ b/tests/unit/test_cli_visualize.py
@@ -1,31 +1,41 @@
 import importlib
+from unittest.mock import MagicMock
+
 from typer.testing import CliRunner
 
 from autoresearch.cli_utils import ascii_bar_graph, summary_table
+from autoresearch.models import QueryResponse
 from autoresearch.orchestration.orchestrator import Orchestrator
 
 
 def test_ascii_bar_graph_basic():
-    graph = ascii_bar_graph({'a': 1, 'b': 2}, width=10)
+    graph = ascii_bar_graph({"a": 1, "b": 2}, width=10)
     lines = graph.splitlines()
     assert len(lines) == 2
-    assert lines[0].count('#') < lines[1].count('#')
+    assert lines[0].count("#") < lines[1].count("#")
 
 
 def test_summary_table_render():
-    table = summary_table({'x': 1})
+    table = summary_table({"x": 1})
     from rich.console import Console
+
     console = Console(record=True, color_system=None)
     console.print(table)
     output = console.export_text()
-    assert 'x' in output
-    assert '1' in output
+    assert "x" in output
+    assert "1" in output
 
 
-def test_search_visualize_option(monkeypatch, mock_run_query):
+def test_search_visualize_option(monkeypatch):
     runner = CliRunner()
 
-    monkeypatch.setattr(Orchestrator, 'run_query', mock_run_query)
+    orch = Orchestrator()
+    run_query_mock = MagicMock(
+        return_value=QueryResponse(
+            answer="ok", citations=[], reasoning=[], metrics={"m": 1}
+        )
+    )
+    monkeypatch.setattr(orch, "run_query", run_query_mock)
 
     import sys
     import types
@@ -51,11 +61,14 @@ def test_search_visualize_option(monkeypatch, mock_run_query):
     def _load(self):
         return ConfigModel.model_construct(loops=1)
 
-    monkeypatch.setattr(ConfigLoader, 'load_config', _load)
-
-    main = importlib.import_module('autoresearch.main')
-    result = runner.invoke(main.app, ['search', 'q', '--visualize'])
+    monkeypatch.setattr(ConfigLoader, "load_config", _load)
+    main_app = importlib.import_module("autoresearch.main.app")
+    monkeypatch.setattr(main_app, "Orchestrator", lambda: orch)
+    main = importlib.import_module("autoresearch.main")
+    result = runner.invoke(main.app, ["search", "q", "--visualize"])
     assert result.exit_code == 0
-    assert 'Knowledge Graph' in result.stdout
-    assert 'm' in result.stdout
-    assert 'Answer' in result.stdout
+    run_query_mock.assert_called_once()
+    assert run_query_mock.call_args.kwargs["visualize"] is True
+    assert "Knowledge Graph" in result.stdout
+    assert "m" in result.stdout
+    assert "Answer" in result.stdout


### PR DESCRIPTION
## Summary
- ensure search CLI forwards the --visualize option to Orchestrator.run_query
- allow Orchestrator.run_query to accept a visualize flag
- test search visual graph uses instance-level run_query patch

## Testing
- `uv run ruff format tests/unit/test_cli_visualize.py src/autoresearch/main/app.py src/autoresearch/orchestration/orchestrator.py`
- `uv run ruff check --fix tests/unit/test_cli_visualize.py src/autoresearch/main/app.py src/autoresearch/orchestration/orchestrator.py`
- `uv run flake8 tests/unit/test_cli_visualize.py src/autoresearch/main/app.py src/autoresearch/orchestration/orchestrator.py`
- `uv run ruff format tests/stubs/prometheus_client.py`
- `uv run ruff check --fix tests/stubs/prometheus_client.py`
- `uv run flake8 tests/stubs/prometheus_client.py`
- `uv run ruff format tests/stubs/structlog.py`
- `uv run ruff check --fix tests/stubs/structlog.py`
- `uv run flake8 tests/stubs/structlog.py`
- `uv run ruff format tests/stubs/loguru.py`
- `uv run ruff check --fix tests/stubs/loguru.py`
- `uv run flake8 tests/stubs/loguru.py`
- `uv run ruff format tests/conftest.py`
- `uv run ruff check --fix tests/conftest.py`
- `uv run flake8 tests/conftest.py`
- `uv run ruff format tests/unit/test_cli_visualize.py`
- `uv run ruff check --fix tests/unit/test_cli_visualize.py`
- `uv run flake8 tests/unit/test_cli_visualize.py`
- `uv run ruff format src/autoresearch/main/app.py src/autoresearch/orchestration/orchestrator.py tests/unit/test_cli_visualize.py`
- `uv run ruff check --fix src/autoresearch/main/app.py src/autoresearch/orchestration/orchestrator.py tests/unit/test_cli_visualize.py`
- `uv run flake8 src/autoresearch/main/app.py src/autoresearch/orchestration/orchestrator.py tests/unit/test_cli_visualize.py`
- `uv run mypy src/autoresearch/main/app.py src/autoresearch/orchestration/orchestrator.py`
- `uv run ruff format tests/stubs/prometheus_client.py`
- `uv run ruff check --fix tests/stubs/prometheus_client.py`
- `uv run flake8 tests/stubs/prometheus_client.py`
- `uv run ruff format tests/stubs/structlog.py`
- `uv run ruff check --fix tests/stubs/structlog.py`
- `uv run flake8 tests/stubs/structlog.py`
- `uv run ruff format tests/stubs/loguru.py`
- `uv run ruff check --fix tests/stubs/loguru.py`
- `uv run flake8 tests/stubs/loguru.py`
- `uv run ruff format tests/conftest.py`
- `uv run ruff check --fix tests/conftest.py`
- `uv run flake8 tests/conftest.py`
- `pytest tests/unit/test_cli_visualize.py::test_search_visualize_option --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_689febe4009c83339dd6eb15401b3e0e