### PR TITLE
Archive environment setup ticket and update failing tests list

### DIFF
--- a/issues/archive/environment-setup-gaps.md
+++ b/issues/archive/environment-setup-gaps.md
@@ -19,5 +19,10 @@ expected tooling.
 - Development dependencies (e.g., `flake8`) are installed without manual steps.
 - `task verify` runs successfully on a fresh environment.
 
+## Resolution
+Go Task and development dependencies install cleanly using the documented
+`uv sync --all-extras` workflow. `task verify` now executes; remaining failures
+stem from application test cases rather than missing tooling.
+
 ## Status
-Open
+Archived

--- a/issues/unit-tests-after-orchestrator-refactor.md
+++ b/issues/unit-tests-after-orchestrator-refactor.md
@@ -5,32 +5,25 @@ breaker manager. The refactor introduced API changes and incomplete updates that
 leave tests in an inconsistent state.
 
 ## Context
-- Progress is currently blocked by unresolved environment setup gaps; see
-  `environment-setup-gaps` for missing tooling and dependencies.
-- The in-progress refactor changed `_cb_manager` usage.
-- Existing tests expect class-level state, causing failures and potential hangs.
+- Environment setup gaps are resolved and tooling like Go Task and `flake8` are
+  available.
+- The refactor changed `_cb_manager` usage from class-level to instance-level.
+- Existing tests still assume class-level state, causing failures and hangs.
 - Fixtures and helper utilities may need redesign to use fresh Orchestrator
- instances per test.
+  instances per test.
 - Additional failures stem from `tests/stubs/numpy.py` shadowing the real
   `numpy` package after installing full extras.
 
 ## Current Failures
+- `tests/unit/test_additional_coverage.py::test_streamlit_metrics` (error)
+- `tests/unit/test_cache.py::test_search_uses_cache`
+- `tests/unit/test_cache.py::test_cache_lifecycle`
+- `tests/unit/test_cache.py::test_cache_is_backend_specific`
 - `tests/unit/test_failure_paths.py::test_external_lookup_unknown_backend`
 - `tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure`
 - `tests/unit/test_failure_scenarios.py::test_external_lookup_unknown_backend`
-- `tests/unit/test_formattemplate_property.py::test_formattemplate_render`
-- `tests/unit/test_main_config_commands.py::test_config_init_command_force`
 - `tests/unit/test_metrics.py::test_metrics_collection_and_endpoint`
-- `tests/unit/test_orchestrator_utils.py::test_rotate_list_property`
-- `tests/unit/test_orchestrator_utils.py::test_calculate_result_confidence`
-- `tests/unit/test_output_formatter_property.py::test_output_formatter_json_markdown`
-- `tests/unit/test_property_evaluate_weights.py::test_evaluate_weights_scale_invariant`
-- `tests/unit/test_property_search.py::test_generate_queries_variants`
-- `tests/unit/test_property_search.py::test_generate_queries_embeddings`
 - `tests/unit/test_property_storage.py::test_pop_lru_order`
-- `tests/unit/test_property_storage.py::test_pop_low_score`
-- `tests/unit/test_property_vector_search.py::test_vector_search_calls_backend`
-- `tests/unit/test_additional_coverage.py::test_streamlit_metrics` (error)
 
 ## Acceptance Criteria
 - Unit tests are updated to accommodate the instance-level `_cb_manager`.


### PR DESCRIPTION
## Summary
- archive resolved environment setup gaps issue
- refresh orchestrator refactor ticket with current failing tests

## Testing
- `task verify` *(fails: tests/unit/test_cache.py::test_search_uses_cache, tests/unit/test_failure_paths.py::test_external_lookup_unknown_backend, tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure, tests/unit/test_property_storage.py::test_pop_lru_order, tests/unit/test_metrics.py::test_metrics_collection_and_endpoint)*
- `uv run pytest tests/unit/test_cache.py -q` *(fails: AttributeError: 'TinyDB' object has no attribute 'truncate')*
- `uv run pytest tests/unit/test_failure_paths.py::test_external_lookup_unknown_backend -q` *(fails: AttributeError: 'Query' object has no attribute 'query')*
- `uv run pytest tests/unit/test_additional_coverage.py::test_streamlit_metrics -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'set')*
- `uv run pytest tests/unit/test_property_storage.py::test_pop_lru_order -q` *(fails: AssertionError: assert ['0', '1'] == ['1', '0'])*

------
https://chatgpt.com/codex/tasks/task_e_68a0ab05955c8333845b27b91211af86