### PR TITLE
ci: run env check before deps install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+# This workflow is manually triggered only.
+# Run it from the Actions tab via "Run workflow" or
+# via the CLI: `gh workflow run CI`.
 on:
   workflow_dispatch:
 
@@ -23,6 +26,8 @@ jobs:
           EOF
       - name: Install uv
         run: python -m pip install uv
+      - name: Check environment
+        run: uv run python scripts/check_env.py
       - name: Install dependencies
         run: uv pip sync uv.lock
       - name: Install extras


### PR DESCRIPTION
## Summary
- check environment in CI before dependency installation
- document manual dispatch for CI workflow

## Testing
- `uv run task check` *(fails: tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt - assert 130 == 0)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bdb6a2e08333a225fca3e8ccaa37