### PR TITLE
Patch Orchestrator instance in CLI tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,13 @@ from uuid import uuid4
 from unittest.mock import patch, MagicMock
 
 import pytest
-from fastapi.testclient import TestClient
 from typer.testing import CliRunner
 from pytest_httpx import httpx_mock  # noqa: F401
+
+try:
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover - fastapi optional in some environments
+    TestClient = MagicMock()
 
 pytest_plugins = ["tests.fixtures.config", "pytest_httpx"]
 


### PR DESCRIPTION
## Summary
- instantiate Orchestrator per CLI invocation in tests
- verify reasoning_mode and primus_start config options reach run_query
- stub FastAPI TestClient when dependency is absent

## Testing
- `python -m pytest tests/unit/test_main_cli.py -k 'search_reasoning_mode_option or search_primus_start_option' --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a013cf1db8833391fc28d828af2de6