### PR TITLE
Enforce Python 3.12 requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install uv
         run: python -m pip install uv
       - name: Check environment
-        run: uv run python scripts/check_env.py
+        run: uv run task check-env
       - name: Install dependencies
         run: uv pip sync uv.lock
       - name: Install extras

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ data in local databases so that searches and knowledge graphs remain on your mac
 The project is built around a modular Python package located under `src/autoresearch/`.
 CLI utilities are provided via Typer and the HTTP API is powered by FastAPI.
 
+Autoresearch requires **Python 3.12 or newer**.
+
 For current capabilities and known limitations see [docs/release_notes.md](docs/release_notes.md).
 
 ## Roadmap

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,10 +8,10 @@ tasks:
       - uv pip install -e .
     desc: "Initialize development environment"
   check:
+    deps: [check-env]
     # Minimal validation for quick feedback. Skips slow tests and scenarios
     # requiring optional UI (`.[ui]`) or VSS (`.[vss]`) extras.
     cmds:
-      - uv run python scripts/check_env.py
       - uv run flake8 src tests
       - uv run mypy src
       - uv run pytest tests/unit -q
@@ -86,11 +86,11 @@ tasks:
     desc: "Run full test suite with coverage reporting"
 
   verify:
+    deps: [check-env]
     # Coverage-enabled check before committing. Still skips slow tests and
     # optional UI (`.[ui]`) and VSS (`.[vss]`) scenarios to keep runtime
     # reasonable.
     cmds:
-      - uv run python scripts/check_env.py
       - uv run flake8 src tests
       - uv run mypy src
       - uv run pytest tests/unit --cov=src --cov-report=term-missing --cov-append
@@ -98,6 +98,11 @@ tasks:
           --cov=src --cov-report=term-missing --cov-append
       - uv run pytest tests/behavior --cov=src --cov-report=xml --cov-report=term-missing
     desc: "Run linting, type checks and fast tests with coverage"
+
+  check-env:
+    cmds:
+      - uv run python scripts/check_env.py
+    desc: "Validate required tool versions"
 
   clean:
     cmds:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,6 +4,8 @@ This guide explains how to install Autoresearch and manage optional features.
 
 Autoresearch uses **uv** for dependency management. The examples below use `uv`.
 
+Autoresearch requires **Python 3.12 or newer**.
+
 ## Requirements
 
 - Python 3.12 or newer (but below 4.0)

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -14,6 +14,11 @@ import sys
 from dataclasses import dataclass
 from importlib import metadata
 
+if sys.version_info < (3, 12):
+    raise SystemExit(
+        f"Python 3.12+ required, found {sys.version_info.major}.{sys.version_info.minor}"
+    )
+
 try:  # pragma: no cover - packaging is required
     from packaging.version import Version
 except ModuleNotFoundError as exc:  # pragma: no cover


### PR DESCRIPTION
## Summary
- fail fast in `check_env.py` when Python is below 3.12
- add a `check-env` task and run it in Taskfile targets and CI
- document the Python 3.12+ requirement in README and installation docs

## Testing
- `task install`
- `task verify` *(fails: command interrupted after partial test run)*

------
https://chatgpt.com/codex/tasks/task_e_68a521dc28f483338772e323926e4ec1