### PR TITLE
Document missing test dependencies

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -2,7 +2,7 @@
 
 This document tracks the progress of tasks for the Autoresearch project,
 organized by phases from the code complete plan. As of **August 16, 2025**, `uv run pytest -q`
-aborts before collecting tests (`ModuleNotFoundError: typer`), so coverage is
+aborts before collecting tests (`ModuleNotFoundError: pytest_httpx`), so coverage is
 unavailable. Issue [unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md)
 lists **13 failing unit tests**, and issue
 [refactor-orchestrator-instance-circuit-breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md) documents the underlying refactor. The **0.1.0** release is now targeted for **March 1, 2026**.
@@ -231,7 +231,7 @@ Coverage could not be generated because `pytest` fails to import `fastapi`
 
 ### Latest Test Results
 
-- `uv run pytest --cov=src` aborts with `ModuleNotFoundError: typer`.
+- `uv run pytest --cov=src` aborts with `ModuleNotFoundError: pytest_httpx`.
   See [unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md) for the
   failing test list.
 - `uv run flake8 src tests` fails: `error: Failed to spawn: flake8`.

--- a/issues/environment-setup-gaps.md
+++ b/issues/environment-setup-gaps.md
@@ -5,7 +5,7 @@ The prepared environment again misses key development tools. `task --version`
 returns `command not found`, and `uv pip list | grep flake8` shows no result.
 `which pytest` resolves to `/root/.pyenv/shims/pytest` instead of
 `.venv/bin/pytest`. Running `uv run pytest -q` aborts with
-`ModuleNotFoundError: typer` before collecting tests. Attempting to install
+`ModuleNotFoundError: pytest_httpx` before collecting tests. Attempting to install
 development extras via `uv pip install -e '.[full,dev]'` triggers downloads of
 hundreds of megabytes of GPU-related packages such as `torch` and
 `nvidia-cudnn-cu12`, making setup impractical without prebuilt wheels. These


### PR DESCRIPTION
## Summary
- Detail current environment setup gaps preventing test runs
- Refresh project progress log with latest failing dependency info

## Testing
- `task --version` *(fails: command not found)*
- `uv pip list | grep flake8 || echo 'no flake8'`
- `uv run pytest -q` *(fails: ModuleNotFoundError: pytest_httpx)*
- `uv run flake8 src tests` *(fails: Failed to spawn: flake8)*
- `uv run mypy src` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68a0e6c51ee08333b2b9dafa89ec4174