### PR TITLE
Add truncate support to tinydb stub

### DIFF
--- a/tests/stubs/tinydb.py
+++ b/tests/stubs/tinydb.py
@@ -69,8 +69,16 @@ except Exception:  # pragma: no cover
         def table(self, name: str) -> "TinyDB":
             return self
 
-        def truncate(self) -> None:  # pragma: no cover - intentionally a no-op
-            """Provide a ``truncate`` method matching TinyDB's interface."""
+        def truncate(self) -> None:
+            """Remove all documents from the table.
+
+            The real TinyDB ``Table`` class returns ``None`` from
+            :meth:`truncate`, so this stub mirrors that behaviour and clears
+            the in-memory data store.
+            """
+
+            self._data.clear()
+            return None
 
         def drop_tables(self) -> None:
             self._data.clear()


### PR DESCRIPTION
## Summary
- clear TinyDB stub data when truncate is called

## Testing
- `uv run black tests/stubs/tinydb.py`
- `uv run isort tests/stubs/tinydb.py`
- `uv run ruff format tests/stubs/tinydb.py`
- `uv run ruff check --fix tests/stubs/tinydb.py`
- `uv run flake8 tests/stubs/tinydb.py`
- `uv run mypy src`
- `uv run pytest tests/unit/test_cache.py::test_search_uses_cache -q --no-cov`
- `uv run pytest -q --no-cov` *(fails: tests/integration/test_api_streaming.py::test_query_stream_param and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a10d727028833380b8d960b597c1cd