### PR TITLE
Document current environment and test gaps

### DIFF
--- a/issues/environment-setup-gaps.md
+++ b/issues/environment-setup-gaps.md
@@ -12,6 +12,17 @@ hundreds of megabytes of GPU-related packages such as `torch` and
 symptoms indicate the automated setup scripts and documentation have drifted
 from the expected tooling.
 
+Creating the virtual environment with `uv venv` and installing
+`uv pip install -e '.[dev-minimal]'` now places `pytest`, `flake8`, and
+`mypy` inside `.venv`, and `which pytest` resolves correctly. However,
+Go Task remains unavailable and `ruff` is missing from the default
+installation. Running linting reveals unresolved issues:
+`uv run ruff check --fix src tests` reports `E402` in
+`src/autoresearch/visualization.py`, and `uv run flake8 src tests`
+flags `E701` in `tests/stubs/a2a.py`. Executing `uv run pytest -q`
+produces 181 failures, primarily `TypeError` exceptions in
+Orchestrator-related integration tests, so `task verify` still fails.
+
 ## Acceptance Criteria
 - Go Task is available after running the setup scripts.
 - Development dependencies (e.g., `flake8`, `pytest-bdd`, `pytest-httpx`) install

--- a/issues/lint-errors-in-stubs.md
+++ b/issues/lint-errors-in-stubs.md
@@ -1,0 +1,11 @@
+# Lint errors in stub modules
+
+## Context
+Running `uv run flake8 src tests` and `uv run ruff check --fix src tests` after installing development extras reveals unresolved lint violations. `ruff` reports `E402` in `src/autoresearch/visualization.py`, and flake8 flags `E701` in `tests/stubs/a2a.py`.
+
+## Acceptance Criteria
+- `ruff check` and `flake8` run cleanly.
+- `task verify` succeeds once lint issues are fixed.
+
+## Status
+Open

--- a/issues/unit-tests-after-orchestrator-refactor.md
+++ b/issues/unit-tests-after-orchestrator-refactor.md
@@ -11,9 +11,11 @@ leave tests in an inconsistent state.
   instances per test.
 - Additional failures stem from `tests/stubs/numpy.py` shadowing the real
   `numpy` package after installing full extras.
-- `uv run pytest -q` currently aborts early with `ModuleNotFoundError: typer`,
-  indicating the development environment lacks required dependencies and must
-  be fixed before addressing these failures.
+- After installing development extras, `uv run pytest -q` executes but
+  reports 181 failures in 7m49s. Many integration cases, such as
+  `tests/integration/test_orchestrator_registered_pairs.py::test_orchestrator_all_registered_pairs`
+  and `tests/integration/test_orchestrator_search_storage.py::test_orchestrator_search_storage`,
+  raise `TypeError: Orchestrator.run_query() missing 1 required positional argument: 'config'`.
 
 ## Current Failures
 - `tests/unit/test_additional_coverage.py::test_streamlit_metrics`
@@ -36,6 +38,10 @@ leave tests in an inconsistent state.
   - assert 403 == 200
 - `tests/unit/test_property_storage.py::test_pop_lru_order`
   - AssertionError: assert ['0', '1'] == ['1', '0']
+- `tests/integration/test_orchestrator_registered_pairs.py::test_orchestrator_all_registered_pairs`
+  - TypeError: `Orchestrator.run_query()` missing 1 required positional argument: `config`
+- `tests/integration/test_orchestrator_search_storage.py::test_orchestrator_search_storage`
+  - TypeError: `Orchestrator.run_query()` missing 1 required positional argument: `config`
 
 ## Acceptance Criteria
 - Unit tests are updated to accommodate the instance-level `_cb_manager`.


### PR DESCRIPTION
## Summary
- Capture missing tooling and failing test run results in `environment-setup-gaps` ticket
- Expand Orchestrator refactor ticket with failing integration tests
- Add `lint-errors-in-stubs` ticket to track `ruff` and `flake8` violations

## Testing
- `uv run ruff check --fix src tests` *(fails: E402 in visualization module)*
- `uv run flake8 src tests` *(fails: E701 in tests/stubs/a2a.py)*
- `uv run mypy src`
- `uv run pytest -q` *(181 failed, 577 passed, 30 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e8295b508333a7f1c2db509942d1