### PR TITLE
Ensure search cache uses expanded query keys

### DIFF
--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -192,9 +192,7 @@ class Search:
         TempSearch.backends = dict(cls.backends)
         TempSearch.embedding_backends = dict(cls.embedding_backends)
         TempSearch._default_backends = dict(cls._default_backends)
-        TempSearch._default_embedding_backends = dict(
-            cls._default_embedding_backends
-        )
+        TempSearch._default_embedding_backends = dict(cls._default_embedding_backends)
         TempSearch._sentence_transformer = None
         try:
             yield TempSearch
@@ -943,7 +941,7 @@ class Search:
                 )
 
             if backend_results:
-                cache_results(text_query, name, backend_results)
+                cache_results(search_query, name, backend_results)
                 cls.add_embeddings(backend_results, query_embedding)
                 for r in backend_results:
                     r.setdefault("backend", name)


### PR DESCRIPTION
## Summary
- align cache writes with the expanded query used for lookups
- exercise caching across backends and query expansion in tests

## Testing
- `uv run ruff format src/autoresearch/search/core.py tests/unit/test_cache.py`
- `uv run ruff check --fix src/autoresearch/search/core.py tests/unit/test_cache.py`
- `uv run flake8 --config .flake8 src/autoresearch/search/core.py tests/unit/test_cache.py`
- `uv run mypy src/autoresearch/search/core.py tests/unit/test_cache.py` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `uv run pytest tests/unit/test_cache.py --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68a15524a5f4833392fcbe0958dd057d