### PR TITLE
Install dev tooling via uv sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
       - Run `uv sync --all-extras` followed by `uv pip install -e .` for the standard setup.
       - Use `uv pip install -e '.[full,dev]'` only to reinstall dependencies if tools are missing or `uv sync` is unavailable.
   - When modifying `pyproject.toml`, regenerate the lock file with `uv lock` before reinstalling.
-  - Codex environments run `scripts/codex_setup.sh`, which delegates to `scripts/setup.sh` and installs all dev dependencies and extras so tools like `flake8`, `mypy`, and `pytest` are available and real rate limits are enforced. The setup script also installs [Go Task](https://taskfile.dev) system-wide so `task` commands work out of the box. After setup, verify `/usr/local/bin/task` exists; if missing, reinstall Go Task using `curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin`.
+  - Codex environments run `scripts/codex_setup.sh`, which delegates to `scripts/setup.sh` and installs all dev dependencies and extras with `uv sync --all-extras` so tools like `flake8`, `mypy`, and `pytest` are available and real rate limits are enforced. The setup script installs [Go Task](https://taskfile.dev) inside the virtual environment. After setup, ensure `task`, `flake8`, and `pytest` resolve to paths under `.venv/bin`.
   - Confirm dev tools are installed with `uv pip list | grep flake8`.
   - After running `scripts/codex_setup.sh`, verify `pytest-cov`, `tomli_w`, `hypothesis`, `freezegun`, `duckdb-extension-vss`, and `fastapi` are present using `uv pip list`.
 - `VECTOR_EXTENSION_PATH` selects the DuckDB vector search extension. Tests

--- a/README.md
+++ b/README.md
@@ -52,10 +52,9 @@ and upgrade instructions.
 The `scripts/setup.sh` helper ensures the lock file is current and installs
 all optional extras so development and runtime dependencies are available for testing.
 Run `scripts/setup.sh` to install dependencies automatically. CI environments
-must include all extras, so ensure `uv pip install -e '.[full,parsers,git,llm,dev]'`
-is executed. The `dev-minimal` option is only for local smoke tests. After
-editing `pyproject.toml`, run `uv lock` and reinstall with the full extras to
-apply updates.
+must include all extras, so run `uv sync --all-extras && uv pip install -e .`.
+The `dev-minimal` option is only for local smoke tests. After editing
+`pyproject.toml`, run `uv lock` and reinstall with all extras to apply updates.
 Several dependencies are pinned for compatibility—`slowapi` is locked to
 **0.1.9** and `fastapi` must be **0.115** or newer. The test suite works both
 with and without extras:
@@ -67,14 +66,15 @@ with and without extras:
   SlowAPI's rate‑limiting middleware. This may change how certain tests
   behave and can make them slower.
 
-Reinstall with `uv pip install -e '.[full,parsers,git,llm,dev]'` if you need
-to disable extras after running the setup script.
+Reinstall with `uv sync --all-extras && uv pip install -e .` if you need
+to restore extras after running the setup script.
 
 ### Using uv
 Python 3.12 or newer is required. Set up the development environment with:
 ```bash
 uv venv
-uv pip install -e '.[full,parsers,git,llm,dev]'
+uv sync --all-extras
+uv pip install -e .
 source .venv/bin/activate
 ```
 If Python 3.11 is selected, `uv` will fail with a message similar to:
@@ -505,7 +505,8 @@ Create a virtual environment, run `uv lock` if `pyproject.toml` changed, and ins
 
 ```bash
 uv venv
-uv pip install -e '.[full,parsers,git,llm,dev]'
+uv sync --all-extras
+uv pip install -e .
 source .venv/bin/activate
 ```
 
@@ -518,8 +519,10 @@ Alternatively you can run the helper script:
 ```
 This installs the same dependencies non-interactively.
 
-The helper installs all dependencies with `uv pip install -e '.[full,parsers,git,llm,dev]'` and
-links the package in editable mode. Tools such as `flake8`, `mypy`, `pytest` and `tomli_w`
+For offline installs, pre-download wheels and source archives and set `WHEELS_DIR` and `ARCHIVES_DIR` before running the setup script.
+
+The helper installs all dependencies with `uv sync --all-extras` and
+links the package in editable mode using `uv pip install -e .`. Tools such as `flake8`, `mypy`, `pytest` and `tomli_w`
 are therefore available for development and testing. Tests will run even without
 extras because stub versions of optional packages are bundled, but coverage is
 limited. Installing extras enables the real implementations—for example
@@ -534,15 +537,15 @@ SlowAPI’s middleware, which enforces rate limits during integration tests.
 - Avoid committing the `.venv` directory and recreate it if dependencies
   become inconsistent.
 - Install development extras with
-  `uv pip install -e '.[full,parsers,git,llm,dev]'` to ensure linters and
+  `uv sync --all-extras && uv pip install -e .` to ensure linters and
   optional features are available.
 
 ## Running tests
 
 All test commands require the project to be installed with the full extras so
 linters, `mypy`, `pytest`, and optional dependencies are available. The
-`scripts/setup.sh` helper installs `.[full,parsers,git,llm,dev]` automatically
-for both local development and CI.
+`scripts/setup.sh` helper installs all extras with `uv sync --all-extras`
+automatically for both local development and CI.
 
 The full suite, including behavior-driven tests, relies on additional optional
 extras such as `pdfminer` and `gitpython`. Tests can run without them using
@@ -550,7 +553,8 @@ bundled stubs, but real behaviour – including SlowAPI rate limiting – is onl
 exercised when the extras are installed. Install them with:
 
 ```bash
-uv pip install -e '.[full,parsers,git,llm,dev]'
+uv sync --all-extras
+uv pip install -e .
 ```
 
 Execute linting and type checks once the development environment is ready:
@@ -577,8 +581,8 @@ uv run pytest -m slow
 ```
 
 Several unit and integration tests rely on `gitpython` and the DuckDB VSS
-extension. Install the corresponding extras as needed, for example
-`uv pip install -e '.[full,parsers,git,llm,dev,vss]'` for the default suites.
+extension. Install the corresponding extras as needed, for example run
+`uv sync --all-extras && uv pip install -e .` for the default suites.
 
 All testing commands are wrapped by `task`, which activates the `.venv`
 environment before running each tool.
@@ -619,7 +623,8 @@ and those that rely on optional extras. Install the extras and run pytest
 without filtering the markers:
 
 ```bash
-uv pip install -e '.[full,parsers,git,llm,dev]'
+uv sync --all-extras
+uv pip install -e .
 uv run pytest -m "slow or requires_ui or requires_vss"
 ```
 
@@ -629,14 +634,15 @@ Previous versions used Poetry for environment management. `uv` now handles depen
 
 ```bash
 uv venv
-uv pip install -e '.[full,parsers,git,llm,dev]'
+uv sync --all-extras
+uv pip install -e .
 ```
 
 Activate the environment with `source .venv/bin/activate` before running commands.
 
 ### Troubleshooting
 
-- If tests fail with `ModuleNotFoundError`, ensure all dependencies are installed in the virtual environment using `uv pip install -e '.[full,parsers,git,llm,dev]'`. Time-based tests rely on `freezegun`, which is included in the development extras.
+- If tests fail with `ModuleNotFoundError`, ensure all dependencies are installed in the virtual environment using `uv sync --all-extras && uv pip install -e .`. Time-based tests rely on `freezegun`, which is included in the development extras.
 - When starting the API with `uvicorn autoresearch.api:app --reload`, install `uvicorn` if the command is not found and verify that port `8000` is free.
 
 ### Smoke test

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,6 +80,18 @@ uv run pytest -q
 uv run pytest tests/behavior
 ```
 
+### Offline installation
+
+To install without network access, pre-download the required packages and point the setup script at their locations:
+
+```bash
+export WHEELS_DIR=/path/to/wheels
+export ARCHIVES_DIR=/path/to/archives
+./scripts/setup.sh
+```
+
+`WHEELS_DIR` should contain wheel files (`*.whl`) and `ARCHIVES_DIR` should contain source archives (`*.tar.gz`). The setup script installs these caches with `uv pip --no-index` so dependencies resolve offline.
+
 ## Minimal installation
 
 The project can be installed with only the minimal optional dependencies:
@@ -103,7 +115,7 @@ extra needed for the test suite. Tests normally rely on stubbed versions of
 these extras, so running the suite without them is recommended. Extras such as
 `slowapi` may enable real behaviour (like rate limiting) that changes how
 assertions are evaluated. If you wish to revert to stub-only testing after
-running the helper, reinstall using `uv pip install -e '.[full,parsers,git,llm,dev]'`. Optional
+running the helper, reinstall using `uv sync --all-extras && uv pip install -e .`. Optional
 features are disabled when their dependencies are missing. Specify extras
 explicitly with pip to enable additional features, e.g. ``pip install "autoresearch[minimal,nlp]"``.
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -20,10 +20,7 @@ else
     exit 1
 fi
 
-# Determine which extras to install (default is full + dev)
-EXTRAS="${1:-full,dev}"
-
-# Create a Python 3.12+ virtual environment and install the requested extras
+# Create a Python 3.12+ virtual environment
 uv venv
 VENV_PYTHON="./.venv/bin/python"
 "$VENV_PYTHON" - <<'EOF'
@@ -31,16 +28,16 @@ import sys
 if sys.version_info < (3, 12):
     raise SystemExit(f"uv venv created Python {sys.version.split()[0]}, but >=3.12 is required")
 EOF
-# Install locked dependencies for the chosen extras
-SYNC_ARGS=""
-IFS=',' read -ra EX_ARR <<< "$EXTRAS"
-for e in "${EX_ARR[@]}"; do
-    SYNC_ARGS+="--extra $e "
-done
-echo "Installing extras: $EXTRAS"
-uv sync $SYNC_ARGS
+
+# Install Go Task inside the virtual environment
+curl -sL https://taskfile.dev/install.sh | sh -s -- -b ./.venv/bin
+
+# Install all locked dependencies and extras
+echo "Installing all extras via uv sync --all-extras"
+uv sync --all-extras
+
 # Link the project in editable mode so tools are available
-uv pip install -e ".[$EXTRAS]"
+uv pip install -e .
 
 # Create extensions directory if it doesn't exist
 mkdir -p extensions
@@ -115,20 +112,17 @@ chmod +x scripts/smoke_test.py
 echo "Running smoke test to verify environment..."
 uv run python scripts/smoke_test.py
 
-
-# Ensure development tools and stubs are present
-ensure_installed() {
-    local pkg="$1"
-    echo "Ensuring $pkg is installed..."
-    if ! uv pip show "$pkg" >/dev/null 2>&1; then
-        uv pip install "$pkg"
+# Verify required CLI tools resolve inside the virtual environment
+source .venv/bin/activate
+for cmd in task flake8 pytest; do
+    cmd_path=$(command -v "$cmd" || true)
+    if [[ "$cmd_path" != "$VIRTUAL_ENV"/* ]]; then
+        echo "$cmd is not resolved inside .venv: $cmd_path" >&2
+        deactivate
+        exit 1
     fi
-}
-
-for pkg in flake8 mypy pytest pytest-bdd pytest-cov tomli_w hypothesis \
-    types-requests types-tabulate types-networkx types-protobuf; do
-    ensure_installed "$pkg"
 done
+deactivate
 
 # Run mypy to ensure type hints are valid and stubs are picked up
 echo "Running mypy..."


### PR DESCRIPTION
## Summary
- install Go Task inside `.venv` and sync all extras with `uv`
- verify `task`, `flake8`, and `pytest` resolve from the virtual environment
- document `WHEELS_DIR`/`ARCHIVES_DIR` for offline installation

## Testing
- `./scripts/setup.sh`
- `task verify` *(failed: exited early during unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d20247c4833382585891133e2e9a