### PR TITLE
Refactor orchestrator test fixture to provide fresh instances

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,16 +5,14 @@ from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.orchestration import metrics
 
 
-@pytest.fixture(autouse=True)
-def orchestrator_runner(monkeypatch):
-    """Provide fresh orchestrator instances for class-level calls in unit tests."""
-    orig_run_query = Orchestrator.run_query
+@pytest.fixture
+def orchestrator_runner():
+    """Return a factory for creating fresh ``Orchestrator`` instances."""
 
-    def run_query_wrapper(query, config, callbacks=None, **kwargs):
-        return orig_run_query(Orchestrator(), query, config, callbacks, **kwargs)
+    def _factory() -> Orchestrator:
+        return Orchestrator()
 
-    monkeypatch.setattr(Orchestrator, "run_query", staticmethod(run_query_wrapper))
-    monkeypatch.setattr(Orchestrator, "_orig_run_query", orig_run_query, raising=False)
+    return _factory
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_agent_communication.py
+++ b/tests/unit/test_agent_communication.py
@@ -47,7 +47,7 @@ def test_agent_registry_coalitions():
     assert AgentRegistry.get_coalition("squad") == ["Simple"]
 
 
-def test_orchestrator_handles_coalitions(monkeypatch, tmp_path):
+def test_orchestrator_handles_coalitions(monkeypatch, tmp_path, orchestrator_runner):
     AgentFactory.register("A1", SimpleAgent)
     AgentFactory.register("A2", SimpleAgent)
     cfg = ConfigModel.model_construct(
@@ -85,7 +85,7 @@ def test_orchestrator_handles_coalitions(monkeypatch, tmp_path):
     monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", str(tmp_path / "rel.json"))
     monkeypatch.setenv("AUTORESEARCH_QUERY_TOKENS", str(tmp_path / "qt.json"))
 
-    Orchestrator.run_query("q", cfg)
+    orchestrator_runner().run_query("q", cfg)
 
     assert executed == ["A1", "A2"]
 

--- a/tests/unit/test_coalition_execution.py
+++ b/tests/unit/test_coalition_execution.py
@@ -17,7 +17,7 @@ class DummyAgent:
         return {}
 
 
-def test_coalition_agents_run_together(monkeypatch, tmp_path):
+def test_coalition_agents_run_together(monkeypatch, tmp_path, orchestrator_runner):
     record = []
     AgentFactory._registry.clear()
 
@@ -37,7 +37,7 @@ def test_coalition_agents_run_together(monkeypatch, tmp_path):
     monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", str(tmp_path / "rel.json"))
     monkeypatch.setenv("AUTORESEARCH_QUERY_TOKENS", str(tmp_path / "qt.json"))
 
-    Orchestrator.run_query("q", cfg)
+    orchestrator_runner().run_query("q", cfg)
 
     assert set(record[:2]) == {"A", "B"}
 

--- a/tests/unit/test_orchestrator_messages.py
+++ b/tests/unit/test_orchestrator_messages.py
@@ -24,7 +24,7 @@ class Receiver(Agent):
         return {"results": {"received": content}}
 
 
-def test_agents_exchange_messages(monkeypatch):
+def test_agents_exchange_messages(monkeypatch, orchestrator_runner):
     cfg = ConfigModel(agents=["Sender", "Receiver"], loops=1, enable_agent_messages=True)
 
     def get_agent(name):
@@ -34,7 +34,7 @@ def test_agents_exchange_messages(monkeypatch):
 
     monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", "/tmp/release_tokens.json")
     monkeypatch.setenv("AUTORESEARCH_QUERY_TOKENS", "/tmp/query_tokens.json")
-    resp = Orchestrator.run_query("test", cfg)
+    resp = orchestrator_runner().run_query("test", cfg)
 
     assert resp.answer == "No answer synthesized"
     assert resp.metrics["delivered_messages"]["Receiver"][0]["content"] == "ping"

--- a/tests/unit/test_orchestrator_order.py
+++ b/tests/unit/test_orchestrator_order.py
@@ -19,7 +19,7 @@ class DummyAgent:
         return {}
 
 
-def test_custom_agents_order():
+def test_custom_agents_order(orchestrator_runner):
     record = []
 
     def get_agent(name):
@@ -30,7 +30,7 @@ def test_custom_agents_order():
         "autoresearch.orchestration.orchestrator.AgentFactory.get",
         side_effect=get_agent,
     ):
-        Orchestrator.run_query("q", cfg)
+        orchestrator_runner().run_query("q", cfg)
 
     assert record == ["A1", "A2", "A3"]
 

--- a/tests/unit/test_reasoning_modes.py
+++ b/tests/unit/test_reasoning_modes.py
@@ -18,7 +18,7 @@ class DummyAgent:
         return {}
 
 
-def _run(cfg):
+def _run(cfg, orchestrator_runner):
     record = []
 
     def get_agent(name):
@@ -28,24 +28,24 @@ def _run(cfg):
         "autoresearch.orchestration.orchestrator.AgentFactory.get",
         side_effect=get_agent,
     ):
-        Orchestrator.run_query("q", cfg)
+        orchestrator_runner().run_query("q", cfg)
 
     return record
 
 
-def test_direct_mode_executes_once():
+def test_direct_mode_executes_once(orchestrator_runner):
     cfg = ConfigModel(loops=3, reasoning_mode=ReasoningMode.DIRECT)
-    record = _run(cfg)
+    record = _run(cfg, orchestrator_runner)
     assert record == ["Synthesizer"]
 
 
-def test_chain_of_thought_mode_loops():
+def test_chain_of_thought_mode_loops(orchestrator_runner):
     cfg = ConfigModel(loops=2, reasoning_mode=ReasoningMode.CHAIN_OF_THOUGHT)
-    record = _run(cfg)
+    record = _run(cfg, orchestrator_runner)
     assert record == ["Synthesizer", "Synthesizer"]
 
 
-def test_chain_of_thought_records_steps():
+def test_chain_of_thought_records_steps(orchestrator_runner):
     cfg = ConfigModel(loops=3, reasoning_mode=ReasoningMode.CHAIN_OF_THOUGHT)
 
     class DummySynth:
@@ -74,7 +74,7 @@ def test_chain_of_thought_records_steps():
         "autoresearch.orchestration.orchestrator.AgentFactory.get",
         return_value=agent,
     ):
-        resp = Orchestrator.run_query("q", cfg)
+        resp = orchestrator_runner().run_query("q", cfg)
 
     steps = [c["content"] for c in resp.reasoning]
     assert steps == ["step-1", "step-2", "step-3"]

--- a/tests/unit/test_token_budget_heuristic.py
+++ b/tests/unit/test_token_budget_heuristic.py
@@ -3,7 +3,7 @@ from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 
 
-def test_token_budget_adjustment(monkeypatch):
+def test_token_budget_adjustment(monkeypatch, orchestrator_runner):
     recorded = {}
 
     def fake_execute_cycle(
@@ -31,6 +31,6 @@ def test_token_budget_adjustment(monkeypatch):
         update={"group_size": 2, "total_groups": 2, "total_agents": 3}
     )
 
-    Orchestrator.run_query("q", cfg)
+    orchestrator_runner().run_query("q", cfg)
 
     assert recorded["budget"] == 13


### PR DESCRIPTION
## Summary
- replace autouse `orchestrator_runner` with factory fixture returning new `Orchestrator` objects
- update unit tests to request the fixture and run queries on those instances
- drop unused class-level patching of `Orchestrator.run_query`

## Testing
- `pytest tests/unit/test_orchestrator_order.py tests/unit/test_coalition_execution.py tests/unit/test_agent_communication.py tests/unit/test_reasoning_modes.py tests/unit/test_token_budget_heuristic.py tests/unit/test_orchestrator_messages.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68a010f02e508333862839aa42984922