### PR TITLE
Reopen testing and environment issues

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -111,6 +111,6 @@ The 1.0.0 milestone aims for a polished, production-ready system:
   lines 178-186; TASK_PROGRESS lines 206-216).
 - Optimize performance across all components and finalize documentation.
 
-[resolve-test-failures]: issues/archive/resolve-current-test-failures.md
+[resolve-test-failures]: issues/resolve-current-test-failures.md
 [align-environment-reqs]: issues/align-environment-with-requirements.md
 [update-release-documentation]: issues/archive/update-release-documentation.md

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -55,8 +55,8 @@ The following tasks remain before publishing **0.1.0-alpha.1**:
 
     Verified flake8 7.3.0, mypy 1.17.1, pytest 8.4.1, pytest-bdd 8.1.0 and
     pydantic 2.11.7; see
-    [align-environment-with-requirements](../issues/align-environment-with-
-    requirements.md).
+    [align-environment-with-requirements](
+      ../issues/align-environment-with-requirements.md).
 - [x] Ensure new dependency pins are reflected in the lock file and docs.
       `slowapi` is locked to **0.1.9** and `fastapi` is at least **0.115.12**,
       matching `pyproject.toml` and [installation.md](installation.md).
@@ -102,4 +102,4 @@ optional extras):
 - [ ] `uv run pytest tests/behavior`
 - [ ] `task coverage` reports at least **90%** total coverage
 
-[resolve-test-failures]: ../issues/archive/resolve-current-test-failures.md
+[resolve-test-failures]: ../issues/resolve-current-test-failures.md

--- a/issues/align-environment-with-requirements.md
+++ b/issues/align-environment-with-requirements.md
@@ -21,4 +21,4 @@ avoid failures and missing tooling.
 Environment verified and aligns with requirements.
 
 ## Status
-Archived
+Open

--- a/issues/resolve-current-test-failures.md
+++ b/issues/resolve-current-test-failures.md
@@ -21,5 +21,5 @@ similar failures and did not report overall coverage.
 - The suite runs without unexpected warnings.
 
 ## Status
-Archived
+Open
 


### PR DESCRIPTION
## Summary
- Reopen `resolve-current-test-failures` and `align-environment-with-requirements` issues with `Status: Open`
- Point roadmap and release plan back to the active issues using slugged paths

## Testing
- `./bin/task verify` *(fails: tests/unit/test_main_cli.py::test_serve_command)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fc1365c883339d65f5e8b39dde02