### PR TITLE
Add explicit mcp_interface import to test

### DIFF
--- a/tests/unit/test_mcp_interface.py
+++ b/tests/unit/test_mcp_interface.py
@@ -1,6 +1,6 @@
-from autoresearch import mcp_interface
 from types import MethodType
 
+from autoresearch import mcp_interface
 from autoresearch.config.models import ConfigModel
 
 


### PR DESCRIPTION
## Summary
- import mcp_interface before mock config load in unit test

## Testing
- `uv run isort tests/unit/test_mcp_interface.py`
- `uv run black tests/unit/test_mcp_interface.py`
- `uv run ruff format tests/unit/test_mcp_interface.py`
- `uv run ruff check --fix tests/unit/test_mcp_interface.py`
- `uv run flake8 tests/unit/test_mcp_interface.py`
- `uv run mypy src`
- `uv run pytest tests/unit/test_mcp_interface.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a02d4e37fc833393ae865153068ba6