### PR TITLE
Refactor CLI tests for instance orchestrator

### DIFF
--- a/tests/stubs/networkx.py
+++ b/tests/stubs/networkx.py
@@ -7,7 +7,13 @@ if "networkx" not in sys.modules:
     nx_stub = types.ModuleType("networkx")
 
     class Graph:
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class DiGraph(Graph):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
 
     nx_stub.Graph = Graph
+    nx_stub.DiGraph = DiGraph
     sys.modules["networkx"] = nx_stub

--- a/tests/stubs/rdflib.py
+++ b/tests/stubs/rdflib.py
@@ -7,7 +7,14 @@ if "rdflib" not in sys.modules:
     rdflib_stub = types.ModuleType("rdflib")
 
     class Graph:
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def open(self, *args, **kwargs):
+            return True
+
+        def close(self) -> None:
+            pass
 
     rdflib_stub.Graph = Graph
     sys.modules["rdflib"] = rdflib_stub


### PR DESCRIPTION
## Summary
- instantiate `Orchestrator` per CLI invocation in tests and patch instance `run_query`
- ensure reasoning mode and primus start options reach `Orchestrator.run_query`
- provide lightweight stubs for `networkx.DiGraph` and `rdflib.Graph`

## Testing
- `pytest -o addopts='' tests/unit/test_main_cli.py -k 'search_reasoning_mode_option or search_primus_start_option'`


------
https://chatgpt.com/codex/tasks/task_e_68a010cb9b74833399d8e2d5d4874a56