### PR TITLE
Refactor search and orchestration state

### DIFF
--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -187,17 +187,19 @@ class Search:
     @classmethod
     @contextmanager
     def temporary_state(cls) -> Iterator[type["Search"]]:
-        """Provide a context-managed Search with isolated state."""
-        original_backends = dict(cls.backends)
-        original_embedding_backends = dict(cls.embedding_backends)
-        original_model = cls._sentence_transformer
+        """Yield a Search subclass with isolated state."""
+        TempSearch = type("TempSearch", (cls,), {})
+        TempSearch.backends = dict(cls.backends)
+        TempSearch.embedding_backends = dict(cls.embedding_backends)
+        TempSearch._default_backends = dict(cls._default_backends)
+        TempSearch._default_embedding_backends = dict(
+            cls._default_embedding_backends
+        )
+        TempSearch._sentence_transformer = None
         try:
-            yield cls
+            yield TempSearch
         finally:
-            cls.backends = original_backends
-            cls.embedding_backends = original_embedding_backends
-            cls._sentence_transformer = original_model
-            cls.close_http_session()
+            TempSearch.close_http_session()
 
     @classmethod
     def get_sentence_transformer(cls) -> Optional[SentenceTransformerType]:

--- a/tests/unit/test_agent_registry.py
+++ b/tests/unit/test_agent_registry.py
@@ -15,22 +15,25 @@ class DummyAgent(Agent):
 
 
 def test_register_and_get_cached_instance():
-    AgentFactory.register("Dummy", DummyAgent)
-    agent1 = AgentFactory.get("Dummy")
-    agent2 = AgentFactory.get("Dummy")
-    assert isinstance(agent1, DummyAgent)
-    assert agent1 is agent2
-    assert "Dummy" in AgentRegistry.list_available()
+    with AgentRegistry.temporary_state(), AgentFactory.temporary_state():
+        AgentFactory.register("Dummy", DummyAgent)
+        agent1 = AgentFactory.get("Dummy")
+        agent2 = AgentFactory.get("Dummy")
+        assert isinstance(agent1, DummyAgent)
+        assert agent1 is agent2
+        assert "Dummy" in AgentRegistry.list_available()
 
 
 def test_get_unknown_agent_raises():
-    with pytest.raises(ValueError):
-        AgentFactory.get("Missing")
+    with AgentRegistry.temporary_state(), AgentFactory.temporary_state():
+        with pytest.raises(ValueError):
+            AgentFactory.get("Missing")
 
 
 def test_reset_instances(monkeypatch):
-    AgentFactory.register("Dummy", DummyAgent)
-    agent1 = AgentFactory.get("Dummy")
-    AgentFactory.reset_instances()
-    agent2 = AgentFactory.get("Dummy")
-    assert agent1 is not agent2
+    with AgentRegistry.temporary_state(), AgentFactory.temporary_state():
+        AgentFactory.register("Dummy", DummyAgent)
+        agent1 = AgentFactory.get("Dummy")
+        AgentFactory.reset_instances()
+        agent2 = AgentFactory.get("Dummy")
+        assert agent1 is not agent2

--- a/tests/unit/test_failure_scenarios.py
+++ b/tests/unit/test_failure_scenarios.py
@@ -28,28 +28,28 @@ def _make_cfg(backends):
 def test_external_lookup_network_failure(monkeypatch):
     def failing_backend(query, max_results):
         raise requests.exceptions.RequestException("fail")
-
-    Search.backends["fail"] = failing_backend
-    cfg = _make_cfg(["fail"])
-    monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
-    with pytest.raises(SearchError) as exc:
-        Search.external_lookup("q", max_results=1)
-    assert isinstance(exc.value.__cause__, requests.exceptions.RequestException)
-    Search.backends.pop("fail")
+    with Search.temporary_state() as search:
+        search.backends["fail"] = failing_backend
+        cfg = _make_cfg(["fail"])
+        monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
+        with pytest.raises(SearchError) as exc:
+            search.external_lookup("q", max_results=1)
+        assert isinstance(exc.value.__cause__, requests.exceptions.RequestException)
 
 
 def test_external_lookup_unknown_backend(monkeypatch):
-    cfg = _make_cfg(["missing"])
-    monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
-    Search.backends.pop("missing", None)
-    monkeypatch.setattr(
-        "autoresearch.search.core.get_cached_results",
-        lambda *_, **__: (_ for _ in ()).throw(
-            AssertionError("cache lookup should not occur for unknown backends")
-        ),
-    )
-    with pytest.raises(SearchError):
-        Search.external_lookup("q", max_results=1)
+    with Search.temporary_state() as search:
+        cfg = _make_cfg(["missing"])
+        monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
+        search.backends.pop("missing", None)
+        monkeypatch.setattr(
+            "autoresearch.search.core.get_cached_results",
+            lambda *_, **__: (_ for _ in ()).throw(
+                AssertionError("cache lookup should not occur for unknown backends")
+            ),
+        )
+        with pytest.raises(SearchError):
+            search.external_lookup("q", max_results=1)
 
 
 def test_external_lookup_fallback(monkeypatch):

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -15,6 +15,7 @@ class DummyConn:
 
 
 def test_metrics_collection_and_endpoint(monkeypatch, orchestrator):
+    metrics.reset_metrics()
     monkeypatch.setattr(duckdb, "connect", lambda *a, **k: DummyConn())
 
     cfg = ConfigModel.model_construct(api=APIConfig())


### PR DESCRIPTION
## Summary
- isolate search registries through a temporary state subclass
- add reset and context managers for agent and metrics registries
- adapt unit tests to the new instance-based APIs

## Testing
- `uv run pytest tests/unit -q` *(fails: ModuleNotFoundError: No module named 'tomli_w')*

------
https://chatgpt.com/codex/tasks/task_e_68a139b3eecc8333826fc7ff5f1ef0ca