### PR TITLE
Link orchestrator issues directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ skipped. `task verify` also fails in
 `tests/unit/test_eviction.py::test_lru_eviction_order`. Packaging checks
 and documentation continue, so the milestone is now targeted for
 **November 15, 2025**. Remaining blockers include these failing tests
-(issues #27 and #28), missing coverage, and packaging scripts that
+([refactor orchestrator to instance-level circuit breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md) and
+[unit tests after orchestrator refactor](issues/unit-tests-after-orchestrator-refactor.md)), missing coverage, and packaging scripts that
 need additional configuration. See
 [docs/release_plan.md](docs/release_plan.md) for the full milestone
 schedule and outstanding tasks.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -3,9 +3,9 @@
 This document tracks the progress of tasks for the Autoresearch project,
 organized by phases from the code complete plan. As of **August 16, 2025**, `pytest`
 aborts before collecting tests (`ModuleNotFoundError: fastapi`), so coverage is
-unavailable. Issue [#28](issues/0028-unit-tests-after-orchestrator-refactor.md)
+unavailable. Issue [unit tests after orchestrator refactor](issues/unit-tests-after-orchestrator-refactor.md)
 lists **13 failing unit tests**, and issue
-[#27](issues/0027-orchestrator-instance-cb-manager.md) documents the underlying
+[refactor orchestrator to instance-level circuit breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md) documents the underlying
 refactor. The **0.1.0** release is now targeted for **March 1, 2026**.
 
 ## Phase 1: Core System Completion (Weeks 1-2)
@@ -228,12 +228,12 @@ Issues #10–#17 remain open until the test suite passes.
 ### Coverage Report
 
 Coverage could not be generated because `pytest` fails to import `fastapi`
-(see [#28](issues/0028-unit-tests-after-orchestrator-refactor.md)).
+(see [unit tests after orchestrator refactor](issues/unit-tests-after-orchestrator-refactor.md)).
 
 ### Latest Test Results
 
 - `pytest --cov=src` aborts with `ModuleNotFoundError: fastapi`.
-  See [#28](issues/0028-unit-tests-after-orchestrator-refactor.md) for the
+  See [unit tests after orchestrator refactor](issues/unit-tests-after-orchestrator-refactor.md) for the
   failing test list.
 - `uv run flake8 src tests` reports no style errors.
 - `uv run mypy src` fails to load `pydantic.mypy` (`No module named 'pydantic'`).

--- a/issues/archive/refactor-orchestrator-instance-circuit-breaker.md
+++ b/issues/archive/refactor-orchestrator-instance-circuit-breaker.md
@@ -22,4 +22,4 @@ tests inconsistent, causing unit failures.
 Completed – instance-level circuit breaker verified by dedicated unit test
 
 ## Related
-- #28
+- [unit tests after orchestrator refactor](../unit-tests-after-orchestrator-refactor.md)

--- a/issues/unit-tests-after-orchestrator-refactor.md
+++ b/issues/unit-tests-after-orchestrator-refactor.md
@@ -5,7 +5,7 @@ breaker manager. The refactor introduced API changes and incomplete updates that
 leave tests in an inconsistent state.
 
 ## Context
-- The in-progress refactor in issue #27 changed `_cb_manager` usage.
+- The in-progress refactor in [refactor orchestrator to instance-level circuit breaker](archive/refactor-orchestrator-instance-circuit-breaker.md) changed `_cb_manager` usage.
 - Existing tests expect class-level state, causing failures and potential hangs.
 - Fixtures and helper utilities may need redesign to use fresh Orchestrator
   instances per test.
@@ -34,4 +34,4 @@ leave tests in an inconsistent state.
 Open
 
 ## Related
-- #27
+- [refactor orchestrator to instance-level circuit breaker](archive/refactor-orchestrator-instance-circuit-breaker.md)


### PR DESCRIPTION
## Summary
- replace `#27`/`#28` references with links to refactor and unit-test tickets

## Testing
- `rg '#27|#28|0027|0028' -n`
- `uv run black --check .`
- `uv run isort --check-only .`
- `uv run ruff format --check src tests`
- `uv run ruff check src tests`
- `uv run flake8 src tests` *(fails: No such file or directory)*
- `uv run mypy src` *(fails: No module named 'pydantic')*
- `uv run pytest -q` *(fails: ModuleNotFoundError: typer)*
- `uv run pytest tests/behavior` *(fails: ModuleNotFoundError: typer)*
- `uv run pytest --cov=src` *(fails: ModuleNotFoundError: typer)*

------
https://chatgpt.com/codex/tasks/task_e_68a02d6866848333875fedb759a6c34c