### PR TITLE
Use lean dev install and document optional extras

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,9 +3,7 @@ version: '3'
 tasks:
   install:
     cmds:
-      - uv venv
       - uv sync --extra dev-minimal
-      - uv pip install -e .
     desc: "Initialize development environment"
   check:
     deps: [check-env]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,21 +58,17 @@ been verified to install successfully with `uv pip install`.
 Use `uv` to manage the environment when working from a clone:
 
 ```bash
-# Create the virtual environment (.venv/)
-uv venv
 # Install pinned dependencies for minimal development
 uv sync --extra dev-minimal
-# Link the project in editable mode
-uv pip install -e .
 # Activate the environment
 source .venv/bin/activate
 ```
 
-Add extras later as needed:
+Add heavy extras on demand:
 
 ```bash
-uv sync --extra nlp --extra ui
-uv pip install -e .
+uv sync --extra ui
+uv sync --extra nlp
 ```
 
 Alternatively run `task install` for the minimal setup or the helper script:
@@ -137,9 +133,8 @@ The helper ensures the lock file is refreshed and installs every optional
 extra needed for the test suite. Tests normally rely on stubbed versions of
 these extras, so running the suite without them is recommended. Extras such as
 `slowapi` may enable real behaviour (like rate limiting) that changes how
-assertions are evaluated. If you wish to revert to stub-only testing after
-running the helper, reinstall using
-`uv sync --extra nlp --extra ui && uv pip install -e .`.
+  assertions are evaluated. If you wish to revert to stub-only testing after
+  running the helper, reinstall using `uv sync --extra ui --extra nlp`.
 Optional features are disabled when their dependencies are missing. Specify
 extras explicitly with pip to enable additional features, e.g.
 ``pip install "autoresearch[minimal,nlp]"``.
@@ -204,9 +199,9 @@ long time or fail on low-memory machines.
 - Install `gcc`, `g++` and the Python development headers beforehand.
 - If compilation hangs or exhausts memory, set `HDBSCAN_NO_OPENMP=1` to
   disable OpenMP optimizations.
-- Consider installing a pre-built wheel with `pip install hdbscan` prior
-  to running `uv pip install -e .`.
-- You can omit heavy extras by specifying only the groups you need,
-  e.g. `uv pip install -e '.[minimal]'` when rapid setup is more important
+- Consider installing a pre-built wheel with `pip install hdbscan` before
+  running `uv sync`.
+- You can omit heavy extras by syncing only the groups you need,
+  e.g. `uv sync --extra dev-minimal` when rapid setup is more important
   than optional features.
 

--- a/issues/archive/optimize-task-install-dependencies.md
+++ b/issues/archive/optimize-task-install-dependencies.md
@@ -12,4 +12,4 @@ extras would improve setup time while still enabling linting and tests.
 - scripts/codex_setup.sh reflects the streamlined dependency set.
 
 ## Status
-Open
+Archived

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Usage: AR_INSTALL_UI=1 AR_INSTALL_GPU=1 ./scripts/codex_setup.sh
+# Usage: AR_INSTALL_UI=1 AR_INSTALL_NLP=1 ./scripts/codex_setup.sh
 # Agent-specific bootstrap; see AGENTS.md for repository-wide guidelines.
 set -euo pipefail
 
@@ -65,10 +65,8 @@ else
 fi
 rm -rf /var/lib/apt/lists/*
 
-# Create virtual environment and install minimal dev dependencies
-uv venv
+# Install minimal dev dependencies
 uv sync --extra dev-minimal
-uv pip install -e .
 
 # Install Go Task inside the virtual environment
 curl -sL https://taskfile.dev/install.sh | sh -s -- -b ./.venv/bin
@@ -77,7 +75,7 @@ curl -sL https://taskfile.dev/install.sh | sh -s -- -b ./.venv/bin
 if [ "${AR_INSTALL_UI:-0}" -eq 1 ]; then
     uv sync --extra ui
 fi
-if [ "${AR_INSTALL_GPU:-0}" -eq 1 ]; then
+if [ "${AR_INSTALL_NLP:-0}" -eq 1 ]; then
     uv sync --extra nlp
 fi
 


### PR DESCRIPTION
## Summary
- limit `task install` to `dev-minimal` extras for faster setup
- clarify `codex_setup.sh` and installation guide on optional `ui`/`nlp` extras
- archive optimized install issue

## Testing
- `task install`
- `task check` *(fails: Signal received: interrupt)*
- `uv run mkdocs build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a52cb98e0083339d9fc9d4ec49a418