### PR TITLE
Wrap documentation to 80 characters

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,94 +1,115 @@
 # Autoresearch Roadmap
 
-This roadmap summarizes planned features for upcoming releases. Dates and milestones align with the [release plan](docs/release_plan.md).
-Installation and environment details are covered in the [README](README.md).
-Last updated **August 19, 2025**. For current test and coverage status, see
-[docs/release_plan.md](docs/release_plan.md). Use Python 3.12+ with
-`uv venv && uv sync --all-extras && uv pip install -e '.[full,parsers,git,llm,dev]'`
+This roadmap summarizes planned features for upcoming releases. Dates and
+milestones align with the [release plan](docs/release_plan.md). Installation and
+environment details are covered in the [README](README.md). Last updated
+**August 19, 2025**. For current test and coverage status, see
+[docs/release_plan.md](docs/release_plan.md). Use Python 3.12+ with:
+
+```
+uv venv && uv sync --all-extras &&
+uv pip install -e '.[full,parsers,git,llm,dev]'
+```
+
 before running tests.
+
 ## Milestones
 
-| Version | Target Date | Key Goals |
-| ------- | ----------- | --------- |
-| 0.1.0-alpha.1 | 2026-03-01 | Alpha preview to collect feedback while resolving test suite failures and aligning environment requirements ([resolve-test-failures], [align-environment-reqs]) |
-| 0.1.0 | 2026-07-01 | Finalize packaging, docs and CI checks with all tests passing ([resolve-test-failures], [update-release-documentation]) |
-| 0.1.1 | 2026-09-15 | Bug fixes and documentation updates |
-| 0.2.0 | 2026-12-01 | API stabilization, configuration hot-reload, improved search backends |
-| 0.3.0 | 2027-03-01 | Distributed execution support, monitoring utilities |
-| 1.0.0 | 2027-06-01 | Full feature set, performance tuning and stable interfaces |
+- 0.1.0-alpha.1 (2026-03-01): Alpha preview to collect feedback while
+  resolving test suite failures and aligning environment requirements
+  ([resolve-test-failures], [align-environment-reqs]).
+- 0.1.0 (2026-07-01): Finalize packaging, docs and CI checks with all tests
+  passing ([resolve-test-failures], [update-release-documentation]).
+- 0.1.1 (2026-09-15): Bug fixes and documentation updates.
+- 0.2.0 (2026-12-01): API stabilization, configuration hot-reload, improved
+  search backends.
+- 0.3.0 (2027-03-01): Distributed execution support, monitoring utilities.
+- 1.0.0 (2027-06-01): Full feature set, performance tuning and stable
+  interfaces.
 
 ### Blockers before 0.1.0-alpha.1
 
-| Blocker | Related Issue |
-| ------- | ------------- |
-| Test suite failures and missing dependencies | [resolve-test-failures] |
-| Development environment misaligned with Python 3.12 and dev tooling | [align-environment-reqs] |
-| Packaging scripts require configuration | [update-release-documentation] |
+- Test suite failures and missing dependencies
+  ([resolve-test-failures]).
+- Development environment misaligned with Python 3.12 and dev tooling
+  ([align-environment-reqs]).
+- Packaging scripts require configuration
+  ([update-release-documentation]).
 
 ## 0.1.0-alpha.1 – Alpha preview
 
 This pre-release provides an early package for testing while packaging tasks
-remain open. Related issues
-([resolve-test-failures],
-[align-environment-reqs])
+remain open. Related issues ([resolve-test-failures], [align-environment-reqs])
 track outstanding test and environment work. Key activities include:
 
 - Provide an installable package for early adopters.
 - Collect feedback while fixing failing tests and packaging issues.
-- Align development environment with project requirements (Python 3.12 and
-  dev tooling).
+- Align development environment with project requirements (Python 3.12 and dev
+  tooling).
 
 ## 0.1.0 – First public preview
 
-The final 0.1.0 release focuses on making the project installable and
-providing complete documentation once the open issues are resolved. Key
-activities include:
+The final 0.1.0 release focuses on making the project installable and providing
+complete documentation once the open issues are resolved. Key activities
+include:
 
 - Running all unit, integration and behavior tests.
 - Finalizing API reference and user guides.
 - Verifying packaging metadata and TestPyPI uploads.
 
-Type checking and tests still fail (see
-[resolve-test-failures]), so
-integration and behavior suites remain blocked. The release was originally
-planned for **July 20, 2025**, but the schedule slipped. The **0.1.0**
-milestone is now targeted for **July 1, 2026** while packaging tasks are
-resolved.
+Type checking and tests still fail (see [resolve-test-failures]), so integration
+and behavior suites remain blocked. The release was originally planned for
+**July 20, 2025**, but the schedule slipped. The **0.1.0** milestone is now
+targeted for **July 1, 2026** while packaging tasks are resolved.
 
 ## 0.1.1 – Bug fixes and documentation updates
 
 Before publishing 0.1.0 the release plan lists several checks:
+
 - Verify all automated tests pass in CI.
 - Review documentation for clarity using a Socratic approach.
 - Conduct a dialectical evaluation of core workflows.
 - Ensure packaging metadata and publish scripts work correctly.
 
 Any remaining issues from these tasks will be addressed in 0.1.1.
-- CLI backup commands and testing utilities remain pending, while specialized agents—Moderator, Specialist, and User—are already implemented (`src/autoresearch/agents/specialized/moderator.py`, `src/autoresearch/agents/specialized/domain_specialist.py`, `src/autoresearch/agents/specialized/user_agent.py`) and will receive comprehensive unit tests once testing passes.
-The 0.1.1 release is planned for **September 15, 2026**.
+
+- CLI backup commands and testing utilities remain pending, while specialized
+  agents—Moderator, Specialist, and User—are already implemented
+  (`src/autoresearch/agents/specialized/moderator.py`,
+  `src/autoresearch/agents/specialized/domain_specialist.py`,
+  `src/autoresearch/agents/specialized/user_agent.py`) and will receive
+  comprehensive unit tests once testing passes. The 0.1.1 release is planned for
+  **September 15, 2026**.
 
 ## 0.2.0 – API stabilization and improved search
 
 The next minor release focuses on API improvements and search enhancements:
-- Complete all search backends with cross-backend ranking and embedding-based search (see tasks in CODE_COMPLETE_PLAN lines 38-46).
-- Add streaming responses and webhook notifications to the REST API (implemented per TASK_PROGRESS lines 143-150).
+
+- Complete all search backends with cross-backend ranking and embedding-based
+  search (see tasks in CODE_COMPLETE_PLAN lines 38-46).
+- Add streaming responses and webhook notifications to the REST API (implemented
+  per TASK_PROGRESS lines 143-150).
 - Support hybrid keyword/semantic search and a unified ranking algorithm.
 - Continue refining the web interface and visualization tools.
 
 ## 0.3.0 – Distributed execution and monitoring
 
 Key features planned for this release include:
-- Distributed agent execution across processes and storage backends (see CODE_COMPLETE_PLAN lines 156-160 and TASK_PROGRESS lines 182-192).
+
+- Distributed agent execution across processes and storage backends (see
+  CODE_COMPLETE_PLAN lines 156-160 and TASK_PROGRESS lines 182-192).
 - Coordination mechanisms for distributed agents and parallel search.
 - Expanded monitoring including real-time metrics and GPU usage.
 
 ## 1.0.0 – Stable interfaces and performance tuning
 
 The 1.0.0 milestone aims for a polished, production-ready system:
-- Complete packaging for all platforms with containerization support (CODE_COMPLETE_PLAN lines 168-176; TASK_PROGRESS lines 194-204).
-- Provide deployment scripts and configuration validation (CODE_COMPLETE_PLAN lines 178-186; TASK_PROGRESS lines 206-216).
-- Optimize performance across all components and finalize documentation.
 
+- Complete packaging for all platforms with containerization support
+  (CODE_COMPLETE_PLAN lines 168-176; TASK_PROGRESS lines 194-204).
+- Provide deployment scripts and configuration validation (CODE_COMPLETE_PLAN
+  lines 178-186; TASK_PROGRESS lines 206-216).
+- Optimize performance across all components and finalize documentation.
 
 [resolve-test-failures]: issues/archive/resolve-current-test-failures.md
 [align-environment-reqs]: issues/align-environment-with-requirements.md

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,7 @@
 # Agents
 
-Autoresearch orchestrates multiple agents in a dialectical cycle. The default roster includes:
+Autoresearch orchestrates multiple agents in a dialectical cycle. The default
+roster includes:
 
 - **Synthesizer** – proposes initial answers.
 - **Contrarian** – challenges assumptions and provides counter arguments.
@@ -16,14 +17,15 @@ Additional specialized agents extend these roles:
 - **Domain Specialist** – provides expert knowledge for a field.
 - **User Agent** – represents user preferences in the dialogue.
 
-Agents communicate via a shared state object and can be customized in `autoresearch.toml`.
+Agents communicate via a shared state object and can be customized in
+`autoresearch.toml`.
 
 When `enable_agent_messages` is set to `true` in the configuration, agents may
-exchange short messages using the `Agent.send_message()` API. Messages are stored
-on the `QueryState` and retrieved with `Agent.get_messages()`. Coalitions can be
-defined in the `[coalitions]` section of the config to broadcast messages among
-groups of agents. Enabling `enable_feedback` allows agents such as the Critic or
-User agent to send feedback messages to their peers during a cycle.
+exchange short messages using the `Agent.send_message()` API. Messages are
+stored on the `QueryState` and retrieved with `Agent.get_messages()`. Coalitions
+can be defined in the `[coalitions]` section of the config to broadcast messages
+among groups of agents. Enabling `enable_feedback` allows agents such as the
+Critic or User agent to send feedback messages to their peers during a cycle.
 
 See [Agent Communication](agent_communication.md) for configuration examples.
 
@@ -32,13 +34,16 @@ See [Agent Communication](agent_communication.md) for configuration examples.
 The agents component consists of several key classes:
 
 - **Agent** - Base class for all agents, providing common functionality
-- **AgentRole** - Enumeration of standard agent roles (Synthesizer, Contrarian, FactChecker, etc.)
+- **AgentRole** - Enumeration of standard agent roles (Synthesizer, Contrarian,
+  FactChecker, etc.)
 - **AgentConfig** - Configuration for an agent
-- **Mixins** - Reusable functionality for agents (PromptGenerator, ModelConfig, ClaimGenerator, ResultGenerator)
+- **Mixins** - Reusable functionality for agents (PromptGenerator, ModelConfig,
+  ClaimGenerator, ResultGenerator)
 - **AgentRegistry** - Registry of available agent types
 - **AgentFactory** - Factory for creating and retrieving agent instances
 
-The relationships between these classes are documented in `docs/diagrams/agents.puml`.
+The relationships between these classes are documented in
+`docs/diagrams/agents.puml`.
 
 ## Adding custom agents
 
@@ -49,13 +54,14 @@ The relationships between these classes are documented in `docs/diagrams/agents.
 ## Adding new LLM adapters
 
 1. Subclass `LLMAdapter` in `src/autoresearch/llm/adapters.py`.
-2. Register the adapter via `LLMFactory.register("mybackend", MyAdapter)` (for example in `src/autoresearch/llm/__init__.py`).
+2. Register the adapter via `LLMFactory.register("mybackend", MyAdapter)` (for
+   example in `src/autoresearch/llm/__init__.py`).
 3. Select it by setting `llm_backend = "mybackend"` in your configuration.
 
 ## Tuning search ranking weights
 
 Autoresearch ships with a small evaluation dataset at
-`examples/search_evaluation.csv`.  You can tune the relative weights of the
+`examples/search_evaluation.csv`. You can tune the relative weights of the
 semantic similarity, BM25 and credibility signals by running the helper script:
 
 ```bash
@@ -65,4 +71,3 @@ python scripts/optimize_search_weights.py
 The script performs a grid search to maximize NDCG and writes the optimized
 values back to a configuration file (defaults to `examples/autoresearch.toml`).
 Provide custom file paths if you want to use your own data or configuration.
-

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,7 +1,10 @@
 # Frequently Asked Questions
 
 ## How do I enable dark mode in the GUI?
+
 Set `Dark Mode` in the sidebar of the Streamlit interface.
 
 ## Why do my token counts change after upgrading?
-Token counts may vary slightly with model updates. Run `Taskfile check-baselines` to ensure usage is within expected limits.
+
+Token counts may vary slightly with model updates. Run
+`Taskfile check-baselines` to ensure usage is within expected limits.

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -1,12 +1,16 @@
 # Release Plan
 
-This document outlines the upcoming release milestones for **Autoresearch**. Dates are aspirational and may shift as development progresses. The publishing workflow follows the steps in [deployment.md](deployment.md). See the [README](../README.md) for installation details and [ROADMAP](../ROADMAP.md) for high-level milestones.
+This document outlines the upcoming release milestones for **Autoresearch**.
+Dates are aspirational and may shift as development progresses. The publishing
+workflow follows the steps in [deployment.md](deployment.md). See the
+[README](../README.md) for installation details and [ROADMAP](../ROADMAP.md) for
+high-level milestones.
 
-The project kicked off in **May 2025** (see the initial commit dated `2025-05-18`).
-This schedule was last updated on **August 19, 2025** and reflects the fact that
-the codebase currently sits at the **unreleased 0.1.0a1** version defined in
-`autoresearch.__version__`. Phase 3 (stabilization/testing/documentation) and
-Phase 4 activities remain planned.
+The project kicked off in **May 2025** (see the initial commit dated
+`2025-05-18`). This schedule was last updated on **August 19, 2025** and
+reflects the fact that the codebase currently sits at the **unreleased 0.1.0a1**
+version defined in `autoresearch.__version__`. Phase 3
+(stabilization/testing/documentation) and Phase 4 activities remain planned.
 
 ## Test and Coverage Status
 
@@ -15,47 +19,55 @@ confirmed in `pyproject.toml` and [installation.md](installation.md).
 
 Phase 2 testing tasks remain incomplete:
 
- - `flake8 src tests` passes.
- - `mypy src` currently stalls and needs configuration.
- - `pytest -q` runs with all dependencies installed but fails due to search
-   scoring bug ([resolve-test-failures]).
- - `pytest --cov=src` not yet run because tests fail.
+- `flake8 src tests` passes.
+- `mypy src` currently stalls and needs configuration.
+- `pytest -q` runs with all dependencies installed but fails due to search
+  scoring bug ([resolve-test-failures]).
+- `pytest --cov=src` not yet run because tests fail.
 
 ## Milestones
 
-| Version | Target Date | Key Goals |
-| ------- | ----------- | --------- |
-| **0.1.0-alpha.1** | 2026-03-01 | Alpha preview to collect feedback while resolving test suite failures ([resolve-test-failures]) |
-| **0.1.0** | 2026-07-01 | Finalize packaging, docs and CI checks with all tests passing ([resolve-test-failures]) |
-| **0.1.1** | 2026-09-15 | Bug fixes and documentation updates |
-| **0.2.0** | 2026-12-01 | API stabilization, configuration hot-reload, improved search backends |
-| **0.3.0** | 2027-03-01 | Distributed execution support, monitoring utilities |
-| **1.0.0** | 2027-06-01 | Full feature set, performance tuning and stable interfaces |
+- **0.1.0-alpha.1** (2026-03-01): Alpha preview to collect feedback while
+  resolving test suite failures ([resolve-test-failures]).
+- **0.1.0** (2026-07-01): Finalize packaging, docs and CI checks with all tests
+  passing ([resolve-test-failures]).
+- **0.1.1** (2026-09-15): Bug fixes and documentation updates.
+- **0.2.0** (2026-12-01): API stabilization, configuration hot-reload,
+  improved search backends.
+- **0.3.0** (2027-03-01): Distributed execution support, monitoring utilities.
+- **1.0.0** (2027-06-01): Full feature set, performance tuning and stable
+  interfaces.
 
 The project originally targeted **0.1.0** for **July 20, 2025**, but the
-schedule slipped. To gather early feedback, an alpha **0.1.0-alpha.1**
-release is scheduled for **March 1, 2026**. The final **0.1.0** milestone is
-now set for **July 1, 2026** while packaging tasks are resolved.
+schedule slipped. To gather early feedback, an alpha **0.1.0-alpha.1** release
+is scheduled for **March 1, 2026**. The final **0.1.0** milestone is now set for
+**July 1, 2026** while packaging tasks are resolved.
 
 The following tasks remain before publishing **0.1.0-alpha.1**:
 
 - [ ] Resolve remaining test failures ([resolve-test-failures]).
-  - [ ] Set up the environment with `uv venv && uv sync --all-extras` and
-      `uv pip install -e '.[full,parsers,git,llm,dev]'`. Verified flake8 7.3.0,
-      mypy 1.17.1, pytest 8.4.1, pytest-bdd 8.1.0 and pydantic 2.11.7; see
-      [align-environment-with-requirements](../issues/align-environment-with-
-      requirements.md).
- - [x] Ensure new dependency pins are reflected in the lock file and docs.
-     `slowapi` is locked to **0.1.9** and `fastapi` is at least **0.115.12**,
-     matching `pyproject.toml` and [installation.md](installation.md).
-- [x] Verify `uv run python -m build` and `uv run python scripts/publish_dev.py --dry-run` create valid packages across platforms.
+  - [ ] Set up the environment with:
+
+    ```
+    uv venv && uv sync --all-extras &&
+    uv pip install -e '.[full,parsers,git,llm,dev]'
+    ```
+
+    Verified flake8 7.3.0, mypy 1.17.1, pytest 8.4.1, pytest-bdd 8.1.0 and
+    pydantic 2.11.7; see
+    [align-environment-with-requirements](../issues/align-environment-with-
+    requirements.md).
+- [x] Ensure new dependency pins are reflected in the lock file and docs.
+      `slowapi` is locked to **0.1.9** and `fastapi` is at least **0.115.12**,
+      matching `pyproject.toml` and [installation.md](installation.md).
+- [x] Verify `uv run python -m build` and
+      `uv run python scripts/publish_dev.py --dry-run` create valid packages
+      across platforms.
 - [ ] Assemble preliminary release notes and confirm README instructions.
 
 ### Blockers before 0.1.0-alpha.1
 
-| Blocker | Related Issue |
-| ------- | ------------- |
-| Test suite failures | [resolve-test-failures] |
+- Test suite failures ([resolve-test-failures])
 
 Resolving these issues will determine the new completion date for **0.1.0**.
 
@@ -63,8 +75,11 @@ Resolving these issues will determine the new completion date for **0.1.0**.
 
 1. **Planning** – finalize scope and update the roadmap.
 2. **Development** – implement features and expand test coverage.
-3. **Stabilization** – fix bugs, write documentation and run the full test suite.
-4. **Publish** – follow the workflow in `deployment.md`: bump the version, run tests, publish to TestPyPI using `./scripts/publish_dev.py`, then release to PyPI with `twine upload dist/*`.
+3. **Stabilization** – fix bugs, write documentation and run the full test
+   suite.
+4. **Publish** – follow the workflow in `deployment.md`: bump the version, run
+   tests, publish to TestPyPI using `./scripts/publish_dev.py`, then release to
+   PyPI with `twine upload dist/*`.
 
 Each milestone may include additional patch releases for critical fixes.
 
@@ -73,12 +88,13 @@ Each milestone may include additional patch releases for critical fixes.
 1. `uv pip install build twine`
 2. `uv run python -m build`
 3. `uv run python scripts/publish_dev.py --dry-run`
-4. Set `TWINE_USERNAME` and `TWINE_PASSWORD` then run `uv run python scripts/publish_dev.py`
-   to upload to TestPyPI.
+4. Set `TWINE_USERNAME` and `TWINE_PASSWORD` then run
+   `uv run python scripts/publish_dev.py` to upload to TestPyPI.
 
 ## CI Checklist
 
-Before tagging **0.1.0**, ensure the following checks pass (after installing optional extras):
+Before tagging **0.1.0**, ensure the following checks pass (after installing
+optional extras):
 
 - [ ] `uv run flake8 src tests`
 - [ ] `uv run mypy src`


### PR DESCRIPTION
## Summary
- wrap milestone tables in the roadmap and release plan into 80-character bullet lists
- split long setup commands into code blocks for readability
- reflow agents and FAQ docs to respect 80-character line limit

## Testing
- `/tmp/task check` *(fails: No such file or directory (flake8))*

------
https://chatgpt.com/codex/tasks/task_e_68a3f86de17883339a9259ff891587d9