### PR TITLE
Add environment version check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,14 @@ Activate the environment with `source .venv/bin/activate` before running command
 - If tests fail with `ModuleNotFoundError`, ensure all dependencies are installed in the virtual environment using `uv sync --all-extras && uv pip install -e .`. Time-based tests rely on `freezegun`, which is included in the development extras.
 - When starting the API with `uvicorn autoresearch.api:app --reload`, install `uvicorn` if the command is not found and verify that port `8000` is free.
 
+### Environment check
+
+Verify that core tooling is installed and meets the minimum versions:
+
+```bash
+uv run python scripts/check_env.py
+```
+
 ### Smoke test
 
 Run the environment smoke test to verify your installation:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,6 +9,7 @@ tasks:
     desc: "Initialize development environment"
   check:
     cmds:
+      - uv run python scripts/check_env.py
       - uv run flake8 src tests
       - uv run mypy src
       - uv run pytest tests/unit -q
@@ -78,6 +79,7 @@ tasks:
 
   verify:
     cmds:
+      - uv run python scripts/check_env.py
       - uv run flake8 src tests
       - uv run mypy src
       - uv run pytest tests/unit --cov=src --cov-report=term-missing --cov-append

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Check development tool versions.
+
+Usage:
+    uv run python scripts/check_env.py
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from importlib import metadata
+
+try:  # pragma: no cover - packaging is required
+    from packaging.version import Version
+except ModuleNotFoundError as exc:  # pragma: no cover
+    raise SystemExit("packaging library is required") from exc
+
+REQUIREMENTS = {
+    "python": "3.12.0",
+    "task": "3.0.0",
+    "flake8": "7.2.0",
+    "mypy": "1.10.0",
+    "pytest": "8.3.5",
+    "pytest-bdd": "8.1.0",
+    "pydantic": "2.0.0",
+}
+
+
+@dataclass
+class CheckResult:
+    name: str
+    current: str
+    required: str
+
+    def ok(self) -> bool:
+        return Version(self.current) >= Version(self.required)
+
+
+class VersionError(RuntimeError):
+    """Raised when a requirement is not satisfied."""
+
+
+def check_python() -> CheckResult:
+    current = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    return CheckResult("Python", current, REQUIREMENTS["python"])
+
+
+def check_task() -> CheckResult:
+    proc = subprocess.run(
+        ["task", "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise VersionError("Go Task is not installed")
+    match = re.search(r"(\d+\.\d+\.\d+)", proc.stdout)
+    if not match:
+        raise VersionError("Could not determine Go Task version")
+    current = match.group(1)
+    return CheckResult("Go Task", current, REQUIREMENTS["task"])
+
+
+def check_module(module: str, package: str | None = None) -> CheckResult:
+    importlib.import_module(module)
+    pkg = package or module
+    current = metadata.version(pkg)
+    required = REQUIREMENTS[pkg]
+    return CheckResult(pkg, current, required)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate required tool versions")
+    parser.parse_args()
+
+    checks = [
+        check_python,
+        check_task,
+        lambda: check_module("flake8"),
+        lambda: check_module("mypy"),
+        lambda: check_module("pytest"),
+        lambda: check_module("pytest_bdd", "pytest-bdd"),
+        lambda: check_module("pydantic"),
+    ]
+
+    errors: list[str] = []
+    for check in checks:
+        try:
+            result = check()
+            if result.ok():
+                print(f"{result.name} {result.current}")
+            else:
+                errors.append(
+                    f"{result.name} {result.current} < required {result.required}"
+                )
+        except Exception as exc:  # pragma: no cover - failure paths
+            errors.append(str(exc))
+
+    if errors:
+        for err in errors:
+            print(f"ERROR: {err}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `check_env.py` script to validate versions of Python, Task, flake8, mypy, pytest, pytest-bdd, and pydantic
- invoke the environment check at the start of `task check` and `task verify`
- document how to run the environment check in the README

## Testing
- `uv run python scripts/check_env.py`
- `task check` *(fails: exit status 2)*
- `task verify` *(fails: exit status 2)*


------
https://chatgpt.com/codex/tasks/task_e_68a4bd972c0c8333b046ccf9bcd83c80