### PR TITLE
Handle TinyDB cache compatibility

### DIFF
--- a/src/autoresearch/cache.py
+++ b/src/autoresearch/cache.py
@@ -220,7 +220,10 @@ def clear() -> None:
         ```
     """
     db = get_db()
-    db.truncate()
+    if hasattr(db, "drop_tables"):
+        db.drop_tables()
+    else:
+        db.table("_default").truncate()
 
 
 # Initialise default cache on import

--- a/tests/stubs/tinydb.py
+++ b/tests/stubs/tinydb.py
@@ -1,20 +1,96 @@
-"""Minimal stub for the :mod:`tinydb` package."""
+"""Minimal stub for the :mod:`tinydb` package.
 
+The stub mimics a subset of TinyDB's API used in the tests. If the real
+``tinydb`` package is available, the stub does nothing and the real module is
+used instead.
+"""
+
+from __future__ import annotations
+
+import importlib
 import sys
 import types
+from typing import Any, Callable, List, Optional
 
-if "tinydb" not in sys.modules:
+try:  # pragma: no cover - exercised when real tinydb is installed
+    importlib.import_module("tinydb")
+except Exception:  # pragma: no cover
     tinydb_stub = types.ModuleType("tinydb")
 
-    class TinyDB:
-        def __init__(self, *args, **kwargs):
-            pass
+    class QueryCondition:
+        """Callable wrapper representing a query condition."""
 
-        def close(self):
-            pass
+        def __init__(self, func: Callable[[dict[str, Any]], bool]):
+            self.func = func
+
+        def __call__(self, doc: dict[str, Any]) -> bool:
+            return self.func(doc)
+
+        def __and__(self, other: "QueryCondition") -> "QueryCondition":
+            return QueryCondition(lambda doc: self(doc) and other(doc))
+
+        def __or__(self, other: "QueryCondition") -> "QueryCondition":
+            return QueryCondition(lambda doc: self(doc) or other(doc))
 
     class Query:
-        pass
+        """Very small implementation of :class:`tinydb.queries.Query`."""
+
+        def __init__(self, path: Optional[List[str]] = None) -> None:
+            self._path: List[str] = path or []
+
+        def __getattr__(self, item: str) -> "Query":
+            return Query(self._path + [item])
+
+        def _extract(self, doc: dict[str, Any]) -> Any:
+            value: Any = doc
+            for part in self._path:
+                if isinstance(value, dict):
+                    value = value.get(part)
+                else:
+                    value = None
+                if value is None:
+                    break
+            return value
+
+        def __eq__(self, other: Any) -> QueryCondition:  # pragma: no cover - trivial
+            return QueryCondition(lambda doc: self._extract(doc) == other)
+
+        def __ne__(self, other: Any) -> QueryCondition:  # pragma: no cover - trivial
+            return QueryCondition(lambda doc: self._extract(doc) != other)
+
+    class TinyDB:
+        """Simplistic in-memory TinyDB replacement."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self._data: List[dict[str, Any]] = []
+
+        # Table handling -------------------------------------------------
+        def table(self, name: str) -> "TinyDB":
+            return self
+
+        def truncate(self) -> None:
+            self._data.clear()
+
+        def drop_tables(self) -> None:
+            self._data.clear()
+
+        # Document operations -------------------------------------------
+        def upsert(self, doc: dict[str, Any], cond: QueryCondition) -> None:
+            for i, existing in enumerate(self._data):
+                if cond(existing):
+                    self._data[i] = doc
+                    break
+            else:
+                self._data.append(doc)
+
+        def get(self, cond: QueryCondition) -> Optional[dict[str, Any]]:
+            for doc in self._data:
+                if cond(doc):
+                    return doc
+            return None
+
+        def close(self) -> None:  # pragma: no cover - nothing to close
+            pass
 
     tinydb_stub.TinyDB = TinyDB
     tinydb_stub.Query = Query

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,5 +1,10 @@
 from threading import Thread
 
+import importlib.util
+
+if not importlib.util.find_spec("tinydb"):
+    import tests.stubs.tinydb  # noqa: F401
+
 from autoresearch import cache
 from autoresearch.search import Search
 from autoresearch.config.models import ConfigModel


### PR DESCRIPTION
## Summary
- handle TinyDB API changes by using drop_tables or table().truncate()
- expand tinydb test stub with upsert, get, drop_tables and Query support
- ensure cache tests import stub when real tinydb is unavailable

## Testing
- `uv run ruff check --fix src/autoresearch/cache.py tests/stubs/tinydb.py tests/unit/test_cache.py`
- `uv run flake8 src tests`
- `uv run mypy src/autoresearch/cache.py tests/stubs/tinydb.py` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `uv run pytest tests/unit/test_cache.py tests/unit/test_cache_extra.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68a0d285b2b083339349a0ef232938c8