### PR TITLE
Avoid numpy stub collisions with real package

### DIFF
--- a/tests/stubs/numpy.py
+++ b/tests/stubs/numpy.py
@@ -1,19 +1,21 @@
 """Minimal stub for :mod:`numpy`.
 
-Attempts to import the real package and falls back to a tiny stub when the
-dependency is unavailable. The stub also exposes ``numpy.random`` so modules
-expecting it can import without errors during tests.
+Registers a tiny stand-in only when the real package cannot be found. The stub
+also exposes ``numpy.random`` so modules expecting it can import without errors
+during tests.  When the real package exists, it is left untouched and the stub
+is available as ``numpy_stub`` for tests that need to install it manually via
+``sys.modules``.
 """
 
+import importlib.util
 import sys
 import types
 
-try:
-    import numpy as np  # type: ignore
-except Exception:
-    np = types.ModuleType("numpy")
-    np.array = lambda *a, **k: []
-    np.random = types.ModuleType("numpy.random")
-    np.random.rand = lambda *a, **k: []
+numpy_stub = types.ModuleType("numpy")
+numpy_stub.array = lambda *a, **k: []
+numpy_stub.random = types.ModuleType("numpy.random")
+numpy_stub.random.rand = lambda *a, **k: []
 
-sys.modules["numpy"] = np
+if importlib.util.find_spec("numpy") is None:  # pragma: no cover - real package present in dev env
+    sys.modules["numpy"] = numpy_stub
+    sys.modules["numpy.random"] = numpy_stub.random

--- a/tests/unit/test_numpy_stub.py
+++ b/tests/unit/test_numpy_stub.py
@@ -1,0 +1,22 @@
+import sys
+
+import numpy as real_numpy
+
+import tests.stubs.numpy as numpy_stub
+
+
+def test_numpy_stub_manual_install(monkeypatch):
+    """Real numpy remains untouched unless the stub is explicitly installed."""
+    assert sys.modules["numpy"] is real_numpy
+
+    # Manually swap in the stub
+    monkeypatch.delitem(sys.modules, "numpy")
+    monkeypatch.delitem(sys.modules, "numpy.random", raising=False)
+    monkeypatch.setitem(sys.modules, "numpy", numpy_stub.numpy_stub)
+    monkeypatch.setitem(sys.modules, "numpy.random", numpy_stub.numpy_stub.random)
+
+    import numpy as np  # noqa: E402
+
+    assert np is numpy_stub.numpy_stub
+    assert np.array(1) == []
+    assert np.random.rand(1) == []


### PR DESCRIPTION
## Summary
- Register `tests/stubs/numpy` only when real numpy is absent
- Allow tests to install numpy stub explicitly via `sys.modules`
- Harden test setup to skip Typer when unavailable

## Testing
- `uv run ruff check --fix tests/stubs/numpy.py tests/unit/test_numpy_stub.py`
- `uv run flake8 tests/stubs/numpy.py tests/unit/test_numpy_stub.py`
- `uv run mypy src` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `uv run ruff check --fix tests/conftest.py`
- `uv run flake8 tests/conftest.py`
- `uv run pytest tests/unit/test_numpy_stub.py -q --cov=tests/unit/test_numpy_stub.py --cov-report=term --cov-fail-under=0`
- `uv pip install --no-deps -e '.[nlp]'`


------
https://chatgpt.com/codex/tasks/task_e_68a0d29742d48333b7e38d687258a119