### PR TITLE
docs: clarify AGENTS policies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,16 +3,19 @@
 ## Snapshot
 - **Purpose:** AI-assisted research orchestration framework.
 - **Primary language:** Python.
-- **Key outputs:** Library, CLI, and documentation for automated research workflows.
+- **Key outputs:** Library, CLI, and documentation for automated research
+  workflows.
 
 ## Environment
-- Run `task install` to initialize the Python 3.12+ environment and install hooks or dependencies.
-- Use **uv** for package management; prefix standalone Python commands with `uv run`.
-- Keep `scripts/codex_setup.sh` aligned with these instructions; it is the only script permitted to reference this file.
+- Run `task install` to initialize the Python 3.12+ environment and install
+  hooks or dependencies.
+- Use **uv** for package management; prefix standalone Python commands
+  with `uv run`.
 
 ## Build and Test
 - `task check` – quick lint, type check, and test run.
-- `task verify` – run before committing; performs linting, type checks, and the full test suite with coverage.
+- `task verify` – run before committing; performs linting, type checks, and
+  the full test suite with coverage.
 - `task clean` – remove build artifacts.
 - For testing details see `docs/testing_guidelines.md` (load only if needed).
 - See `tests/AGENTS.md` for test markers and extras.
@@ -24,19 +27,24 @@
 - Additional style guidance lives in `CONTRIBUTING.md` (load only if needed).
 
 ## Dialectical Process
-- Apply a Socratic approach: state assumptions, question them, compare alternatives, and refine based on evidence.
+- Apply a Socratic approach: state assumptions, question them, compare
+  alternatives, and refine based on evidence.
 - Document reasoning steps in commits and discussions.
 
 ## Policy
-- Only `scripts/codex_setup.sh` may mention `AGENTS.md`; do not reference this file elsewhere.
-- This file's scope is the entire repository; nested `AGENTS.md` files override these rules.
+- Only `scripts/codex_setup.sh` may mention `AGENTS.md`; keep it aligned
+  with these instructions.
+- This file's scope is the entire repository; nested `AGENTS.md` files
+  override these rules.
 - For extensive details, consult docs under `docs/` as required.
 
 ## Changelog
-- 2025-08-19: Added project snapshot, environment steps, Task commands, coding conventions, and AGENTS referencing policy.
-- 2025-08-19: Added `AGENTS.md` for [src](src/AGENTS.md), [scripts](scripts/AGENTS.md),
-  and [examples](examples/AGENTS.md).
-- 2025-08-19: Documented `uv` usage and added guidelines for the `extensions/` directory.
-
-This `AGENTS.md` follows the AGENTS.md spec: its scope is the entire repo and nested rules override it.
+- 2025-08-19: Added project snapshot, environment steps, Task commands,
+  coding conventions, and AGENTS referencing policy.
+- 2025-08-19: Added `AGENTS.md` for [src](src/AGENTS.md),
+  [scripts](scripts/AGENTS.md), and [examples](examples/AGENTS.md).
+- 2025-08-19: Documented `uv` usage and added guidelines for the
+  `extensions/` directory.
+- 2025-08-19: Trimmed redundant instructions and enforced 80-character
+  lines across AGENTS files.
 

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -8,4 +8,5 @@ These instructions apply to files in the `examples/` directory.
 
 ## Licensing
 - Assume sample data is covered by the project's AGPL-3.0 license unless noted.
-- Document third-party assets with their original licenses and required attribution.
+- Document third-party assets with their original licenses and required
+  attribution.

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -3,7 +3,7 @@
 These instructions apply to files in the `extensions/` directory.
 
 ## Coding style
-- Follow repository conventions: PEP 8 with 4-space indentation and lines ≤100 characters.
+- Follow repository conventions.
 - Organize imports with `isort`'s default profile.
 
 ## Tooling

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -3,13 +3,15 @@
 These instructions apply to files in the `src/` directory.
 
 ## Coding style
-- Follow the repository's PEP 8 settings: 4-space indentation and lines ≤100 characters.
+- Follow repository conventions.
 - Organize imports with `isort`'s default profile.
 
 ## Docstrings
-- Provide Google-style docstrings for all public classes, functions, and modules.
+- Provide Google-style docstrings for all public classes, functions, and
+  modules.
 - Include `Args`, `Returns`, and `Raises` sections when applicable.
 
 ## Type checking
 - Use explicit type hints for function signatures and critical variables.
-- Run `task check` to validate types before committing. When invoking tools directly, prefix them with `uv run`.
+- Run `task check` to validate types before committing. When invoking tools
+  directly, prefix them with `uv run`.


### PR DESCRIPTION
## Summary
- enforce 80-character wrapping across AGENTS files
- drop redundant style reminders from extensions and src directives
- record AGENTS policy cleanup in root changelog

## Testing
- `task check` *(fails: tests/unit/test_monitor_cli.py::test_monitor_prompts_and_passes_callbacks - assert 130 == 0)*

------
https://chatgpt.com/codex/tasks/task_e_68a508704e2883339aecf246646adb53