### PR TITLE
Document in-repo issue tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,13 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 - Changes to tooling must be reflected in both this document and `scripts/codex_setup.sh` so documentation and setup stay in sync.
 - Changes under `tests/` must keep this document and `scripts/codex_setup.sh` in sync to reflect new test requirements.
 
+## Issue tracking
+- Track work items in the `/issues` directory.
+- Tickets use the template and naming rules in [`issues/README.md`](issues/README.md).
+- File names are slugged titles without numeric prefixes.
+- When work is finished, set `Status` to `Archived` and move the ticket to `/issues/archive/` without renaming.
+- When issue tooling changes, update this file, `issues/AGENTS.md`, and `scripts/codex_setup.sh` to keep documentation and setup aligned.
+
 ## Binary artifacts
 - Do not commit binary files such as `.duckdb_extension` modules.
 - Required binaries are downloaded during setup and referenced via `VECTOR_EXTENSION_PATH`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ need additional configuration. See
 [docs/release_plan.md](docs/release_plan.md) for the full milestone
 schedule and outstanding tasks.
 
+## Issue tracking
+
+Work items are tracked in-repo under [`issues/`](issues). Tickets follow
+the template and naming conventions in
+[`issues/README.md`](issues/README.md). File names are slugged titles
+without numeric prefixes. When a ticket is complete, set its `Status` to
+`Archived` and move the file to [`issues/archive/`](issues/archive)
+without renaming.
+
 ## Installation
 
 Autoresearch requires **Python 3.12 or newer**. The `scripts/setup.sh` helper

--- a/issues/AGENTS.md
+++ b/issues/AGENTS.md
@@ -1,0 +1,10 @@
+# Issues directory guidelines
+
+Follow these rules when managing in-repo tickets.
+
+- Use the template and naming conventions in [README.md](README.md).
+- File names are slugged titles with no numeric prefixes.
+- Open tickets stay in this directory. Move completed ones to `archive/`
+  with `Status` set to `Archived` and do not rename them.
+- Keep this file and the repository root `AGENTS.md` current when issue
+  tooling evolves.


### PR DESCRIPTION
## Summary
- Document project issue tracker in README and AGENTS guidelines
- Add AGENTS instructions for `issues/` directory

## Testing
- `task verify` *(fails: 21 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a010f9f8908333bd411dd034766c94