### PR TITLE
Clarify environment gaps and test dependencies

### DIFF
--- a/issues/environment-setup-gaps.md
+++ b/issues/environment-setup-gaps.md
@@ -7,7 +7,9 @@ prints nothing, `uv pip list | grep flake8` shows no result, and `uv run pytest
 -q` aborts with `ModuleNotFoundError: typer`. Attempting to reinstall
 dependencies with `uv pip install -e '.[full,parsers,git,llm,dev]'` begins
 downloading hundreds of megabytes of CUDA-enabled packages, making setup
-impractical without prebuilt wheels. The virtual environment also exposes
+impractical without prebuilt wheels. Running `uv sync --all-extras` triggers the
+same large downloads for GPU-backed libraries such as Torch and NVIDIA CUDA
+components. The virtual environment also exposes
 `pytest` via a pyenv shim instead of `.venv/bin/pytest`. These symptoms suggest
 the automated setup scripts and documentation remain out of sync with the
 expected tooling.

--- a/issues/unit-tests-after-orchestrator-refactor.md
+++ b/issues/unit-tests-after-orchestrator-refactor.md
@@ -5,6 +5,8 @@ breaker manager. The refactor introduced API changes and incomplete updates that
 leave tests in an inconsistent state.
 
 ## Context
+- Progress is currently blocked by unresolved environment setup gaps; see
+  `environment-setup-gaps` for missing tooling and dependencies.
 - The in-progress refactor changed `_cb_manager` usage.
 - Existing tests expect class-level state, causing failures and potential hangs.
 - Fixtures and helper utilities may need redesign to use fresh Orchestrator


### PR DESCRIPTION
## Summary
- Document heavy downloads triggered by `uv sync --all-extras`
- Note that unit tests are blocked until `environment-setup-gaps` resolves missing tooling

## Testing
- `which task`
- `uv pip list | grep flake8`
- `uv run pytest -q` *(fails: ModuleNotFoundError: typer)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a8ac4490833380c2eb8d2c5d5414