### PR TITLE
docs: add Go Task installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ tests. Use `scripts/setup.sh` when the full dependency set is required. CI
 environments install every extra with `uv sync --all-extras && uv pip install -e .`.
 After editing `pyproject.toml`, regenerate `uv.lock` with `uv lock` and reinstall
 with the needed extras to apply updates.
+
+Install [Go Task](https://taskfile.dev) to run the `task` commands:
+
+```bash
+curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
+```
+
+The `scripts/setup.sh` helper installs Go Task automatically when it is missing.
 Several dependencies are pinned for compatibility—`slowapi` is locked to
 **0.1.9** and `fastapi` must be **0.115** or newer. The test suite works both
 with and without extras:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,6 +10,18 @@ Autoresearch requires **Python 3.12 or newer**.
 
 - Python 3.12 or newer (but below 4.0)
 - `git` and build tools if compiling optional packages
+- Go Task for running `task` commands
+
+### Install Go Task
+
+Go Task executes the project's Taskfile targets. Install it with:
+
+```bash
+curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
+```
+
+The `scripts/setup.sh` helper installs Go Task automatically when it is
+missing.
 
 ### Core dependencies
 

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -55,14 +55,23 @@ def check_python() -> CheckResult:
 
 
 def check_task() -> CheckResult:
-    proc = subprocess.run(
-        ["task", "--version"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        proc = subprocess.run(
+            ["task", "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise VersionError(
+            "Go Task is not installed. Install it from "
+            "https://taskfile.dev/installation/ or run scripts/setup.sh"
+        ) from exc
     if proc.returncode != 0:
-        raise VersionError("Go Task is not installed")
+        raise VersionError(
+            "Go Task is not installed. Install it from "
+            "https://taskfile.dev/installation/ or run scripts/setup.sh"
+        )
     match = re.search(r"(\d+\.\d+\.\d+)", proc.stdout)
     if not match:
         raise VersionError("Could not determine Go Task version")

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -33,8 +33,11 @@ if sys.version_info < (3, 12):
     raise SystemExit(f"uv venv created Python {sys.version.split()[0]}, but >=3.12 is required")
 EOF
 
-# Install Go Task inside the virtual environment
-curl -sL https://taskfile.dev/install.sh | sh -s -- -b ./.venv/bin
+# Install Go Task inside the virtual environment if missing to avoid reinstalling
+if [ ! -x .venv/bin/task ]; then
+    echo "Installing Go Task..."
+    curl -sL https://taskfile.dev/install.sh | sh -s -- -b ./.venv/bin
+fi
 
 # Install all locked dependencies and extras
 echo "Installing all extras via uv sync --all-extras"


### PR DESCRIPTION
## Summary
- document Go Task installation in README and installation guide
- hint in check_env.py when Go Task is missing
- setup.sh installs Go Task only if it isn't already present

## Testing
- `task check`
- `uv run flake8 scripts/check_env.py`
- `uv run mypy scripts/check_env.py`
- `uv run mkdocs build` *(fails: No such file or directory: mkdocs)*
- `PATH=/root/.local/bin uv run python scripts/check_env.py` *(shows hint when Go Task missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a52cc19ed48333882818304261234c