### PR TITLE
Introduce reusable dummy storage fixture for CLI tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ try:
 except Exception:  # pragma: no cover - fastapi optional in some environments
     TestClient = MagicMock()
 
-pytest_plugins = ["tests.fixtures.config", "pytest_httpx"]
+pytest_plugins = ["tests.fixtures.config", "tests.fixtures.storage", "pytest_httpx"]
 
 if importlib.util.find_spec("autoresearch") is None:
     src_path = Path(__file__).resolve().parents[1] / "src"

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -10,6 +10,11 @@ This directory provides reusable fixtures for building test contexts.
   data directory. The returned `ConfigContext` bundles the loader, loaded
   `ConfigModel`, and the data directory.
 
+## Storage helpers
+
+- `dummy_storage` – registers a minimal `autoresearch.storage` stub so tests
+  can import the storage module without hitting real backends.
+
 ### Composing scenarios
 
 Fixtures can be combined to craft richer test cases:

--- a/tests/fixtures/storage.py
+++ b/tests/fixtures/storage.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import sys
+import types
+from typing import Iterator
+
+import pytest
+
+
+@pytest.fixture()
+def dummy_storage(monkeypatch: pytest.MonkeyPatch) -> Iterator[types.ModuleType]:
+    """Register a minimal ``autoresearch.storage`` stub for tests.
+
+    The fixture installs a lightweight module with a ``StorageManager`` and
+    ``setup`` function so that tests depending on the storage layer can import
+    ``autoresearch.storage`` without touching real storage backends.
+    """
+    module = types.ModuleType("autoresearch.storage")
+
+    class StorageManager:  # pragma: no cover - simple stub
+        @staticmethod
+        def persist_claim(claim):
+            pass
+
+        @staticmethod
+        def setup(*args, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+    module.StorageManager = StorageManager
+    module.setup = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "autoresearch.storage", module)
+    try:
+        yield module
+    finally:
+        sys.modules.pop("autoresearch.storage", None)

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -1,32 +1,18 @@
-import sys
 import importlib
-import types
 from pathlib import Path
 from typer.testing import CliRunner
 
 
-def test_cli_help_no_ansi(monkeypatch):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+def test_cli_help_no_ansi(dummy_storage, monkeypatch):
     from autoresearch.config.models import ConfigModel
     from autoresearch.config.loader import ConfigLoader
 
     def _load(self):
         return ConfigModel.model_construct(loops=1)
 
-    monkeypatch.setattr(ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False)
+    monkeypatch.setattr(
+        ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False
+    )
     monkeypatch.setattr(ConfigLoader, "env_path", Path("dummy.env"), raising=False)
     monkeypatch.setattr(ConfigLoader, "load_config", _load)
     main = importlib.import_module("autoresearch.main")
@@ -37,28 +23,16 @@ def test_cli_help_no_ansi(monkeypatch):
     assert "Usage:" in result.stdout
 
 
-def test_search_help_includes_interactive(monkeypatch):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+def test_search_help_includes_interactive(dummy_storage, monkeypatch):
     from autoresearch.config.models import ConfigModel
     from autoresearch.config.loader import ConfigLoader
 
     def _load(self):
         return ConfigModel.model_construct(loops=1)
 
-    monkeypatch.setattr(ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False)
+    monkeypatch.setattr(
+        ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False
+    )
     monkeypatch.setattr(ConfigLoader, "env_path", Path("dummy.env"), raising=False)
     monkeypatch.setattr(ConfigLoader, "load_config", _load)
     main = importlib.import_module("autoresearch.main")
@@ -69,28 +43,16 @@ def test_search_help_includes_interactive(monkeypatch):
     assert "--loops" in result.stdout
 
 
-def test_search_help_includes_visualize(monkeypatch):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+def test_search_help_includes_visualize(dummy_storage, monkeypatch):
     from autoresearch.config.models import ConfigModel
     from autoresearch.config.loader import ConfigLoader
 
     def _load(self):
         return ConfigModel.model_construct(loops=1)
 
-    monkeypatch.setattr(ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False)
+    monkeypatch.setattr(
+        ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False
+    )
     monkeypatch.setattr(ConfigLoader, "env_path", Path("dummy.env"), raising=False)
     monkeypatch.setattr(ConfigLoader, "load_config", _load)
     main = importlib.import_module("autoresearch.main")
@@ -100,21 +62,7 @@ def test_search_help_includes_visualize(monkeypatch):
     assert "--visualize" in result.stdout
 
 
-def test_search_loops_option(monkeypatch):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+def test_search_loops_option(dummy_storage, monkeypatch):
     from autoresearch.config.models import ConfigModel
     from autoresearch.config.loader import ConfigLoader
     from autoresearch.models import QueryResponse
@@ -126,7 +74,9 @@ def test_search_loops_option(monkeypatch):
         loaded["loops"] = cfg.loops
         return cfg
 
-    monkeypatch.setattr(ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False)
+    monkeypatch.setattr(
+        ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False
+    )
     monkeypatch.setattr(ConfigLoader, "env_path", Path("dummy.env"), raising=False)
     monkeypatch.setattr(ConfigLoader, "load_config", _load)
 
@@ -150,28 +100,16 @@ def test_search_loops_option(monkeypatch):
     assert captured["loops"] == 4
 
 
-def test_search_help_includes_ontology_flags(monkeypatch):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+def test_search_help_includes_ontology_flags(dummy_storage, monkeypatch):
     from autoresearch.config.models import ConfigModel
     from autoresearch.config.loader import ConfigLoader
 
     def _load(self):
         return ConfigModel.model_construct(loops=1)
 
-    monkeypatch.setattr(ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False)
+    monkeypatch.setattr(
+        ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False
+    )
     monkeypatch.setattr(ConfigLoader, "env_path", Path("dummy.env"), raising=False)
     monkeypatch.setattr(ConfigLoader, "load_config", _load)
     main = importlib.import_module("autoresearch.main")
@@ -180,28 +118,16 @@ def test_search_help_includes_ontology_flags(monkeypatch):
     assert result.exit_code == 0
 
 
-def test_visualize_help_includes_layout(monkeypatch):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+def test_visualize_help_includes_layout(dummy_storage, monkeypatch):
     from autoresearch.config.models import ConfigModel
     from autoresearch.config.loader import ConfigLoader
 
     def _load(self):
         return ConfigModel.model_construct(loops=1)
 
-    monkeypatch.setattr(ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False)
+    monkeypatch.setattr(
+        ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False
+    )
     monkeypatch.setattr(ConfigLoader, "env_path", Path("dummy.env"), raising=False)
     monkeypatch.setattr(ConfigLoader, "load_config", _load)
     main = importlib.import_module("autoresearch.main")

--- a/tests/unit/test_cli_visualize.py
+++ b/tests/unit/test_cli_visualize.py
@@ -26,7 +26,7 @@ def test_summary_table_render():
     assert "1" in output
 
 
-def test_search_visualize_option(monkeypatch):
+def test_search_visualize_option(dummy_storage, monkeypatch):
     runner = CliRunner()
 
     orch = Orchestrator()
@@ -36,24 +36,6 @@ def test_search_visualize_option(monkeypatch):
         )
     )
     monkeypatch.setattr(orch, "run_query", run_query_mock)
-
-    import sys
-    import types
-
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
 
     from autoresearch.config.models import ConfigModel
     from autoresearch.config.loader import ConfigLoader

--- a/tests/unit/test_main_first_run_detection.py
+++ b/tests/unit/test_main_first_run_detection.py
@@ -1,26 +1,11 @@
 import importlib
-import sys
-import types
 
 from typer.testing import CliRunner
 
 
-def test_first_run_detection_respects_search_paths(tmp_path, monkeypatch, config_loader):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
-
+def test_first_run_detection_respects_search_paths(
+    tmp_path, monkeypatch, config_loader, dummy_storage
+):
     from autoresearch.config.models import ConfigModel
     from autoresearch.config.loader import ConfigLoader
 


### PR DESCRIPTION
## Summary
- add `dummy_storage` fixture registering a lightweight `autoresearch.storage` stub
- switch CLI-related tests to use the shared fixture instead of inlining stubs
- document the new fixture and enable it through `pytest_plugins`

## Testing
- `uv run ruff format tests/fixtures/storage.py tests/unit/test_cli_help.py tests/unit/test_cli_visualize.py tests/unit/test_main_first_run_detection.py tests/conftest.py`
- `uv run ruff check --fix tests/fixtures/storage.py tests/unit/test_cli_help.py tests/unit/test_cli_visualize.py tests/unit/test_main_first_run_detection.py tests/conftest.py`
- `uv run flake8 tests/fixtures/storage.py tests/unit/test_cli_help.py tests/unit/test_cli_visualize.py tests/unit/test_main_first_run_detection.py tests/conftest.py`
- `mypy src`
- `pytest tests/unit/test_cli_help.py tests/unit/test_cli_visualize.py tests/unit/test_main_first_run_detection.py --cov=src --cov-report=term-missing --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68a02d8974e483338c5df027897e6f8d