### PR TITLE
Ensure deterministic LRU eviction order

### DIFF
--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -604,13 +604,13 @@ class StorageManager(metaclass=StorageManagerMeta):
                         nodes_to_evict.append(popped)
             elif policy == "lru":
                 # LRU policy: evict least recently used nodes deterministically
-                for _ in range(batch_size):
+                while len(nodes_to_evict) < batch_size and StorageManager.state.lru:
                     popped = StorageManager._pop_lru()
                     if popped and StorageManager.context.graph.has_node(popped):
                         nodes_to_evict.append(popped)
             else:
                 # Unknown policy - default to LRU for safety
-                for _ in range(batch_size):
+                while len(nodes_to_evict) < batch_size and StorageManager.state.lru:
                     popped = StorageManager._pop_lru()
                     if popped and StorageManager.context.graph.has_node(popped):
                         nodes_to_evict.append(popped)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,10 @@ if importlib.util.find_spec("autoresearch") is None:
     src_path = Path(__file__).resolve().parents[1] / "src"
     sys.path.insert(0, str(src_path))
 
-
+# Ensure real dependencies are loaded before test stubs
+import networkx  # noqa: F401,E402
+import rdflib  # noqa: F401,E402
+import prometheus_client  # noqa: F401,E402
 import tests.stubs  # noqa: F401,E402
 
 from autoresearch.config.loader import ConfigLoader  # noqa: E402


### PR DESCRIPTION
## Summary
- enforce batch-based LRU evictions in `StorageManager._enforce_ram_budget`
- stabilise eviction tests with fixed timestamps and in-memory RDF backend
- load real networkx, rdflib, and prometheus client during tests

## Testing
- `uv run ruff check src/autoresearch/storage.py tests/unit/test_eviction.py tests/conftest.py`
- `uv run flake8 src/autoresearch/storage.py tests/unit/test_eviction.py tests/conftest.py`
- `uv run mypy src/autoresearch/storage.py`
- `pytest --no-cov tests/unit/test_eviction.py::test_lru_eviction_order -q`

------
https://chatgpt.com/codex/tasks/task_e_68a010eb2e60833399d9b62dbf3a35f9