### PR TITLE
Refactor storage stubs into fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,11 @@ try:
 except Exception:  # pragma: no cover - fastapi optional in some environments
     TestClient = MagicMock()
 
-pytest_plugins = ["tests.fixtures.config", "pytest_httpx"]
+pytest_plugins = [
+    "tests.fixtures.config",
+    "tests.fixtures.storage",
+    "pytest_httpx",
+]
 
 if importlib.util.find_spec("autoresearch") is None:
     src_path = Path(__file__).resolve().parents[1] / "src"

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -25,3 +25,8 @@ def test_with_extra_data(config_context):
 
 Extend the `config_context` setup or modify the generated files to suit
 complex testing needs.
+
+## Storage helpers
+
+- `dummy_storage` – registers a no-op `autoresearch.storage` module so tests
+  can run without initializing the real storage system.

--- a/tests/fixtures/storage.py
+++ b/tests/fixtures/storage.py
@@ -1,0 +1,28 @@
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture()
+def dummy_storage(monkeypatch: pytest.MonkeyPatch):
+    """Register a no-op ``autoresearch.storage`` module for tests.
+
+    The stub provides a minimal ``StorageManager`` with the methods used by
+    tests and ensures calls to ``setup`` are harmless.
+    """
+    module = types.ModuleType("autoresearch.storage")
+
+    class StorageManager:
+        @staticmethod
+        def persist_claim(claim) -> None:  # pragma: no cover - no-op
+            pass
+
+        @staticmethod
+        def setup(*_args, **_kwargs) -> None:  # pragma: no cover - no-op
+            pass
+
+    module.StorageManager = StorageManager
+    module.setup = lambda *_a, **_k: None
+    monkeypatch.setitem(sys.modules, "autoresearch.storage", module)
+    return module

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -1,26 +1,10 @@
 import importlib
-import sys
-import types
 from pathlib import Path
 
 from typer.testing import CliRunner
 
 
-def test_cli_help_no_ansi(monkeypatch):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+def test_cli_help_no_ansi(monkeypatch, dummy_storage):
     from autoresearch.config.loader import ConfigLoader
     from autoresearch.config.models import ConfigModel
 
@@ -40,21 +24,7 @@ def test_cli_help_no_ansi(monkeypatch):
     assert "Usage:" in result.stdout
 
 
-def test_search_help_includes_interactive(monkeypatch):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+def test_search_help_includes_interactive(monkeypatch, dummy_storage):
     from autoresearch.config.loader import ConfigLoader
     from autoresearch.config.models import ConfigModel
 
@@ -74,21 +44,7 @@ def test_search_help_includes_interactive(monkeypatch):
     assert "--loops" in result.stdout
 
 
-def test_search_help_includes_visualize(monkeypatch):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+def test_search_help_includes_visualize(monkeypatch, dummy_storage):
     from autoresearch.config.loader import ConfigLoader
     from autoresearch.config.models import ConfigModel
 
@@ -107,21 +63,7 @@ def test_search_help_includes_visualize(monkeypatch):
     assert "--visualize" in result.stdout
 
 
-def test_search_loops_option(monkeypatch):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+def test_search_loops_option(monkeypatch, dummy_storage):
     from autoresearch.config.loader import ConfigLoader
     from autoresearch.config.models import ConfigModel
     from autoresearch.models import QueryResponse
@@ -157,21 +99,7 @@ def test_search_loops_option(monkeypatch):
     assert captured["loops"] == 4
 
 
-def test_search_help_includes_ontology_flags(monkeypatch):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+def test_search_help_includes_ontology_flags(monkeypatch, dummy_storage):
     from autoresearch.config.loader import ConfigLoader
     from autoresearch.config.models import ConfigModel
 
@@ -189,21 +117,7 @@ def test_search_help_includes_ontology_flags(monkeypatch):
     assert result.exit_code == 0
 
 
-def test_visualize_help_includes_layout(monkeypatch):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+def test_visualize_help_includes_layout(monkeypatch, dummy_storage):
     from autoresearch.config.loader import ConfigLoader
     from autoresearch.config.models import ConfigModel
 

--- a/tests/unit/test_cli_visualize.py
+++ b/tests/unit/test_cli_visualize.py
@@ -26,7 +26,7 @@ def test_summary_table_render():
     assert "1" in output
 
 
-def test_search_visualize_option(monkeypatch):
+def test_search_visualize_option(monkeypatch, dummy_storage):
     runner = CliRunner()
 
     orch = Orchestrator()
@@ -36,24 +36,6 @@ def test_search_visualize_option(monkeypatch):
         )
     )
     monkeypatch.setattr(orch, "run_query", run_query_mock)
-
-    import sys
-    import types
-
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
 
     from autoresearch.config.models import ConfigModel
     from autoresearch.config.loader import ConfigLoader

--- a/tests/unit/test_main_first_run_detection.py
+++ b/tests/unit/test_main_first_run_detection.py
@@ -1,25 +1,11 @@
 import importlib
-import sys
-import types
 
 from typer.testing import CliRunner
 
 
-def test_first_run_detection_respects_search_paths(tmp_path, monkeypatch, config_loader):
-    dummy_storage = types.ModuleType("autoresearch.storage")
-
-    class StorageManager:
-        @staticmethod
-        def persist_claim(claim):
-            pass
-
-        @staticmethod
-        def setup(*a, **k):
-            pass
-
-    dummy_storage.StorageManager = StorageManager
-    dummy_storage.setup = lambda *a, **k: None
-    monkeypatch.setitem(sys.modules, "autoresearch.storage", dummy_storage)
+def test_first_run_detection_respects_search_paths(
+    tmp_path, monkeypatch, config_loader, dummy_storage
+):
 
     from autoresearch.config.models import ConfigModel
     from autoresearch.config.loader import ConfigLoader


### PR DESCRIPTION
## Summary
- add `dummy_storage` fixture providing a no-op `autoresearch.storage` module
- load new fixture via `pytest_plugins` and document in fixture README
- simplify CLI tests to use the shared fixture

## Testing
- `uv run python -m pytest tests/unit/test_cli_help.py tests/unit/test_cli_visualize.py tests/unit/test_main_first_run_detection.py -q --override-ini="addopts="`


------
https://chatgpt.com/codex/tasks/task_e_68a02fe4d868833388dcb259d6e3ee98