### PR TITLE
Enable CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, macos-14]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Verify Python version
+        run: |
+          python - <<'EOF'
+          import sys
+          major, minor = sys.version_info[:2]
+          assert major == 3 and minor >= 12, f"Python 3.12 or newer required, got {major}.{minor}"
+          EOF
+      - name: Install uv
+        run: python -m pip install uv
+      - name: Install dependencies
+        run: uv pip sync uv.lock
+      - name: Run task verify
+        run: uv run task verify

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,9 +142,9 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 - When new scripts or tasks are added, update both this file and `scripts/codex_setup.sh` accordingly.
 
 ## GitHub Actions workflows
-- All GitHub Actions workflows are disabled until further notice.
-- Store workflow files in `.github/workflows.disabled`; `.github/workflows` must remain empty.
-- Each workflow file must start with `# NOTE: This workflow is disabled. Move to .github/workflows to enable.`
+- The CI workflow in `.github/workflows/ci.yml` is dispatch-only.
+- All workflows must be dispatch-only or remain disabled in `.github/workflows.disabled`.
+- Disabled workflow files must start with `# NOTE: This workflow is disabled. Move to .github/workflows to enable.`
 - Standardize on these actions versions:
   - `actions/checkout@v4`
   - `actions/setup-python@v5`

--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -14,21 +14,12 @@ from prometheus_client import Counter, Histogram
 
 from .circuit_breaker import CircuitBreakerState
 
-
 log = logging.getLogger(__name__)
 
-QUERY_COUNTER = Counter(
-    "autoresearch_queries_total", "Total number of queries processed"
-)
-ERROR_COUNTER = Counter(
-    "autoresearch_errors_total", "Total number of errors during processing"
-)
-TOKENS_IN_COUNTER = Counter(
-    "autoresearch_tokens_in_total", "Total input tokens processed"
-)
-TOKENS_OUT_COUNTER = Counter(
-    "autoresearch_tokens_out_total", "Total output tokens produced"
-)
+QUERY_COUNTER = Counter("autoresearch_queries_total", "Total number of queries processed")
+ERROR_COUNTER = Counter("autoresearch_errors_total", "Total number of errors during processing")
+TOKENS_IN_COUNTER = Counter("autoresearch_tokens_in_total", "Total input tokens processed")
+TOKENS_OUT_COUNTER = Counter("autoresearch_tokens_out_total", "Total output tokens produced")
 EVICTION_COUNTER = Counter(
     "autoresearch_duckdb_evictions_total",
     "Total nodes evicted from RAM to DuckDB",
@@ -75,14 +66,17 @@ def reset_metrics() -> None:
 @contextmanager
 def temporary_metrics() -> Iterator[None]:
     """Provide a context where metric counters are restored on exit."""
-    snapshot = [c._value.get() for c in [
-        QUERY_COUNTER,
-        ERROR_COUNTER,
-        TOKENS_IN_COUNTER,
-        TOKENS_OUT_COUNTER,
-        EVICTION_COUNTER,
-        KUZU_QUERY_COUNTER,
-    ]]
+    snapshot = [
+        c._value.get()
+        for c in [
+            QUERY_COUNTER,
+            ERROR_COUNTER,
+            TOKENS_IN_COUNTER,
+            TOKENS_OUT_COUNTER,
+            EVICTION_COUNTER,
+            KUZU_QUERY_COUNTER,
+        ]
+    ]
     hist_sum = KUZU_QUERY_TIME._sum.get()
     hist_count = KUZU_QUERY_TIME._count.get()
     try:
@@ -113,6 +107,7 @@ def temporary_metrics() -> Iterator[None]:
                 "Failed to restore Kuzu query histogram snapshot",
                 exc_info=True,
             )
+
 
 def _get_system_usage() -> Tuple[float, float, float, float]:
     """Return CPU, memory, GPU utilization, and GPU memory in MB."""
@@ -215,9 +210,7 @@ class OrchestrationMetrics:
         self.error_counts[agent_name] += 1
         ERROR_COUNTER.inc()
 
-    def record_circuit_breaker(
-        self, agent_name: str, state: CircuitBreakerState
-    ) -> None:
+    def record_circuit_breaker(self, agent_name: str, state: CircuitBreakerState) -> None:
         """Record the circuit breaker ``state`` for ``agent_name``."""
         self.circuit_breakers[agent_name] = state
 
@@ -259,8 +252,7 @@ class OrchestrationMetrics:
         return {
             "total_duration_seconds": total_duration,
             "cycles_completed": len(self.cycle_durations),
-            "avg_cycle_duration_seconds": total_duration
-            / max(1, len(self.cycle_durations)),
+            "avg_cycle_duration_seconds": total_duration / max(1, len(self.cycle_durations)),
             "total_tokens": {
                 "input": total_tokens_in,
                 "output": total_tokens_out,
@@ -320,9 +312,7 @@ class OrchestrationMetrics:
         data[query] = self._total_tokens()
         path.write_text(json.dumps(data, indent=2))
 
-    def check_query_regression(
-        self, query: str, baseline_path: Path, threshold: int = 0
-    ) -> bool:
+    def check_query_regression(self, query: str, baseline_path: Path, threshold: int = 0) -> bool:
         """Return ``True`` if token usage exceeds the baseline."""
         if not baseline_path.exists():
             return False


### PR DESCRIPTION
## Summary
- make CI workflow dispatch-only to run `task verify` on Python 3.12 for Ubuntu and macOS
- document dispatch-only workflow policy in AGENTS
- fix metrics module lint by adding required spacing

## Testing
- `uv run black src/autoresearch/orchestration/metrics.py`
- `uv run isort src/autoresearch/orchestration/metrics.py`
- `uv run ruff check --fix src/autoresearch/orchestration/metrics.py`
- `uv run flake8 src tests`
- `uv run mypy src` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `uv run pytest -q` *(fails: 29 errors during collection; missing pytest_bdd, property modules, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a24de821908333a7a429db1da2b0c7