### PR TITLE
Preserve RequestException cause in SearchError

### DIFF
--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -192,9 +192,7 @@ class Search:
         TempSearch.backends = dict(cls.backends)
         TempSearch.embedding_backends = dict(cls.embedding_backends)
         TempSearch._default_backends = dict(cls._default_backends)
-        TempSearch._default_embedding_backends = dict(
-            cls._default_embedding_backends
-        )
+        TempSearch._default_embedding_backends = dict(cls._default_embedding_backends)
         TempSearch._sentence_transformer = None
         try:
             yield TempSearch
@@ -922,7 +920,7 @@ class Search:
                     backend=name,
                     query=text_query,
                     suggestion="Check your network connection and ensure the search backend is properly configured",
-                )
+                ) from exc
             except json.JSONDecodeError as exc:
                 log.warning(f"{name} search returned invalid JSON: {exc}")
                 raise SearchError(


### PR DESCRIPTION
## Summary
- chain `SearchError` to underlying `requests` errors during search

## Testing
- `uv run isort src/autoresearch/search/core.py`
- `uv run black src/autoresearch/search/core.py`
- `uv run ruff format src/autoresearch/search/core.py tests/unit/test_failure_scenarios.py`
- `uv run ruff check --fix src/autoresearch/search/core.py tests/unit/test_failure_scenarios.py`
- `uv run flake8 src/autoresearch/search/core.py tests/unit/test_failure_scenarios.py`
- `uv run mypy src/autoresearch/search/core.py` (fails: "type" has no attribute "backends"...)
- `uv run pytest tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a1552c3d648333bd9bead6c435ee6e