### PR TITLE
Document environment setup gaps

### DIFF
--- a/issues/environment-setup-gaps.md
+++ b/issues/environment-setup-gaps.md
@@ -3,12 +3,14 @@
 ## Context
 The prepared environment again misses key development tools. `task --version`
 returns `command not found`, and `uv pip list | grep flake8` shows no result.
-Running `uv run pytest -q` initially fails with missing plugins such as
-`pytest_httpx` and `pytest-bdd` until they are installed manually. Attempting to
-use `uv sync --all-extras` pulls hundreds of megabytes of GPU related packages,
-making setup impractical without prebuilt wheels. These symptoms indicate the
-automated setup scripts and documentation have drifted from the expected
-tooling.
+`which pytest` resolves to `/root/.pyenv/shims/pytest` instead of
+`.venv/bin/pytest`. Running `uv run pytest -q` aborts with
+`ModuleNotFoundError: typer` before collecting tests. Attempting to install
+development extras via `uv pip install -e '.[full,dev]'` triggers downloads of
+hundreds of megabytes of GPU-related packages such as `torch` and
+`nvidia-cudnn-cu12`, making setup impractical without prebuilt wheels. These
+symptoms indicate the automated setup scripts and documentation have drifted
+from the expected tooling.
 
 ## Acceptance Criteria
 - Go Task is available after running the setup scripts.

--- a/issues/unit-tests-after-orchestrator-refactor.md
+++ b/issues/unit-tests-after-orchestrator-refactor.md
@@ -11,6 +11,9 @@ leave tests in an inconsistent state.
   instances per test.
 - Additional failures stem from `tests/stubs/numpy.py` shadowing the real
   `numpy` package after installing full extras.
+- `uv run pytest -q` currently aborts early with `ModuleNotFoundError: typer`,
+  indicating the development environment lacks required dependencies and must
+  be fixed before addressing these failures.
 
 ## Current Failures
 - `tests/unit/test_additional_coverage.py::test_streamlit_metrics`


### PR DESCRIPTION
## Summary
- note missing dev tools in environment setup ticket
- highlight that unit test work is blocked by missing dependencies

## Testing
- ❌ `task --version` (command not found)
- ❌ `uv run pytest -q` (ModuleNotFoundError: typer)
- ❌ `uv run flake8 src tests` (missing flake8)
- ❌ `uv run mypy src` (No module named 'pydantic')


------
https://chatgpt.com/codex/tasks/task_e_68a0cb2035b08333ba3ae837cb3892ac