### PR TITLE
Check twine credentials before dev publish

### DIFF
--- a/scripts/publish_dev.py
+++ b/scripts/publish_dev.py
@@ -1,11 +1,23 @@
 #!/usr/bin/env python
-"""Publish a development build to the TestPyPI repository."""
+"""Publish a development build to the TestPyPI repository.
+
+Usage:
+    uv run scripts/publish_dev.py [--dry-run]
+
+Required environment variables:
+    TWINE_USERNAME -- TestPyPI username
+    TWINE_PASSWORD -- TestPyPI password
+
+The script builds the package and uploads it to TestPyPI using ``twine``.
+"""
 
 from __future__ import annotations
 
 import argparse
 import shutil
 import subprocess
+import os
+import sys
 from pathlib import Path
 
 
@@ -37,8 +49,20 @@ def main(argv: list[str] | None = None) -> int:
         print("Dry run selected; skipping upload")
         return 0
 
+    if not os.getenv("TWINE_USERNAME") or not os.getenv("TWINE_PASSWORD"):
+        print("TWINE_USERNAME and TWINE_PASSWORD must be set in the environment")
+        return 1
+
     upload_cmd = ["uv", "run", "twine", "upload", "--repository", "testpypi", *files]
-    return subprocess.call(upload_cmd)
+    result = subprocess.run(upload_cmd, capture_output=True, text=True)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode != 0:
+        if "403" in result.stdout or "403" in result.stderr:
+            print("Upload failed: received HTTP 403 from repository")
+            return 1
+        return result.returncode
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- document usage and required TestPyPI credentials in `publish_dev.py`
- validate `TWINE_USERNAME`/`TWINE_PASSWORD` before uploading
- surface 403 responses from `twine upload`

## Testing
- `uv run ruff check scripts/publish_dev.py`
- `uv run black --check scripts/publish_dev.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'freezegun')*


------
https://chatgpt.com/codex/tasks/task_e_68a4de0e3b10833399c63df3ad605cf9