### PR TITLE
Ensure cached search results include backend field

### DIFF
--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -901,6 +901,8 @@ class Search:
             cached = get_cached_results(search_query, name)
             if cached is not None:
                 cls.add_embeddings(cached, query_embedding)
+                for r in cached:
+                    r.setdefault("backend", name)
                 return name, cached[:max_results]
 
             try:
@@ -944,10 +946,10 @@ class Search:
                 )
 
             if backend_results:
-                cache_results(search_query, name, backend_results)
-                cls.add_embeddings(backend_results, query_embedding)
                 for r in backend_results:
                     r.setdefault("backend", name)
+                cache_results(search_query, name, backend_results)
+                cls.add_embeddings(backend_results, query_embedding)
             return name, backend_results
 
         max_workers = getattr(cfg.search, "max_workers", len(cfg.search.backends))


### PR DESCRIPTION
## Summary
- Tag cached search results with their backend before storing them.
- Preserve backend context when returning cached hits.

## Testing
- `uv run ruff format src/autoresearch/search/core.py tests/unit/test_cache.py`
- `uv run ruff check --fix src/autoresearch/search/core.py tests/unit/test_cache.py`
- `uv run flake8 src/autoresearch/search/core.py tests/unit/test_cache.py`
- `uv run mypy src/autoresearch/search/core.py`
- `uv run pytest tests/unit/test_cache.py::test_search_uses_cache -q -o addopts=`


------
https://chatgpt.com/codex/tasks/task_e_68a1eee2aafc8333963af34ee20903e5