### PR TITLE
Add algorithm documentation references

### DIFF
--- a/src/autoresearch/search/__init__.py
+++ b/src/autoresearch/search/__init__.py
@@ -1,6 +1,9 @@
 """Search subpackage.
 
-See :mod:`docs.search_spec` for behaviour and test details.
+See :mod:`docs.search_spec` for behaviour and test details. Algorithm
+background for relevance ranking lives in
+``docs/algorithms/bm25.md``, ``docs/algorithms/semantic_similarity.md``,
+and ``docs/algorithms/source_credibility.md``.
 """
 
 from .core import Search, get_search

--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -12,6 +12,13 @@ The module includes:
 2. Decorator for registering search backends
 3. Built-in backends for DuckDuckGo and Serper
 4. Error handling for network issues, timeouts, and invalid responses
+
+See also the algorithm references in ``docs/algorithms`` for detailed
+descriptions of the ranking components:
+
+* ``docs/algorithms/bm25.md`` – lexical BM25 scoring
+* ``docs/algorithms/semantic_similarity.md`` – embedding-based similarity
+* ``docs/algorithms/source_credibility.md`` – domain credibility heuristics
 """
 
 from __future__ import annotations

--- a/tests/unit/test_algorithm_docs.py
+++ b/tests/unit/test_algorithm_docs.py
@@ -1,0 +1,44 @@
+"""Ensure algorithm documentation references in search module stay valid.
+
+The ranking components rely on BM25, semantic similarity and source
+credibility heuristics. Their implementations reference algorithm docs; this
+test asserts those paths exist to avoid stale links.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autoresearch.search import core
+
+
+DOC_PATHS = {
+    "bm25": "docs/algorithms/bm25.md",
+    "semantic": "docs/algorithms/semantic_similarity.md",
+    "credibility": "docs/algorithms/source_credibility.md",
+}
+
+
+def repo_root() -> Path:
+    """Return the repository root path."""
+
+    return Path(__file__).resolve().parents[2]
+
+
+def test_algorithm_docs_exist() -> None:
+    """Algorithm documentation files referenced in docstrings must exist."""
+
+    root = repo_root()
+    for rel_path in DOC_PATHS.values():
+        assert (root / rel_path).is_file(), f"Missing documentation: {rel_path}"
+
+
+def test_core_docstrings_reference_docs() -> None:
+    """Core search functions should mention their algorithm docs."""
+
+    assert DOC_PATHS["bm25"] in (core.calculate_bm25_scores.__doc__ or "")
+    assert DOC_PATHS["semantic"] in (core.calculate_semantic_similarity.__doc__ or "")
+    assert DOC_PATHS["credibility"] in (core.assess_source_credibility.__doc__ or "")
+    module_doc = core.__doc__ or ""
+    for rel_path in DOC_PATHS.values():
+        assert rel_path in module_doc


### PR DESCRIPTION
## Summary
- cross-reference BM25, semantic similarity, and source credibility docs in search module
- validate algorithm doc references with unit tests

## Testing
- `uv run black --check src/autoresearch/search/core.py src/autoresearch/search/__init__.py tests/unit/test_algorithm_docs.py`
- `uv run flake8 src/autoresearch/search/core.py src/autoresearch/search/__init__.py tests/unit/test_algorithm_docs.py`
- `uv run mypy src/autoresearch/search/core.py src/autoresearch/search/__init__.py tests/unit/test_algorithm_docs.py` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'tomli_w')*

------
https://chatgpt.com/codex/tasks/task_e_68a4bda3bd408333b40dbf7f125323c5