### PR TITLE
Align cache and search typing

### DIFF
--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -549,7 +549,7 @@ def serve_a2a(
             if a2a_interface is not None:
                 a2a_interface.stop()
             console.print("[bold yellow]Server stopped[/bold yellow]")
-            return 0
+            return
 
         # Keep the main thread running until interrupted
         while True:

--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -114,6 +114,7 @@ def temporary_metrics() -> Iterator[None]:
                 exc_info=True,
             )
 
+
 def _get_system_usage() -> Tuple[float, float, float, float]:
     """Return CPU, memory, GPU utilization, and GPU memory in MB."""
     try:


### PR DESCRIPTION
## Summary
- streamline metrics utilities and restore context manager spacing
- improve search type hints and expose cache helpers
- centralize cache path management and gracefully halt A2A server

## Testing
- `flake8 src/autoresearch/cache.py src/autoresearch/search/core.py src/autoresearch/orchestration/metrics.py src/autoresearch/main/app.py`
- `mypy src`
- `pytest tests/unit/test_cache_extra.py::test_get_db_after_teardown -q --cov=src --cov-fail-under=0`
- `pytest tests/unit/test_core_modules_additional.py::test_search_stub_backend -q --cov=src --cov-fail-under=0`
- `pytest tests/unit/test_failure_paths.py::test_external_lookup_unknown_backend -q --cov=src --cov-fail-under=0`
- `pytest tests/unit/test_main_cli.py::test_search_primus_start_option -q --cov=src --cov-fail-under=0`
- `pytest tests/unit/test_main_monitor_commands.py::test_serve_a2a_command -q --cov=src --cov-fail-under=0`
- `pytest tests/unit/test_metrics.py::test_metrics_collection_and_endpoint -q --cov=src --cov-fail-under=0`
- `pytest -q` *(fails: test_cache_lifecycle, test_search_stub_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68a24d9ed3e083339f8853f5ea2f1921