### PR TITLE
Clarify AGENTS scopes and missing files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,6 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 - Keep `scripts/codex_setup.sh` in sync with these instructions; see the script for full setup, offline installs, and DuckDB extension options.
 - Use Python 3.12+ and manage dependencies with `uv`; run all commands inside the virtual environment (`uv venv && uv sync --all-extras`).
 - `VECTOR_EXTENSION_PATH` must point to `extensions/vss_stub.duckdb_extension` unless a real `vss.duckdb_extension` is available.
-- Documents in `docs/inspirational_docs/` are inspirational only; cite external sources from `docs/external_research_papers/`.
 - Remove build artifacts with `task clean` and delete temporary files such as `kg.duckdb` or `rdf_store`.
 
 ## Tooling
@@ -29,6 +28,11 @@ Adopt a multi-disciplinary, dialectical approach: propose solutions, critically 
 - Avoid committing binary artifacts; the `extensions/` directory is placeholder only.
 - GitHub Actions workflows must be dispatch-only, use `actions/checkout@v4`, `actions/setup-python@v5`, and `actions/upload-artifact@v4`, and verify Python 3.12+.
 - Write focused commits with imperative subject lines ≤ 50 characters, wrap bodies at 72 characters, and reference related issues.
+
+## Missing AGENTS files
+- `src/` — add instructions for source code conventions.
+- `scripts/` — document usage patterns for helper scripts.
+- `examples/` — clarify expectations for example projects.
 
 ## Changelog
 - 2025-08-18: Refer to `tests/AGENTS.md` and `docs/AGENTS.md` for scoped rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ verification. [investigate-mypy-hang](issues/archive/investigate-mypy-hang.md).
 - Pin Python version and expand setup checks to prevent environment drift. [align-environment-with-requirements](issues/align-environment-with-requirements.md)
 - Enable Pydantic plugin for static type analysis. [resolve-current-test-failures](issues/resolve-current-test-failures.md)
 - Document final release workflow and TestPyPI publishing steps.
+- Consolidated `AGENTS.md` guidance, clarified directory scopes, and noted missing instructions for `src/`, `scripts/`, and `examples/`.
 
 ## [0.1.0-alpha.1] - 2026-03-01
 - Verified source and wheel builds succeed; TestPyPI upload failed with 403 Forbidden.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,5 +1,7 @@
 # Documentation Guidelines
 
+These instructions apply to files in the `docs/` directory.
+
 ## Citation rules
 - Provide a working URL or relative path for every citation.
 - Use inline links or reference-style footnotes.

--- a/issues/AGENTS.md
+++ b/issues/AGENTS.md
@@ -1,6 +1,6 @@
 # Issues directory guidelines
 
-Follow these rules when managing in-repo tickets.
+These rules apply to files in this directory. Follow them when managing in-repo tickets.
 
 - Use the template and naming conventions in [issues/README.md](README.md).
 - File names must be slugged titles; numeric identifiers in filenames or

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,5 +1,7 @@
 # Test Guidelines
 
+These instructions apply to files in the `tests/` directory.
+
 ## Markers
 - Use `slow` for tests that exceed typical runtime or touch external
   services.
@@ -9,7 +11,7 @@
 - Register any new markers in `pytest.ini`.
 
 ## Required extras
-- Install dev dependencies with `uv pip install -e '.[full,parsers,git,llm,dev]'`.
+- Install base dev dependencies as described in the repository root `AGENTS.md`.
 - Include `.[nlp]` when running tests marked `requires_nlp`.
 - Add extras corresponding to any other markers as needed.
 


### PR DESCRIPTION
## Summary
- Clarify AGENTS scopes for docs, tests, and issues directories
- List directories lacking AGENTS guidance in repository root
- Note AGENTS consolidation in changelog

## Testing
- `task verify` *(fails: command not found)*
- `uv run pytest` *(fails: No module named 'pytest_httpx')*
- `uv run flake8 AGENTS.md docs/AGENTS.md tests/AGENTS.md issues/AGENTS.md CHANGELOG.md` *(fails: flake8 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c7ca62a08333890aa0f040950024