### PR TITLE
Document search algorithms and add normalization references

### DIFF
--- a/docs/algorithms/bm25.md
+++ b/docs/algorithms/bm25.md
@@ -2,22 +2,30 @@
 
 The BM25 ranking function scores a document *D* for query *Q* as:
 
-\[score(D, Q) = \sum_{q_i \in Q} IDF(q_i) \cdot \frac{f(q_i, D) (k_1 + 1)}{f(q_i, D) + k_1 (1 - b + b \cdot \frac{|D|}{avgdl})}\]
+\[
+score(D, Q) = \sum_{q_i \in Q} IDF(q_i)
+  \cdot \frac{f(q_i, D) (k_1 + 1)}
+         {f(q_i, D) + k_1 \left(1 - b + b \cdot \frac{|D|}{avgdl}\right)}
+\]
 
 where:
 
 - `f(q_i, D)` is the term frequency of `q_i` in `D`
 - `|D|` is the length of the document in tokens
 - `avgdl` is the average document length in the corpus
-- `k1` and `b` are hyperparameters, typically `k1` in `[1.2, 2.0]` and `b` around `0.75`
+- `k1` and `b` are hyperparameters, typically `k1` in `[1.2, 2.0]` and
+  `b` around `0.75`
 
-Autoresearch uses the `rank-bm25` Python implementation and normalizes scores by
-scaling them into the [0, 1] range. Each score is divided by the maximum so BM25
-values can be combined with other ranking strategies.
+Autoresearch uses the `rank-bm25` Python implementation and normalizes
+scores by scaling them into the `[0, 1]` range. Each score is divided by the
+maximum so BM25 values can be combined with other ranking strategies.
 
 ## References
 
 - Stephen Robertson and Hugo Zaragoza. "The Probabilistic Relevance Framework:
   BM25 and Beyond." *Foundations and Trends in Information Retrieval* 3(4),
-  2009. [https://plg.uwaterloo.ca/~msmucker/research/information_retrieval/RobertsonZaragoza2009.pdf](https://plg.uwaterloo.ca/~msmucker/research/information_retrieval/RobertsonZaragoza2009.pdf)
-- `rank-bm25` library: [https://github.com/dorianbrown/rank_bm25](https://github.com/dorianbrown/rank_bm25)
+  2009.[^robertson]
+- `rank-bm25` library[^rbm25]
+
+[^robertson]: https://doi.org/10.1561/1500000019
+[^rbm25]: https://github.com/dorianbrown/rank_bm25

--- a/docs/algorithms/semantic_similarity.md
+++ b/docs/algorithms/semantic_similarity.md
@@ -1,13 +1,22 @@
 # Semantic Similarity Ranking
 
-Autoresearch measures semantic relevance by comparing sentence embeddings.
+Autoresearch measures semantic relevance by comparing sentence embeddings with
+cosine similarity.
 
-\[score(D, Q) = \frac{v_q \cdot v_d}{\|v_q\| \|v_d\|}\]
+\[
+s(D, Q) = \frac{v_q \cdot v_d}{\|v_q\| \|v_d\|}
+\]
 
-The cosine similarity between the query vector `v_q` and a document vector `v_d`
-produces scores in the `[-1, 1]` range. No additional normalization is applied.
+Scores `s` lie in `[-1, 1]`. They are normalized to `[0, 1]` for ranking:
+
+\[
+n(D, Q) = \frac{s(D, Q) + 1}{2}
+\]
+
+This scaling allows combination with other non-negative metrics.
 
 ## References
 
 - Nils Reimers and Iryna Gurevych. "Sentence-BERT: Sentence Embeddings using
-  Siamese BERT-Networks." 2019. [https://arxiv.org/abs/1908.10084](https://arxiv.org/abs/1908.10084)
+  Siamese BERT-Networks." 2019.
+  [https://arxiv.org/abs/1908.10084](https://arxiv.org/abs/1908.10084)

--- a/docs/algorithms/source_credibility.md
+++ b/docs/algorithms/source_credibility.md
@@ -1,9 +1,9 @@
 # Source Credibility Heuristics
 
-Autoresearch estimates credibility using heuristic domain authority scores. Each
-recognized domain receives a value between 0 and 1 derived from curated lists of
-trusted sources. Higher scores indicate more reliable domains and affect the
-weight of a document in the final ranking.
+Autoresearch estimates credibility using heuristic domain authority scores.
+Each recognized domain receives a value between 0 and 1 derived from curated
+lists of trusted sources. Higher scores indicate more reliable domains and
+affect the weight of a document in the final ranking.
 
 ## Scoring algorithm
 
@@ -23,6 +23,9 @@ The :code:`AUTHORITY` table maps domains and suffixes such as ``.edu`` or
 ``.gov`` to scores in the :math:`[0, 1]` interval. Unknown domains default to
 ``0.5``.
 
+These heuristic scores are already normalized to ``[0, 1]`` and require no
+additional scaling before being combined with other ranking metrics.
+
 ## Example ranking
 
 Assume three results share the same base relevance score of ``0.7`` and a
@@ -40,5 +43,6 @@ final = (1 - w) * relevance + w * credibility
 
 ## References
 
-- Moz. "Domain Authority."
-  [https://moz.com/learn/seo/domain-authority](https://moz.com/learn/seo/domain-authority)
+- Moz. "Domain Authority."[^moz]
+
+[^moz]: https://moz.com/learn/seo/domain-authority

--- a/docs/search_backends.md
+++ b/docs/search_backends.md
@@ -2,8 +2,9 @@
 
 Autoresearch can combine results from multiple search backends. By default the
 system merges all responses and ranks them together using a hybrid algorithm
-that mixes BM25 keyword scores, semantic similarity of embeddings and the
-credibility of each source.
+that mixes [BM25 keyword scores](algorithms/bm25.md),
+[semantic similarity](algorithms/semantic_similarity.md) and
+[source credibility](algorithms/source_credibility.md).
 
 Enable or disable backends in the `[search]` section of `autoresearch.toml`:
 
@@ -29,5 +30,5 @@ source_credibility_weight = 0.1
 ```
 
 Use `scripts/optimize_search_weights.py` with a labelled evaluation dataset to
-automatically discover good values. The script runs a grid search and updates the
-configuration file with the best-performing weights.
+automatically discover good values. The script runs a grid search and updates
+the configuration file with the best-performing weights.

--- a/docs/search_spec.md
+++ b/docs/search_spec.md
@@ -1,20 +1,32 @@
 # Search Module Specification
 
-This specification outlines expected behaviors for the `autoresearch.search` module.
+This specification outlines expected behaviors for the
+`autoresearch.search` module.
 
 ## Query Generation
-- `Search.generate_queries` normalizes raw user text and returns a list of variants for external lookup.
-- When `return_embeddings=True` it yields deterministic numeric embeddings of the cleaned query.
+- `Search.generate_queries` normalizes raw user text and returns a list of
+  variants for external lookup.
+- When `return_embeddings=True` it yields deterministic numeric embeddings of
+  the cleaned query.
 
 ## Backend Selection
-- `Search.external_lookup` uses `config.search.backends` to determine which registered backends to call.
-- Results from each backend are cached via `SearchCache` using the query and backend name.
-- Cached results must be reused on subsequent lookups without invoking the backend again.
+- `Search.external_lookup` uses `config.search.backends` to determine which
+  registered backends to call.
+- Results from each backend are cached via `SearchCache` using the query and
+  backend name.
+- Cached results must be reused on subsequent lookups without invoking the
+  backend again.
 
 ## DomainAuthorityScore Ranking
-- Credibility ranking relies on `DomainAuthorityScore` entries that map domains to scores in `[0,1]`.
-- `Search.assess_source_credibility` assigns the configured score for known domains and a default of `0.5` otherwise.
-- Final result ordering uses weighted combination of BM25, semantic similarity, and domain authority scores.
+- Credibility ranking relies on `DomainAuthorityScore` entries that map
+  domains to scores in `[0,1]`. See
+  [source credibility heuristics](algorithms/source_credibility.md).
+- `Search.assess_source_credibility` assigns the configured score for known
+  domains and a default of `0.5` otherwise.
+- Final result ordering uses weighted combination of
+  [BM25](algorithms/bm25.md),
+  [semantic similarity](algorithms/semantic_similarity.md), and
+  [domain authority scores](algorithms/source_credibility.md).
 
 ## Tests
 Property-based tests in `tests/unit/test_relevance_ranking.py` verify:


### PR DESCRIPTION
## Summary
- Document and normalize search algorithm details for BM25, semantic similarity, and source credibility
- Link algorithm docs from search modules and user guides
- Improve context-aware search docs and comment clarity

## Testing
- `./bin/task verify` *(fails: tests/unit/test_main_monitor_commands.py::test_monitor_command - assert 130 == 0)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d738e4708333b0fc8501253cdd98