### PR TITLE
docs: note failing tests and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ workflow is detailed in [docs/releasing.md](docs/releasing.md).
 
 Current checks show `uv run --extra dev-minimal flake8 src tests` and
 `uv run --extra dev-minimal mypy src` passing. `uv run --extra
-dev-minimal pytest -q` completes with all tests passing and coverage
-above the 90% threshold enforced by `--cov-fail-under=90`.
+dev-minimal pytest -q --cov=src --cov-report=term` returns failing tests
+with total coverage around 67%.
 
 See [docs/release_plan.md](docs/release_plan.md#alpha-release-checklist) for the
 alpha release checklist.

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -22,8 +22,8 @@ Current checks show:
 
 - `uv run --extra dev-minimal flake8 src tests` passes.
 - `uv run --extra dev-minimal mypy src` reports no issues.
-- `uv run --extra dev-minimal pytest -q` returns failing tests with total
-  coverage around 67%.
+- `uv run --extra dev-minimal pytest -q --cov=src --cov-report=term`
+  returns failing tests with total coverage around 67%.
 
 ## Milestones
 


### PR DESCRIPTION
## Summary
- Clarify in README that pytest currently fails and coverage hovers around 67%
- Mirror the same test command and coverage note in docs/release_plan.md

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run --extra dev-minimal flake8 src tests`
- `uv run --extra dev-minimal mypy src`
- `uv run --extra dev-minimal pytest -q --maxfail=1`
- `uv run mkdocs build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a53eacaae883339fd131ae28135236