### PR TITLE
Align test stubs with updated search and metrics APIs

### DIFF
--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -19,8 +19,8 @@ def test_search_uses_cache(monkeypatch):
         calls["count"] += 1
         return [{"title": "Python", "url": "https://python.org"}]
 
-    with Search.temporary_state() as search:
-        search.backends = {"dummy": backend}
+    with Search.temporary_state():
+        monkeypatch.setattr(Search, "backends", {"dummy": backend})
         cfg = ConfigModel.model_construct(loops=1)
         cfg.search.backends = ["dummy"]
         # Disable context-aware search to avoid issues with SearchContext
@@ -29,14 +29,14 @@ def test_search_uses_cache(monkeypatch):
         monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
 
         # first call uses backend
-        results1 = search.external_lookup("python")
+        results1 = Search.external_lookup("python")
         assert calls["count"] == 1
         assert len(results1) == 1
         assert results1[0]["title"] == "Python"
         assert results1[0]["url"] == "https://python.org"
 
         # second call should be served from cache
-        results2 = search.external_lookup("python")
+        results2 = Search.external_lookup("python")
         assert calls["count"] == 1
         assert len(results2) == len(results1)
         assert results2[0]["title"] == results1[0]["title"]
@@ -106,8 +106,8 @@ def test_cache_is_backend_specific(monkeypatch):
         calls["b2"] += 1
         return [{"title": "B2", "url": "u2"}]
 
-    with Search.temporary_state() as search:
-        search.backends = {"b1": backend1, "b2": backend2}
+    with Search.temporary_state():
+        monkeypatch.setattr(Search, "backends", {"b1": backend1, "b2": backend2})
 
         cfg1 = ConfigModel.model_construct(loops=1)
         cfg1.search.backends = ["b1"]
@@ -117,21 +117,21 @@ def test_cache_is_backend_specific(monkeypatch):
         cfg2.search.context_aware.enabled = False
 
         monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg1)
-        results1 = search.external_lookup("python")
+        results1 = Search.external_lookup("python")
         assert calls == {"b1": 1, "b2": 0}
         assert len(results1) == 1
         assert results1[0]["title"] == "B1"
         assert results1[0]["url"] == "u1"
 
         monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg2)
-        results2 = search.external_lookup("python")
+        results2 = Search.external_lookup("python")
         assert calls == {"b1": 1, "b2": 1}
         assert len(results2) == 1
         assert results2[0]["title"] == "B2"
         assert results2[0]["url"] == "u2"
 
         monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg1)
-        results3 = search.external_lookup("python")
+        results3 = Search.external_lookup("python")
         assert calls == {"b1": 1, "b2": 1}
         assert len(results3) == len(results1)
         assert results3[0]["title"] == results1[0]["title"]


### PR DESCRIPTION
## Summary
- patch `Search` backend registry in cache tests
- adjust search failure tests to use global backend mapping
- call metrics endpoint directly in metrics test

## Testing
- `uv run pytest --cov=src --cov-report=term-missing --cov-fail-under=90 -q`

------
https://chatgpt.com/codex/tasks/task_e_68a14780a230833391e048b88840f841