### PR TITLE
Refactor run_query patch in cb manager test

### DIFF
--- a/tests/unit/test_orchestrator_cb_manager.py
+++ b/tests/unit/test_orchestrator_cb_manager.py
@@ -10,7 +10,8 @@ def test_cb_manager_is_instance_scoped():
     o1 = Orchestrator()
     o2 = Orchestrator()
 
-    with patch.object(Orchestrator, "run_query", Orchestrator._orig_run_query):
+    orig_run_query = Orchestrator.run_query
+    with patch.object(Orchestrator, "run_query", orig_run_query):
         with patch(
             "autoresearch.orchestration.orchestrator.OrchestrationUtils.execute_cycle",
             return_value=0,


### PR DESCRIPTION
## Summary
- ensure `Orchestrator.run_query` patch uses original method stored in a local variable

## Testing
- `uv run isort tests/unit/test_orchestrator_cb_manager.py`
- `uv run black tests/unit/test_orchestrator_cb_manager.py`
- `uv run ruff format tests/unit/test_orchestrator_cb_manager.py`
- `uv run ruff check tests/unit/test_orchestrator_cb_manager.py --fix`
- `uv run flake8 tests/unit/test_orchestrator_cb_manager.py`
- `uv run mypy src`
- `uv run pytest tests/unit/test_orchestrator_cb_manager.py -q` *(fails: Coverage failure: total of 21 is less than fail-under=90)*

------
https://chatgpt.com/codex/tasks/task_e_68a02d60bf4c8333b429e299d04f19c2