### PR TITLE
Track missing Go Task setup

### DIFF
--- a/issues/codex-setup-missing-go-task.md
+++ b/issues/codex-setup-missing-go-task.md
@@ -1,0 +1,15 @@
+# Codex setup missing Go Task and dev dependencies
+
+## Context
+- Starting environment lacked `task` command and dev packages like `pytest`.
+- Root guidelines expect `scripts/codex_setup.sh` to install Go Task system-wide and dev dependencies.
+- Manual install of Go Task and running `uv pip install -e '.[full,dev]'` were required.
+- Verify whether `codex_setup.sh` failed or needs adjustments to ensure tools are available.
+
+## Acceptance Criteria
+- Go Task (`task`) is available after running setup.
+- Dev dependencies including `pytest` are installed in `.venv`.
+- Update `scripts/codex_setup.sh` and documentation if additional steps are required.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- note environment gap where Go Task and dev packages were absent despite setup expectations

## Testing
- `uv run pytest tests/unit -q` *(fails: 8 failed, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bbce5f508333bbc923c2b7f31a6c