### PR TITLE
Fix metrics test lambda return type

### DIFF
--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -34,8 +34,8 @@ def test_metrics_collection_and_endpoint(monkeypatch, orchestrator):
         CONTENT_TYPE_LATEST="text/plain",
         generate_latest=lambda: (
             f"autoresearch_queries_total {metrics.QUERY_COUNTER._value.get()}\n"
-            f"autoresearch_tokens_in_total {metrics.TOKENS_IN_COUNTER._value.get()}\n".encode()
-        ),
+            f"autoresearch_tokens_in_total {metrics.TOKENS_IN_COUNTER._value.get()}\n"
+        ).encode(),
     )
     monkeypatch.setitem(sys.modules, "prometheus_client", prom)
     from autoresearch.api.routing import metrics_endpoint


### PR DESCRIPTION
## Summary
- ensure metrics test's `prom.generate_latest` returns single bytes object

## Testing
- `uv run pytest tests/unit/test_metrics.py::test_metrics_collection_and_endpoint` *(fails: Required test coverage of 90% not reached, but test itself passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1553683808333b809731536ba5d34