### PR TITLE
Use fresh orchestrators in tests

### DIFF
--- a/tests/integration/test_cli_http.py
+++ b/tests/integration/test_cli_http.py
@@ -38,7 +38,7 @@ class DummyStorage:
 def _patch_run_query(monkeypatch):
     original = Orchestrator.run_query
 
-    def wrapper(query, config, callbacks=None, **kwargs):
+    def wrapper(self, query, config, callbacks=None, **kwargs):
         # Set DummyStorage as the delegate
         from autoresearch.storage import set_delegate
 
@@ -46,6 +46,7 @@ def _patch_run_query(monkeypatch):
 
         try:
             return original(
+                self,
                 query,
                 config,
                 callbacks,

--- a/tests/integration/test_config_hot_reload.py
+++ b/tests/integration/test_config_hot_reload.py
@@ -137,7 +137,7 @@ def test_config_hot_reload(tmp_path, monkeypatch):
     with loader.watching(on_change):
         loader.load_config()
         events.append((loader.config.agents, loader.config.search.backends))
-        Orchestrator.run_query("q", loader.config)
+        Orchestrator().run_query("q", loader.config)
         cfg_file.write_text(
             tomli_w.dumps(
                 {
@@ -152,7 +152,7 @@ def test_config_hot_reload(tmp_path, monkeypatch):
         repo.index.add([str(cfg_file)])
         repo.index.commit("update config")
         time.sleep(0.1)
-        Orchestrator.run_query("q", loader.config)
+        Orchestrator().run_query("q", loader.config)
 
     assert calls == ["AgentA", "AgentB"]
     assert stored == ["AgentA", "AgentB"]

--- a/tests/integration/test_config_hot_reload_components.py
+++ b/tests/integration/test_config_hot_reload_components.py
@@ -129,7 +129,7 @@ def test_config_hot_reload_components(tmp_path, monkeypatch):
     with loader.watching(on_change):
         loader.load_config()
         events.append((loader.config.agents, loader.config.search.backends))
-        Orchestrator.run_query("q", loader.config)
+        Orchestrator().run_query("q", loader.config)
         cfg_file.write_text(
             tomli_w.dumps(
                 {
@@ -144,7 +144,7 @@ def test_config_hot_reload_components(tmp_path, monkeypatch):
         repo.index.add([str(cfg_file)])
         repo.index.commit("update config")
         time.sleep(0.1)
-        Orchestrator.run_query("q", loader.config)
+        Orchestrator().run_query("q", loader.config)
 
     assert calls == ["AgentA", "AgentB"]
     assert search_calls == ["b1", "b2"]
@@ -237,7 +237,7 @@ def test_config_hot_reload_search_weights_and_storage(tmp_path, monkeypatch):
             loader.config.storage.duckdb_path,
         )
     )
-    Orchestrator.run_query("q", loader.config)
+    Orchestrator().run_query("q", loader.config)
     cfg_file.write_text(
         tomli_w.dumps(
             {
@@ -256,7 +256,7 @@ def test_config_hot_reload_search_weights_and_storage(tmp_path, monkeypatch):
     repo.index.add([str(cfg_file)])
     repo.index.commit("update config")
     time.sleep(0.2)
-    Orchestrator.run_query("q", loader.config)
+    Orchestrator().run_query("q", loader.config)
     loader.stop_watching()
 
     assert weights == [(0.7, 0.2, 0.1), (0.2, 0.7, 0.1)]

--- a/tests/integration/test_end_to_end_user_flows.py
+++ b/tests/integration/test_end_to_end_user_flows.py
@@ -87,7 +87,7 @@ def test_end_to_end_successful_flow(monkeypatch):
 
     cfg = ConfigModel(agents=["Searcher", "Synthesizer"], loops=1)
 
-    resp = Orchestrator.run_query("q", cfg)
+    resp = Orchestrator().run_query("q", cfg)
 
     assert isinstance(resp, QueryResponse)
     assert calls == ["Searcher", "Synthesizer"]
@@ -112,7 +112,7 @@ def test_end_to_end_search_failure(monkeypatch):
     cfg = ConfigModel(agents=["Searcher"], loops=1, max_errors=1)
 
     with pytest.raises(OrchestrationError) as exc:
-        Orchestrator.run_query("q", cfg)
+        Orchestrator().run_query("q", cfg)
 
     assert calls == ["Searcher"]
     assert stored == []

--- a/tests/integration/test_orchestrator_all_agent_combinations.py
+++ b/tests/integration/test_orchestrator_all_agent_combinations.py
@@ -72,7 +72,7 @@ def test_orchestrator_all_agent_combinations(monkeypatch, agents):
     monkeypatch.setattr(Orchestrator, "_capture_token_usage", no_token_capture)
 
     cfg = ConfigModel(agents=list(agents), loops=1)
-    response = Orchestrator.run_query("q", cfg)
+    response = Orchestrator().run_query("q", cfg)
 
     assert isinstance(response, QueryResponse)
     assert calls == list(agents)

--- a/tests/integration/test_orchestrator_all_pairings.py
+++ b/tests/integration/test_orchestrator_all_pairings.py
@@ -53,7 +53,7 @@ def test_orchestrator_all_agent_pairings(monkeypatch, agents):
     monkeypatch.setattr(Orchestrator, "_capture_token_usage", no_token_capture)
 
     cfg = ConfigModel(agents=list(agents), loops=1)
-    response = Orchestrator.run_query("q", cfg)
+    response = Orchestrator().run_query("q", cfg)
 
     assert isinstance(response, QueryResponse)
     assert calls == list(agents)

--- a/tests/integration/test_orchestrator_combinations.py
+++ b/tests/integration/test_orchestrator_combinations.py
@@ -79,7 +79,7 @@ def test_orchestrator_agent_combinations(monkeypatch, agents):
     )
 
     cfg = ConfigModel(agents=list(agents), loops=1)
-    response = Orchestrator.run_query("q", cfg)
+    response = Orchestrator().run_query("q", cfg)
     assert isinstance(response, QueryResponse)
     assert calls == list(agents)
     assert search_calls == calls
@@ -119,7 +119,7 @@ def test_orchestrator_agent_pairings(monkeypatch, agents):
     )
 
     cfg = ConfigModel(agents=list(agents), loops=1)
-    response = Orchestrator.run_query("q", cfg)
+    response = Orchestrator().run_query("q", cfg)
     assert isinstance(response, QueryResponse)
     assert calls == list(agents)
     assert search_calls == calls
@@ -170,7 +170,7 @@ def test_orchestrator_failure_modes(monkeypatch, agents, fail_index):
 
     cfg = ConfigModel(agents=list(agents), loops=1, max_errors=1)
     with pytest.raises(OrchestrationError):
-        Orchestrator.run_query("q", cfg)
+        Orchestrator().run_query("q", cfg)
 
     failing_agent = agents[fail_index]
     if failing_agent == "Synthesizer":

--- a/tests/integration/test_orchestrator_combinations_complete.py
+++ b/tests/integration/test_orchestrator_combinations_complete.py
@@ -66,7 +66,7 @@ def test_all_agent_pairs(monkeypatch, agents):
     cfg.loops = 1
     cfg.enable_feedback = True
 
-    response = Orchestrator.run_query("q", cfg)
+    response = Orchestrator().run_query("q", cfg)
     assert isinstance(response, QueryResponse)
     assert response.answer
 
@@ -87,6 +87,6 @@ def test_registered_coalitions(monkeypatch, coalition):
     cfg.loops = 1
     cfg.enable_feedback = True
 
-    response = Orchestrator.run_query("q", cfg)
+    response = Orchestrator().run_query("q", cfg)
     assert isinstance(response, QueryResponse)
     assert response.answer

--- a/tests/integration/test_orchestrator_registered_pairs.py
+++ b/tests/integration/test_orchestrator_registered_pairs.py
@@ -42,7 +42,7 @@ def test_orchestrator_all_registered_pairs(monkeypatch, pair):
     cfg = ConfigModel(agents=pair, loops=1)
 
     # Execute
-    response = Orchestrator.run_query("q", cfg)
+    response = Orchestrator().run_query("q", cfg)
 
     # Verify
     assert isinstance(response, QueryResponse)

--- a/tests/integration/test_orchestrator_search_storage.py
+++ b/tests/integration/test_orchestrator_search_storage.py
@@ -56,7 +56,7 @@ def test_orchestrator_search_storage(monkeypatch):
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader()._config = None
 
-    resp = Orchestrator.run_query("q", cfg)
+    resp = Orchestrator().run_query("q", cfg)
     assert isinstance(resp, QueryResponse)
     assert calls == ["TestAgent"]
     assert stored == [
@@ -124,7 +124,7 @@ def test_orchestrator_multiple_agents_aggregate_results(monkeypatch):
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader()._config = None
 
-    resp = Orchestrator.run_query("q", cfg)
+    resp = Orchestrator().run_query("q", cfg)
     assert isinstance(resp, QueryResponse)
     assert calls == ["Searcher", "Synthesizer"]
     assert stored == [
@@ -157,8 +157,8 @@ def test_orchestrator_persists_across_queries(monkeypatch):
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader()._config = None
 
-    resp1 = Orchestrator.run_query("q1", cfg)
-    resp2 = Orchestrator.run_query("q2", cfg)
+    resp1 = Orchestrator().run_query("q1", cfg)
+    resp2 = Orchestrator().run_query("q2", cfg)
 
     assert isinstance(resp1, QueryResponse)
     assert isinstance(resp2, QueryResponse)
@@ -230,7 +230,7 @@ def test_orchestrator_uses_config_context(config_context, monkeypatch):
     cfg.agents = ["Searcher", "Synthesizer"]
     cfg.loops = 1
 
-    resp = Orchestrator.run_query("q", cfg)
+    resp = Orchestrator().run_query("q", cfg)
 
     assert isinstance(resp, QueryResponse)
     assert calls == ["Searcher", "Synthesizer"]

--- a/tests/integration/test_query_latency_memory_tokens.py
+++ b/tests/integration/test_query_latency_memory_tokens.py
@@ -42,7 +42,7 @@ def test_query_latency_memory_tokens(monkeypatch, token_baseline):
 
     memory_before = StorageManager._current_ram_mb()
     start = time.perf_counter()
-    response = Orchestrator.run_query("q", cfg)
+    response = Orchestrator().run_query("q", cfg)
     latency = time.perf_counter() - start
     memory_after = StorageManager._current_ram_mb()
 

--- a/tests/integration/test_query_performance.py
+++ b/tests/integration/test_query_performance.py
@@ -71,7 +71,7 @@ def test_query_performance(monkeypatch) -> None:
 
     _, mem_before = get_metrics()
     start = time.perf_counter()
-    response = Orchestrator.run_query("performance test query", cfg)
+    response = Orchestrator().run_query("performance test query", cfg)
     latency = time.perf_counter() - start
     _, mem_after = get_metrics()
 

--- a/tests/integration/test_query_performance_benchmark.py
+++ b/tests/integration/test_query_performance_benchmark.py
@@ -86,7 +86,7 @@ def test_token_budget_limit(monkeypatch, token_baseline):
     ConfigLoader()._config = None
 
     # Execute
-    response = Orchestrator.run_query("q", cfg)
+    response = Orchestrator().run_query("q", cfg)
     tokens = response.metrics["execution_metrics"]["agent_tokens"]
 
     token_baseline(tokens)

--- a/tests/integration/test_simple_orchestration.py
+++ b/tests/integration/test_simple_orchestration.py
@@ -38,7 +38,7 @@ def test_orchestrator_run_query(monkeypatch):
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader()._config = None
 
-    response = Orchestrator.run_query("q", cfg)
+    response = Orchestrator().run_query("q", cfg)
     assert isinstance(response, QueryResponse)
     assert calls == ["Synthesizer"]
     assert response.answer == "Answer from Synthesizer"

--- a/tests/integration/test_token_budget_benchmark.py
+++ b/tests/integration/test_token_budget_benchmark.py
@@ -39,7 +39,7 @@ def test_token_usage_budget_regression(monkeypatch, token_baseline):
         api=SimpleNamespace(role_permissions={"anonymous": ["query"]}),
     )
 
-    Orchestrator.run_query("q", cfg)
+    Orchestrator().run_query("q", cfg)
     tokens = {"Dummy": {"in": 3, "out": 8}}
 
     token_baseline(tokens)

--- a/tests/integration/test_token_usage_integration.py
+++ b/tests/integration/test_token_usage_integration.py
@@ -44,7 +44,7 @@ def test_token_usage_matches_baseline(monkeypatch, token_baseline):
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader()._config = None
 
-    response = Orchestrator.run_query("q", cfg)
+    response = Orchestrator().run_query("q", cfg)
     tokens = response.metrics["execution_metrics"]["agent_tokens"]
 
     baseline = json.loads(BASELINE_PATH.read_text())

--- a/tests/integration/test_token_usage_regression.py
+++ b/tests/integration/test_token_usage_regression.py
@@ -43,7 +43,7 @@ def test_token_usage_regression(monkeypatch):
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader()._config = None
 
-    response = Orchestrator.run_query("q", cfg)
+    response = Orchestrator().run_query("q", cfg)
     tokens = response.metrics["execution_metrics"]["agent_tokens"]
     total_tokens = sum(v.get("in", 0) + v.get("out", 0) for v in tokens.values())
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,18 +1,26 @@
 import pytest
 from types import SimpleNamespace
+from typing import Callable
 
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.orchestration import metrics
 
 
 @pytest.fixture
-def orchestrator_runner():
+def orchestrator_factory():
     """Return a factory for creating fresh ``Orchestrator`` instances."""
 
     def _factory() -> Orchestrator:
         return Orchestrator()
 
     return _factory
+
+
+@pytest.fixture
+def orchestrator(orchestrator_factory: Callable[[], Orchestrator]) -> Orchestrator:
+    """Provide a fresh ``Orchestrator`` instance for each test."""
+
+    return orchestrator_factory()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_agent_communication.py
+++ b/tests/unit/test_agent_communication.py
@@ -46,7 +46,7 @@ def test_agent_registry_coalitions():
     assert AgentRegistry.get_coalition("squad") == ["Simple"]
 
 
-def test_orchestrator_handles_coalitions(monkeypatch, tmp_path, orchestrator_runner):
+def test_orchestrator_handles_coalitions(monkeypatch, tmp_path, orchestrator):
     AgentFactory.register("A1", SimpleAgent)
     AgentFactory.register("A2", SimpleAgent)
     cfg = ConfigModel.model_construct(
@@ -84,7 +84,7 @@ def test_orchestrator_handles_coalitions(monkeypatch, tmp_path, orchestrator_run
     monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", str(tmp_path / "rel.json"))
     monkeypatch.setenv("AUTORESEARCH_QUERY_TOKENS", str(tmp_path / "qt.json"))
 
-    orchestrator_runner().run_query("q", cfg)
+    orchestrator.run_query("q", cfg)
 
     assert executed == ["A1", "A2"]
 

--- a/tests/unit/test_api_error_handling.py
+++ b/tests/unit/test_api_error_handling.py
@@ -23,10 +23,10 @@ def _setup(monkeypatch):
     return cfg
 
 
-def test_query_endpoint_runtime_error(monkeypatch, orchestrator_runner):
+def test_query_endpoint_runtime_error(monkeypatch, orchestrator):
     _setup(monkeypatch)
 
-    orch = orchestrator_runner()
+    orch = orchestrator
 
     def raise_error(q, c, callbacks=None):
         raise RuntimeError("fail")
@@ -41,9 +41,9 @@ def test_query_endpoint_runtime_error(monkeypatch, orchestrator_runner):
     assert data["metrics"]["error"] == "fail"
 
 
-def test_query_endpoint_invalid_response(monkeypatch, orchestrator_runner):
+def test_query_endpoint_invalid_response(monkeypatch, orchestrator):
     _setup(monkeypatch)
-    orch = orchestrator_runner()
+    orch = orchestrator
     monkeypatch.setattr(orch, "run_query", lambda q, c, callbacks=None: {"foo": "bar"})
     monkeypatch.setattr("autoresearch.api.routing.create_orchestrator", lambda: orch)
     client = TestClient(app)

--- a/tests/unit/test_cli_visualize.py
+++ b/tests/unit/test_cli_visualize.py
@@ -25,10 +25,10 @@ def test_summary_table_render():
     assert "1" in output
 
 
-def test_search_visualize_option(monkeypatch, dummy_storage, orchestrator_runner):
+def test_search_visualize_option(monkeypatch, dummy_storage, orchestrator):
     runner = CliRunner()
 
-    orch = orchestrator_runner()
+    orch = orchestrator
     run_query_mock = MagicMock(
         return_value=QueryResponse(
             answer="ok", citations=[], reasoning=[], metrics={"m": 1}

--- a/tests/unit/test_coalition_execution.py
+++ b/tests/unit/test_coalition_execution.py
@@ -16,7 +16,7 @@ class DummyAgent:
         return {}
 
 
-def test_coalition_agents_run_together(monkeypatch, tmp_path, orchestrator_runner):
+def test_coalition_agents_run_together(monkeypatch, tmp_path, orchestrator):
     record = []
     AgentFactory._registry.clear()
 
@@ -36,7 +36,7 @@ def test_coalition_agents_run_together(monkeypatch, tmp_path, orchestrator_runne
     monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", str(tmp_path / "rel.json"))
     monkeypatch.setenv("AUTORESEARCH_QUERY_TOKENS", str(tmp_path / "qt.json"))
 
-    orchestrator_runner().run_query("q", cfg)
+    orchestrator.run_query("q", cfg)
 
     assert set(record[:2]) == {"A", "B"}
 

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -16,10 +16,10 @@ main_app = importlib.import_module("autoresearch.main.app")  # noqa: E402
 from autoresearch.models import QueryResponse  # noqa: E402
 
 
-def test_search_default_output_tty(monkeypatch, mock_run_query, orchestrator_runner):
+def test_search_default_output_tty(monkeypatch, mock_run_query, orchestrator):
     runner = CliRunner()
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    orch = orchestrator_runner()
+    orch = orchestrator
     monkeypatch.setattr(orch, "run_query", MethodType(mock_run_query, orch))
     monkeypatch.setattr(main_app, "Orchestrator", lambda: orch)
     result = runner.invoke(app, ["search", "q"])
@@ -27,11 +27,11 @@ def test_search_default_output_tty(monkeypatch, mock_run_query, orchestrator_run
     assert "# Answer" in result.stdout
 
 
-def test_search_default_output_json(monkeypatch, mock_run_query, orchestrator_runner):
+def test_search_default_output_json(monkeypatch, mock_run_query, orchestrator):
     runner = CliRunner()
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
-    orch = orchestrator_runner()
+    orch = orchestrator
     monkeypatch.setattr(orch, "run_query", MethodType(mock_run_query, orch))
     monkeypatch.setattr(main_app, "Orchestrator", lambda: orch)
     result = runner.invoke(app, ["search", "q"])
@@ -41,7 +41,7 @@ def test_search_default_output_json(monkeypatch, mock_run_query, orchestrator_ru
 
 @pytest.mark.parametrize("mode", ["direct", "dialectical"])
 def test_search_reasoning_mode_option(
-    monkeypatch, mode, config_loader, orchestrator_runner
+    monkeypatch, mode, config_loader, orchestrator
 ):
     runner = CliRunner()
 
@@ -61,7 +61,7 @@ def test_search_reasoning_mode_option(
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
     monkeypatch.setattr(main_app, "_config_loader", config_loader)
-    orch = orchestrator_runner()
+    orch = orchestrator
     monkeypatch.setattr(orch, "run_query", MethodType(_run, orch))
     monkeypatch.setattr(main_app, "Orchestrator", lambda: orch)
 
@@ -71,7 +71,7 @@ def test_search_reasoning_mode_option(
     assert captured["mode"].value == mode
 
 
-def test_search_primus_start_option(monkeypatch, config_loader, orchestrator_runner):
+def test_search_primus_start_option(monkeypatch, config_loader, orchestrator):
     runner = CliRunner()
 
     captured = {}
@@ -90,7 +90,7 @@ def test_search_primus_start_option(monkeypatch, config_loader, orchestrator_run
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
     monkeypatch.setattr(main_app, "_config_loader", config_loader)
-    orch = orchestrator_runner()
+    orch = orchestrator
     monkeypatch.setattr(orch, "run_query", MethodType(_run, orch))
     monkeypatch.setattr(main_app, "Orchestrator", lambda: orch)
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -14,14 +14,14 @@ class DummyConn:
         return self
 
 
-def test_metrics_collection_and_endpoint(monkeypatch, orchestrator_runner):
+def test_metrics_collection_and_endpoint(monkeypatch, orchestrator):
     monkeypatch.setattr(duckdb, "connect", lambda *a, **k: DummyConn())
 
     cfg = ConfigModel.model_construct(api=APIConfig())
     cfg.api.role_permissions["anonymous"] = ["query", "metrics"]
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader.reset_instance()
-    orch = orchestrator_runner()
+    orch = orchestrator
 
     def fake_run_query(query, config, callbacks=None, **kwargs):
         metrics.record_query()

--- a/tests/unit/test_orchestrator_cb_manager.py
+++ b/tests/unit/test_orchestrator_cb_manager.py
@@ -1,7 +1,7 @@
 from autoresearch.config.models import ConfigModel
 
 
-def test_circuit_breaker_state_is_instance_isolated(monkeypatch, orchestrator_runner):
+def test_circuit_breaker_state_is_instance_isolated(monkeypatch, orchestrator_factory):
     cfg = ConfigModel(loops=1, agents=["Synthesizer"])
 
     call = {"count": 0}
@@ -27,8 +27,8 @@ def test_circuit_breaker_state_is_instance_isolated(monkeypatch, orchestrator_ru
         fail_first,
     )
 
-    o1 = orchestrator_runner()
-    o2 = orchestrator_runner()
+    o1 = orchestrator_factory()
+    o2 = orchestrator_factory()
 
     o1.run_query("q", cfg)
     o2.run_query("q", cfg)

--- a/tests/unit/test_orchestrator_messages.py
+++ b/tests/unit/test_orchestrator_messages.py
@@ -23,7 +23,7 @@ class Receiver(Agent):
         return {"results": {"received": content}}
 
 
-def test_agents_exchange_messages(monkeypatch, orchestrator_runner):
+def test_agents_exchange_messages(monkeypatch, orchestrator):
     cfg = ConfigModel(agents=["Sender", "Receiver"], loops=1, enable_agent_messages=True)
 
     def get_agent(name):
@@ -33,7 +33,7 @@ def test_agents_exchange_messages(monkeypatch, orchestrator_runner):
 
     monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", "/tmp/release_tokens.json")
     monkeypatch.setenv("AUTORESEARCH_QUERY_TOKENS", "/tmp/query_tokens.json")
-    resp = orchestrator_runner().run_query("test", cfg)
+    resp = orchestrator.run_query("test", cfg)
 
     assert resp.answer == "No answer synthesized"
     assert resp.metrics["delivered_messages"]["Receiver"][0]["content"] == "ping"

--- a/tests/unit/test_orchestrator_order.py
+++ b/tests/unit/test_orchestrator_order.py
@@ -19,7 +19,7 @@ class DummyAgent:
         return {}
 
 
-def test_custom_agents_order(orchestrator_runner):
+def test_custom_agents_order(orchestrator):
     record = []
 
     def get_agent(name):
@@ -30,12 +30,12 @@ def test_custom_agents_order(orchestrator_runner):
         "autoresearch.orchestration.orchestrator.AgentFactory.get",
         side_effect=get_agent,
     ):
-        orchestrator_runner().run_query("q", cfg)
+        orchestrator.run_query("q", cfg)
 
     assert record == ["A1", "A2", "A3"]
 
 
-def test_async_custom_agents_concurrent(orchestrator_runner):
+def test_async_custom_agents_concurrent(orchestrator):
     record = []
 
     def get_agent(name):
@@ -46,8 +46,8 @@ def test_async_custom_agents_concurrent(orchestrator_runner):
         "autoresearch.orchestration.orchestrator.AgentFactory.get",
         side_effect=get_agent,
     ):
-        orchestrator = orchestrator_runner()
-        asyncio.run(orchestrator.run_query_async("q", cfg, concurrent=True))
+        orch = orchestrator
+        asyncio.run(orch.run_query_async("q", cfg, concurrent=True))
 
     assert sorted(record) == ["A1", "A2", "A3"]
 

--- a/tests/unit/test_parallel_module.py
+++ b/tests/unit/test_parallel_module.py
@@ -43,7 +43,7 @@ def test_calculate_result_confidence():
     assert 0.5 <= score <= 1.0
 
 
-def test_execute_parallel_query_basic(monkeypatch, orchestrator_runner):
+def test_execute_parallel_query_basic(monkeypatch, orchestrator_factory):
     cfg = ConfigModel.model_construct(agents=[], loops=1)
 
     class DummySpan:
@@ -86,8 +86,8 @@ def test_execute_parallel_query_basic(monkeypatch, orchestrator_runner):
             metrics={"token_usage": {"total": 10, "max_tokens": 100}, "errors": []},
         )
 
-    orc1 = orchestrator_runner()
-    orc2 = orchestrator_runner()
+    orc1 = orchestrator_factory()
+    orc2 = orchestrator_factory()
     mock1 = MagicMock(side_effect=run_query_stub)
     mock2 = MagicMock(side_effect=run_query_stub)
     monkeypatch.setattr(orc1, "run_query", mock1)
@@ -122,7 +122,7 @@ def test_execute_parallel_query_basic(monkeypatch, orchestrator_runner):
     assert mock1.called and mock2.called
 
 
-def test_execute_parallel_query_agent_error(monkeypatch, caplog, orchestrator_runner):
+def test_execute_parallel_query_agent_error(monkeypatch, caplog, orchestrator_factory):
     cfg = ConfigModel.model_construct(agents=[], loops=1)
 
     class DummySpan:
@@ -160,7 +160,7 @@ def test_execute_parallel_query_agent_error(monkeypatch, caplog, orchestrator_ru
     ):
         raise AgentError("boom", agent_name="A")
 
-    orc = orchestrator_runner()
+    orc = orchestrator_factory()
     mock_run = MagicMock(side_effect=run_query_error)
     monkeypatch.setattr(orc, "run_query", mock_run)
 

--- a/tests/unit/test_reasoning_modes.py
+++ b/tests/unit/test_reasoning_modes.py
@@ -17,7 +17,7 @@ class DummyAgent:
         return {}
 
 
-def _run(cfg, orchestrator_runner):
+def _run(cfg, orchestrator_factory):
     record = []
 
     def get_agent(name):
@@ -27,24 +27,24 @@ def _run(cfg, orchestrator_runner):
         "autoresearch.orchestration.orchestrator.AgentFactory.get",
         side_effect=get_agent,
     ):
-        orchestrator_runner().run_query("q", cfg)
+        orchestrator_factory().run_query("q", cfg)
 
     return record
 
 
-def test_direct_mode_executes_once(orchestrator_runner):
+def test_direct_mode_executes_once(orchestrator_factory):
     cfg = ConfigModel(loops=3, reasoning_mode=ReasoningMode.DIRECT)
-    record = _run(cfg, orchestrator_runner)
+    record = _run(cfg, orchestrator_factory)
     assert record == ["Synthesizer"]
 
 
-def test_chain_of_thought_mode_loops(orchestrator_runner):
+def test_chain_of_thought_mode_loops(orchestrator_factory):
     cfg = ConfigModel(loops=2, reasoning_mode=ReasoningMode.CHAIN_OF_THOUGHT)
-    record = _run(cfg, orchestrator_runner)
+    record = _run(cfg, orchestrator_factory)
     assert record == ["Synthesizer", "Synthesizer"]
 
 
-def test_chain_of_thought_records_steps(orchestrator_runner):
+def test_chain_of_thought_records_steps(orchestrator_factory):
     cfg = ConfigModel(loops=3, reasoning_mode=ReasoningMode.CHAIN_OF_THOUGHT)
 
     class DummySynth:
@@ -73,7 +73,7 @@ def test_chain_of_thought_records_steps(orchestrator_runner):
         "autoresearch.orchestration.orchestrator.AgentFactory.get",
         return_value=agent,
     ):
-        resp = orchestrator_runner().run_query("q", cfg)
+        resp = orchestrator_factory().run_query("q", cfg)
 
     steps = [c["content"] for c in resp.reasoning]
     assert steps == ["step-1", "step-2", "step-3"]

--- a/tests/unit/test_token_budget_heuristic.py
+++ b/tests/unit/test_token_budget_heuristic.py
@@ -2,7 +2,7 @@ from autoresearch.config.models import ConfigModel
 from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 
 
-def test_token_budget_adjustment(monkeypatch, orchestrator_runner):
+def test_token_budget_adjustment(monkeypatch, orchestrator):
     recorded = {}
 
     def fake_execute_cycle(
@@ -30,6 +30,6 @@ def test_token_budget_adjustment(monkeypatch, orchestrator_runner):
         update={"group_size": 2, "total_groups": 2, "total_agents": 3}
     )
 
-    orchestrator_runner().run_query("q", cfg)
+    orchestrator.run_query("q", cfg)
 
     assert recorded["budget"] == 13


### PR DESCRIPTION
## Summary
- provide fixtures that create new `Orchestrator` instances per test
- update tests to invoke `run_query` with explicit config on a fresh orchestrator
- ensure coverage plugin runs during unit tests

## Testing
- `uv run pytest tests/unit -q` *(fails: assert 403 == 200; coverage 66.61% < 90%)*

------
https://chatgpt.com/codex/tasks/task_e_68a10d6ac540833390bffa621c315a36