### PR TITLE
Clean up test imports and document setup gaps

### DIFF
--- a/issues/environment-setup-gaps.md
+++ b/issues/environment-setup-gaps.md
@@ -1,0 +1,16 @@
+# Address environment setup gaps for dev tooling
+
+## Context
+Initial repository environment lacked the Go Task binary and development
+packages like `flake8`, causing `task verify` to fail. Manual installation of
+`task` and `uv pip install -e '.[full,parsers,git,llm,dev]'` was required before
+linting and tests could run. This suggests the automated setup scripts or
+documentation are out of sync with the expected tooling.
+
+## Acceptance Criteria
+- Go Task is available after running the provided setup scripts.
+- Development dependencies (e.g., `flake8`) are installed without manual steps.
+- `task verify` runs successfully on a fresh environment.
+
+## Status
+Open

--- a/issues/unit-tests-after-orchestrator-refactor.md
+++ b/issues/unit-tests-after-orchestrator-refactor.md
@@ -24,6 +24,15 @@ leave tests in an inconsistent state.
 - `tests/unit/test_orchestrator_errors.py::test_parallel_query_timeout_claims`
 - `tests/unit/test_parallel_module.py::test_execute_parallel_query_basic`
 - `tests/unit/test_parallel_module.py::test_execute_parallel_query_agent_error`
+- `tests/unit/test_orchestrator_utils.py::test_execute_cycle_calls_agf`
+- `tests/unit/test_orchestrator_utils.py::test_execute_cycle_sends_cancel`
+- `tests/unit/test_output_formatter_property.py::test_format_all_shapes`
+- `tests/unit/test_property_evaluate_weights.py::test_suggest_weights`
+- `tests/unit/test_property_search.py::test_ordering`
+- `tests/unit/test_property_search.py::test_weight_interpretation`
+- `tests/unit/test_property_storage.py::test_store_and_retrieve`
+- `tests/unit/test_property_storage.py::test_handles_missing`
+- `tests/unit/test_property_vector_search.py::test_vector_search_interface`
 
 ## Acceptance Criteria
 - Unit tests are updated to accommodate the instance-level `_cb_manager`.

--- a/tests/unit/test_agent_communication.py
+++ b/tests/unit/test_agent_communication.py
@@ -2,7 +2,6 @@ from autoresearch.agents.base import Agent, AgentRole
 from autoresearch.agents.messages import MessageProtocol
 from autoresearch.agents.registry import AgentFactory, AgentRegistry
 from autoresearch.config.models import ConfigModel
-from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.orchestration.state import QueryState
 

--- a/tests/unit/test_coalition_execution.py
+++ b/tests/unit/test_coalition_execution.py
@@ -1,5 +1,4 @@
 
-from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.config.models import ConfigModel
 from autoresearch.agents.registry import AgentFactory
 

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -1,5 +1,6 @@
 from typer.testing import CliRunner
 from unittest.mock import patch, MagicMock
+from types import MethodType
 import sys
 import pytest
 
@@ -10,7 +11,6 @@ sys.modules.setdefault("pynndescent", MagicMock())
 
 from autoresearch.main import app  # noqa: E402
 import importlib  # noqa: E402
-from types import MethodType
 
 main_app = importlib.import_module("autoresearch.main.app")  # noqa: E402
 from autoresearch.models import QueryResponse  # noqa: E402

--- a/tests/unit/test_orchestrator_messages.py
+++ b/tests/unit/test_orchestrator_messages.py
@@ -1,6 +1,5 @@
 from autoresearch.agents.base import Agent, AgentRole
 from autoresearch.config.models import ConfigModel
-from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.agents.registry import AgentFactory
 from autoresearch.orchestration.state import QueryState
 

--- a/tests/unit/test_reasoning_modes.py
+++ b/tests/unit/test_reasoning_modes.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from autoresearch.config.models import ConfigModel
-from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.orchestration import ReasoningMode
 
 

--- a/tests/unit/test_token_budget_heuristic.py
+++ b/tests/unit/test_token_budget_heuristic.py
@@ -1,5 +1,4 @@
 from autoresearch.config.models import ConfigModel
-from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 
 


### PR DESCRIPTION
## Summary
- Remove unused `Orchestrator` imports from several unit tests and tidy CLI test imports
- Track additional failing tests after the Orchestrator refactor
- Add issue for missing Go Task and dev dependencies in fresh environments

## Testing
- `task verify` *(fails: failing unit tests)*
- `uv run flake8 tests/unit/test_agent_communication.py tests/unit/test_coalition_execution.py tests/unit/test_main_cli.py tests/unit/test_orchestrator_messages.py tests/unit/test_reasoning_modes.py tests/unit/test_token_budget_heuristic.py`


------
https://chatgpt.com/codex/tasks/task_e_68a09b3512248333b4c5d04c4475f585