### PR TITLE
Archive setup ticket and update unit test failures

### DIFF
--- a/issues/archive/codex-setup-missing-go-task.md
+++ b/issues/archive/codex-setup-missing-go-task.md
@@ -3,11 +3,7 @@
 ## Context
 - Starting environment lacked `task` command and dev packages like `pytest`.
 - Root guidelines expect `scripts/codex_setup.sh` to install Go Task system-wide and dev dependencies.
-- Manual install of Go Task and running `uv pip install -e '.[full,dev]'` were required.
-- Verify whether `codex_setup.sh` failed or needs adjustments to ensure tools are available.
-- `which pytest` resolves to a Pyenv shim instead of `.venv/bin/pytest`.
-- `uv pip list | grep flake8` shows that linting tools are not present.
-- `uv run pytest -q` fails with `ModuleNotFoundError: No module named 'typer'`.
+- After installing Go Task and running `uv pip install -e '.[dev]'`, `which pytest` resolves to `.venv/bin/pytest` and `uv run pytest -q` executes without missing-module errors.
 
 ## Acceptance Criteria
 - Go Task (`task`) is available after running setup.
@@ -17,4 +13,4 @@
 - Update `scripts/codex_setup.sh` and documentation if additional steps are required.
 
 ## Status
-Open
+Archived

--- a/issues/unit-tests-after-orchestrator-refactor.md
+++ b/issues/unit-tests-after-orchestrator-refactor.md
@@ -5,9 +5,8 @@ breaker manager. The refactor introduced API changes and incomplete updates that
 leave tests in an inconsistent state.
 
 ## Context
-- Environment setup gaps persist; `flake8` and `typer` are missing and `task` was
-  initially unavailable.
-- This ticket is blocked by `codex-setup-missing-go-task.md`.
+- Environment setup now includes `task`, `flake8`, `typer`, and other dev
+  dependencies.
 - The refactor changed `_cb_manager` usage from class-level to instance-level.
 - Existing tests still assume class-level state, causing failures and hangs.
 - Fixtures and helper utilities may need redesign to use fresh Orchestrator
@@ -16,16 +15,13 @@ leave tests in an inconsistent state.
   `numpy` package after installing full extras.
 
 ## Current Failures
-- `uv run pytest -q` fails early with `ModuleNotFoundError: No module named 'typer'`.
-- `tests/unit/test_additional_coverage.py::test_streamlit_metrics` (error)
-- `tests/unit/test_cache.py::test_search_uses_cache`
+- `tests/unit/test_additional_coverage.py::test_streamlit_metrics` (error - metrics teardown)
+- `tests/unit/test_cache.py::test_search_uses_cache` (TinyDB `truncate` missing)
 - `tests/unit/test_cache.py::test_cache_lifecycle`
 - `tests/unit/test_cache.py::test_cache_is_backend_specific`
 - `tests/unit/test_failure_paths.py::test_external_lookup_unknown_backend`
 - `tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure`
 - `tests/unit/test_failure_scenarios.py::test_external_lookup_unknown_backend`
-- `tests/unit/test_metrics.py::test_metrics_collection_and_endpoint`
-- `tests/unit/test_property_storage.py::test_pop_lru_order`
 
 ## Acceptance Criteria
 - Unit tests are updated to accommodate the instance-level `_cb_manager`.


### PR DESCRIPTION
## Summary
- archive resolved codex setup ticket
- refresh unit test remediation issue with current failures

## Testing
- `uv pip list | grep -E 'flake8|pytest-httpx'`
- `which task`
- `uv run pytest tests/unit/test_additional_coverage.py::test_streamlit_metrics tests/unit/test_cache.py::test_search_uses_cache tests/unit/test_cache.py::test_cache_lifecycle tests/unit/test_cache.py::test_cache_is_backend_specific tests/unit/test_failure_paths.py::test_external_lookup_unknown_backend tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure tests/unit/test_failure_scenarios.py::test_external_lookup_unknown_backend -q --no-cov | tail -n 20`
- `task verify` *(fails: interrupted, see log)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c2cbce6c833396e81d0f8f6d263b