### PR TITLE
Align docs on test status

### DIFF
--- a/CODE_COMPLETE_PLAN.md
+++ b/CODE_COMPLETE_PLAN.md
@@ -7,9 +7,20 @@ Based on a thorough analysis of the Autoresearch codebase, I've developed a comp
 
 As of **August 24, 2025**, Autoresearch targets an **0.1.0-alpha.1** preview
 on **November 15, 2025** and a final **0.1.0** release on **March 1, 2026**.
-Failing tests and documentation gaps remain open; see
-[resolve-current-test-failures](issues/resolve-current-test-failures.md) and
-[update-release-documentation](issues/update-release-documentation.md).
+`uv run flake8 src tests` fails in
+`src/autoresearch/orchestration/metrics.py:102:1` (E303), `uv run mypy src`
+reports missing attributes in `src/autoresearch/search/core.py`, and `uv run
+pytest -q` fails in
+`tests/unit/test_cache.py::test_search_uses_cache`,
+`tests/unit/test_cache.py::test_cache_is_backend_specific`,
+`tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure`,
+`tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt`,
+and `tests/unit/test_metrics.py::test_metrics_collection_and_endpoint`, so
+coverage is not generated and integration and behavior suites are skipped.
+Outstanding issues include these failing tests
+([resolve-current-test-failures](issues/resolve-current-test-failures.md))
+and release documentation updates
+([update-release-documentation](issues/update-release-documentation.md)).
 
 ## 1. Core System Completion
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ skipped. An **0.1.0-alpha.1** preview is scheduled for **November 15,
 2025**, with the final **0.1.0** milestone targeted for **March 1, 2026**.
 Remaining blockers include these failing tests
 ([resolve-current-test-failures](issues/resolve-current-test-failures.md))
-and packaging scripts that need additional configuration. See
-[docs/release_plan.md](docs/release_plan.md) for the full milestone
+and release documentation updates
+([update-release-documentation](issues/update-release-documentation.md)).
+See [docs/release_plan.md](docs/release_plan.md) for the full milestone
 schedule and outstanding tasks.
 
 ## Issue tracking

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,13 +2,20 @@
 
 This roadmap summarizes planned features for upcoming releases. Dates and milestones align with the [release plan](docs/release_plan.md).
 Last updated **August 24, 2025**.
-Phase 2 testing tasks remain incomplete: `uv run flake8 src tests` reports
-E303 in `src/autoresearch/orchestration/metrics.py:102:1`, `uv run mypy src`
-raises attribute errors in `src/autoresearch/search/core.py`, and `uv run
-pytest -q` fails in multiple unit tests. To collect feedback while these
-issues
-([resolve-current-test-failures](issues/resolve-current-test-failures.md))
-are addressed, an alpha pre-release precedes the final 0.1.0 milestone.
+Phase 2 testing tasks remain incomplete: `uv run flake8 src tests` fails in
+`src/autoresearch/orchestration/metrics.py:102:1` (E303), `uv run mypy src`
+reports missing attributes in `src/autoresearch/search/core.py`, and `uv run
+pytest -q` fails in
+`tests/unit/test_cache.py::test_search_uses_cache`,
+`tests/unit/test_cache.py::test_cache_is_backend_specific`,
+`tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure`,
+`tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt`,
+and `tests/unit/test_metrics.py::test_metrics_collection_and_endpoint`, so
+coverage is not generated and integration and behavior suites are skipped.
+To collect feedback while
+[resolve-current-test-failures](issues/resolve-current-test-failures.md) and
+[update-release-documentation](issues/update-release-documentation.md) are
+addressed, an alpha pre-release precedes the final 0.1.0 milestone.
 ## Milestones
 
 | Version | Target Date | Key Goals |

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,9 +1,18 @@
 # Autoresearch Project - Task Progress
 
 This document tracks the progress of tasks for the Autoresearch project,
-organized by phases from the code complete plan. Current lint, type, and test
-checks all pass (`flake8`, `mypy`, and `pytest`). The **0.1.0** release is now
-targeted for **March 1, 2026**.
+organized by phases from the code complete plan. `uv run flake8 src tests`
+fails in `src/autoresearch/orchestration/metrics.py:102:1` (E303), `uv run mypy src`
+reports missing attributes in `src/autoresearch/search/core.py`, and `uv run
+pytest -q` fails in
+`tests/unit/test_cache.py::test_search_uses_cache`,
+`tests/unit/test_cache.py::test_cache_is_backend_specific`,
+`tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure`,
+`tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt`,
+and `tests/unit/test_metrics.py::test_metrics_collection_and_endpoint`, so
+coverage is not generated and integration and behavior suites are skipped.
+An **0.1.0-alpha.1** preview is scheduled for **November 15, 2025**, with the
+final **0.1.0** release targeted for **March 1, 2026**.
 
 ## Phase 1: Core System Completion (Weeks 1-2)
 
@@ -224,13 +233,13 @@ These behavior test issues remain open until the test suite passes.
 
 ### Coverage Report
 
-`pytest` runs with coverage and meets the 90% threshold.
+Coverage is not generated because tests fail.
 
 ### Latest Test Results
 
-- `uv run flake8 src tests` – no issues
-- `uv run mypy src` – success, no type errors
-- `uv run pytest -q` – all tests pass
+- `uv run flake8 src tests` – fails in `src/autoresearch/orchestration/metrics.py:102:1` (E303)
+- `uv run mypy src` – missing attributes in `src/autoresearch/search/core.py`
+- `uv run pytest -q` – fails in `tests/unit/test_cache.py::test_search_uses_cache`, `tests/unit/test_cache.py::test_cache_is_backend_specific`, `tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure`, `tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt`, and `tests/unit/test_metrics.py::test_metrics_collection_and_endpoint`
 
 ### Performance Baselines
 

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -5,12 +5,19 @@ This document outlines the upcoming release milestones for **Autoresearch**. Dat
 The project kicked off in **May 2025** (see the initial commit dated `2025-05-18`).
 This schedule was last updated on **August 24, 2025** and reflects the fact that
 the codebase currently sits at the **unreleased 0.1.0a1** version defined in
-`autoresearch.__version__`.
-Phase 2 testing tasks remain incomplete: `uv run flake8 src tests` reports
-`src/autoresearch/orchestration/metrics.py:102:1: E303`, `uv run mypy src`
-raises attribute errors in `src/autoresearch/search/core.py`, and `uv run
-pytest -q` fails in several unit tests. Phase 3 (stabilization/testing/documentation)
-and Phase 4 activities remain planned.
+`autoresearch.__version__`. Phase 2 testing tasks remain incomplete:
+`uv run flake8 src tests` fails in
+`src/autoresearch/orchestration/metrics.py:102:1` (E303), `uv run mypy src`
+reports missing attributes in `src/autoresearch/search/core.py`, and `uv run
+pytest -q` fails in
+`tests/unit/test_cache.py::test_search_uses_cache`,
+`tests/unit/test_cache.py::test_cache_is_backend_specific`,
+`tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure`,
+`tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt`,
+and `tests/unit/test_metrics.py::test_metrics_collection_and_endpoint`, so
+coverage is not generated and integration and behavior suites are skipped.
+Phase 3 (stabilization/testing/documentation) and Phase 4 activities remain
+planned.
 
 ## Milestones
 


### PR DESCRIPTION
## Summary
- align README, roadmap, release plan, and code-complete plan on failing test status and 0.1.0 milestones
- link release-documentation issue using slug-based filenames
- sync task progress report with current failing checks

## Testing
- `task verify` *(fails: src/autoresearch/cache.py:26: argument 1 to "Path" has incompatible type "str | None"; expected "str | PathLike[str]")*


------
https://chatgpt.com/codex/tasks/task_e_68a204151d648333b7d245c6d574dfbe