### PR TITLE
Handle server interrupts cleanly

### DIFF
--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -491,6 +491,7 @@ def serve(
         server.run()
     except KeyboardInterrupt:
         console.print("[bold yellow]Server stopped[/bold yellow]")
+        raise typer.Exit(code=0)
 
 
 @app.command()
@@ -551,6 +552,7 @@ def serve_a2a(
         if a2a_interface is not None:
             a2a_interface.stop()
         console.print("[bold yellow]Server stopped[/bold yellow]")
+        raise typer.Exit(code=0)
     except Exception as e:
         console.print(f"[bold red]Error starting A2A server:[/bold red] {str(e)}")
 


### PR DESCRIPTION
## Summary
- ensure `serve` and `serve_a2a` commands exit with code 0 on KeyboardInterrupt and print "Server stopped"

## Testing
- `uv run isort src/autoresearch/main/app.py --check-only`
- `uv run ruff format src/autoresearch/main/app.py`
- `uv run ruff check --fix src/autoresearch/main/app.py tests/unit/test_main_monitor_commands.py`
- `uv run flake8 src/autoresearch/main/app.py tests/unit/test_main_monitor_commands.py`
- `uv run mypy src/autoresearch/main/app.py` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `uv run pytest tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt -q --cov=src --cov-report=term-missing --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_68a1553205348333899ca10d4aaeecc0