### PR TITLE
Expand coverage scope

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,9 @@
 [run]
+source = src/autoresearch
 omit =
+    src/autoresearch/config/models.py
+    src/autoresearch/test_tools.py
+    */tests/*
+
 [report]
-include = src/autoresearch/config/models.py
+include = src/autoresearch/*


### PR DESCRIPTION
## Summary
- include all modules under `src/autoresearch` in coverage analysis
- omit generated config and test helpers from coverage

## Testing
- `task verify` *(fails: KeyboardInterrupt during tests)*
- `task coverage` *(fails: KeyboardInterrupt during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fc26b2a083339925ce8b3d0e2ab1