### PR TITLE
Refresh roadmap and track current test failures

### DIFF
--- a/CODE_COMPLETE_PLAN.md
+++ b/CODE_COMPLETE_PLAN.md
@@ -3,6 +3,14 @@
 
 Based on a thorough analysis of the Autoresearch codebase, I've developed a comprehensive plan to bring the project to completion. This plan addresses all aspects of the system, from core functionality to testing and documentation.
 
+## Status
+
+As of **August 24, 2025**, Autoresearch targets an **0.1.0-alpha.1** preview
+on **November 15, 2025** and a final **0.1.0** release on **March 1, 2026**.
+Failing tests and documentation gaps remain open; see
+[resolve-current-test-failures](issues/resolve-current-test-failures.md) and
+[update-release-documentation](issues/update-release-documentation.md).
+
 ## 1. Core System Completion
 
 ### 1.1 Orchestration System

--- a/README.md
+++ b/README.md
@@ -12,16 +12,22 @@ Autoresearch is currently in the **Development** phase preparing for the
 upcoming **0.1.0** release. The version is defined in
 `autoresearch.__version__` and mirrored in `pyproject.toml`, but it has
 **not** been published yet. The first official release was originally
-planned for **July 20, 2025**, but the schedule slipped. Running `task
-coverage` on **August 14, 2025** fails in
-`tests/unit/test_main_config_commands.py::test_config_init_command_force`,
-so coverage is not generated and integration and behavior suites are
-skipped. `task verify` also fails in
-`tests/unit/test_eviction.py::test_lru_eviction_order`. Packaging checks
-and documentation continue, so the milestone is now targeted for
-**November 15, 2025**. Remaining blockers include these failing tests
-(issues [refactor-orchestrator-instance-circuit-breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md) and [unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md)), missing coverage, and packaging scripts that
-need additional configuration. See
+planned for **July 20, 2025**, but the schedule slipped. `uv run flake8
+src tests` now fails in
+`src/autoresearch/orchestration/metrics.py:102:1` (E303) and `uv run mypy
+src` reports missing attributes in `src/autoresearch/search/core.py`.
+`uv run pytest -q` fails in
+`tests/unit/test_cache.py::test_search_uses_cache`,
+`tests/unit/test_cache.py::test_cache_is_backend_specific`,
+`tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure`,
+`tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt`,
+and `tests/unit/test_metrics.py::test_metrics_collection_and_endpoint`, so
+coverage is not generated and integration and behavior suites are
+skipped. An **0.1.0-alpha.1** preview is scheduled for **November 15,
+2025**, with the final **0.1.0** milestone targeted for **March 1, 2026**.
+Remaining blockers include these failing tests
+([resolve-current-test-failures](issues/resolve-current-test-failures.md))
+and packaging scripts that need additional configuration. See
 [docs/release_plan.md](docs/release_plan.md) for the full milestone
 schedule and outstanding tasks.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,20 +1,20 @@
 # Autoresearch Roadmap
 
 This roadmap summarizes planned features for upcoming releases. Dates and milestones align with the [release plan](docs/release_plan.md).
-Last updated **August 17, 2025**.
-Phase 2 testing tasks are complete: `uv run flake8 src tests`,
-`uv run mypy src`, and `uv run pytest -m 'not requires_nlp' -q` all pass after
-installing development extras, enabling coverage generation. To collect
-feedback while related issues
-([refactor-orchestrator-instance-circuit-breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md),
-[unit-tests-after-orchestrator-refactor](issues/archive/unit-tests-after-orchestrator-refactor.md))
-remain archived, an alpha pre-release precedes the final 0.1.0 milestone.
+Last updated **August 24, 2025**.
+Phase 2 testing tasks remain incomplete: `uv run flake8 src tests` reports
+E303 in `src/autoresearch/orchestration/metrics.py:102:1`, `uv run mypy src`
+raises attribute errors in `src/autoresearch/search/core.py`, and `uv run
+pytest -q` fails in multiple unit tests. To collect feedback while these
+issues
+([resolve-current-test-failures](issues/resolve-current-test-failures.md))
+are addressed, an alpha pre-release precedes the final 0.1.0 milestone.
 ## Milestones
 
 | Version | Target Date | Key Goals |
 | ------- | ----------- | --------- |
-| 0.1.0-alpha.1 | 2025-11-15 | Alpha preview to gather feedback while testing settles ([refactor-orchestrator-instance-circuit-breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md), [unit-tests-after-orchestrator-refactor](issues/archive/unit-tests-after-orchestrator-refactor.md)) |
-| 0.1.0 | 2026-03-01 | Finalize packaging, docs and CI checks with tests passing ([refactor-orchestrator-instance-circuit-breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md), [unit-tests-after-orchestrator-refactor](issues/archive/unit-tests-after-orchestrator-refactor.md)) |
+| 0.1.0-alpha.1 | 2025-11-15 | Alpha preview to gather feedback while testing settles ([resolve-current-test-failures](issues/resolve-current-test-failures.md)) |
+| 0.1.0 | 2026-03-01 | Finalize packaging, docs and CI checks with tests passing ([resolve-current-test-failures](issues/resolve-current-test-failures.md), [update-release-documentation](issues/update-release-documentation.md)) |
 | 0.1.1 | 2026-05-15 | Bug fixes and documentation updates |
 | 0.2.0 | 2026-08-01 | API stabilization, configuration hot-reload, improved search backends |
 | 0.3.0 | 2026-10-15 | Distributed execution support, monitoring utilities |
@@ -23,10 +23,9 @@ remain archived, an alpha pre-release precedes the final 0.1.0 milestone.
 ## 0.1.0-alpha.1 – Alpha preview
 
 This pre-release provides an early package for testing while packaging tasks
-remain open. Related issues
-([refactor-orchestrator-instance-circuit-breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md),
-[unit-tests-after-orchestrator-refactor](issues/archive/unit-tests-after-orchestrator-refactor.md)) are archived. Key activities
-include:
+remain open. Related issue
+([resolve-current-test-failures](issues/resolve-current-test-failures.md)) is
+open. Key activities include:
 
 - Provide an installable package for early adopters.
 - Collect feedback while fixing failing tests and packaging issues.
@@ -41,10 +40,12 @@ activities include:
 - Finalizing API reference and user guides.
 - Verifying packaging metadata and TestPyPI uploads.
 
-Unit tests now pass, so integration and behavior suites can run and coverage
-reports are generated. The release was originally planned for **July 20, 2025**, but
-the schedule slipped. The **0.1.0** milestone is now targeted for **March 1, 2026**
-while packaging tasks are resolved.
+Unit tests still fail (see
+[resolve-current-test-failures](issues/resolve-current-test-failures.md)),
+so integration and behavior suites remain blocked and coverage reports are
+not generated. The release was originally planned for **July 20, 2025**, but
+the schedule slipped. The **0.1.0** milestone is now targeted for **March 1,
+2026** while packaging tasks are resolved.
 
 ## 0.1.1 – Bug fixes and documentation updates
 

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,13 +1,16 @@
 # Autoresearch Project - Task Progress
 
 This document tracks the progress of tasks for the Autoresearch project,
-organized by phases from the code complete plan. After installing missing
-testing dependencies (`pytest-bdd`, `pytest-httpx`, `pytest-cov`, and `tomli_w`),
-the behavior test suite runs but the first failure occurs in
-`test_async_query_result` where the async status response lacks an "answer"
-field. Issue [unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md)
-lists **13 failing unit tests**, and issue
-[refactor-orchestrator-instance-circuit-breaker](issues/archive/refactor-orchestrator-instance-circuit-breaker.md) documents the underlying refactor. The **0.1.0** release is now targeted for **March 1, 2026**.
+organized by phases from the code complete plan. After installing development
+extras with `uv sync --all-extras`, `uv run flake8 src tests` fails in
+`src/autoresearch/orchestration/metrics.py:102:1`, `uv run mypy src` reports six
+attribute errors in `src/autoresearch/search/core.py`, and `uv run pytest -q`
+fails in `tests/unit/test_cache.py::test_search_uses_cache`,
+`tests/unit/test_cache.py::test_cache_is_backend_specific`,
+`tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure`,
+`tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt`,
+and `tests/unit/test_metrics.py::test_metrics_collection_and_endpoint`. The
+**0.1.0** release is now targeted for **March 1, 2026**.
 
 ## Phase 1: Core System Completion (Weeks 1-2)
 
@@ -72,30 +75,30 @@ lists **13 failing unit tests**, and issue
 
 ### 2.2 Integration Tests
 
-- [ ] Complete cross-component integration tests [#1](issues/archive/0001-complete-cross-component-integration-tests.md)
-  - [ ] Test orchestrator with all agent combinations [#2](issues/archive/0002-test-orchestrator-with-all-agent-combinations.md)
-  - [ ] Verify storage integration with search functionality [#3](issues/archive/0003-verify-storage-integration-with-search-functionality.md)
-  - [ ] Test configuration hot-reload with all components [#4](issues/archive/0004-test-configuration-hot-reload-with-all-components.md)
-  - [ ] Add performance tests [#5](issues/archive/0005-add-performance-tests.md)
-  - [ ] Implement benchmarks for query processing time [#6](issues/archive/0006-implement-benchmarks-for-query-processing-time.md)
-  - [ ] Test memory usage under various conditions [#7](issues/archive/0007-test-memory-usage-under-various-conditions.md)
-  - [ ] Verify token usage optimization [#8](issues/archive/0008-verify-token-usage-optimization.md)
-  - [ ] Monitor token usage regressions automatically [#9](issues/archive/0009-monitor-token-usage-regressions-automatically.md)
+- [ ] Complete cross-component integration tests [complete-cross-component-integration-tests](issues/archive/complete-cross-component-integration-tests.md)
+  - [ ] Test orchestrator with all agent combinations [test-orchestrator-with-all-agent-combinations](issues/archive/test-orchestrator-with-all-agent-combinations.md)
+  - [ ] Verify storage integration with search functionality [verify-storage-integration-with-search-functionality](issues/archive/verify-storage-integration-with-search-functionality.md)
+  - [ ] Test configuration hot-reload with all components [test-configuration-hot-reload-with-all-components](issues/archive/test-configuration-hot-reload-with-all-components.md)
+  - [ ] Add performance tests [add-performance-tests](issues/archive/add-performance-tests.md)
+  - [ ] Implement benchmarks for query processing time [implement-benchmarks-for-query-processing-time](issues/archive/implement-benchmarks-for-query-processing-time.md)
+  - [ ] Test memory usage under various conditions [test-memory-usage-under-various-conditions](issues/archive/test-memory-usage-under-various-conditions.md)
+  - [ ] Verify token usage optimization [verify-token-usage-optimization](issues/archive/verify-token-usage-optimization.md)
+  - [ ] Monitor token usage regressions automatically [monitor-token-usage-regressions-automatically](issues/archive/monitor-token-usage-regressions-automatically.md)
 
-Issues #1–#9 remain open and require further work.
+These integration test issues remain open and require further work.
 
 ### 2.3 Behavior Tests
 
-- [ ] Complete BDD test scenarios [#10](issues/archive/0010-complete-bdd-test-scenarios.md)
-  - [ ] Add scenarios for all user-facing features [#11](issues/archive/0011-add-scenarios-for-all-user-facing-features.md)
-  - [ ] Test all reasoning modes with realistic queries [#12](issues/archive/0012-test-all-reasoning-modes-with-realistic-queries.md)
-  - [ ] Verify error handling and recovery [#13](issues/archive/0013-verify-error-handling-and-recovery.md)
-- [ ] Enhance test step definitions [#14](issues/archive/0014-enhance-test-step-definitions.md)
-  - [ ] Add more detailed assertions [#15](issues/archive/0015-add-more-detailed-assertions.md)
-  - [ ] Implement better test isolation [#16](issues/archive/0016-implement-better-test-isolation.md)
-  - [ ] Create more comprehensive test contexts [#17](issues/archive/0017-create-more-comprehensive-test-contexts.md)
+- [ ] Complete BDD test scenarios [complete-bdd-test-scenarios](issues/archive/complete-bdd-test-scenarios.md)
+  - [ ] Add scenarios for all user-facing features [add-scenarios-for-all-user-facing-features](issues/archive/add-scenarios-for-all-user-facing-features.md)
+  - [ ] Test all reasoning modes with realistic queries [test-all-reasoning-modes-with-realistic-queries](issues/archive/test-all-reasoning-modes-with-realistic-queries.md)
+  - [ ] Verify error handling and recovery [verify-error-handling-and-recovery](issues/archive/verify-error-handling-and-recovery.md)
+- [ ] Enhance test step definitions [enhance-test-step-definitions](issues/archive/enhance-test-step-definitions.md)
+  - [ ] Add more detailed assertions [add-more-detailed-assertions](issues/archive/add-more-detailed-assertions.md)
+  - [ ] Implement better test isolation [implement-better-test-isolation](issues/archive/implement-better-test-isolation.md)
+  - [ ] Create more comprehensive test contexts [create-more-comprehensive-test-contexts](issues/archive/create-more-comprehensive-test-contexts.md)
 
-Issues #10–#17 remain open until the test suite passes.
+These behavior test issues remain open until the test suite passes.
 
 ### 4.1 Code Documentation
 
@@ -228,21 +231,21 @@ Issues #10–#17 remain open until the test suite passes.
 
 ### Coverage Report
 
-Coverage could not be generated because `pytest` fails to import `fastapi`
-(see [unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md)).
+Coverage could not be generated because `uv run pytest -q` reports
+failures; see [resolve-current-test-failures](issues/resolve-current-test-failures.md).
 
 ### Latest Test Results
 
-- Installed missing test dependencies (`pytest-bdd`, `pytest-httpx`,
-  `pytest-cov`, and `tomli_w`).
-- `uv run pytest tests/behavior -q --maxfail=1` fails:
-  `tests/behavior/steps/api_async_query_steps.py::test_async_query_result`
-  asserts `data.get("answer")` is `None`.
-- `uv run pytest --cov=src` continues to fail; see
-  [unit-tests-after-orchestrator-refactor](issues/unit-tests-after-orchestrator-refactor.md)
-  for the failing test list.
-- `uv run flake8 src tests` fails: `error: Failed to spawn: flake8`.
-- `uv run mypy src` fails to load `pydantic.mypy` (`No module named 'pydantic'`).
+- `uv run flake8 src tests` reports:
+  `src/autoresearch/orchestration/metrics.py:102:1: E303 too many blank lines (4)`.
+- `uv run mypy src` reports six attribute errors in
+  `src/autoresearch/search/core.py`.
+- `uv run pytest -q` fails:
+  - `tests/unit/test_cache.py::test_search_uses_cache` – `SearchError: Unknown search backend 'dummy'`
+  - `tests/unit/test_cache.py::test_cache_is_backend_specific` – `SearchError: Unknown search backend 'b1'`
+  - `tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure` – `assert False`
+  - `tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt` – `assert 130 == 0`
+  - `tests/unit/test_metrics.py::test_metrics_collection_and_endpoint` – `assert 403 == 200`
 
 ### Performance Baselines
 

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -3,20 +3,21 @@
 This document outlines the upcoming release milestones for **Autoresearch**. Dates are aspirational and may shift as development progresses. The publishing workflow follows the steps in [deployment.md](deployment.md).
 
 The project kicked off in **May 2025** (see the initial commit dated `2025-05-18`).
-This schedule was last updated on **August 17, 2025** and reflects the fact that
+This schedule was last updated on **August 24, 2025** and reflects the fact that
 the codebase currently sits at the **unreleased 0.1.0a1** version defined in
 `autoresearch.__version__`.
-Phase 2 testing tasks are now complete: `uv run flake8 src tests`, `uv run mypy src`,
-and `uv run pytest -m 'not requires_nlp' -q` all pass after installing development
-extras, enabling coverage generation. Phase 3 (stabilization/testing/documentation)
+Phase 2 testing tasks remain incomplete: `uv run flake8 src tests` reports
+`src/autoresearch/orchestration/metrics.py:102:1: E303`, `uv run mypy src`
+raises attribute errors in `src/autoresearch/search/core.py`, and `uv run
+pytest -q` fails in several unit tests. Phase 3 (stabilization/testing/documentation)
 and Phase 4 activities remain planned.
 
 ## Milestones
 
 | Version | Target Date | Key Goals |
 | ------- | ----------- | --------- |
-| **0.1.0-alpha.1** | 2025-11-15 | Alpha preview to gather feedback while testing settles ([refactor-orchestrator-instance-circuit-breaker](../issues/archive/refactor-orchestrator-instance-circuit-breaker.md), [unit-tests-after-orchestrator-refactor](../issues/archive/unit-tests-after-orchestrator-refactor.md)) |
-| **0.1.0** | 2026-03-01 | Finalize packaging, docs and CI checks with tests passing ([refactor-orchestrator-instance-circuit-breaker](../issues/archive/refactor-orchestrator-instance-circuit-breaker.md), [unit-tests-after-orchestrator-refactor](../issues/archive/unit-tests-after-orchestrator-refactor.md)) |
+| **0.1.0-alpha.1** | 2025-11-15 | Alpha preview to gather feedback while testing settles ([resolve-current-test-failures](../issues/resolve-current-test-failures.md)) |
+| **0.1.0** | 2026-03-01 | Finalize packaging, docs and CI checks with tests passing ([resolve-current-test-failures](../issues/resolve-current-test-failures.md), [update-release-documentation](../issues/update-release-documentation.md)) |
 | **0.1.1** | 2026-05-15 | Bug fixes and documentation updates |
 | **0.2.0** | 2026-08-01 | API stabilization, configuration hot-reload, improved search backends |
 | **0.3.0** | 2026-10-15 | Distributed execution support, monitoring utilities |
@@ -29,14 +30,16 @@ now set for **March 1, 2026** while packaging tasks are resolved.
 
 The following tasks remain before publishing **0.1.0**:
 
-- [x] Resolve flake8 errors and failing tests listed in [unit-tests-after-orchestrator-refactor](../issues/archive/unit-tests-after-orchestrator-refactor.md); `uv run flake8 src tests`, `uv run mypy src`, and `uv run pytest -m 'not requires_nlp' -q` now pass, enabling `task coverage` to reach ≥90% total coverage.
+- [ ] Resolve flake8 errors and failing tests ([resolve-current-test-failures](../issues/resolve-current-test-failures.md)); `uv run flake8 src tests`, `uv run mypy src`, and `uv run pytest -q` currently fail.
 - [ ] Install optional dependencies with `uv pip install -e '.[full,parsers,git,llm,dev]'` so the full unit, integration and behavior suites run successfully.
 - [ ] Ensure new dependency pins are reflected in the lock file and docs. `slowapi` is locked to **0.1.9** and `fastapi` must be **0.115** or newer.
 - [ ] Verify `python -m build` and `scripts/publish_dev.py` create valid packages across platforms.
 - [ ] Assemble final release notes and confirm README instructions.
+- [ ] Keep release documentation synchronized across project files ([update-release-documentation](../issues/update-release-documentation.md)).
 
 ### Current Blockers
 
+- Failing tests and linter/type-checking errors ([resolve-current-test-failures](../issues/resolve-current-test-failures.md)).
 - Packaging scripts require additional configuration before they run reliably.
 
 Resolving these issues will determine the new completion date for **0.1.0**.

--- a/issues/archive/environment-setup-gaps.md
+++ b/issues/archive/environment-setup-gaps.md
@@ -54,4 +54,4 @@ setup.
 - `task verify` runs successfully on a fresh environment.
 
 ## Status
-Open
+Archived

--- a/issues/resolve-current-test-failures.md
+++ b/issues/resolve-current-test-failures.md
@@ -1,0 +1,15 @@
+# Resolve current test failures
+
+## Context
+Recent test runs show multiple failures and lint issues:
+- `src/autoresearch/orchestration/metrics.py:102:1: E303 too many blank lines (4)` from `uv run flake8 src tests`
+- Six attribute errors in `src/autoresearch/search/core.py` from `uv run mypy src`
+- Failing tests in `tests/unit/test_cache.py::test_search_uses_cache`, `tests/unit/test_cache.py::test_cache_is_backend_specific`, `tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure`, `tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt`, and `tests/unit/test_metrics.py::test_metrics_collection_and_endpoint`
+
+## Acceptance Criteria
+- Flake8 runs without errors
+- `uv run mypy src` completes without type errors
+- `uv run pytest -q` passes with all tests succeeding
+
+## Status
+Open

--- a/issues/update-release-documentation.md
+++ b/issues/update-release-documentation.md
@@ -1,0 +1,12 @@
+# Update release documentation
+
+## Context
+Project documents such as `README.md`, `ROADMAP.md`, `CODE_COMPLETE_PLAN.md`, `TASK_PROGRESS.md`, and `docs/release_plan.md` require ongoing maintenance to stay aligned with the 0.1.0 milestone and future releases.
+
+## Acceptance Criteria
+- All referenced documents reflect the current milestone and outstanding work
+- Release notes and milestone tables link to slug-based issue filenames
+- Documentation updates are coordinated with code changes
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- sync roadmap, release plan, and progress docs to show failing tests and March 1, 2026 target
- replace numeric issue references with slug links and add status blocks
- record new tickets for test failures and doc maintenance; archive obsolete setup ticket

## Testing
- `flake8 --version`
- `mypy --version`
- `pytest --version --override-ini addopts=`
- `uv run flake8 src tests` *(fails: E303)*
- `uv run mypy src` *(fails: attr-defined errors)*
- `uv run pytest -q` *(fails: 5 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a147d04b3c8333bce73eddcf954846