### PR TITLE
Refine setup scripts and env guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,15 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
       - Run `uv sync --all-extras` followed by `uv pip install -e .` for the standard setup.
       - Use `uv pip install -e '.[full,dev]'` only to reinstall dependencies if tools are missing or `uv sync` is unavailable.
   - When modifying `pyproject.toml`, regenerate the lock file with `uv lock` before reinstalling.
-  - Codex environments run `scripts/codex_setup.sh`, which delegates to `scripts/setup.sh` and installs all dev dependencies and extras with `uv sync --all-extras` so tools like `flake8`, `mypy`, and `pytest` are available and real rate limits are enforced. The setup script installs [Go Task](https://taskfile.dev) inside the virtual environment. After setup, ensure `task`, `flake8`, and `pytest` resolve to paths under `.venv/bin`.
-  - Confirm dev tools are installed with `uv pip list | grep flake8`.
+    - Codex environments run `scripts/codex_setup.sh`, which delegates to `scripts/setup.sh` and installs all dev dependencies and extras with `uv sync --all-extras` so tools like `flake8`, `mypy`, and `pytest` are available and real rate limits are enforced. The setup script installs [Go Task](https://taskfile.dev) inside the virtual environment. After setup, ensure `task`, `flake8`, and `pytest` resolve to paths under `.venv/bin`.
+    - Confirm dev tools are installed with `uv pip list | grep flake8`.
+    - Verify each CLI tool runs from the virtual environment:
+      - `task --version`
+      - `flake8 --version`
+      - `pytest --version`
+      - `mypy --version`
+      If any command is missing, rerun `scripts/codex_setup.sh` or reinstall
+      with `uv sync --all-extras && uv pip install -e .`.
   - After running `scripts/codex_setup.sh`, verify `pytest`, `pytest-bdd`, `pytest-httpx`, `pytest-cov`, `flake8`, `hypothesis`, `tomli_w`, `freezegun`, `duckdb-extension-vss`, `a2a-sdk`, `GitPython`, `pdfminer-six`, `python-docx`, `sentence-transformers`, `transformers`, `spacy`, `bertopic`, `fastapi`, `responses`, `uvicorn`, and `psutil` are present using `uv pip list`.
 - `VECTOR_EXTENSION_PATH` selects the DuckDB vector search extension. Tests
     must either disable the `vector_extension` entirely or point this variable
@@ -72,6 +79,13 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
   must run inside this environment.
 - Verify the environment by running `which pytest` and ensure it resolves
   to `.venv/bin/pytest`.
+- Confirm tool availability and versions:
+  - `task --version`
+  - `flake8 --version`
+  - `mypy --version`
+  - `pytest --version`
+  If any command fails, reinstall with `uv sync --all-extras` or rerun
+  `scripts/codex_setup.sh`.
 - Run `task verify` before committing; it performs linting, type checking,
   and all tests with coverage (see [`Taskfile.yml`](Taskfile.yml)).
 - Generate explicit coverage reports with `task coverage`.

--- a/issues/environment-setup-gaps.md
+++ b/issues/environment-setup-gaps.md
@@ -33,6 +33,20 @@ The active environment also provides Python 3.11 even though project
 documentation specifies Python 3.12 or newer, further complicating
 setup.
 
+## 2025-08-17
+- Ran `scripts/codex_setup.sh` after removing `.venv`.
+  - Go Task, `flake8`, `mypy`, and `pytest` installed in `.venv`.
+  - Setup failed to download the DuckDB VSS extension due to network
+    errors but continued with a stub.
+- `task verify` executed `flake8`, `mypy`, and unit tests; one test
+  failed: `tests/unit/test_metrics.py::test_metrics_collection_and_endpoint`
+  returned 403.
+- Dev tools resolve inside the virtual environment:
+  - `task --version` → `3.44.1`
+  - `flake8 --version` → `7.3.0`
+  - `mypy --version` → `1.17.1`
+  - `pytest --version` → `8.4.1`
+
 ## Acceptance Criteria
 - Go Task is available after running the setup scripts.
 - Development dependencies (e.g., `flake8`, `pytest-bdd`, `pytest-httpx`) install

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -114,13 +114,18 @@ uv run python scripts/smoke_test.py
 
 # Verify required CLI tools resolve inside the virtual environment
 source .venv/bin/activate
-for cmd in task flake8 pytest; do
+for cmd in task flake8 pytest mypy; do
     cmd_path=$(command -v "$cmd" || true)
     if [[ "$cmd_path" != "$VIRTUAL_ENV"/* ]]; then
         echo "$cmd is not resolved inside .venv: $cmd_path" >&2
         deactivate
         exit 1
     fi
+    "$cmd" --version >/dev/null 2>&1 || {
+        echo "$cmd failed to run" >&2
+        deactivate
+        exit 1
+    }
 done
 deactivate
 


### PR DESCRIPTION
## Summary
- add explicit Python 3.12 detection and CLI checks for task, flake8, pytest, and mypy
- ensure spaCy downloads have pip and list mypy as required dev dependency
- expand AGENTS environment setup and verification guidance; record setup results in issue

## Testing
- `./scripts/codex_setup.sh` *(fails: Could not establish connection while downloading DuckDB extensions)*
- `task verify` *(fails: tests/unit/test_metrics.py::test_metrics_collection_and_endpoint returned 403)*
- `task --version`
- `flake8 --version`
- `mypy --version`
- `pytest --version`


------
https://chatgpt.com/codex/tasks/task_e_68a1394f6e0c8333b1a62c52201188a3