### PR TITLE
docs: align install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ See [docs/installation.md](docs/installation.md) for details on optional feature
 and upgrade instructions.
 The `scripts/setup.sh` helper ensures `uv.lock` is current and installs
 all optional extras so development and runtime dependencies are available for testing.
-Run `scripts/setup.sh` to install dependencies automatically. CI environments
-must include all extras, so run `uv sync --all-extras && uv pip install -e '.[full,parsers,git,llm,dev]'`.
-The `dev-minimal` option is only for local smoke tests. After editing
-`pyproject.toml`, regenerate `uv.lock` with `uv lock` and reinstall with all extras to apply updates.
+Run `task install` or `scripts/setup.sh` to install dependencies automatically.
+CI environments must include all extras, so run `uv sync --all-extras && uv pip install -e .`.
+After editing `pyproject.toml`, regenerate `uv.lock` with `uv lock` and
+reinstall with all extras to apply updates.
 Several dependencies are pinned for compatibility—`slowapi` is locked to
 **0.1.9** and `fastapi` must be **0.115** or newer. The test suite works both
 with and without extras:
@@ -79,17 +79,19 @@ with and without extras:
   SlowAPI's rate‑limiting middleware. This may change how certain tests
   behave and can make them slower.
 
-Reinstall with `uv sync --all-extras && uv pip install -e '.[full,parsers,git,llm,dev]'` if you need
-to restore extras after running the setup script.
+Reinstall with `uv sync --all-extras && uv pip install -e .` if you need to
+restore extras after running the setup script.
 
 ### Using uv
 Python 3.12 or newer is required. Set up the development environment with:
 ```bash
 uv venv
 uv sync --all-extras
-uv pip install -e '.[full,parsers,git,llm,dev]'
+uv pip install -e .
 source .venv/bin/activate
 ```
+`uv venv` creates the virtual environment in `.venv/` by default. Activate it
+with the last command or prefix tools with `uv run`.
 If Python 3.11 is selected, `uv` will fail with a message similar to:
 ```
 Because autoresearch requires Python >=3.12,<4.0 and the current Python is
@@ -524,23 +526,23 @@ Create a virtual environment, run `uv lock` if `pyproject.toml` changed, and ins
 ```bash
 uv venv
 uv sync --all-extras
-uv pip install -e '.[full,parsers,git,llm,dev]'
+uv pip install -e .
 source .venv/bin/activate
 ```
 
-Alternatively you can run the helper script:
+Alternatively run `task install` or the helper script:
 
 ```bash
+task install
+# or
 ./scripts/setup.sh
-# For a lightweight local setup:
-# ./scripts/setup.sh dev-minimal
 ```
-This installs the same dependencies non-interactively.
+These commands install the same dependencies non-interactively.
 
 For offline installs, pre-download wheels and source archives and set `WHEELS_DIR` and `ARCHIVES_DIR` before running the setup script.
 
 The helper installs all dependencies with `uv sync --all-extras` and
-links the package in editable mode using `uv pip install -e '.[full,parsers,git,llm,dev]'`. Tools such as `flake8`, `mypy`, `pytest` and `tomli_w`
+links the package in editable mode using `uv pip install -e .`. Tools such as `flake8`, `mypy`, `pytest` and `tomli_w`
 are therefore available for development and testing. Tests will run even without
 extras because stub versions of optional packages are bundled, but coverage is
 limited. Installing extras enables the real implementations—for example
@@ -555,7 +557,7 @@ SlowAPI’s middleware, which enforces rate limits during integration tests.
 - Avoid committing the `.venv` directory and recreate it if dependencies
   become inconsistent.
 - Install development extras with
-  `uv sync --all-extras && uv pip install -e '.[full,parsers,git,llm,dev]'` to ensure linters and
+  `uv sync --all-extras && uv pip install -e .` to ensure linters and
   optional features are available.
 
 ## Running tests
@@ -572,7 +574,7 @@ exercised when the extras are installed. Install them with:
 
 ```bash
 uv sync --all-extras
-uv pip install -e '.[full,parsers,git,llm,dev]'
+uv pip install -e .
 ```
 
 Execute linting and type checks once the development environment is ready:
@@ -600,7 +602,7 @@ uv run pytest -m slow
 
 Several unit and integration tests rely on `gitpython` and the DuckDB VSS
 extension. Install the corresponding extras as needed, for example run
-`uv sync --all-extras && uv pip install -e '.[full,parsers,git,llm,dev]'` for the default suites.
+`uv sync --all-extras && uv pip install -e .` for the default suites.
 
 All testing commands are wrapped by `task`, which activates the `.venv`
 environment before running each tool.
@@ -642,7 +644,7 @@ without filtering the markers:
 
 ```bash
 uv sync --all-extras
-uv pip install -e '.[full,parsers,git,llm,dev]'
+uv pip install -e .
 uv run pytest -m "slow or requires_ui or requires_vss"
 ```
 
@@ -653,14 +655,14 @@ Previous versions used Poetry for environment management. `uv` now handles depen
 ```bash
 uv venv
 uv sync --all-extras
-uv pip install -e '.[full,parsers,git,llm,dev]'
+uv pip install -e .
 ```
 
 Activate the environment with `source .venv/bin/activate` before running commands.
 
 ### Troubleshooting
 
-- If tests fail with `ModuleNotFoundError`, ensure all dependencies are installed in the virtual environment using `uv sync --all-extras && uv pip install -e '.[full,parsers,git,llm,dev]'`. Time-based tests rely on `freezegun`, which is included in the development extras.
+- If tests fail with `ModuleNotFoundError`, ensure all dependencies are installed in the virtual environment using `uv sync --all-extras && uv pip install -e .`. Time-based tests rely on `freezegun`, which is included in the development extras.
 - When starting the API with `uvicorn autoresearch.api:app --reload`, install `uvicorn` if the command is not found and verify that port `8000` is free.
 
 ### Smoke test

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,15 +56,26 @@ been verified to install successfully with `uv pip install`.
 Use `uv` to manage the environment when working from a clone:
 
 ```bash
-# Create the virtual environment
+# Create the virtual environment (.venv/)
 uv venv
-# Full feature set including development tools (required for CI)
-uv pip install -e '.[full,parsers,git,llm,dev]'
-# Lightweight install for quick smoke tests
-# uv pip install -e '.[dev-minimal]'
+# Install pinned dependencies and all extras
+uv sync --all-extras
+# Link the project in editable mode
+uv pip install -e .
+# Activate the environment
+source .venv/bin/activate
 ```
-Run `uv lock` whenever you change `pyproject.toml` to update `uv.lock` before syncing.
-Selecting Python 3.11 results in an error similar to:
+
+Alternatively run `task install` or the setup helper:
+
+```bash
+task install
+# or
+./scripts/setup.sh
+```
+
+Run `uv lock` whenever you change `pyproject.toml` to update `uv.lock`
+before syncing. Selecting Python 3.11 results in an error similar to:
 ```
 Because autoresearch requires Python >=3.12,<4.0 and the current Python is
 3.11.*, no compatible version could be found.
@@ -86,7 +97,8 @@ uv run pytest tests/behavior
 
 ### Offline installation
 
-To install without network access, pre-download the required packages and point the setup script at their locations:
+To install without network access, pre-download the required packages and
+point the setup script at their locations:
 
 ```bash
 export WHEELS_DIR=/path/to/wheels
@@ -94,7 +106,9 @@ export ARCHIVES_DIR=/path/to/archives
 ./scripts/setup.sh
 ```
 
-`WHEELS_DIR` should contain wheel files (`*.whl`) and `ARCHIVES_DIR` should contain source archives (`*.tar.gz`). The setup script installs these caches with `uv pip --no-index` so dependencies resolve offline.
+`WHEELS_DIR` should contain wheel files (`*.whl`) and `ARCHIVES_DIR` should
+contain source archives (`*.tar.gz`). The setup script installs these caches
+with `uv pip --no-index` so dependencies resolve offline.
 
 ## Minimal installation
 
@@ -104,14 +118,10 @@ The project can be installed with only the minimal optional dependencies:
 pip install autoresearch[minimal]
 ```
 
-If you cloned the repository, run the setup helper. Omit the argument to
-install all extras required for CI; use `dev-minimal` only for quick smoke
-tests:
+If you cloned the repository, run the setup helper:
 
 ```bash
 ./scripts/setup.sh
-# For a lightweight local setup:
-# ./scripts/setup.sh dev-minimal
 ```
 
 The helper ensures the lock file is refreshed and installs every optional
@@ -119,9 +129,11 @@ extra needed for the test suite. Tests normally rely on stubbed versions of
 these extras, so running the suite without them is recommended. Extras such as
 `slowapi` may enable real behaviour (like rate limiting) that changes how
 assertions are evaluated. If you wish to revert to stub-only testing after
-running the helper, reinstall using `uv sync --all-extras && uv pip install -e .`. Optional
-features are disabled when their dependencies are missing. Specify extras
-explicitly with pip to enable additional features, e.g. ``pip install "autoresearch[minimal,nlp]"``.
+running the helper, reinstall using
+`uv sync --all-extras && uv pip install -e .`.
+Optional features are disabled when their dependencies are missing. Specify
+extras explicitly with pip to enable additional features, e.g.
+``pip install "autoresearch[minimal,nlp]"``.
 
 ## Optional extras
 
@@ -152,7 +164,9 @@ To upgrade an existing installation run:
 python scripts/upgrade.py
 ```
 
-The helper script installs or upgrades using `uv pip`. When a `pyproject.toml` is present it runs `uv pip install -U autoresearch`; otherwise it falls back to `pip install -U autoresearch`.
+The helper script installs or upgrades using `uv pip`. When a
+`pyproject.toml` is present it runs `uv pip install -U autoresearch`;
+otherwise it falls back to `pip install -U autoresearch`.
 
 Use pip extras when upgrading to ensure optional dependencies remain
 installed. For example:
@@ -182,7 +196,7 @@ long time or fail on low-memory machines.
 - If compilation hangs or exhausts memory, set `HDBSCAN_NO_OPENMP=1` to
   disable OpenMP optimizations.
 - Consider installing a pre-built wheel with `pip install hdbscan` prior
-  to running `uv pip install -e '.[full,parsers,git,llm,dev]'`.
+  to running `uv pip install -e .`.
 - You can omit heavy extras by specifying only the groups you need,
   e.g. `uv pip install -e '.[minimal]'` when rapid setup is more important
   than optional features.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Usage: ./scripts/setup.sh
+# Create .venv and install all extras using uv.
 # Ensure we are running with Python 3.12 or newer
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- sync README and installation docs to use `uv sync --all-extras && uv pip install -e .`
- document `.venv/` location and reference `task install`
- clarify `scripts/setup.sh` usage and purpose

## Testing
- ⚠️ `task check` (missing flake8; attempted `task install` but aborted large downloads)


------
https://chatgpt.com/codex/tasks/task_e_68a3fc2e96d883338df11ee6b1fd27be