### PR TITLE
test: register requires_nlp marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,8 @@ markers = [
     "slow: tests that take a long time to run",
     "requires_ui: tests that depend on the ui extra",
     "requires_vss: tests that depend on the vss extra",
-    "requires_git: tests that depend on the git extra"
+    "requires_git: tests that depend on the git extra",
+    "requires_nlp: tests needing NLP resources"
 ]
 
 [tool.mypy]


### PR DESCRIPTION
## Summary
- register `requires_nlp` pytest marker in configuration
- ensure NLP-dependent tests remain annotated with `@pytest.mark.requires_nlp`

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit -q` *(fails: 22 errors during collection)*
- `uv run pytest tests/integration -m "not slow" -q` *(fails: 7 errors during collection)*
- `uv run pytest tests/behavior -q` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*


------
https://chatgpt.com/codex/tasks/task_e_68a3f2bc59748333a81c824b7e220c70