### PR TITLE
docs: document Go Task installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,12 @@ environments install every extra with `uv sync --all-extras && uv pip install -e
 After editing `pyproject.toml`, regenerate `uv.lock` with `uv lock` and reinstall
 with the needed extras to apply updates.
 The `task` commands rely on [Go Task](https://taskfile.dev/). Install it
-separately if it is not already available on your system.
+with your package manager (for example `brew install go-task/tap/go-task` on
+macOS) or use the official install script:
+
+```bash
+curl -sSL https://taskfile.dev/install.sh | sh
+```
 Several dependencies are pinned for compatibility—`slowapi` is locked to
 **0.1.9** and `fastapi` must be **0.115** or newer. The test suite works both
 with and without extras:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,6 +11,19 @@ Autoresearch requires **Python 3.12 or newer**.
 - Python 3.12 or newer (but below 4.0)
 - `git` and build tools if compiling optional packages
 
+### Go Task
+
+Autoresearch uses [Go Task](https://taskfile.dev/) to run Taskfile commands.
+Install it before invoking `task`:
+
+```bash
+# macOS
+brew install go-task/tap/go-task
+
+# Linux
+curl -sSL https://taskfile.dev/install.sh | sh
+```
+
 ### Core dependencies
 
 The following packages are required at the minimum versions listed. Each has

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -55,14 +55,25 @@ def check_python() -> CheckResult:
 
 
 def check_task() -> CheckResult:
-    proc = subprocess.run(
-        ["task", "--version"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        proc = subprocess.run(
+            ["task", "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        hint = (
+            "Go Task is not installed. Install it from https://taskfile.dev/ "
+            "or run scripts/setup.sh"
+        )
+        raise VersionError(hint) from exc
     if proc.returncode != 0:
-        raise VersionError("Go Task is not installed")
+        hint = (
+            "Go Task is not installed. Install it from https://taskfile.dev/ "
+            "or run scripts/setup.sh"
+        )
+        raise VersionError(hint)
     match = re.search(r"(\d+\.\d+\.\d+)", proc.stdout)
     if not match:
         raise VersionError("Could not determine Go Task version")

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -33,8 +33,11 @@ if sys.version_info < (3, 12):
     raise SystemExit(f"uv venv created Python {sys.version.split()[0]}, but >=3.12 is required")
 EOF
 
-# Install Go Task inside the virtual environment
-curl -sL https://taskfile.dev/install.sh | sh -s -- -b ./.venv/bin
+# Install Go Task inside the virtual environment if missing
+if [ ! -x .venv/bin/task ]; then
+    echo "Installing Go Task..."
+    curl -sL https://taskfile.dev/install.sh | sh -s -- -b ./.venv/bin
+fi
 
 # Install all locked dependencies and extras
 echo "Installing all extras via uv sync --all-extras"


### PR DESCRIPTION
## Summary
- document how to install Go Task in README and installation guide
- hint about installing Go Task in check_env.py
- only install Go Task in setup.sh when missing

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit -q` *(fails: Required test coverage of 90% not reached. Total coverage: 67.25%)*
- `uv run python scripts/check_env.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5337b08c0833381b99f8858145040