### PR TITLE
docs: fix archived issue links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,24 @@ Reference issues by slugged filename (for example,
 
 ## [Unreleased]
 - Track environment alignment to ensure Python 3.12 and dev tooling are
-  available. [align-environment-with-requirements](issues/align-environment-with-requirements.md)
+  available.
+    [align-environment-with-requirements]
  - Update release plan with revised milestone schedule.
-  - Add rich configuration context fixtures with sample data for tests. [create-more-comprehensive-test-contexts](issues/archive/create-more-comprehensive-test-contexts.md)
+  - Add rich configuration context fixtures with sample data for tests.
+    [create-more-comprehensive-test-contexts]
 - Optimize mypy configuration to skip site packages, preventing hangs during
 verification. [investigate-mypy-hang](issues/archive/investigate-mypy-hang.md).
 - Document virtual environment best practices in the developer guide.
-- Synchronize release documentation across project files. [update-release-documentation](issues/archive/update-release-documentation.md)
-- Fix BM25 search scoring method signature. [resolve-current-test-failures](issues/resolve-current-test-failures.md)
-- Correct search backend registration and reset logic. [resolve-current-test-failures](issues/resolve-current-test-failures.md)
-- Pin Python version and expand setup checks to prevent environment drift. [align-environment-with-requirements](issues/align-environment-with-requirements.md)
-- Enable Pydantic plugin for static type analysis. [resolve-current-test-failures](issues/resolve-current-test-failures.md)
+ - Synchronize release documentation across project files.
+    [update-release-documentation]
+ - Fix BM25 search scoring method signature.
+    [resolve-current-test-failures]
+ - Correct search backend registration and reset logic.
+    [resolve-current-test-failures]
+ - Pin Python version and expand setup checks to prevent environment drift.
+    [align-environment-with-requirements]
+ - Enable Pydantic plugin for static type analysis.
+    [resolve-current-test-failures]
 - Document final release workflow and TestPyPI publishing steps.
 - Clarified directory scopes and noted missing instructions for `src/`, `scripts/`, and `examples/`.
 
@@ -34,15 +41,21 @@ Planned first public release bringing the core research workflow to life.
 ### Highlights
 - CLI, HTTP API and Streamlit interfaces for local-first research.
 - Dialectical orchestrator coordinating multiple agents with hot-reloadable configuration.
-- Hybrid DuckDB/RDF knowledge graph persistence and plugin-based search backends (files, Git and web).
+- Hybrid DuckDB/RDF knowledge graph persistence and plugin-based search backends
+  (files, Git and web).
 - Prometheus metrics, interactive mode and graph visualization utilities.
 
 ### Improvements
 - Refined token budget heuristics and asynchronous cancellation handling.
 - Cleaned up CLI commands and installer scripts.
 - Numerous bug fixes and reliability tweaks since the initial prototype was created in May 2025.
-- Exposed token usage capture helper on the orchestrator for easier testing
-  ([issues/resolve-current-test-failures.md](issues/resolve-current-test-failures.md)).
+  - Exposed token usage capture helper on the orchestrator for easier testing
+    ([resolve-current-test-failures]).
 
 See the [release plan](docs/release_plan.md) for upcoming milestones.
+
+[align-environment-with-requirements]: issues/archive/align-environment-with-requirements.md
+[create-more-comprehensive-test-contexts]: issues/archive/create-more-comprehensive-test-contexts.md
+[update-release-documentation]: issues/archive/update-release-documentation.md
+[resolve-current-test-failures]: issues/archive/resolve-current-test-failures.md
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Current checks show `flake8` and `mypy` passing, while `pytest -q`
 fails during collection due to missing optional dependencies like
 `tomli_w`, `freezegun`, and `pytest_bdd`.
 
-Outstanding test work is tracked in
-[resolve-current-test-failures](issues/resolve-current-test-failures.md).
+Outstanding test work was tracked in
+[resolve-current-test-failures](issues/archive/resolve-current-test-failures.md).
 
 See [docs/release_plan.md](docs/release_plan.md#alpha-release-checklist) for the
 alpha release checklist.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,5 +106,5 @@ The 1.0.0 milestone aims for a polished, production-ready system:
 - Optimize performance across all components and finalize documentation.
 
 [resolve-test-failures]: issues/archive/resolve-current-test-failures.md
-[align-environment-reqs]: issues/align-environment-with-requirements.md
+[align-environment-reqs]: issues/archive/align-environment-with-requirements.md
 [update-release-documentation]: issues/archive/update-release-documentation.md


### PR DESCRIPTION
## Summary
- fix broken links to archived issues in README and ROADMAP
- normalize changelog issue references and point to archived tickets

## Testing
- `task check` *(fails: flake8 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ff7a5acc83338cf7a47c068a417c