### PR TITLE
Trim blank lines before system usage helper

### DIFF
--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -97,8 +97,6 @@ def temporary_metrics() -> Iterator[None]:
             pass
 
 
-
-
 def _get_system_usage() -> Tuple[float, float, float, float]:
     """Return CPU, memory, GPU utilization, and GPU memory in MB."""
     try:


### PR DESCRIPTION
## Summary
- reduce extra blank lines before `_get_system_usage`

## Testing
- `uv run flake8 src tests`

------
https://chatgpt.com/codex/tasks/task_e_68a1551d63948333824670be2f34b877