### PR TITLE
Use asyncio tasks for background queries

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -182,7 +182,9 @@ curl -X DELETE http://localhost:8000/config
 
 ### `POST /query/async`
 
-Run a query in the background and return an identifier.
+Run a query in the background and return an identifier. Queries are
+scheduled as `asyncio.Task` objects within the server's event loop, and the
+task ID can be used to poll for completion or cancel the work.
 
 ```bash
 curl -X POST http://localhost:8000/query/async \
@@ -221,13 +223,16 @@ When complete:
 
 ### `DELETE /query/<id>`
 
-Cancel a running asynchronous query and remove it from the server.
+Cancel a running asynchronous query and remove it from the server. The task is
+cancelled using `Task.cancel()` and deleted from the in-memory registry.
 
 ```bash
 curl -X DELETE http://localhost:8000/query/<id>
 ```
 
-Returns `{"status": "cancelled"}` when the task is terminated or `{"status": "finished"}` if it already completed. Unknown IDs return **404**.
+Returns `canceled` when the task is terminated. If the query already
+completed, the task will have been removed and the endpoint responds with
+**404**.
 
  
 

--- a/tests/behavior/steps/reasoning_mode_api_steps.py
+++ b/tests/behavior/steps/reasoning_mode_api_steps.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import patch
 
 from pytest_bdd import given, parsers, scenario, then, when
@@ -223,10 +224,10 @@ def send_async_query(test_context: dict, query: str, mode: str, config: ConfigMo
                 "state": state,
             }
         query_id = submit.json()["query_id"]
-        future = client.app.state.async_tasks.get(query_id)
-        if future is not None:
-            while not future.done():
-                pass
+        task = client.app.state.async_tasks.get(query_id)
+        assert isinstance(task, asyncio.Task)
+        while not task.done():
+            pass
         response = client.get(f"/query/{query_id}")
     state["active"] = False
     data = {}


### PR DESCRIPTION
## Summary
- replace thread-based async query runner with `asyncio.create_task`
- track background queries by `asyncio.Task` for simpler status checks
- update API docs and behavior tests for task-based execution

## Testing
- `uv run black src/autoresearch/api/routing.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/reasoning_mode_api_steps.py`
- `uv run isort src/autoresearch/api/routing.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/reasoning_mode_api_steps.py`
- `uv run ruff format src/autoresearch/api/routing.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/reasoning_mode_api_steps.py`
- `uv run ruff check --fix src/autoresearch/api/routing.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/reasoning_mode_api_steps.py`
- `uv run flake8 src/autoresearch/api/routing.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/reasoning_mode_api_steps.py`
- `uv run mypy src` *(fails: Error importing plugin "pydantic.mypy"))*
- `uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_httpx')*
- `uv run pytest tests/behavior` *(fails: KeyboardInterrupt importing numpy)*
- `uv run pytest --cov=src` *(fails: ModuleNotFoundError: No module named 'pytest_httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68a139b8d7a08333a5fe26d9a9666b00