### PR TITLE
Check backend exists before cache lookup

### DIFF
--- a/tests/unit/test_failure_scenarios.py
+++ b/tests/unit/test_failure_scenarios.py
@@ -1,11 +1,12 @@
 import sys
 import types
+
 import pytest
 import requests
 
+from autoresearch import distributed
 from autoresearch.errors import SearchError
 from autoresearch.search import Search
-from autoresearch import distributed
 
 
 def _make_cfg(backends):
@@ -41,6 +42,12 @@ def test_external_lookup_unknown_backend(monkeypatch):
     cfg = _make_cfg(["missing"])
     monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
     Search.backends.pop("missing", None)
+    monkeypatch.setattr(
+        "autoresearch.search.core.get_cached_results",
+        lambda *_, **__: (_ for _ in ()).throw(
+            AssertionError("cache lookup should not occur for unknown backends")
+        ),
+    )
     with pytest.raises(SearchError):
         Search.external_lookup("q", max_results=1)
 


### PR DESCRIPTION
## Summary
- Verify each backend exists before looking up cached search results
- Fail fast with `SearchError` for unknown backends
- Guard tests against cache usage for invalid backends

## Testing
- `uv run black src/autoresearch/search/core.py tests/unit/test_failure_paths.py tests/unit/test_failure_scenarios.py`
- `uv run isort src/autoresearch/search/core.py tests/unit/test_failure_paths.py tests/unit/test_failure_scenarios.py`
- `uv run ruff format src/autoresearch/search/core.py tests/unit/test_failure_paths.py tests/unit/test_failure_scenarios.py`
- `uv run ruff check --fix src/autoresearch/search/core.py tests/unit/test_failure_paths.py tests/unit/test_failure_scenarios.py`
- `uv run flake8 src/autoresearch/search/core.py tests/unit/test_failure_paths.py tests/unit/test_failure_scenarios.py`
- `uv run mypy src`
- `uv run pytest -q` *(fails: TypeError: Orchestrator.run_noexcept() takes 2 positional arguments but 3 were given)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d29982f08333b29731a6173b6d62