### PR TITLE
Replace numeric issue references with issue file links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ skipped. `task verify` also fails in
 `tests/unit/test_eviction.py::test_lru_eviction_order`. Packaging checks
 and documentation continue, so the milestone is now targeted for
 **November 15, 2025**. Remaining blockers include these failing tests
-(issues #27 and #28), missing coverage, and packaging scripts that
+(issues [refactor-orchestrator-instance-circuit-breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md) and [unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md)), missing coverage, and packaging scripts that
 need additional configuration. See
 [docs/release_plan.md](docs/release_plan.md) for the full milestone
 schedule and outstanding tasks.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -3,9 +3,9 @@
 This document tracks the progress of tasks for the Autoresearch project,
 organized by phases from the code complete plan. As of **August 16, 2025**, `pytest`
 aborts before collecting tests (`ModuleNotFoundError: fastapi`), so coverage is
-unavailable. Issue [#28](issues/0028-unit-tests-after-orchestrator-refactor.md)
+unavailable. Issue [unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md)
 lists **13 failing unit tests**, and issue
-[#27](issues/0027-orchestrator-instance-cb-manager.md) documents the underlying
+[refactor-orchestrator-instance-circuit-breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md) documents the underlying
 refactor. The **0.1.0** release is now targeted for **March 1, 2026**.
 
 ## Phase 1: Core System Completion (Weeks 1-2)
@@ -228,12 +228,12 @@ Issues #10–#17 remain open until the test suite passes.
 ### Coverage Report
 
 Coverage could not be generated because `pytest` fails to import `fastapi`
-(see [#28](issues/0028-unit-tests-after-orchestrator-refactor.md)).
+(see [unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md)).
 
 ### Latest Test Results
 
 - `pytest --cov=src` aborts with `ModuleNotFoundError: fastapi`.
-  See [#28](issues/0028-unit-tests-after-orchestrator-refactor.md) for the
+  See [unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md) for the
   failing test list.
 - `uv run flake8 src tests` reports no style errors.
 - `uv run mypy src` fails to load `pydantic.mypy` (`No module named 'pydantic'`).


### PR DESCRIPTION
## Summary
- link README roadmap blockers to issue files instead of #27/#28
- update task progress document to reference archival and failing-test issues

## Testing
- `task verify` *(fails: F401 'Orchestrator' imported but unused)*

------
https://chatgpt.com/codex/tasks/task_e_68a02f8c21848333a04c506dca092185