### PR TITLE
Clarify issue style and slugged filenames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,8 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 ## Issue tracking
 - Track work items in the `/issues` directory.
 - If the issue tracker directory moves or is renamed, update this section to reference the new location.
-- Tickets use the template and naming rules in [`issues/README.md`](issues/README.md).
-- File names are slugged titles without numeric prefixes.
-- Do not include numeric identifiers in ticket titles or content; reference tickets by slugged filenames.
+- Tickets follow the template and style guide in [`issues/README.md`](issues/README.md).
+- File names must be slugged titles; numeric identifiers in filenames or content are prohibited. Reference issues by slugged filename.
 - When work is finished, set `Status` to `Archived` and move the ticket to `/issues/archive/` without renaming.
 - When issue tooling changes, update this file, `issues/AGENTS.md`, and `scripts/codex_setup.sh` to keep documentation and setup aligned.
 

--- a/issues/AGENTS.md
+++ b/issues/AGENTS.md
@@ -2,8 +2,9 @@
 
 Follow these rules when managing in-repo tickets.
 
-- Use the template and naming conventions in [README.md](README.md).
-- File names are slugged titles with no numeric prefixes.
+- Use the template and naming conventions in [issues/README.md](README.md).
+- File names must be slugged titles; numeric identifiers in filenames or
+  ticket content are prohibited. Reference issues by slugged filename.
 - Open tickets stay in this directory. Move completed ones to `archive/`
   with `Status` set to `Archived` and do not rename them.
 - Keep this file and the repository root `AGENTS.md` current when issue

--- a/issues/README.md
+++ b/issues/README.md
@@ -3,7 +3,7 @@
 This directory holds planning tickets. Write each issue in the following format:
 
 ```
-# Title of the issue
+# Title in sentence case
 
 ## Context
 Describe background and motivation.
@@ -14,6 +14,12 @@ List the requirements for completion.
 ## Status
 Open
 ```
+
+## Style guide
+
+- Titles are written in **sentence case**.
+- Include the `Context`, `Acceptance Criteria`, and `Status` sections with
+  those exact headings.
 
 ## Naming
 File names must be slugged (kebab-case) titles with no numeric prefixes.


### PR DESCRIPTION
## Summary
- document sentence-case titles and required sections for issues
- cross-link AGENTS files to issues/README.md and forbid numeric IDs

## Testing
- `uv run black --check .` *(fails: would reformat 198 files)*
- `uv run isort --check-only .` *(fails: imports incorrectly sorted in multiple files)*
- `uv run ruff format --check src tests` *(fails: 149 files would be reformatted)*
- `uv run ruff check src tests`
- `uv run flake8 src tests` *(fails: flake8 not found)*
- `uv run mypy src` *(fails: missing pydantic plugin)*
- `uv run pytest -q` *(fails: ModuleNotFoundError: pytest_httpx)*
- `uv run pytest tests/behavior -q` *(fails: ModuleNotFoundError: pytest_httpx)*
- `uv run pytest --cov=src` *(fails: ModuleNotFoundError: pytest_httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68a147d729148333a94d284d646a4f06