### PR TITLE
docs: refine release notes and installation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ tests. Use `scripts/setup.sh` when the full dependency set is required. CI
 environments install every extra with `uv sync --all-extras && uv pip install -e .`.
 After editing `pyproject.toml`, regenerate `uv.lock` with `uv lock` and reinstall
 with the needed extras to apply updates.
+The `task` commands rely on [Go Task](https://taskfile.dev/). Install it
+separately if it is not already available on your system.
 Several dependencies are pinned for compatibility—`slowapi` is locked to
 **0.1.9** and `fastapi` must be **0.115** or newer. The test suite works both
 with and without extras:
@@ -77,6 +79,10 @@ with and without extras:
 
 Reinstall optional features with
 `uv sync --extra nlp --extra ui && uv pip install -e .` if you need them later.
+CLI operations such as document ingestion require optional packages like
+`python-docx` and `pdfminer.six`. If the CLI exits with
+`ModuleNotFoundError`, install these packages or sync the appropriate extras
+as described in [docs/installation.md](docs/installation.md).
 
 ### Using uv
 Python 3.12 or newer is required. Set up the development environment with:

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -11,6 +11,12 @@ to produce evidence-backed answers and stores data on the user's machine.
 - Uses local databases for searches and knowledge graphs.
 - Manages dependencies with uv and supports optional extras for features like
   rate limiting.
+- Supports direct, dialectical, and chain-of-thought modes for queries (see
+  [agent system](agent_system.md)).
+- Pluggable search and storage backends enable local-first workflows (see
+  [search backends](search_backends.md) and [storage](storage.md)).
+- Quickstart and advanced guides help explore features (see [quickstart
+  guides](quickstart_guides.md) and [advanced usage](advanced_usage.md)).
 
 ## Known Limitations
 
@@ -22,5 +28,11 @@ to produce evidence-backed answers and stores data on the user's machine.
 - Quick start commands expect an LLM backend like LM Studio; without one,
   searches fail.
 - Loading the VSS extension may require network access and can fail offline.
+- `task` commands need Go Task; install it as noted in
+  [installation](installation.md).
+- CLI operations error without `python-docx` or `pdfminer.six`; see
+  [installation](installation.md).
+- VSS search and some tests require network access; see
+  [DuckDB compatibility](duckdb_compatibility.md).
 
 For installation and usage instructions see the [README](../README.md).

--- a/issues/archive/assemble-release-notes-and-validate-readme.md
+++ b/issues/archive/assemble-release-notes-and-validate-readme.md
@@ -12,4 +12,4 @@ project. They have not been assembled or reviewed in the repository.
 - Cross-links between release notes and README added where appropriate.
 
 ## Status
-Open
+Archived


### PR DESCRIPTION
## Summary
- expand release notes with more capabilities, limitations, and doc cross-links
- clarify that Go Task and optional packages are needed for installation and CLI usage
- archive the "assemble-release-notes-and-validate-readme" issue

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit -q`
- `task verify`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68a52ca6c5c48333a2bd0e6c4c5c2819