### PR TITLE
docs: add scoped agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@
 
 ## Changelog
 - 2025-08-19: Added project snapshot, environment steps, Task commands, coding conventions, and AGENTS referencing policy.
+- 2025-08-19: Added `AGENTS.md` for [src](src/AGENTS.md), [scripts](scripts/AGENTS.md),
+  and [examples](examples/AGENTS.md).
 
 This `AGENTS.md` follows the AGENTS.md spec: its scope is the entire repo and nested rules override it.
 

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,11 @@
+# Example Data Guidelines
+
+These instructions apply to files in the `examples/` directory.
+
+## Purpose
+- Showcase typical usage patterns; keep examples minimal and focused.
+- Do not rely on proprietary services or credentials.
+
+## Licensing
+- Assume sample data is covered by the project's AGPL-3.0 license unless noted.
+- Document third-party assets with their original licenses and required attribution.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,15 @@
+# Script Guidelines
+
+These instructions apply to files in the `scripts/` directory.
+
+## Usage
+- Provide a clear CLI interface or usage comment at the top of each script.
+- Validate inputs and fail fast on incorrect usage.
+
+## Safety
+- Avoid destructive actions without an explicit confirmation flag.
+- Do not require elevated privileges or modify user system settings.
+
+## Cross-platform
+- Use POSIX-compliant shell features or portable Python constructs.
+- Test on Linux and macOS; avoid hard-coded paths and file extensions.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,15 @@
+# Source Code Guidelines
+
+These instructions apply to files in the `src/` directory.
+
+## Coding style
+- Follow the repository's PEP 8 settings: 4-space indentation and lines ≤100 characters.
+- Organize imports with `isort`'s default profile.
+
+## Docstrings
+- Provide Google-style docstrings for all public classes, functions, and modules.
+- Include `Args`, `Returns`, and `Raises` sections when applicable.
+
+## Type checking
+- Use explicit type hints for function signatures and critical variables.
+- Run `task check` to validate types before committing.


### PR DESCRIPTION
## Summary
- scope build docs with new `AGENTS.md` files for `src/`, `scripts/`, and `examples`
- reference the new docs from the root `AGENTS.md`

## Testing
- `task check`

------
https://chatgpt.com/codex/tasks/task_e_68a3d7262f0c8333b9e9ff26da8c2838