### PR TITLE
Document failing tests and missing task command

### DIFF
--- a/issues/missing-task-command.md
+++ b/issues/missing-task-command.md
@@ -1,0 +1,13 @@
+# Missing task command after setup
+
+## Context
+- `task --version` returns `command not found` in the prepared environment.
+- Root guidelines expect Go Task to be available under `/usr/local/bin/task`.
+
+## Acceptance Criteria
+- `task --version` reports a valid version after environment setup.
+- Setup scripts install Go Task or document manual installation steps.
+- Documentation stays in sync with tooling requirements.
+
+## Status
+Open

--- a/issues/unit-tests-after-orchestrator-refactor.md
+++ b/issues/unit-tests-after-orchestrator-refactor.md
@@ -15,13 +15,20 @@ leave tests in an inconsistent state.
   `numpy` package after installing full extras.
 
 ## Current Failures
-- `tests/unit/test_additional_coverage.py::test_streamlit_metrics` (error - metrics teardown)
-- `tests/unit/test_cache.py::test_search_uses_cache` (TinyDB `truncate` missing)
+- `tests/unit/test_additional_coverage.py::test_streamlit_metrics`
+  - teardown fixture `reset_orchestration_metrics` fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'set'
+- `tests/unit/test_cache.py::test_search_uses_cache`
+  - AttributeError: 'TinyDB' object has no attribute 'truncate'
 - `tests/unit/test_cache.py::test_cache_lifecycle`
+  - AssertionError: assert False
 - `tests/unit/test_cache.py::test_cache_is_backend_specific`
+  - AttributeError: 'TinyDB' object has no attribute 'truncate'
 - `tests/unit/test_failure_paths.py::test_external_lookup_unknown_backend`
+  - AttributeError: 'Query' object has no attribute 'query'
 - `tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure`
+  - AttributeError: 'Query' object has no attribute 'query'
 - `tests/unit/test_failure_scenarios.py::test_external_lookup_unknown_backend`
+  - AttributeError: 'Query' object has no attribute 'query'
 
 ## Acceptance Criteria
 - Unit tests are updated to accommodate the instance-level `_cb_manager`.


### PR DESCRIPTION
## Summary
- capture current unit test failures after Orchestrator refactor
- track missing `task` binary in environment setup

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest -q` *(fails: `test_streamlit_metrics`, cache and external lookup tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c4bc82088333b7eb57658a9c984c