### PR TITLE
Document environment gaps

### DIFF
--- a/issues/codex-setup-missing-go-task.md
+++ b/issues/codex-setup-missing-go-task.md
@@ -5,10 +5,15 @@
 - Root guidelines expect `scripts/codex_setup.sh` to install Go Task system-wide and dev dependencies.
 - Manual install of Go Task and running `uv pip install -e '.[full,dev]'` were required.
 - Verify whether `codex_setup.sh` failed or needs adjustments to ensure tools are available.
+- `which pytest` resolves to a Pyenv shim instead of `.venv/bin/pytest`.
+- `uv pip list | grep flake8` shows that linting tools are not present.
+- `uv run pytest -q` fails with `ModuleNotFoundError: No module named 'typer'`.
 
 ## Acceptance Criteria
 - Go Task (`task`) is available after running setup.
-- Dev dependencies including `pytest` are installed in `.venv`.
+- Dev dependencies including `pytest`, `flake8`, and `typer` are installed in `.venv`.
+- `which pytest` resolves to `.venv/bin/pytest`.
+- `uv run pytest -q` completes without missing-module errors.
 - Update `scripts/codex_setup.sh` and documentation if additional steps are required.
 
 ## Status

--- a/issues/unit-tests-after-orchestrator-refactor.md
+++ b/issues/unit-tests-after-orchestrator-refactor.md
@@ -5,8 +5,9 @@ breaker manager. The refactor introduced API changes and incomplete updates that
 leave tests in an inconsistent state.
 
 ## Context
-- Environment setup gaps are resolved and tooling like Go Task and `flake8` are
-  available.
+- Environment setup gaps persist; `flake8` and `typer` are missing and `task` was
+  initially unavailable.
+- This ticket is blocked by `codex-setup-missing-go-task.md`.
 - The refactor changed `_cb_manager` usage from class-level to instance-level.
 - Existing tests still assume class-level state, causing failures and hangs.
 - Fixtures and helper utilities may need redesign to use fresh Orchestrator
@@ -15,6 +16,7 @@ leave tests in an inconsistent state.
   `numpy` package after installing full extras.
 
 ## Current Failures
+- `uv run pytest -q` fails early with `ModuleNotFoundError: No module named 'typer'`.
 - `tests/unit/test_additional_coverage.py::test_streamlit_metrics` (error)
 - `tests/unit/test_cache.py::test_search_uses_cache`
 - `tests/unit/test_cache.py::test_cache_lifecycle`


### PR DESCRIPTION
## Summary
- Note missing dev dependencies and flaky environment checks
- Record test failures blocked by absent packages

## Testing
- `uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `task verify` *(fails: Failed to spawn: `flake8`)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c0d929d083338d2734eedd5f6606