### PR TITLE
Align orchestration utils imports

### DIFF
--- a/issues/environment-setup-gaps.md
+++ b/issues/environment-setup-gaps.md
@@ -13,18 +13,14 @@ symptoms indicate the automated setup scripts and documentation have drifted
 from the expected tooling.
 
 Creating the virtual environment with `uv venv` and installing
-`uv pip install -e '.[dev-minimal]'` now places `pytest`, `flake8`, and
-`mypy` inside `.venv`, and `which pytest` resolves correctly. However,
-Go Task remains unavailable and `ruff` is missing from the default
-installation. Manual steps are also required to add `black` and `isort`.
-Running linting reveals unresolved issues: `uv run ruff check --fix src
-tests` reports `E402` in `src/autoresearch/visualization.py`, and
-`uv run flake8 src tests` flags `E701` in `tests/stubs/a2a.py`.
-Executing `uv run pytest tests/unit/test_cache.py::test_cache_lifecycle -q`
-fails the coverage check (`fail-under=90`) even though the test passes.
-Running the full suite still produces 181 failures, primarily
-`TypeError` exceptions in Orchestrator-related integration tests, so
-`task verify` remains broken.
+`uv pip install -e '.[dev-minimal]'` now places `pytest`, `flake8`, `mypy`, and
+`ruff` inside `.venv`, and `which pytest` resolves correctly. However,
+Go Task remains unavailable and manual steps are still required to add `black`
+and `isort`. Running a targeted test such as
+`uv run pytest tests/unit/test_cache.py::test_cache_lifecycle -q` succeeds but
+fails the coverage check (`fail-under=90`). The full test suite continues to
+produce hundreds of failures, primarily `TypeError` exceptions in
+Orchestrator-related integration tests, so `task verify` remains broken.
 
 ## Acceptance Criteria
 - Go Task is available after running the setup scripts.

--- a/issues/lint-errors-in-stubs.md
+++ b/issues/lint-errors-in-stubs.md
@@ -1,11 +1,13 @@
 # Lint errors in stub modules
 
 ## Context
-Running `uv run flake8 src tests` and `uv run ruff check --fix src tests` after installing development extras reveals unresolved
-lint violations. `ruff` reports `E402` in `src/autoresearch/visualization.py`, and flake8 flags `E701` in `tests/stubs/a2a.py`.
-After reordering imports in `visualization.py`, `ruff check src/autoresearch/visualization.py` passes. A fresh `flake8 src tests`
-run does not reproduce the earlier `E701` warning in `tests/stubs/a2a.py`. However, `uv run pytest` continues to fail because
-coverage remains below the required threshold.
+Running `uv run flake8 src tests` and `uv run ruff check --fix src tests` after installing development extras previously revealed
+lint violations. `ruff` reported `E402` in `src/autoresearch/visualization.py`, and flake8 flagged `E701` in `tests/stubs/a2a.py`.
+
+After fixing the import order in `src/autoresearch/orchestration/orchestration_utils.py` and reinstalling dev dependencies,
+`uv run ruff check src tests` and `uv run flake8 src tests` now pass without errors. The test suite still fails because the
+coverage threshold is not met and broader orchestrator tests error, so `task verify` remains blocked by
+[`unit-tests-after-orchestrator-refactor.md`](unit-tests-after-orchestrator-refactor.md).
 
 ## Acceptance Criteria
 - `ruff check` and `flake8` run cleanly.

--- a/issues/unit-tests-after-orchestrator-refactor.md
+++ b/issues/unit-tests-after-orchestrator-refactor.md
@@ -23,7 +23,7 @@ leave tests in an inconsistent state.
 - `tests/unit/test_cache.py::test_search_uses_cache`
   - AttributeError: 'TinyDB' object has no attribute 'truncate'
 - `tests/unit/test_cache.py::test_cache_lifecycle`
-  - AssertionError: assert False
+  - passes but coverage check fails (`fail-under=90`)
 - `tests/unit/test_cache.py::test_cache_is_backend_specific`
   - AttributeError: 'TinyDB' object has no attribute 'truncate'
 - `tests/unit/test_failure_paths.py::test_external_lookup_unknown_backend`

--- a/src/autoresearch/orchestration/orchestration_utils.py
+++ b/src/autoresearch/orchestration/orchestration_utils.py
@@ -1,14 +1,19 @@
-from __future__ import annotations
-
 """Utility helpers for orchestration components.
 
 This module groups functions that were previously attached dynamically to
-:class:`~autoresearch.orchestration.orchestrator.Orchestrator`.  Keeping them in a
+:class:`~autoresearch.orchestration.orchestrator.Orchestrator`. Keeping them in a
 separate utility class makes the helpers easier to import directly in tests and
 other modules without relying on dynamic attribute assignment.
 """
 
+from __future__ import annotations
+
 from .budgeting import _apply_adaptive_token_budget
+from .error_handling import (
+    _apply_recovery_strategy,
+    _categorize_error,
+    _handle_agent_error,
+)
 from .execution import (
     _call_agent_start_callback,
     _check_agent_can_execute,
@@ -23,11 +28,6 @@ from .execution import (
     _log_sources,
     _persist_claims,
     _rotate_list,
-)
-from .error_handling import (
-    _apply_recovery_strategy,
-    _categorize_error,
-    _handle_agent_error,
 )
 from .token_utils import _capture_token_usage, _execute_with_adapter
 from .utils import calculate_result_confidence, get_memory_usage


### PR DESCRIPTION
## Summary
- ensure orchestration utilities follow import order conventions
- document current dev-environment limitations and lint progress in issue tickets

## Testing
- `uv run ruff check src tests`
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit/test_cache.py::test_cache_lifecycle -q` *(fails: Coverage failure: total of 20 is less than fail-under=90)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f51095d8833397ba89d0470a1c66