### PR TITLE
Use slugged issue links in changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 - If the issue tracker directory moves or is renamed, update this section to reference the new location.
 - Tickets follow the template and style guide in [`issues/README.md`](issues/README.md).
 - File names must be slugged titles; numeric identifiers in filenames or content are prohibited. Reference issues by slugged filename.
+- In `CHANGELOG.md`, link issues using their slugged filenames (for example, `issues/archive/example-issue.md`) and avoid numeric prefixes.
 - When work is finished, set `Status` to `Archived` and move the ticket to `/issues/archive/` without renaming.
 - When issue tooling changes, update this file, `issues/AGENTS.md`, and `scripts/codex_setup.sh` to keep documentation and setup aligned.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+Reference issues by slugged filename (for example,
+`issues/archive/example-issue.md`) and avoid numeric prefixes.
+
 ## [Unreleased]
 - Update release plan to align milestones with the 2025 development timeline.
-  - Add rich configuration context fixtures with sample data for tests. [#17](issues/archive/0017-create-more-comprehensive-test-contexts.md)
+  - Add rich configuration context fixtures with sample data for tests. [create-more-comprehensive-test-contexts](issues/archive/create-more-comprehensive-test-contexts.md)
 - Optimize mypy configuration to skip site packages, preventing hangs during
-verification. [#22](issues/archive/0022-investigate-mypy-hang.md).
+verification. [investigate-mypy-hang](issues/archive/investigate-mypy-hang.md).
 - Document virtual environment best practices in the developer guide.
 
 ## [0.1.0-alpha.1] - 2025-08-09


### PR DESCRIPTION
## Summary
- remove numeric prefixes from archived issue links
- document slugged issue link requirement for changelog entries

## Testing
- `uv run black --check .` *(fails: would reformat 197 files)*
- `uv run isort --check-only .` *(fails: import sorting issues)*
- `uv run ruff format src tests --check` *(fails: would reformat files)*
- `uv run ruff check --fix src tests`
- `uv run flake8 src tests`
- `uv run mypy src` *(fails: 10 errors)*
- `uv run pytest -q` *(fails: 4 failed, 355 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a20418a9208333bc5b6533648d20f4