### PR TITLE
Clarify Search core typing

### DIFF
--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -114,6 +114,7 @@ class hybridmethod:
 
     def __get__(self, obj: Any, objtype: type | None = None) -> Callable[..., Any]:
         if obj is None:
+            assert objtype is not None
 
             def wrapper(*args: Any, **kwargs: Any) -> Any:
                 instance = objtype.get_instance()  # type: ignore[attr-defined]
@@ -158,12 +159,10 @@ class Search:
         Dict[str, Callable[[np.ndarray, int], List[Dict[str, Any]]]]
     ] = {}
     # Expose shared instance registries for legacy access
-    backends: ClassVar[Dict[str, Callable[[str, int], List[Dict[str, Any]]]]] = (
-        _default_backends
+    backends: Dict[str, Callable[[str, int], List[Dict[str, Any]]]] = _default_backends
+    embedding_backends: Dict[str, Callable[[np.ndarray, int], List[Dict[str, Any]]]] = (
+        _default_embedding_backends
     )
-    embedding_backends: ClassVar[
-        Dict[str, Callable[[np.ndarray, int], List[Dict[str, Any]]]]
-    ] = _default_embedding_backends
     _shared_instance: ClassVar[Optional["Search"]] = None
 
     def __init__(self, cache: Optional[SearchCache] = None) -> None:
@@ -174,7 +173,7 @@ class Search:
             str, Callable[[np.ndarray, int], List[Dict[str, Any]]]
         ] = dict(self._default_embedding_backends)
         self._sentence_transformer: Optional[SentenceTransformerType] = None
-        self.cache = cache or get_cache()
+        self.cache: SearchCache = cache or get_cache()
 
     @classmethod
     def get_instance(cls) -> "Search":


### PR DESCRIPTION
## Summary
- ensure hybridmethod uses non-null objtype before accessing shared instance
- treat backends as instance data and annotate cache type for Search

## Testing
- `uv run black src/autoresearch/search/core.py`
- `uv run isort src/autoresearch/search/core.py`
- `uv run ruff format src/autoresearch/search/core.py`
- `uv run ruff check --fix src/autoresearch/search/core.py`
- `uv run flake8 src/autoresearch/search/core.py` *(fails: No such file or directory)*
- `uv run mypy src/autoresearch/search/core.py`
- `uv run mypy src` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `uv run pytest -q` *(fails: No module named 'pytest_httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68a20e5e10b483339d80c6eb152df16b