### PR TITLE
docs: add specs for additional modules

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -17,6 +17,32 @@ documented behaviour.
 | `src/autoresearch/storage.py` | [storage.md](storage.md) | `../../tests/unit/test_storage*.py`<br>`../../tests/integration/test_*storage*.py`<br>`../../tests/behavior/features/storage_search_integration.feature` |
 | `src/autoresearch/synthesis.py` | [synthesis.md](synthesis.md) | `../../tests/behavior/features/synthesis.feature` |
 | `src/autoresearch/tracing.py` | [tracing.md](tracing.md) | `../../tests/behavior/features/tracing.feature` |
+| `src/autoresearch/a2a_interface.py` | [a2a-interface.md](a2a-interface.md) | `../../tests/unit/test_a2a_interface.py<br>../../tests/integration/test_a2a_interface.py<br>../../tests/behavior/features/a2a_interface.feature` |
+| `src/autoresearch/agents/` | [agents.md](agents.md) | `../../tests/unit/test_advanced_agents.py<br>../../tests/unit/test_agents_llm.py<br>../../tests/unit/test_specialized_agents.py` |
+| `src/autoresearch/api/` | [api.md](api.md) | `../../tests/unit/test_api.py<br>../../tests/unit/test_api_error_handling.py<br>../../tests/unit/test_api_imports.py` |
+| `src/autoresearch/cli_backup.py` | [cli-backup.md](cli-backup.md) | `../../tests/unit/test_cli_backup_extra.py` |
+| `src/autoresearch/cli_helpers.py` | [cli-helpers.md](cli-helpers.md) | `../../tests/unit/test_cli_helpers.py` |
+| `src/autoresearch/cli_utils.py` | [cli-utils.md](cli-utils.md) | `../../tests/unit/test_cli_utils_extra.py` |
+| `src/autoresearch/config_utils.py` | [config-utils.md](config-utils.md) | `../../tests/unit/test_streamlit_app_edgecases.py<br>../../tests/unit/test_streamlit_utils.py` |
+| `src/autoresearch/config/` | [config.md](config.md) | `../../tests/unit/test_config_env_file.py<br>../../tests/unit/test_config_errors.py<br>../../tests/unit/test_config_loader_defaults.py` |
+| `src/autoresearch/distributed/` | [distributed.md](distributed.md) | `../../tests/unit/test_distributed.py<br>../../tests/unit/test_distributed_extra.py<br>../../tests/integration/test_distributed_agent_storage.py` |
+| `src/autoresearch/error_utils.py` | [error-utils.md](error-utils.md) | `../../tests/unit/test_error_utils_additional.py` |
+| `src/autoresearch/errors.py` | [errors.md](errors.md) | `../../tests/unit/test_config_errors.py<br>../../tests/unit/test_config_validation_errors.py<br>../../tests/unit/test_errors.py` |
+| `src/autoresearch/extensions.py` | [extensions.md](extensions.md) | `../../tests/unit/test_vss_extension_loader.py<br>../../tests/unit/test_duckdb_storage_backend.py` |
+| `src/autoresearch/kg_reasoning.py` | [kg-reasoning.md](kg-reasoning.md) | `../../tests/unit/test_kg_reasoning.py` |
+| `src/autoresearch/llm/` | [llm.md](llm.md) | `../../tests/unit/test_agents_llm.py<br>../../tests/unit/test_llm_adapter.py<br>../../tests/unit/test_llm_capabilities.py` |
+| `src/autoresearch/logging_utils.py` | [logging-utils.md](logging-utils.md) | `../../tests/unit/test_logging_utils.py` |
+| `src/autoresearch/main/` | [main.md](main.md) | `../../tests/unit/test_main_backup_commands.py<br>../../tests/unit/test_main_cli.py<br>../../tests/unit/test_main_config_commands.py` |
+| `src/autoresearch/mcp_interface.py` | [mcp-interface.md](mcp-interface.md) | `../../tests/unit/test_mcp_interface.py<br>../../tests/behavior/features/mcp_interface.feature` |
+| `src/autoresearch/models.py` | [models.md](models.md) | `../../tests/unit/test_models_docstrings.py` |
+| `src/autoresearch/monitor/` | [monitor.md](monitor.md) | `../../tests/unit/test_main_monitor_commands.py<br>../../tests/unit/test_monitor_cli.py<br>../../tests/unit/test_resource_monitor_gpu.py` |
+| `src/autoresearch/resource_monitor.py` | [resource-monitor.md](resource-monitor.md) | `../../tests/unit/test_resource_monitor_gpu.py` |
+| `src/autoresearch/storage_backends.py` | [storage-backends.md](storage-backends.md) | `../../tests/unit/test_duckdb_storage_backend.py<br>../../tests/unit/test_duckdb_storage_backend_extended.py` |
+| `src/autoresearch/storage_backup.py` | [storage-backup.md](storage-backup.md) | `../../tests/unit/test_storage_backup.py` |
+| `src/autoresearch/streamlit_app.py` | [streamlit-app.md](streamlit-app.md) | `../../tests/unit/test_streamlit_app_edgecases.py` |
+| `src/autoresearch/streamlit_ui.py` | [streamlit-ui.md](streamlit-ui.md) | `../../tests/unit/test_streamlit_ui_helpers.py` |
+| `src/autoresearch/test_tools.py` | [test-tools.md](test-tools.md) | `../../tests/unit/test_test_tools.py` |
+| `src/autoresearch/visualization.py` | [visualization.md](visualization.md) | `../../tests/unit/test_visualization.py<br>../../tests/behavior/features/visualization_cli.feature` |
 
 ## Mapping specs to tests
 

--- a/docs/specs/a2a-interface.md
+++ b/docs/specs/a2a-interface.md
@@ -1,0 +1,9 @@
+# A2A Interface
+
+A2A (Agent-to-Agent) interface for Autoresearch.
+
+## Traceability
+
+- `../../tests/unit/test_a2a_interface.py`
+- `../../tests/integration/test_a2a_interface.py`
+- `../../tests/behavior/features/a2a_interface.feature`

--- a/docs/specs/agents.md
+++ b/docs/specs/agents.md
@@ -1,0 +1,9 @@
+# Agents
+
+Dialectical agent infrastructure.
+
+## Traceability
+
+- `../../tests/unit/test_advanced_agents.py`
+- `../../tests/unit/test_agents_llm.py`
+- `../../tests/unit/test_specialized_agents.py`

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1,0 +1,9 @@
+# Api
+
+FastAPI app aggregator for Autoresearch.
+
+## Traceability
+
+- `../../tests/unit/test_api.py`
+- `../../tests/unit/test_api_error_handling.py`
+- `../../tests/unit/test_api_imports.py`

--- a/docs/specs/cli-backup.md
+++ b/docs/specs/cli-backup.md
@@ -1,0 +1,7 @@
+# Cli Backup
+
+Typer commands for managing database backups.
+
+## Traceability
+
+- `../../tests/unit/test_cli_backup_extra.py`

--- a/docs/specs/cli-helpers.md
+++ b/docs/specs/cli-helpers.md
@@ -1,0 +1,7 @@
+# Cli Helpers
+
+Small helper utilities used by the CLI.
+
+## Traceability
+
+- `../../tests/unit/test_cli_helpers.py`

--- a/docs/specs/cli-utils.md
+++ b/docs/specs/cli-utils.md
@@ -1,0 +1,7 @@
+# Cli Utils
+
+CLI utilities for consistent formatting and accessibility.
+
+## Traceability
+
+- `../../tests/unit/test_cli_utils_extra.py`

--- a/docs/specs/config-utils.md
+++ b/docs/specs/config-utils.md
@@ -1,0 +1,8 @@
+# Config Utils
+
+Configuration helper utilities for the Streamlit app.
+
+## Traceability
+
+- `../../tests/unit/test_streamlit_app_edgecases.py`
+- `../../tests/unit/test_streamlit_utils.py`

--- a/docs/specs/config.md
+++ b/docs/specs/config.md
@@ -1,0 +1,9 @@
+# Config
+
+Specification for config module.
+
+## Traceability
+
+- `../../tests/unit/test_config_env_file.py`
+- `../../tests/unit/test_config_errors.py`
+- `../../tests/unit/test_config_loader_defaults.py`

--- a/docs/specs/distributed.md
+++ b/docs/specs/distributed.md
@@ -1,0 +1,9 @@
+# Distributed
+
+Distributed execution utilities.
+
+## Traceability
+
+- `../../tests/unit/test_distributed.py`
+- `../../tests/unit/test_distributed_extra.py`
+- `../../tests/integration/test_distributed_agent_storage.py`

--- a/docs/specs/error-utils.md
+++ b/docs/specs/error-utils.md
@@ -1,0 +1,7 @@
+# Error Utils
+
+Error handling utilities for consistent error reporting across interfaces.
+
+## Traceability
+
+- `../../tests/unit/test_error_utils_additional.py`

--- a/docs/specs/errors.md
+++ b/docs/specs/errors.md
@@ -1,0 +1,9 @@
+# Errors
+
+Error hierarchy for Autoresearch.
+
+## Traceability
+
+- `../../tests/unit/test_config_errors.py`
+- `../../tests/unit/test_config_validation_errors.py`
+- `../../tests/unit/test_errors.py`

--- a/docs/specs/extensions.md
+++ b/docs/specs/extensions.md
@@ -1,0 +1,8 @@
+# Extensions
+
+DuckDB extension management module.
+
+## Traceability
+
+- `../../tests/unit/test_vss_extension_loader.py`
+- `../../tests/unit/test_duckdb_storage_backend.py`

--- a/docs/specs/kg-reasoning.md
+++ b/docs/specs/kg-reasoning.md
@@ -1,0 +1,7 @@
+# Kg Reasoning
+
+Helper utilities for ontology reasoning and advanced SPARQL queries.
+
+## Traceability
+
+- `../../tests/unit/test_kg_reasoning.py`

--- a/docs/specs/llm.md
+++ b/docs/specs/llm.md
@@ -1,0 +1,9 @@
+# Llm
+
+Language Model (LLM) integration module for Autoresearch.
+
+## Traceability
+
+- `../../tests/unit/test_agents_llm.py`
+- `../../tests/unit/test_llm_adapter.py`
+- `../../tests/unit/test_llm_capabilities.py`

--- a/docs/specs/logging-utils.md
+++ b/docs/specs/logging-utils.md
@@ -1,0 +1,8 @@
+# Logging Utils
+
+Logging utilities that combine loguru and structlog for structured JSON
+logging.
+
+## Traceability
+
+- `../../tests/unit/test_logging_utils.py`

--- a/docs/specs/main.md
+++ b/docs/specs/main.md
@@ -1,0 +1,9 @@
+# Main
+
+CLI entry points.
+
+## Traceability
+
+- `../../tests/unit/test_main_backup_commands.py`
+- `../../tests/unit/test_main_cli.py`
+- `../../tests/unit/test_main_config_commands.py`

--- a/docs/specs/mcp-interface.md
+++ b/docs/specs/mcp-interface.md
@@ -1,0 +1,8 @@
+# Mcp Interface
+
+MCP protocol integration using fastmcp.
+
+## Traceability
+
+- `../../tests/unit/test_mcp_interface.py`
+- `../../tests/behavior/features/mcp_interface.feature`

--- a/docs/specs/models.md
+++ b/docs/specs/models.md
@@ -1,0 +1,7 @@
+# Models
+
+This module provides data models for Autoresearch.
+
+## Traceability
+
+- `../../tests/unit/test_models_docstrings.py`

--- a/docs/specs/monitor.md
+++ b/docs/specs/monitor.md
@@ -1,0 +1,9 @@
+# Monitor
+
+Interactive monitoring commands for Autoresearch.
+
+## Traceability
+
+- `../../tests/unit/test_main_monitor_commands.py`
+- `../../tests/unit/test_monitor_cli.py`
+- `../../tests/unit/test_resource_monitor_gpu.py`

--- a/docs/specs/resource-monitor.md
+++ b/docs/specs/resource-monitor.md
@@ -1,0 +1,7 @@
+# Resource Monitor
+
+Background resource usage monitoring utilities.
+
+## Traceability
+
+- `../../tests/unit/test_resource_monitor_gpu.py`

--- a/docs/specs/storage-backends.md
+++ b/docs/specs/storage-backends.md
@@ -1,0 +1,8 @@
+# Storage Backends
+
+Storage backend implementations for the autoresearch project.
+
+## Traceability
+
+- `../../tests/unit/test_duckdb_storage_backend.py`
+- `../../tests/unit/test_duckdb_storage_backend_extended.py`

--- a/docs/specs/storage-backup.md
+++ b/docs/specs/storage-backup.md
@@ -1,0 +1,7 @@
+# Storage Backup
+
+Storage backup and restore functionality for the Autoresearch project.
+
+## Traceability
+
+- `../../tests/unit/test_storage_backup.py`

--- a/docs/specs/streamlit-app.md
+++ b/docs/specs/streamlit-app.md
@@ -1,0 +1,7 @@
+# Streamlit App
+
+Streamlit GUI for Autoresearch.
+
+## Traceability
+
+- `../../tests/unit/test_streamlit_app_edgecases.py`

--- a/docs/specs/streamlit-ui.md
+++ b/docs/specs/streamlit-ui.md
@@ -1,0 +1,7 @@
+# Streamlit Ui
+
+Helper functions for the Streamlit user interface.
+
+## Traceability
+
+- `../../tests/unit/test_streamlit_ui_helpers.py`

--- a/docs/specs/test-tools.md
+++ b/docs/specs/test-tools.md
@@ -1,0 +1,7 @@
+# Test Tools
+
+Testing tools for A2A/MCP interactions.
+
+## Traceability
+
+- `../../tests/unit/test_test_tools.py`

--- a/docs/specs/visualization.md
+++ b/docs/specs/visualization.md
@@ -1,0 +1,8 @@
+# Visualization
+
+Utilities for generating graphical representations of query results.
+
+## Traceability
+
+- `../../tests/unit/test_visualization.py`
+- `../../tests/behavior/features/visualization_cli.feature`


### PR DESCRIPTION
## Summary
- add specification files for modules under `src/autoresearch/`
- link specs to existing unit and behavior tests
- extend traceability matrix with new module entries

## Testing
- `./bin/task verify` *(fails: No module named 'flake8')*
- `./bin/task install` *(fails: exit status 130)*

------
https://chatgpt.com/codex/tasks/task_e_68a508767e288333b006de90071fac25