### PR TITLE
docs: add release workflow guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ planned for **July 20, 2025**, but the schedule slipped. An
 the final **0.1.0** milestone targeted for **June 1, 2026**. See
 [ROADMAP.md](ROADMAP.md) for feature milestones and
 [docs/release_plan.md](docs/release_plan.md) for the full schedule,
-outstanding tasks, and current test and coverage status.
+outstanding tasks, and current test and coverage status. The release
+workflow is detailed in [docs/releasing.md](docs/releasing.md).
 
 Current checks show `flake8` and `mypy` passing, while `pytest -q`
 fails during collection due to missing optional dependencies like

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -2,7 +2,8 @@
 
 This document outlines the upcoming release milestones for **Autoresearch**.
 Dates are aspirational and may shift as development progresses. The publishing
-workflow follows the steps in [deployment.md](deployment.md). See the
+workflow follows the steps in [deployment.md](deployment.md). Detailed release
+commands are documented in [releasing.md](releasing.md). See the
 [README](../README.md) for installation details and [ROADMAP](../ROADMAP.md) for
 high-level milestones.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,22 @@
+# Releasing
+
+Follow these steps to publish a new version of Autoresearch.
+
+- Update the version in `pyproject.toml` and
+  `src/autoresearch/__init__.py`. Commit the change and tag the release.
+- Build the distribution files.
+
+  ```bash
+  uv run python -m build
+  ```
+- Upload the build to TestPyPI for validation.
+
+  ```bash
+  uv run python scripts/publish_dev.py --dry-run
+  uv run python scripts/publish_dev.py
+  ```
+- Release to PyPI once the TestPyPI upload is verified.
+
+  ```bash
+  uv run twine upload dist/*
+  ```


### PR DESCRIPTION
## Summary
- document step-by-step release procedure with uv commands
- link release guide from README and release plan

## Testing
- `uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68a4de1674788333aa03d5409e53bdc5