### PR TITLE
Handle KeyboardInterrupt in A2A server start

### DIFF
--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -543,7 +543,13 @@ def serve_a2a(
         console.print("\nPress Ctrl+C to stop the server")
 
         # Start the server
-        a2a_interface.start()
+        try:
+            a2a_interface.start()
+        except KeyboardInterrupt:
+            if a2a_interface is not None:
+                a2a_interface.stop()
+            console.print("[bold yellow]Server stopped[/bold yellow]")
+            return 0
 
         # Keep the main thread running until interrupted
         while True:


### PR DESCRIPTION
## Summary
- handle KeyboardInterrupt when starting the A2A server so the app stops cleanly

## Testing
- `uv run pytest tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68a1ef0932008333bd97c6a9ee8c8e4d