### PR TITLE
Stub graph deps and isolate config examples

### DIFF
--- a/tests/stubs/networkx.py
+++ b/tests/stubs/networkx.py
@@ -7,7 +7,16 @@ if "networkx" not in sys.modules:
     nx_stub = types.ModuleType("networkx")
 
     class Graph:
-        pass
+        def __init__(self, *args, **kwargs):
+            """Minimal graph stub accepting any arguments."""
+            pass
+
+    class DiGraph(Graph):
+        """Minimal directed graph stub."""
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
 
     nx_stub.Graph = Graph
+    nx_stub.DiGraph = DiGraph
     sys.modules["networkx"] = nx_stub

--- a/tests/stubs/rdflib.py
+++ b/tests/stubs/rdflib.py
@@ -7,7 +7,13 @@ if "rdflib" not in sys.modules:
     rdflib_stub = types.ModuleType("rdflib")
 
     class Graph:
-        pass
+        def __init__(self, *args, **kwargs):
+            """Minimal RDF graph stub accepting any arguments."""
+            pass
+
+        def open(self, *args, **kwargs):
+            """Stub open method returning self."""
+            return self
 
     rdflib_stub.Graph = Graph
     sys.modules["rdflib"] = rdflib_stub


### PR DESCRIPTION
## Summary
- add minimal networkx and rdflib graph stubs for tests
- copy example config files to a temp dir when testing config init
- restore bundled .env.example

## Testing
- `python -m pytest tests/unit/test_main_config_commands.py::test_config_init_command_force -q -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68a010e85d44833380960cacf7dff511