### PR TITLE
Add version bump script and task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,6 +93,11 @@ tasks:
       - find . -type d -name '.mypy_cache' -exec rm -rf {} +
     desc: "Remove Python cache directories"
 
+  bump-version:
+    cmds:
+      - uv run python scripts/bump_version.py {{.CLI_ARGS}}
+    desc: "Update project version numbers"
+
   check-baselines:
     cmds:
       - uv run python scripts/check_token_regression.py --threshold 5

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -57,18 +57,19 @@ Resolving these items will determine the new completion date for **0.1.0**.
 2. **Development** – implement features and expand test coverage.
 3. **Stabilization** – fix bugs, write documentation and run the full test
    suite.
-4. **Publish** – follow the workflow in `deployment.md`: bump the version, run
-   tests, publish to TestPyPI using `./scripts/publish_dev.py`, then release to
-   PyPI with `twine upload dist/*`.
+4. **Publish** – follow the workflow in `deployment.md`: run
+   `task bump-version -- <new-version>`, run tests, publish to TestPyPI using
+   `./scripts/publish_dev.py`, then release to PyPI with `twine upload dist/*`.
 
 Each milestone may include additional patch releases for critical fixes.
 
 ## Packaging Workflow
 
-1. `uv pip install build twine`
-2. `uv run python -m build`
-3. `uv run python scripts/publish_dev.py --dry-run`
-4. Set `TWINE_USERNAME` and `TWINE_PASSWORD` then run
+1. `task bump-version -- <new-version>`
+2. `uv pip install build twine`
+3. `uv run python -m build`
+4. `uv run python scripts/publish_dev.py --dry-run`
+5. Set `TWINE_USERNAME` and `TWINE_PASSWORD` then run
    `uv run python scripts/publish_dev.py` to upload to TestPyPI.
 
 ## CI Checklist

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Update project version in pyproject.toml and src/autoresearch/__init__.py.
+
+Usage:
+    uv run python scripts/bump_version.py 0.1.1
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+INIT_FILE = ROOT / "src" / "autoresearch" / "__init__.py"
+
+
+def _update_pyproject(version: str) -> None:
+    content = PYPROJECT.read_text()
+    new_content = re.sub(r'(?m)^version = "[^"]+"', f'version = "{version}"', content)
+    PYPROJECT.write_text(new_content)
+
+
+def _update_init(version: str) -> None:
+    content = INIT_FILE.read_text()
+    new_content = re.sub(r'__version__ = "[^"]+"', f'__version__ = "{version}"', content)
+    INIT_FILE.write_text(new_content)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate version string and update project files."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="New version, e.g., 0.1.1")
+    args = parser.parse_args(argv)
+
+    try:
+        Version(args.version)
+    except InvalidVersion as exc:
+        raise SystemExit(f"Invalid version '{args.version}': {exc}")
+
+    _update_pyproject(args.version)
+    _update_init(args.version)
+    print(f"Version updated to {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/bump_version.py` to update project version in pyproject and `__init__`
- wire a `bump-version` task into Taskfile
- document using the new task during release prep

## Testing
- `task install`
- `task verify` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a4de11ce2c8333bc930875fe101e80