### PR TITLE
Use orchestrator_runner in tests and isolate circuit breaker state

### DIFF
--- a/tests/unit/test_api_error_handling.py
+++ b/tests/unit/test_api_error_handling.py
@@ -5,7 +5,6 @@ from autoresearch.config.models import ConfigModel, APIConfig
 from autoresearch.config.loader import ConfigLoader
 import types
 import contextlib
-from autoresearch.orchestration.orchestrator import Orchestrator
 
 
 def _setup(monkeypatch):
@@ -24,10 +23,10 @@ def _setup(monkeypatch):
     return cfg
 
 
-def test_query_endpoint_runtime_error(monkeypatch):
+def test_query_endpoint_runtime_error(monkeypatch, orchestrator_runner):
     _setup(monkeypatch)
 
-    orch = Orchestrator()
+    orch = orchestrator_runner()
 
     def raise_error(q, c, callbacks=None):
         raise RuntimeError("fail")
@@ -42,9 +41,9 @@ def test_query_endpoint_runtime_error(monkeypatch):
     assert data["metrics"]["error"] == "fail"
 
 
-def test_query_endpoint_invalid_response(monkeypatch):
+def test_query_endpoint_invalid_response(monkeypatch, orchestrator_runner):
     _setup(monkeypatch)
-    orch = Orchestrator()
+    orch = orchestrator_runner()
     monkeypatch.setattr(orch, "run_query", lambda q, c, callbacks=None: {"foo": "bar"})
     monkeypatch.setattr("autoresearch.api.routing.create_orchestrator", lambda: orch)
     client = TestClient(app)

--- a/tests/unit/test_cli_visualize.py
+++ b/tests/unit/test_cli_visualize.py
@@ -5,7 +5,6 @@ from typer.testing import CliRunner
 
 from autoresearch.cli_utils import ascii_bar_graph, summary_table
 from autoresearch.models import QueryResponse
-from autoresearch.orchestration.orchestrator import Orchestrator
 
 
 def test_ascii_bar_graph_basic():
@@ -26,10 +25,10 @@ def test_summary_table_render():
     assert "1" in output
 
 
-def test_search_visualize_option(monkeypatch, dummy_storage):
+def test_search_visualize_option(monkeypatch, dummy_storage, orchestrator_runner):
     runner = CliRunner()
 
-    orch = Orchestrator()
+    orch = orchestrator_runner()
     run_query_mock = MagicMock(
         return_value=QueryResponse(
             answer="ok", citations=[], reasoning=[], metrics={"m": 1}

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -14,13 +14,12 @@ import importlib  # noqa: E402
 
 main_app = importlib.import_module("autoresearch.main.app")  # noqa: E402
 from autoresearch.models import QueryResponse  # noqa: E402
-from autoresearch.orchestration.orchestrator import Orchestrator  # noqa: E402
 
 
-def test_search_default_output_tty(monkeypatch, mock_run_query):
+def test_search_default_output_tty(monkeypatch, mock_run_query, orchestrator_runner):
     runner = CliRunner()
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    orch = Orchestrator()
+    orch = orchestrator_runner()
     monkeypatch.setattr(orch, "run_query", MethodType(mock_run_query, orch))
     monkeypatch.setattr(main_app, "Orchestrator", lambda: orch)
     result = runner.invoke(app, ["search", "q"])
@@ -28,11 +27,11 @@ def test_search_default_output_tty(monkeypatch, mock_run_query):
     assert "# Answer" in result.stdout
 
 
-def test_search_default_output_json(monkeypatch, mock_run_query):
+def test_search_default_output_json(monkeypatch, mock_run_query, orchestrator_runner):
     runner = CliRunner()
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
-    orch = Orchestrator()
+    orch = orchestrator_runner()
     monkeypatch.setattr(orch, "run_query", MethodType(mock_run_query, orch))
     monkeypatch.setattr(main_app, "Orchestrator", lambda: orch)
     result = runner.invoke(app, ["search", "q"])
@@ -41,7 +40,9 @@ def test_search_default_output_json(monkeypatch, mock_run_query):
 
 
 @pytest.mark.parametrize("mode", ["direct", "dialectical"])
-def test_search_reasoning_mode_option(monkeypatch, mode, config_loader):
+def test_search_reasoning_mode_option(
+    monkeypatch, mode, config_loader, orchestrator_runner
+):
     runner = CliRunner()
 
     captured = {}
@@ -60,7 +61,7 @@ def test_search_reasoning_mode_option(monkeypatch, mode, config_loader):
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
     monkeypatch.setattr(main_app, "_config_loader", config_loader)
-    orch = Orchestrator()
+    orch = orchestrator_runner()
     monkeypatch.setattr(orch, "run_query", MethodType(_run, orch))
     monkeypatch.setattr(main_app, "Orchestrator", lambda: orch)
 
@@ -70,7 +71,7 @@ def test_search_reasoning_mode_option(monkeypatch, mode, config_loader):
     assert captured["mode"].value == mode
 
 
-def test_search_primus_start_option(monkeypatch, config_loader):
+def test_search_primus_start_option(monkeypatch, config_loader, orchestrator_runner):
     runner = CliRunner()
 
     captured = {}
@@ -89,7 +90,7 @@ def test_search_primus_start_option(monkeypatch, config_loader):
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
     monkeypatch.setattr(main_app, "_config_loader", config_loader)
-    orch = Orchestrator()
+    orch = orchestrator_runner()
     monkeypatch.setattr(orch, "run_query", MethodType(_run, orch))
     monkeypatch.setattr(main_app, "Orchestrator", lambda: orch)
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -7,7 +7,6 @@ from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import APIConfig, ConfigModel
 from autoresearch.models import QueryResponse
 from autoresearch.orchestration import metrics
-from autoresearch.orchestration.orchestrator import Orchestrator
 
 
 class DummyConn:
@@ -15,14 +14,14 @@ class DummyConn:
         return self
 
 
-def test_metrics_collection_and_endpoint(monkeypatch):
+def test_metrics_collection_and_endpoint(monkeypatch, orchestrator_runner):
     monkeypatch.setattr(duckdb, "connect", lambda *a, **k: DummyConn())
 
     cfg = ConfigModel.model_construct(api=APIConfig())
     cfg.api.role_permissions["anonymous"] = ["query", "metrics"]
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader.reset_instance()
-    orch = Orchestrator()
+    orch = orchestrator_runner()
 
     def fake_run_query(query, config, callbacks=None, **kwargs):
         metrics.record_query()

--- a/tests/unit/test_orchestrator_cb_manager.py
+++ b/tests/unit/test_orchestrator_cb_manager.py
@@ -1,24 +1,41 @@
-from unittest.mock import patch
-
 from autoresearch.config.models import ConfigModel
-from autoresearch.orchestration.orchestrator import Orchestrator
 
 
-def test_cb_manager_is_instance_scoped():
+def test_circuit_breaker_state_is_instance_isolated(monkeypatch, orchestrator_runner):
     cfg = ConfigModel(loops=1, agents=["Synthesizer"])
 
-    o1 = Orchestrator()
-    o2 = Orchestrator()
+    call = {"count": 0}
 
-    orig_run_query = Orchestrator.run_query
-    with patch.object(Orchestrator, "run_query", orig_run_query):
-        with patch(
-            "autoresearch.orchestration.orchestrator.OrchestrationUtils.execute_cycle",
-            return_value=0,
-        ):
-            o1.run_query("q", cfg)
-            o2.run_query("q", cfg)
+    def fail_first(
+        agent_name,
+        state,
+        config,
+        metrics,
+        callbacks,
+        agent_factory,
+        storage_manager,
+        loop,
+        cb_manager,
+    ):
+        call["count"] += 1
+        if call["count"] == 1:
+            cb_manager.update_circuit_breaker(agent_name, "critical")
+        return 0
 
-    assert o1._cb_manager is not None
-    assert o2._cb_manager is not None
-    assert o1._cb_manager is not o2._cb_manager
+    monkeypatch.setattr(
+        "autoresearch.orchestration.execution._execute_agent",
+        fail_first,
+    )
+
+    o1 = orchestrator_runner()
+    o2 = orchestrator_runner()
+
+    o1.run_query("q", cfg)
+    o2.run_query("q", cfg)
+
+    state1 = o1.get_circuit_breaker_state("Synthesizer")
+    state2 = o2.get_circuit_breaker_state("Synthesizer")
+
+    assert state1["failure_count"] > 0
+    assert state2["failure_count"] == 0
+    assert state2["state"] == "closed"

--- a/tests/unit/test_orchestrator_errors.py
+++ b/tests/unit/test_orchestrator_errors.py
@@ -128,7 +128,9 @@ def test_retry_with_backoff_on_transient_error(monkeypatch, test_config):
     )
 
 
-def test_orchestrator_raises_after_error(monkeypatch, test_config, failing_agent):
+def test_orchestrator_raises_after_error(
+    monkeypatch, test_config, failing_agent, orchestrator_runner
+):
     """Test that the orchestrator raises an OrchestrationError after an agent error.
 
     This test verifies that when an agent raises an exception during execution,
@@ -145,14 +147,14 @@ def test_orchestrator_raises_after_error(monkeypatch, test_config, failing_agent
 
     # Execute and Verify
     with pytest.raises(OrchestrationError) as excinfo:
-        Orchestrator().run_query("test query", test_config)
+        orchestrator_runner().run_query("test query", test_config)
 
     # Verify the error contains the agent errors
     assert excinfo.value.context.get("errors") is not None
     assert len(excinfo.value.context["errors"]) > 0
 
 
-def test_invalid_agent_name_raises(test_config):
+def test_invalid_agent_name_raises(test_config, orchestrator_runner):
     """Test that using an invalid agent name raises an OrchestrationError.
 
     This test verifies that when an unknown agent name is specified in the
@@ -164,7 +166,7 @@ def test_invalid_agent_name_raises(test_config):
 
     # Execute and Verify
     with pytest.raises(OrchestrationError) as excinfo:
-        Orchestrator().run_query("test query", test_config)
+        orchestrator_runner().run_query("test query", test_config)
 
     # Verify the error contains the agent errors
     assert excinfo.value.context.get("errors") is not None
@@ -176,7 +178,7 @@ def test_invalid_agent_name_raises(test_config):
     assert any("Unknown" in msg and "agent" in msg.lower() for msg in error_messages)
 
 
-def test_callback_error_propagates(test_config):
+def test_callback_error_propagates(test_config, orchestrator_runner):
     """Test that errors in callbacks propagate to the caller.
 
     This test verifies that when a callback function raises an exception,
@@ -190,7 +192,7 @@ def test_callback_error_propagates(test_config):
 
     # Execute and Verify
     with pytest.raises(RuntimeError):
-        Orchestrator().run_query(
+        orchestrator_runner().run_query(
             "test query",
             test_config,
             callbacks={"on_cycle_start": bad_callback},
@@ -204,7 +206,9 @@ def test_callback_error_propagates(test_config):
         (RuntimeError, "runtime error"),
     ],
 )
-def test_agent_error_is_wrapped(monkeypatch, test_config, error_type, error_message):
+def test_agent_error_is_wrapped(
+    monkeypatch, test_config, error_type, error_message, orchestrator_runner
+):
     """Test that agent errors are wrapped in AgentError.
 
     This test verifies that when an agent raises an exception during execution,
@@ -233,7 +237,7 @@ def test_agent_error_is_wrapped(monkeypatch, test_config, error_type, error_mess
 
     # Execute and Verify
     with pytest.raises(OrchestrationError) as excinfo:
-        Orchestrator().run_query("test query", test_config)
+        orchestrator_runner().run_query("test query", test_config)
 
     # Verify the error contains agent errors
     assert excinfo.value.context.get("errors") is not None
@@ -246,7 +250,7 @@ def test_agent_error_is_wrapped(monkeypatch, test_config, error_type, error_mess
     assert any(error_message in error for error in error_strings)
 
 
-def test_parallel_query_error_claims(monkeypatch):
+def test_parallel_query_error_claims(monkeypatch, orchestrator_runner):
     """Errors from parallel groups are added to the response claims."""
 
     cfg = ConfigModel(agents=[], loops=1)
@@ -272,7 +276,7 @@ def test_parallel_query_error_claims(monkeypatch):
     synthesizer = MagicMock()
     synthesizer.execute.return_value = {"answer": "final"}
 
-    orchestrator = Orchestrator()
+    orchestrator = orchestrator_runner()
     monkeypatch.setattr(
         orchestrator,
         "run_query",
@@ -293,7 +297,7 @@ def test_parallel_query_error_claims(monkeypatch):
     assert any("Error in agent group ['B']" in c for c in resp.reasoning)
 
 
-def test_parallel_query_timeout_claims(monkeypatch):
+def test_parallel_query_timeout_claims(monkeypatch, orchestrator_runner):
     """Timeouts from parallel groups are added to the response claims."""
 
     cfg = ConfigModel(agents=[], loops=1)
@@ -328,7 +332,7 @@ def test_parallel_query_timeout_claims(monkeypatch):
     synthesizer = MagicMock()
     synthesizer.execute.return_value = {"answer": "final"}
 
-    orchestrator = Orchestrator()
+    orchestrator = orchestrator_runner()
     monkeypatch.setattr(
         orchestrator,
         "run_query",

--- a/tests/unit/test_orchestrator_order.py
+++ b/tests/unit/test_orchestrator_order.py
@@ -35,7 +35,7 @@ def test_custom_agents_order(orchestrator_runner):
     assert record == ["A1", "A2", "A3"]
 
 
-def test_async_custom_agents_concurrent():
+def test_async_custom_agents_concurrent(orchestrator_runner):
     record = []
 
     def get_agent(name):
@@ -46,7 +46,7 @@ def test_async_custom_agents_concurrent():
         "autoresearch.orchestration.orchestrator.AgentFactory.get",
         side_effect=get_agent,
     ):
-        orchestrator = Orchestrator()
+        orchestrator = orchestrator_runner()
         asyncio.run(orchestrator.run_query_async("q", cfg, concurrent=True))
 
     assert sorted(record) == ["A1", "A2", "A3"]

--- a/tests/unit/test_parallel_module.py
+++ b/tests/unit/test_parallel_module.py
@@ -9,7 +9,6 @@ import pytest
 from autoresearch.config.models import ConfigModel
 from autoresearch.models import QueryResponse
 from autoresearch.orchestration import parallel
-from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.errors import AgentError, OrchestrationError
 
 
@@ -44,7 +43,7 @@ def test_calculate_result_confidence():
     assert 0.5 <= score <= 1.0
 
 
-def test_execute_parallel_query_basic(monkeypatch):
+def test_execute_parallel_query_basic(monkeypatch, orchestrator_runner):
     cfg = ConfigModel.model_construct(agents=[], loops=1)
 
     class DummySpan:
@@ -87,8 +86,8 @@ def test_execute_parallel_query_basic(monkeypatch):
             metrics={"token_usage": {"total": 10, "max_tokens": 100}, "errors": []},
         )
 
-    orc1 = Orchestrator()
-    orc2 = Orchestrator()
+    orc1 = orchestrator_runner()
+    orc2 = orchestrator_runner()
     mock1 = MagicMock(side_effect=run_query_stub)
     mock2 = MagicMock(side_effect=run_query_stub)
     monkeypatch.setattr(orc1, "run_query", mock1)
@@ -123,7 +122,7 @@ def test_execute_parallel_query_basic(monkeypatch):
     assert mock1.called and mock2.called
 
 
-def test_execute_parallel_query_agent_error(monkeypatch, caplog):
+def test_execute_parallel_query_agent_error(monkeypatch, caplog, orchestrator_runner):
     cfg = ConfigModel.model_construct(agents=[], loops=1)
 
     class DummySpan:
@@ -161,7 +160,7 @@ def test_execute_parallel_query_agent_error(monkeypatch, caplog):
     ):
         raise AgentError("boom", agent_name="A")
 
-    orc = Orchestrator()
+    orc = orchestrator_runner()
     mock_run = MagicMock(side_effect=run_query_error)
     monkeypatch.setattr(orc, "run_query", mock_run)
 


### PR DESCRIPTION
## Summary
- use `orchestrator_runner` fixture to build fresh `Orchestrator` instances across tests
- replace direct `_cb_manager` access with `get_circuit_breaker_state`
- add regression test ensuring circuit breaker state is isolated per orchestrator

## Testing
- `pytest tests/unit/test_main_cli.py -q --cov-fail-under=0`
- `pytest tests/unit/test_orchestrator_errors.py -q --cov-fail-under=0`
- `pytest tests/unit/test_orchestrator_cb_manager.py -q --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68a0d2951c488333a9b43b6a8656961e