### PR TITLE
Clarify monitor command test imports

### DIFF
--- a/tests/unit/test_main_monitor_commands.py
+++ b/tests/unit/test_main_monitor_commands.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from typer.testing import CliRunner
+from typer.testing import CliRunner  # Typer's CLI test runner
 
 from autoresearch.main import app
 


### PR DESCRIPTION
## Summary
- clarify Typer CLI test runner import in monitor command tests

## Testing
- `uv run black tests/unit/test_main_monitor_commands.py`
- `uv run isort -v tests/unit/test_main_monitor_commands.py`
- `uv run ruff format tests/unit/test_main_monitor_commands.py`
- `uv run ruff check --fix tests/unit/test_main_monitor_commands.py`
- `uv run flake8 tests/unit/test_main_monitor_commands.py`
- `uv run mypy src` *(fails: Argument 1 to "Path" has incompatible type "str | None"; expected "str | PathLike[str]" [arg-type], and 9 more errors)*
- `uv run pytest -o addopts='' tests/unit/test_main_monitor_commands.py`

------
https://chatgpt.com/codex/tasks/task_e_68a20e6d47148333bd6548ad921b7009