### PR TITLE
Clarify ticket references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 - Track work items in the `/issues` directory.
 - Tickets use the template and naming rules in [`issues/README.md`](issues/README.md).
 - File names are slugged titles without numeric prefixes.
+- Do not include numeric identifiers in ticket titles or content; reference tickets by slugged filenames.
 - When work is finished, set `Status` to `Archived` and move the ticket to `/issues/archive/` without renaming.
 - When issue tooling changes, update this file, `issues/AGENTS.md`, and `scripts/codex_setup.sh` to keep documentation and setup aligned.
 

--- a/issues/README.md
+++ b/issues/README.md
@@ -18,6 +18,7 @@ Open
 ## Naming
 File names must be slugged (kebab-case) titles with no numeric prefixes.
 For example: `refactor-orchestrator-instance-circuit-breaker.md`.
+Do not include numeric identifiers in ticket titles or content; reference tickets by slugged filenames.
 
 ## Workflow
 Set `Status` to `Open` while work is active. When finished, change it to


### PR DESCRIPTION
## Summary
- reinforce slug-only ticket references in issue guidelines
- document avoiding numeric identifiers in ticket titles and content

## Testing
- `uv run black --check .` *(fails: 199 files would be reformatted)*
- `uv run isort . --check-only` *(fails: imports unsorted in many files)*
- `uv run ruff format --check src tests` *(fails: 142 files would be reformatted)*
- `uv run ruff check --fix src tests` *(fails: found 18 errors, 5 fixed, 13 remaining)*
- `uv run flake8 src tests` *(fails: module level import not at top of file)*
- `uv run mypy src`
- `uv run pytest -q` *(fails: 221 failed, 538 passed, 28 skipped, 97 deselected, 41 warnings, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68a031bc29d88333b765a1ce7ef65526