### PR TITLE
Include query text in QueryResponse

### DIFF
--- a/src/autoresearch/models.py
+++ b/src/autoresearch/models.py
@@ -5,9 +5,10 @@ It contains Pydantic models that define the structure of data used throughout th
 particularly for query requests, responses, and related data structures.
 """
 
-from pydantic import BaseModel, Field
-from typing import Any, Dict, List, Optional
 from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
 
 
 class ReasoningMode(str, Enum):
@@ -64,12 +65,14 @@ class QueryResponse(BaseModel):
     It includes the final answer, supporting citations, reasoning steps, and execution metrics.
 
     Attributes:
+        query (Optional[str]): The original query that produced this response.
         answer (str): The final answer to the user's query.
         citations (List[Any]): A list of citations or sources that support the answer.
         reasoning (List[Any]): A list of reasoning steps or explanations that led to the answer.
         metrics (Dict[str, Any]): Performance and execution metrics for the query processing.
     """
 
+    query: Optional[str] = Field(None, description="The original query that produced this response")
     answer: str
     citations: List[Any]
     reasoning: List[Any]
@@ -79,6 +82,4 @@ class QueryResponse(BaseModel):
 class BatchQueryRequest(BaseModel):
     """Request model for executing multiple queries."""
 
-    queries: List[QueryRequest] = Field(
-        ..., description="List of queries to execute sequentially"
-    )
+    queries: List[QueryRequest] = Field(..., description="List of queries to execute sequentially")

--- a/tests/behavior/steps/common_steps.py
+++ b/tests/behavior/steps/common_steps.py
@@ -3,7 +3,7 @@ import os
 import shlex
 
 import pytest
-from pytest_bdd import given, parsers, when, then
+from pytest_bdd import given, parsers, then, when
 
 from autoresearch import cache, tracing
 from autoresearch.agents.registry import AgentRegistry
@@ -116,6 +116,7 @@ def temp_config(tmp_path, monkeypatch, mock_llm_adapter):
 def dummy_query_response(monkeypatch):
     """Provide a deterministic orchestrator result for interface tests."""
     response = QueryResponse(
+        query="test query",
         answer="test answer",
         citations=["source"],
         reasoning=["step"],
@@ -204,18 +205,14 @@ def orchestrator_failure(monkeypatch):
     return _simulate
 
 
-@given(
-    parsers.re(
-        "the (?:Autoresearch )?application is running(?: with default configuration)?"
-    )
-)
+@given(parsers.re("the (?:Autoresearch )?application is running(?: with default configuration)?"))
 def application_running(temp_config):
     """Ensure the application runs with isolated config and mocked LLM."""
     return
 
 
 # Shared CLI step implementations
-@when(parsers.parse('I run `{command}`'))
+@when(parsers.parse("I run `{command}`"))
 def run_cli_command(cli_runner, bdd_context, command, isolate_network, restore_environment):
     args = shlex.split(command)
     if args and args[0] == "autoresearch":


### PR DESCRIPTION
## Summary
- allow QueryResponse to carry the original query string
- update test helper to populate query field

## Testing
- `uv run flake8 src/autoresearch/models.py tests/behavior/steps/common_steps.py`
- `uv run mypy src/autoresearch/models.py`
- `uv run pytest tests/unit/test_failure_scenarios.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a10d6e99dc83338d1ea7f8707f5442