### PR TITLE
test: align BM25 score usage and add regression

### DIFF
--- a/tests/unit/test_bm25_scoring.py
+++ b/tests/unit/test_bm25_scoring.py
@@ -1,0 +1,37 @@
+"""Regression tests for BM25 scoring implementation."""
+
+from typing import Any, Dict, List
+
+import numpy as np
+import pytest
+from rank_bm25 import BM25Okapi
+
+try:
+    import docx  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    import tests.stubs.docx  # noqa: F401
+
+from autoresearch.search import Search
+
+
+def test_calculate_bm25_scores_real_documents() -> None:
+    """Calculate BM25 scores using the real library and verify normalization."""
+    docs: List[Dict[str, Any]] = [
+        {"title": "Python scripting", "snippet": "Python is great for scripting."},
+        {"title": "Java docs", "snippet": "This document talks about Java."},
+        {
+            "title": "Programming languages",
+            "snippet": "Python and Java both are programming languages.",
+        },
+    ]
+    query = "python"
+
+    scores = Search.calculate_bm25_scores(query=query, documents=docs)
+
+    query_tokens = Search.preprocess_text(query)
+    corpus = [Search.preprocess_text(d["title"] + " " + d.get("snippet", "")) for d in docs]
+    bm25 = BM25Okapi(corpus)
+    expected = bm25.get_scores(query_tokens)
+    expected = expected / expected.max()
+
+    assert scores == pytest.approx(expected.tolist())

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,5 +1,6 @@
 import importlib.util
 from threading import Thread  # for thread-safety test
+from typing import Any, Dict, List
 
 if not importlib.util.find_spec("tinydb"):
     import tests.stubs.tinydb  # noqa: F401
@@ -9,8 +10,8 @@ from autoresearch.config.models import ConfigModel
 from autoresearch.search import Search
 
 
-def assert_bm25_signature(query, documents):
-    """Ensure bm25 stub receives ``(query, documents)`` in that order."""
+def assert_bm25_signature(query: str, documents: List[Dict[str, Any]]) -> List[float]:
+    """Ensure BM25 stub receives ``(query, documents)`` in that order."""
     assert isinstance(query, str)
     assert isinstance(documents, list)
     return [1.0] * len(documents)

--- a/tests/unit/test_monitor_cli.py
+++ b/tests/unit/test_monitor_cli.py
@@ -1,13 +1,21 @@
+from typing import Any, Dict, List
+
 from typer.testing import CliRunner
-from autoresearch.main import app
-from autoresearch.config.models import ConfigModel, StorageConfig
+
+try:
+    import docx  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    import tests.stubs.docx  # noqa: F401
+
 from autoresearch.config.loader import ConfigLoader
-from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.config.models import ConfigModel, StorageConfig
+from autoresearch.main import app
 from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.search import Search
 
 
-def assert_bm25_signature(query, documents):
+def assert_bm25_signature(query: str, documents: List[Dict[str, Any]]) -> List[float]:
     """Stub ensuring BM25 receives ``(query, documents)``."""
     assert isinstance(query, str)
     assert isinstance(documents, list)
@@ -17,7 +25,7 @@ def assert_bm25_signature(query, documents):
 def dummy_run_query(query, config, callbacks=None, **kwargs):
     assert callbacks is not None and "on_cycle_end" in callbacks
     # Exercise BM25 scoring to verify call signature
-    Search.calculate_bm25_scores(query, [{"title": "t", "url": "u"}])
+    Search.calculate_bm25_scores(query=query, documents=[{"title": "t", "url": "u"}])
     dummy_state = type(
         "S",
         (),


### PR DESCRIPTION
## Summary
- align BM25 test stubs with current `Search.calculate_bm25_scores` signature
- ensure monitor CLI test invokes BM25 stub correctly and loads missing dependencies
- add regression test validating real BM25 scoring and normalization

## Testing
- `uv run pytest tests/unit/test_cache.py tests/unit/test_monitor_cli.py tests/unit/test_bm25_scoring.py -q`
- `uv run flake8 tests/unit/test_cache.py tests/unit/test_monitor_cli.py tests/unit/test_bm25_scoring.py`
- `uv run mypy src/autoresearch/search/core.py tests/unit/test_cache.py tests/unit/test_monitor_cli.py tests/unit/test_bm25_scoring.py` *(fails: Module has no attribute "get_logger" in tests/stubs/structlog.py, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a3fc1e52ac8333b17a7ef7caee0bd3