### PR TITLE
Refresh roadmap and release plan

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,20 +1,20 @@
 # Autoresearch Roadmap
 
 This roadmap summarizes planned features for upcoming releases. Dates and milestones align with the [release plan](docs/release_plan.md).
-Last updated **August 20, 2025**.
-Phase 2 testing tasks remain open: `task verify` fails with 13 unit tests
-following the Orchestrator refactor, so coverage is not generated. See
-[#28](issues/0028-unit-tests-after-orchestrator-refactor.md) for the full
-list of failures. To collect feedback while these issues
-([#27](issues/0027-orchestrator-instance-cb-manager.md),
-[#28](issues/0028-unit-tests-after-orchestrator-refactor.md)) are
-resolved, an alpha pre-release precedes the final 0.1.0 milestone.
+Last updated **August 16, 2025**.
+Phase 2 testing tasks remain open: `task verify` currently stops at flake8 due
+to unused imports and the unit tests listed in
+[unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md)
+remain failing, so coverage is not generated. To collect feedback while these
+issues ([refactor-orchestrator-instance-circuit-breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md),
+[unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md))
+are resolved, an alpha pre-release precedes the final 0.1.0 milestone.
 ## Milestones
 
 | Version | Target Date | Key Goals |
 | ------- | ----------- | --------- |
-| 0.1.0-alpha.1 | 2025-11-15 | Alpha preview to gather feedback while fixing tests (#27, #28) |
-| 0.1.0 | 2026-03-01 | Finalize packaging, docs and CI checks once tests pass (#27, #28) |
+| 0.1.0-alpha.1 | 2025-11-15 | Alpha preview to gather feedback while fixing tests ([refactor-orchestrator-instance-circuit-breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md), [unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md)) |
+| 0.1.0 | 2026-03-01 | Finalize packaging, docs and CI checks once tests pass ([refactor-orchestrator-instance-circuit-breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md), [unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md)) |
 | 0.1.1 | 2026-05-15 | Bug fixes and documentation updates |
 | 0.2.0 | 2026-08-01 | API stabilization, configuration hot-reload, improved search backends |
 | 0.3.0 | 2026-10-15 | Distributed execution support, monitoring utilities |
@@ -23,8 +23,8 @@ resolved, an alpha pre-release precedes the final 0.1.0 milestone.
 ## 0.1.0-alpha.1 – Alpha preview
 
 This pre-release provides an early package for testing while unit tests and
-packaging tasks remain open ([#27](issues/0027-orchestrator-instance-cb-manager.md),
-[#28](issues/0028-unit-tests-after-orchestrator-refactor.md)). Key activities
+packaging tasks remain open ([refactor-orchestrator-instance-circuit-breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md),
+[unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md)). Key activities
 include:
 
 - Provide an installable package for early adopters.
@@ -40,14 +40,13 @@ activities include:
 - Finalizing API reference and user guides.
 - Verifying packaging metadata and TestPyPI uploads.
 
-Unit tests still fail (`tests/unit/test_api_error_handling.py::test_query_endpoint_runtime_error` and
+Unit tests still fail (for example,
 `tests/unit/test_cli_help.py::test_search_loops_option`), so coverage is not
 generated and integration and behavior suites remain pending. The release was
 originally planned for **July 20, 2025**, but the schedule slipped. The
 **0.1.0** milestone is now targeted for **March 1, 2026** while these failures
-(Issues [#27](issues/0027-orchestrator-instance-cb-manager.md) and
-[#28](issues/0028-unit-tests-after-orchestrator-refactor.md)) and packaging tasks are
-resolved.
+([unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md))
+and packaging tasks are resolved.
 
 ## 0.1.1 – Bug fixes and documentation updates
 

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -3,20 +3,21 @@
 This document outlines the upcoming release milestones for **Autoresearch**. Dates are aspirational and may shift as development progresses. The publishing workflow follows the steps in [deployment.md](deployment.md).
 
 The project kicked off in **May 2025** (see the initial commit dated `2025-05-18`).
-This schedule was last updated on **August 20, 2025** and reflects the fact that
+This schedule was last updated on **August 16, 2025** and reflects the fact that
 the codebase currently sits at the **unreleased 0.1.0a1** version defined in
 `autoresearch.__version__`.
-Phase 2 testing tasks remain open: `task coverage` fails in
-`tests/unit/test_main_config_commands.py::test_config_init_command_force`
-and coverage is not generated, so Phase 3 (stabilization/testing/documentation)
-and Phase 4 activities remain planned.
+Phase 2 testing tasks remain open: `task verify` stops at flake8 due to unused
+imports and `uv run pytest` reports failures such as
+`tests/unit/test_cli_help.py::test_search_loops_option`, so coverage is not
+generated and Phase 3 (stabilization/testing/documentation) and Phase 4 activities
+remain planned.
 
 ## Milestones
 
 | Version | Target Date | Key Goals |
 | ------- | ----------- | --------- |
-| **0.1.0-alpha.1** | 2025-11-15 | Alpha preview to gather feedback while fixing tests (#27, #28) |
-| **0.1.0** | 2026-03-01 | Finalize packaging, docs and CI checks once tests pass (#27, #28) |
+| **0.1.0-alpha.1** | 2025-11-15 | Alpha preview to gather feedback while fixing tests ([refactor-orchestrator-instance-circuit-breaker](../issues/archive/refactor-orchestrator-instance-circuit-breaker.md), [unit-tests-after-orchestrator-refactor](../issues/unit-tests-after-orchestrator-refactor.md)) |
+| **0.1.0** | 2026-03-01 | Finalize packaging, docs and CI checks once tests pass ([refactor-orchestrator-instance-circuit-breaker](../issues/archive/refactor-orchestrator-instance-circuit-breaker.md), [unit-tests-after-orchestrator-refactor](../issues/unit-tests-after-orchestrator-refactor.md)) |
 | **0.1.1** | 2026-05-15 | Bug fixes and documentation updates |
 | **0.2.0** | 2026-08-01 | API stabilization, configuration hot-reload, improved search backends |
 | **0.3.0** | 2026-10-15 | Distributed execution support, monitoring utilities |
@@ -24,15 +25,15 @@ and Phase 4 activities remain planned.
 
 The project originally targeted **0.1.0** for **July 20, 2025**, but the
 schedule slipped. To gather early feedback, an alpha **0.1.0-alpha.1**
-release is scheduled for **November 15, 2025** even as `task coverage` fails
-in `tests/unit/test_main_config_commands.py::test_config_init_command_force`
-and `task verify` fails in `tests/unit/test_eviction.py::test_lru_eviction_order`.
+release is scheduled for **November 15, 2025** even as `task verify` stops at
+flake8 and `uv run pytest` fails in `tests/unit/test_cli_help.py::test_search_loops_option`.
 The final **0.1.0** milestone is now set for **March 1, 2026** while these
-failures (issues #27 and #28) and packaging tasks are resolved.
+failures (see [unit-tests-after-orchestrator-refactor](../issues/unit-tests-after-orchestrator-refactor.md)) and packaging tasks
+are resolved.
 
 The following tasks remain before publishing **0.1.0**:
 
-- [ ] Resolve failing tests and re-run `task coverage` to reach ≥90% total coverage (issues #27 and #28).
+- [ ] Resolve flake8 errors and failing tests listed in [unit-tests-after-orchestrator-refactor](../issues/unit-tests-after-orchestrator-refactor.md) and re-run `task coverage` to reach ≥90% total coverage.
 - [ ] Install optional dependencies with `uv pip install -e '.[full,parsers,git,llm,dev]'` so the full unit, integration and behavior suites run successfully.
 - [ ] Ensure new dependency pins are reflected in the lock file and docs. `slowapi` is locked to **0.1.9** and `fastapi` must be **0.115** or newer.
 - [ ] Verify `python -m build` and `scripts/publish_dev.py` create valid packages across platforms.
@@ -40,8 +41,8 @@ The following tasks remain before publishing **0.1.0**:
 
 ### Current Blockers
 
-- Unit tests failing (`tests/unit/test_main_config_commands.py::test_config_init_command_force`,
-  `tests/unit/test_eviction.py::test_lru_eviction_order`); see issues #27 and #28.
+- Unit tests failing (for example,
+  `tests/unit/test_cli_help.py::test_search_loops_option`); see [unit-tests-after-orchestrator-refactor](../issues/unit-tests-after-orchestrator-refactor.md).
 - Packaging scripts require additional configuration before they run reliably.
 
 Resolving these issues will determine the new completion date for **0.1.0**.


### PR DESCRIPTION
## Summary
- update roadmap with flake8 stop, failing tests, and issue links without numeric prefixes
- revise release plan to mirror current failures and dependency versions

## Testing
- `task verify` (fails: F401, E402 in tests)
- `uv run pytest tests/unit/test_api_error_handling.py::test_query_endpoint_runtime_error tests/unit/test_cli_help.py::test_search_loops_option -q` (fails: KeyError in test_search_loops_option)


------
https://chatgpt.com/codex/tasks/task_e_68a02699f1308333bc9657af5387e007