### PR TITLE
Document credibility scoring algorithm

### DIFF
--- a/docs/algorithms/source_credibility.md
+++ b/docs/algorithms/source_credibility.md
@@ -5,6 +5,40 @@ recognized domain receives a value between 0 and 1 derived from curated lists of
 trusted sources. Higher scores indicate more reliable domains and affect the
 weight of a document in the final ranking.
 
+## Scoring algorithm
+
+The credibility score :math:`s(d)` for a document with domain :math:`d` is
+computed using the following logic:
+
+```text
+if d in AUTHORITY:
+    return AUTHORITY[d]
+for suffix, value in AUTHORITY.items():
+    if d.endswith(suffix):
+        return value
+return 0.5
+```
+
+The :code:`AUTHORITY` table maps domains and suffixes such as ``.edu`` or
+``.gov`` to scores in the :math:`[0, 1]` interval. Unknown domains default to
+``0.5``.
+
+## Example ranking
+
+Assume three results share the same base relevance score of ``0.7`` and a
+``source_credibility_weight`` of ``0.2``. The final score is
+
+```
+final = (1 - w) * relevance + w * credibility
+```
+
+| URL                                   | Credibility | Final score | Rank |
+|---------------------------------------|-------------|-------------|------|
+| https://en.wikipedia.org/wiki/Python  | 0.90        | 0.74        | 1    |
+| https://dept.example.edu/resource     | 0.80        | 0.72        | 2    |
+| https://unknown.xyz/post              | 0.50        | 0.64        | 3    |
+
 ## References
 
-- Moz. "Domain Authority." [https://moz.com/learn/seo/domain-authority](https://moz.com/learn/seo/domain-authority)
+- Moz. "Domain Authority."
+  [https://moz.com/learn/seo/domain-authority](https://moz.com/learn/seo/domain-authority)

--- a/tests/unit/test_source_credibility_scores.py
+++ b/tests/unit/test_source_credibility_scores.py
@@ -1,0 +1,44 @@
+"""Tests for source credibility scoring logic."""
+
+from unittest.mock import MagicMock, patch
+
+from autoresearch.config.models import SearchConfig
+from autoresearch.search import Search
+
+
+def test_assess_source_credibility_partial_domains():
+    docs = [
+        {"url": "https://dept.university.edu/paper"},
+        {"url": "https://agency.gov/report"},
+        {"url": "https://unknown.io/post"},
+    ]
+    scores = Search.assess_source_credibility(docs)
+    assert scores == [0.8, 0.85, 0.5]
+
+
+def test_rank_results_prefers_higher_credibility():
+    docs = [
+        {"url": "https://dept.university.edu/paper"},
+        {"url": "https://unknown.io/post"},
+    ]
+    cfg = MagicMock()
+    cfg.search = SearchConfig(
+        use_bm25=True,
+        use_semantic_similarity=True,
+        use_source_credibility=True,
+        bm25_weight=0.0,
+        semantic_similarity_weight=0.0,
+        source_credibility_weight=1.0,
+    )
+    with (
+        patch("autoresearch.search.core.get_config", return_value=cfg),
+        patch.object(Search, "calculate_bm25_scores", return_value=[0.5, 0.5]),
+        patch.object(
+            Search, "calculate_semantic_similarity", return_value=[0.5, 0.5]
+        ),
+    ):
+        ranked = Search.rank_results("query", docs)
+    assert [r["url"] for r in ranked] == [
+        "https://dept.university.edu/paper",
+        "https://unknown.io/post",
+    ]


### PR DESCRIPTION
## Summary
- describe credibility scoring with pseudo-code and example table
- test domain authority heuristics and ranking impact

## Testing
- `uv run flake8 tests/unit/test_source_credibility_scores.py`
- `uv run pytest tests/unit/test_source_credibility_scores.py`
- `uv run mypy tests/unit/test_source_credibility_scores.py` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68a3bf69c35c8333966f504d97ffbd69