### PR TITLE
Document metrics permission and update tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,9 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   - Run the entire suite with coverage: `uv run pytest --cov=src`.
   - Execute any targeted tests in `tests/targeted` separately and fold them into the
     main test directories once validated.
+- Requests to the `/metrics` endpoint must include an API key mapped to a role
+  with the `metrics` permission (the default `admin` role works). Tests hitting
+  this endpoint should set the `X-API-Key` header accordingly.
 - Before running any tests, install the development extras with
   `uv pip install -e '.[full,parsers,git,llm,dev]'`. These extras are required
   for full test runs, including integration and behavior tests.

--- a/README.md
+++ b/README.md
@@ -204,10 +204,15 @@ Then send a request with the helper client:
 from autoresearch.mcp_interface import query
 print(query("What is quantum computing?")["answer"])
 ```
-Send a query and check collected metrics:
+Send a query and check collected metrics. The `/metrics` endpoint requires an
+API key whose role grants the `metrics` permission (the built-in `admin` role
+includes it):
 ```bash
-curl -X POST http://localhost:8000/query -d '{"query": "Explain machine learning"}' -H "Content-Type: application/json"
-curl http://localhost:8000/metrics
+curl -X POST http://localhost:8000/query \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: secret" \
+  -d '{"query": "Explain machine learning"}'
+curl -H "X-API-Key: secret" http://localhost:8000/metrics
 ```
 
 To search your own documents or repositories, enable the `local_file` or

--- a/tests/unit/test_main_monitor_commands.py
+++ b/tests/unit/test_main_monitor_commands.py
@@ -29,7 +29,7 @@ def test_serve_a2a_command(mock_a2a_interface_class):
 
     assert result.exit_code == 0
     mock_a2a_interface_class.assert_called_once_with(host="localhost", port=8765)
-    assert "Starting A2A server" in result.stdout
+    assert "Starting A2A server on localhost:8765" in result.stdout
 
 
 @patch("autoresearch.a2a_interface.A2AInterface")

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -17,8 +17,9 @@ class DummyConn:
 def test_metrics_collection_and_endpoint(monkeypatch, orchestrator):
     monkeypatch.setattr(duckdb, "connect", lambda *a, **k: DummyConn())
 
-    cfg = ConfigModel.model_construct(api=APIConfig())
-    cfg.api.role_permissions["anonymous"] = ["query", "metrics"]
+    cfg = ConfigModel.model_construct(
+        api=APIConfig(api_keys={"secret": "admin"})
+    )
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader.reset_instance()
     orch = orchestrator
@@ -60,7 +61,7 @@ def test_metrics_collection_and_endpoint(monkeypatch, orchestrator):
     )
 
     client = TestClient(app)
-    headers = {"X-API-Key": ""}
+    headers = {"X-API-Key": "secret"}
     client.post("/query", headers=headers, json={"query": "hi"})
 
     assert metrics.QUERY_COUNTER._value.get() == start_queries + 1


### PR DESCRIPTION
## Summary
- clarify that metrics endpoint requires API key with `metrics` permission
- check for host and port in serve-a2a CLI output
- send API key when testing metrics collection endpoint

## Testing
- `flake8 src tests/unit/test_metrics.py tests/unit/test_main_monitor_commands.py`
- `mypy src` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `python -m pytest tests/unit/test_main_monitor_commands.py::test_serve_a2a_command tests/unit/test_metrics.py::test_metrics_collection_and_endpoint -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a139985e888333bf2c55a6da22cbfc