### PR TITLE
Reopen test and environment issues

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,6 +105,6 @@ The 1.0.0 milestone aims for a polished, production-ready system:
   lines 178-186; TASK_PROGRESS lines 206-216).
 - Optimize performance across all components and finalize documentation.
 
-[resolve-test-failures]: issues/archive/resolve-current-test-failures.md
+[resolve-test-failures]: issues/resolve-current-test-failures.md
 [align-environment-reqs]: issues/align-environment-with-requirements.md
 [update-release-documentation]: issues/archive/update-release-documentation.md

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -82,4 +82,4 @@ optional extras):
 - [ ] `uv run pytest tests/behavior`
 - [ ] `task coverage` reports at least **90%** total coverage
 
-[resolve-test-failures]: ../issues/archive/resolve-current-test-failures.md
+[resolve-test-failures]: ../issues/resolve-current-test-failures.md

--- a/issues/align-environment-with-requirements.md
+++ b/issues/align-environment-with-requirements.md
@@ -21,4 +21,5 @@ avoid failures and missing tooling.
 Environment verified and aligns with requirements.
 
 ## Status
-Archived
+Open
+

--- a/issues/resolve-current-test-failures.md
+++ b/issues/resolve-current-test-failures.md
@@ -21,5 +21,5 @@ similar failures and did not report overall coverage.
 - The suite runs without unexpected warnings.
 
 ## Status
-Archived
+Open
 


### PR DESCRIPTION
## Summary
- Move previously archived issues back to active status and mark them open
- Update roadmap and release plan links to reference reopened issues

## Testing
- `uv run flake8 src tests` *(fails: tests/unit/test_bm25_scoring.py:5:1: F401 'numpy as np' imported but unused)*
- `uv run mypy src`
- `uv run pytest -q` *(368 passed, 5 skipped, 97 deselected, 33 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a40067569c8333ada27bf52eee53f0