### PR TITLE
Define TinyDB stub spec and no-op truncate

### DIFF
--- a/tests/stubs/tinydb.py
+++ b/tests/stubs/tinydb.py
@@ -8,6 +8,7 @@ used instead.
 from __future__ import annotations
 
 import importlib
+import importlib.machinery
 import sys
 import types
 from typing import Any, Callable, List, Optional
@@ -68,8 +69,8 @@ except Exception:  # pragma: no cover
         def table(self, name: str) -> "TinyDB":
             return self
 
-        def truncate(self) -> None:
-            self._data.clear()
+        def truncate(self) -> None:  # pragma: no cover - intentionally a no-op
+            """Provide a ``truncate`` method matching TinyDB's interface."""
 
         def drop_tables(self) -> None:
             self._data.clear()
@@ -94,4 +95,5 @@ except Exception:  # pragma: no cover
 
     tinydb_stub.TinyDB = TinyDB
     tinydb_stub.Query = Query
+    tinydb_stub.__spec__ = importlib.machinery.ModuleSpec("tinydb", loader=None)
     sys.modules["tinydb"] = tinydb_stub


### PR DESCRIPTION
## Summary
- ensure tinydb stub reports a module spec so `importlib.util.find_spec` succeeds
- expose a no-op `truncate` method to match TinyDB's interface

## Testing
- `uv run ruff format tests/stubs/tinydb.py`
- `uv run ruff check tests/stubs/tinydb.py`
- `uv run python - <<'PY'\nimport importlib.util, sys, runpy\nsys.modules.pop('tinydb', None)\nsys.path = [p for p in sys.path if 'site-packages' not in p]\nrunpy.run_path('tests/stubs/tinydb.py')\nprint(importlib.util.find_spec('tinydb'))\nPY`
- `uv run pytest tests/unit/test_cache.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a1090e1be083339d1143a5cba49b37