### PR TITLE
docs: record coverage results and drop old test-failure links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,10 @@ verification. [investigate-mypy-hang](issues/archive/investigate-mypy-hang.md).
  - Synchronize release documentation across project files.
     [update-release-documentation]
  - Fix BM25 search scoring method signature.
-    [resolve-current-test-failures]
  - Correct search backend registration and reset logic.
-    [resolve-current-test-failures]
  - Pin Python version and expand setup checks to prevent environment drift.
     [align-environment-with-requirements]
-- Enable Pydantic plugin for static type analysis.
-    [resolve-current-test-failures]
+ - Enable Pydantic plugin for static type analysis.
 - Document final release workflow and TestPyPI publishing steps.
 - Clarified directory scopes and noted missing instructions for `src/`, `scripts/`, and `examples/`.
 
@@ -49,13 +46,11 @@ Planned first public release bringing the core research workflow to life.
 - Refined token budget heuristics and asynchronous cancellation handling.
 - Cleaned up CLI commands and installer scripts.
 - Numerous bug fixes and reliability tweaks since the initial prototype was created in May 2025.
-  - Exposed token usage capture helper on the orchestrator for easier testing
-    ([resolve-current-test-failures]).
+  - Exposed token usage capture helper on the orchestrator for easier testing.
 
 See the [release plan](docs/release_plan.md) for upcoming milestones.
 
 [align-environment-with-requirements]: issues/align-environment-with-requirements.md
 [create-more-comprehensive-test-contexts]: issues/archive/create-more-comprehensive-test-contexts.md
 [update-release-documentation]: issues/archive/update-release-documentation.md
-[resolve-current-test-failures]: issues/resolve-current-test-failures.md
 

--- a/CODE_COMPLETE_PLAN.md
+++ b/CODE_COMPLETE_PLAN.md
@@ -11,8 +11,7 @@ preview on **2026-03-01** and a final **0.1.0** release on
 fails with `Error importing plugin "pydantic.mypy": No module named
 'pydantic'`, and `uv run pytest -q` stops with 30 collection errors
 including missing `pytest_bdd`, so integration and behavior suites remain
-failing. Outstanding issues include these checks
-([resolve-current-test-failures](issues/resolve-current-test-failures.md)).
+failing.
 
 ## 1. Core System Completion
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,10 +16,9 @@ before running tests.
 ## Milestones
 
 - 0.1.0-alpha.1 (2026-03-01): Alpha preview to collect feedback while
-  resolving test suite failures and aligning environment requirements
-  ([resolve-test-failures], [align-environment-reqs]).
+  aligning environment requirements ([align-environment-reqs]).
 - 0.1.0 (2026-07-01): Finalize packaging, docs and CI checks with all tests
-  passing ([resolve-test-failures], [update-release-documentation]).
+  passing ([update-release-documentation]).
 - 0.1.1 (2026-09-15): Bug fixes and documentation updates.
 - 0.2.0 (2026-12-01): API stabilization, configuration hot-reload, improved
   search backends.
@@ -33,8 +32,8 @@ alpha release checklist.
 ## 0.1.0-alpha.1 – Alpha preview
 
 This pre-release provides an early package for testing while packaging tasks
-remain open. Related issues ([resolve-test-failures], [align-environment-reqs])
-track outstanding test and environment work. Key activities include:
+remain open. Related issue ([align-environment-reqs]) tracks outstanding
+environment work. Key activities include:
 
 - Provide an installable package for early adopters.
 - Collect feedback while fixing failing tests and packaging issues.
@@ -51,10 +50,10 @@ include:
 - Finalizing API reference and user guides.
 - Verifying packaging metadata and TestPyPI uploads.
 
-Type checking and tests still fail (see [resolve-test-failures]), so integration
-and behavior suites remain blocked. The release was originally planned for
-**July 20, 2025**, but the schedule slipped. The **0.1.0** milestone is now
-targeted for **July 1, 2026** while packaging tasks are resolved.
+Type checking and tests still fail, so integration and behavior suites remain
+blocked. The release was originally planned for **July 20, 2025**, but the
+schedule slipped. The **0.1.0** milestone is now targeted for **July 1, 2026**
+while packaging tasks are resolved.
 
 ## 0.1.1 – Bug fixes and documentation updates
 
@@ -105,6 +104,5 @@ The 1.0.0 milestone aims for a polished, production-ready system:
   lines 178-186; TASK_PROGRESS lines 206-216).
 - Optimize performance across all components and finalize documentation.
 
-[resolve-test-failures]: issues/resolve-current-test-failures.md
 [align-environment-reqs]: issues/align-environment-with-requirements.md
 [update-release-documentation]: issues/archive/update-release-documentation.md

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -3,8 +3,7 @@
 This document tracks the progress of tasks for the Autoresearch project,
 organized by phases from the code complete plan. As of **August 18, 2025**, see
 [docs/release_plan.md](docs/release_plan.md) for current test and coverage
-status. Outstanding test failures are tracked in
-[resolve-current-test-failures](issues/resolve-current-test-failures.md).
+status.
 An **0.1.0-alpha.1** preview is scheduled for **2026-03-01**, with
 the final **0.1.0** release targeted for **July 1, 2026**.
 
@@ -227,15 +226,16 @@ These behavior test issues remain open until the test suite passes.
 
 ### Coverage Report
 
-Coverage is generated but fails to meet the 90% threshold.
+`task coverage` reports roughly 67% total coverage, below the 90% threshold,
+and several tests fail.
 
 ### Latest Test Results
 
 - `task --version` – 3.44.1
 - `uv run --extra dev-minimal flake8 src tests` – passes
 - `uv run --extra dev-minimal mypy src` – success
-- `uv run --extra dev-minimal pytest -q` – long-running; partial log shows
-  363 passed, 8 skipped, 97 deselected, coverage ≥90%
+- `uv run --extra dev-minimal pytest -q` – reports failing tests and
+  ~67% coverage
 
 ### Performance Baselines
 

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -22,15 +22,14 @@ Current checks show:
 
 - `uv run --extra dev-minimal flake8 src tests` passes.
 - `uv run --extra dev-minimal mypy src` reports no issues.
-- `uv run --extra dev-minimal pytest -q` completes with all tests passing and
-  coverage above the 90% threshold enforced by `--cov-fail-under=90`.
+- `uv run --extra dev-minimal pytest -q` returns failing tests with total
+  coverage around 67%.
 
 ## Milestones
 
-- **0.1.0-alpha.1** (2026-03-01): Alpha preview to collect feedback while
-  resolving test suite failures ([resolve-test-failures]).
-- **0.1.0** (2026-07-01): Finalize packaging, docs and CI checks with all tests
-  passing ([resolve-test-failures]).
+- **0.1.0-alpha.1** (2026-03-01): Alpha preview to collect feedback.
+- **0.1.0** (2026-07-01): Finalize packaging, docs and CI checks with all
+  tests passing.
 - **0.1.1** (2026-09-15): Bug fixes and documentation updates.
 - **0.2.0** (2026-12-01): API stabilization, configuration hot-reload,
   improved search backends.
@@ -45,8 +44,7 @@ now set for **July 1, 2026** while packaging tasks are resolved.
 
 ### Alpha release checklist
 
-- [ ] Resolve remaining test failures ([resolve-test-failures])
-- [ ] `task coverage` reports at least **90%** total coverage
+- [ ] `task coverage` reports at least **90%** total coverage (currently ~67%)
 - [ ] Assemble preliminary release notes and confirm README instructions
 
 Resolving these items will determine the new completion date for **0.1.0**.
@@ -82,5 +80,3 @@ optional extras):
 - [ ] `uv run pytest -q`
 - [ ] `uv run pytest tests/behavior`
 - [ ] `task coverage` reports at least **90%** total coverage
-
-[resolve-test-failures]: ../issues/resolve-current-test-failures.md


### PR DESCRIPTION
## Summary
- document current coverage and failing tests in release plan and task progress
- strip `resolve-test-failures` references from roadmap, changelog, and other docs
- clarify status in code completion plan

## Testing
- `uv run --extra dev-minimal flake8 src tests`
- `uv run --extra dev-minimal mypy src`
- `task coverage` *(fails: coverage ~67%, tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68a52cc82a6c8333a1bebb7cfaed1889