### PR TITLE
docs: add environment alignment ticket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Planned first public release bringing the core research workflow to life.
 
 See the [release plan](docs/release_plan.md) for upcoming milestones.
 
-[align-environment-with-requirements]: issues/align-environment-with-requirements.md
+[align-environment-with-requirements]: issues/archive/align-environment-with-requirements.md
 [create-more-comprehensive-test-contexts]: issues/archive/create-more-comprehensive-test-contexts.md
 [update-release-documentation]: issues/archive/update-release-documentation.md
 

--- a/issues/align-environment-with-requirements.md
+++ b/issues/align-environment-with-requirements.md
@@ -1,0 +1,14 @@
+# Align environment with requirements
+
+## Context
+The environment setup instructions still have gaps, leading to inconsistent developer installs. Some
+systems miss Python 3.12 or required tooling, causing task failures and missing dependencies.
+
+## Acceptance Criteria
+- Documented steps install Python 3.12 and all required development tools.
+- `task install` completes on a clean machine without manual fixes.
+- Environment checks verify versions align with project requirements.
+
+## Status
+Open
+


### PR DESCRIPTION
## Summary
- link existing changelog reference to archived environment alignment ticket
- add open issue for unresolved environment setup gaps

## Testing
- `task check` *(fails: hang during unit tests; manually interrupted)*
- `task verify` *(fails: interrupted after running unit tests with coverage)*

------
https://chatgpt.com/codex/tasks/task_e_68a53ea487f883338b68f2717cf49396