### PR TITLE
Fix visualization import order

### DIFF
--- a/issues/environment-setup-gaps.md
+++ b/issues/environment-setup-gaps.md
@@ -16,12 +16,15 @@ Creating the virtual environment with `uv venv` and installing
 `uv pip install -e '.[dev-minimal]'` now places `pytest`, `flake8`, and
 `mypy` inside `.venv`, and `which pytest` resolves correctly. However,
 Go Task remains unavailable and `ruff` is missing from the default
-installation. Running linting reveals unresolved issues:
-`uv run ruff check --fix src tests` reports `E402` in
-`src/autoresearch/visualization.py`, and `uv run flake8 src tests`
-flags `E701` in `tests/stubs/a2a.py`. Executing `uv run pytest -q`
-produces 181 failures, primarily `TypeError` exceptions in
-Orchestrator-related integration tests, so `task verify` still fails.
+installation. Manual steps are also required to add `black` and `isort`.
+Running linting reveals unresolved issues: `uv run ruff check --fix src
+tests` reports `E402` in `src/autoresearch/visualization.py`, and
+`uv run flake8 src tests` flags `E701` in `tests/stubs/a2a.py`.
+Executing `uv run pytest tests/unit/test_cache.py::test_cache_lifecycle -q`
+fails the coverage check (`fail-under=90`) even though the test passes.
+Running the full suite still produces 181 failures, primarily
+`TypeError` exceptions in Orchestrator-related integration tests, so
+`task verify` remains broken.
 
 ## Acceptance Criteria
 - Go Task is available after running the setup scripts.

--- a/issues/lint-errors-in-stubs.md
+++ b/issues/lint-errors-in-stubs.md
@@ -1,7 +1,11 @@
 # Lint errors in stub modules
 
 ## Context
-Running `uv run flake8 src tests` and `uv run ruff check --fix src tests` after installing development extras reveals unresolved lint violations. `ruff` reports `E402` in `src/autoresearch/visualization.py`, and flake8 flags `E701` in `tests/stubs/a2a.py`.
+Running `uv run flake8 src tests` and `uv run ruff check --fix src tests` after installing development extras reveals unresolved
+lint violations. `ruff` reports `E402` in `src/autoresearch/visualization.py`, and flake8 flags `E701` in `tests/stubs/a2a.py`.
+After reordering imports in `visualization.py`, `ruff check src/autoresearch/visualization.py` passes. A fresh `flake8 src tests`
+run does not reproduce the earlier `E701` warning in `tests/stubs/a2a.py`. However, `uv run pytest` continues to fail because
+coverage remains below the required threshold.
 
 ## Acceptance Criteria
 - `ruff check` and `flake8` run cleanly.

--- a/src/autoresearch/visualization.py
+++ b/src/autoresearch/visualization.py
@@ -1,14 +1,14 @@
-from __future__ import annotations
-
 """Utilities for generating graphical representations of query results."""
 
-from typing import Any, Dict
+from __future__ import annotations
 
-import networkx as nx
+from pathlib import Path
+from typing import Any
+
 import matplotlib
 import matplotlib.pyplot as plt
+import networkx as nx
 import rdflib
-from pathlib import Path
 
 from .models import QueryResponse
 
@@ -93,7 +93,7 @@ def save_rdf_graph(
     """
 
     plt.figure(figsize=(8, 6))
-    nodes: Dict[str, int] = {}
+    nodes: dict[str, int] = {}
     idx = 0
     for s, p, o in graph:
         s_str, o_str = str(s), str(o)


### PR DESCRIPTION
## Summary
- resolve ruff E402 by moving visualization imports to module top
- document environment setup gaps and lint progress in issue tickets

## Testing
- `uv run ruff check --fix src/autoresearch/visualization.py tests/stubs/a2a.py`
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit/test_cache.py::test_cache_lifecycle -q` *(fails: Coverage failure: total of 20 is less than fail-under=90)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f337944083338d97229b3c739cf1