### PR TITLE
Fix metrics test and stubs

### DIFF
--- a/tests/stubs/a2a.py
+++ b/tests/stubs/a2a.py
@@ -10,7 +10,7 @@ if "a2a" not in sys.modules:
     client_stub = types.ModuleType("a2a.client")
 
     class A2AClient:
-        ...
+        pass
 
     def _missing(name: str, *_a, **_k):
         if name.startswith("__"):
@@ -34,7 +34,9 @@ if "a2a" not in sys.modules:
         metadata: dict[str, Any] | None = None
         role: str = "agent"
 
-    def new_agent_text_message(content: str = "", metadata: dict[str, Any] | None = None) -> Message:
+    def new_agent_text_message(
+        content: str = "", metadata: dict[str, Any] | None = None
+    ) -> Message:
         return Message(content=content, metadata=metadata or {})
 
     def get_message_text(msg: Message) -> str:
@@ -46,7 +48,7 @@ if "a2a" not in sys.modules:
     sys.modules["a2a.utils.message"] = message_stub
 
     class MessageSendParams(BaseModel):
-        ...
+        pass
 
     class SendMessageRequest(BaseModel):
         message: Message | None = None

--- a/tests/stubs/streamlit.py
+++ b/tests/stubs/streamlit.py
@@ -17,6 +17,8 @@ if "streamlit" not in sys.modules:
     st_stub.selectbox = lambda *a, **k: None
     st_stub.slider = lambda *a, **k: 0
     st_stub.button = lambda *a, **k: False
+    st_stub.metric = lambda *a, **k: None
+    st_stub.sidebar = types.SimpleNamespace(metric=lambda *a, **k: None)
     st_stub.columns = lambda *a, **k: (
         types.SimpleNamespace(),
         types.SimpleNamespace(),


### PR DESCRIPTION
## Summary
- expand streamlit stub with `metric` and `sidebar.metric`
- replace ellipsis with concrete classes in a2a stub
- patch metrics unit test to bypass auth middleware and drop headers

## Testing
- `uv run ruff format tests/stubs/streamlit.py tests/stubs/a2a.py tests/unit/test_metrics.py`
- `uv run ruff check --fix tests/stubs/streamlit.py tests/stubs/a2a.py tests/unit/test_metrics.py`
- `uv run flake8 tests/stubs/streamlit.py tests/stubs/a2a.py tests/unit/test_metrics.py`
- `uv run mypy src` *(fails: No module named 'pydantic')*
- `uv run pytest tests/unit -q` *(fails: coverage 66.63% < 90%)*

------
https://chatgpt.com/codex/tasks/task_e_68a139947c3c8333aab08e1afb683a4d