### PR TITLE
Ensure metrics test sets permissions via API key header

### DIFF
--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -61,14 +61,15 @@ def test_metrics_collection_and_endpoint(monkeypatch):
     )
 
     client = TestClient(app)
-    client.post("/query", json={"query": "hi"})
+    headers = {"X-API-Key": ""}
+    client.post("/query", headers=headers, json={"query": "hi"})
 
     assert metrics.QUERY_COUNTER._value.get() == start_queries + 1
     assert metrics.ERROR_COUNTER._value.get() == start_errors + 1
     assert metrics.TOKENS_IN_COUNTER._value.get() >= 5
     assert metrics.TOKENS_OUT_COUNTER._value.get() >= 7
 
-    resp = client.get("/metrics")
+    resp = client.get("/metrics", headers=headers)
     assert resp.status_code == 200
     body = resp.text
     assert "autoresearch_queries_total" in body


### PR DESCRIPTION
## Summary
- Add an empty `X-API-Key` header to the metrics unit test so `AuthMiddleware` assigns permissions before querying metrics

## Testing
- `uv run pytest tests/unit/test_metrics.py::test_metrics_collection_and_endpoint -q -o addopts= -p no:cov`


------
https://chatgpt.com/codex/tasks/task_e_68a0d29086448333888dd58f3dfe17ef