### PR TITLE
Stub make_filtering_bound_logger

### DIFF
--- a/tests/stubs/structlog.py
+++ b/tests/stubs/structlog.py
@@ -18,9 +18,14 @@ except Exception:  # pragma: no cover - fall back to stub
     def configure(*args, **kwargs):  # noqa: D401 - simple placeholder
         """Stubbed configure function."""
 
+    def make_filtering_bound_logger(level):  # noqa: D401 - simple placeholder
+        """Return the stubbed :class:`BoundLogger` regardless of level."""
+        return BoundLogger
+
     structlog_stub.BoundLogger = BoundLogger
     structlog_stub.get_logger = get_logger
     structlog_stub.configure = configure
+    structlog_stub.make_filtering_bound_logger = make_filtering_bound_logger
     sys.modules["structlog"] = structlog_stub
 else:  # pragma: no cover - real library available
     sys.modules["structlog"] = _structlog


### PR DESCRIPTION
## Summary
- add `make_filtering_bound_logger` to the `structlog` test stub so logging utils can call it without the real library

## Testing
- `pytest tests/integration/test_cli_http.py::test_help_cli -q` *(fails: not found)*
- `pytest tests/integration/test_cli_http.py::test_cli_flow -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68a10912c2c08333b81b41f84ff69253