### PR TITLE
Ensure search cache stores copies of results

### DIFF
--- a/src/autoresearch/cache.py
+++ b/src/autoresearch/cache.py
@@ -10,6 +10,7 @@ backwards compatibility, and thin wrapper functions mirror the original API.
 from __future__ import annotations
 
 import os
+from copy import deepcopy
 from pathlib import Path
 from threading import Lock
 from typing import Any, Dict, List, Optional
@@ -55,7 +56,11 @@ class SearchCache:
         """Store search results for a specific query/backend combination."""
         db = self.get_db()
         db.upsert(
-            {"query": query, "backend": backend, "results": results},
+            {
+                "query": query,
+                "backend": backend,
+                "results": deepcopy(results),
+            },
             (Query().query == query) & (Query().backend == backend),
         )
 
@@ -67,7 +72,7 @@ class SearchCache:
         condition = (Query().query == query) & (Query().backend == backend)
         row = db.get(condition)
         if row:
-            return list(row.get("results", []))
+            return deepcopy(row.get("results", []))
         return None
 
     def clear(self) -> None:


### PR DESCRIPTION
## Summary
- deep-copy search results before writing to TinyDB cache
- return deep copies of cached results to prevent mutation

## Testing
- `uv run pytest tests/unit/test_cache.py` *(fails: Coverage failure: total of 22 is less than fail-under=90)*
- `uv run ruff format src/autoresearch/cache.py tests/unit/test_cache.py`
- `uv run ruff check --fix src/autoresearch/cache.py tests/unit/test_cache.py`
- `uv run flake8 src/autoresearch/cache.py tests/unit/test_cache.py`
- `uv run mypy src/autoresearch/cache.py` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68a2489546e483339b423cf12a32dee5