### PR TITLE
Document missing packages and Python mismatch

### DIFF
--- a/issues/environment-setup-gaps.md
+++ b/issues/environment-setup-gaps.md
@@ -27,6 +27,12 @@ After manually installing `pytest-bdd`, `pytest-httpx`, `pytest-cov`, and
 `tests/behavior/steps/api_async_query_steps.py::test_async_query_result`
 because the async status response lacks an "answer" field.
 
+Subsequent test attempts surface additional `ModuleNotFoundError`
+failures for runtime dependencies such as `uvicorn` and `psutil`.
+The active environment also provides Python 3.11 even though project
+documentation specifies Python 3.12 or newer, further complicating
+setup.
+
 ## Acceptance Criteria
 - Go Task is available after running the setup scripts.
 - Development dependencies (e.g., `flake8`, `pytest-bdd`, `pytest-httpx`) install


### PR DESCRIPTION
## Summary
- record missing runtime packages like uvicorn and psutil in environment setup issue
- note mismatch between Python 3.12 requirement and Python 3.11 environment

## Testing
- `uv run pytest -q` *(fails: No module named 'pytest_httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68a12372f0988333ab4ec29cde94a3c8