### PR TITLE
Add scoring simulation and heuristic property tests

### DIFF
--- a/docs/algorithms/source_credibility.md
+++ b/docs/algorithms/source_credibility.md
@@ -41,6 +41,25 @@ final = (1 - w) * relevance + w * credibility
 | https://dept.example.edu/resource     | 0.80        | 0.72        | 2    |
 | https://unknown.xyz/post              | 0.50        | 0.64        | 3    |
 
+## Evaluation results
+
+The final ranking score :math:`s(d)` combines normalized BM25
+(:math:`b(d)`), semantic similarity (:math:`m(d)`), and credibility
+(:math:`c(d)`):
+
+\[
+s(d) = w_{bm25} b(d) + w_{sem} m(d) + w_{cred} c(d)
+\]
+
+Running `uv run scripts/simulate_scoring.py --query "python"` on the
+sample dataset yields the following ranked scores:
+
+| ID | Final | BM25 | Semantic | Credibility |
+|----|-------|------|----------|-------------|
+| 3  | 0.96  | 1.00 | 1.00     | 0.80        |
+| 1  | 0.90  | 0.90 | 0.89     | 0.90        |
+| 2  | 0.12  | 0.00 | 0.00     | 0.60        |
+
 ## References
 
 - Moz. "Domain Authority."[^moz]

--- a/docs/algorithms/validation.md
+++ b/docs/algorithms/validation.md
@@ -1,0 +1,15 @@
+# Algorithm Validation
+
+This document summarizes evaluations of ranking and token budgeting
+heuristics.
+
+## Scoring heuristics
+
+Running `uv run scripts/simulate_scoring.py --query "python"` on the
+sample dataset produced a ranking consistent with the formula in
+[source_credibility.md](source_credibility.md).
+
+## Token budget heuristics
+
+Property-based tests verify that weighted scores remain normalized and
+that `suggest_token_budget` grows monotonically with token usage.

--- a/docs/token_budget_spec.md
+++ b/docs/token_budget_spec.md
@@ -22,6 +22,24 @@ This specification outlines expected behaviors for the token budgeting helpers i
 - Otherwise returns `max(current_budget, 1)`.
 - Budgets are never allowed to drop below `1` token.
 
+Expressed as equations, the suggested budget :math:`B'` is:
+
+\[
+\begin{aligned}
+\text{expand\_threshold} &= B (1 + m)\\
+\text{shrink\_threshold} &= B (1 - m)\\
+B' &=
+  \begin{cases}
+    \max(\lfloor \max(\delta, \bar{u})(1+m) \rfloor, 1), & \delta > \text{expand\_threshold}\ \text{or}\ \bar{u} > B \\
+    \max(\lfloor \bar{u}(1+m) \rfloor, 1), & \delta < \text{shrink\_threshold}\ \text{and}\ \bar{u} < \text{shrink\_threshold} \\
+    \max(B, 1), & \text{otherwise}
+  \end{cases}
+\end{aligned}
+\]
+
+The function is monotonic in :math:`\delta`: for identical histories,
+if :math:`\delta_1 \le \delta_2` then :math:`B'(\delta_1) \le B'(\delta_2)`.
+
 ## Tests
 Unit tests in `tests/unit/test_metrics_token_budget_spec.py` exercise:
 - Threshold adaptation based on prompt history.

--- a/scripts/simulate_scoring.py
+++ b/scripts/simulate_scoring.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+"""Simulate BM25, semantic similarity, and source credibility weighting.
+
+Usage:
+    uv run scripts/simulate_scoring.py --query "example"
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import List, TypedDict
+
+from rank_bm25 import BM25Okapi
+
+
+class Doc(TypedDict):
+    id: int
+    text: str
+    credibility: float
+
+
+SAMPLE_DOCS: List[Doc] = [
+    {
+        "id": 1,
+        "text": "Python is a programming language that lets you work quickly",
+        "credibility": 0.9,
+    },
+    {
+        "id": 2,
+        "text": "Snakes are legless reptiles known for their flexibility",
+        "credibility": 0.6,
+    },
+    {
+        "id": 3,
+        "text": "Monty Python was a British surreal comedy group",
+        "credibility": 0.8,
+    },
+]
+
+WEIGHTS = (0.4, 0.4, 0.2)  # semantic, bm25, credibility
+
+
+def tokenize(text: str) -> List[str]:
+    """Return lowercase tokens."""
+    return text.lower().split()
+
+
+def cosine_similarity(vec1: List[int], vec2: List[int]) -> float:
+    """Compute cosine similarity between integer vectors."""
+    dot = sum(a * b for a, b in zip(vec1, vec2))
+    norm1 = sum(a * a for a in vec1) ** 0.5
+    norm2 = sum(b * b for b in vec2) ** 0.5
+    return dot / norm1 / norm2 if norm1 and norm2 else 0.0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simulate scoring heuristics")
+    parser.add_argument("--query", required=True, help="Search query")
+    args = parser.parse_args()
+
+    corpus = [tokenize(d["text"]) for d in SAMPLE_DOCS]
+    bm25 = BM25Okapi(corpus)
+    bm25_scores = bm25.get_scores(tokenize(args.query))
+    bm25_max = max(bm25_scores) or 1
+    bm25_norm = [s / bm25_max for s in bm25_scores]
+
+    vocab = sorted({w for doc in corpus for w in doc})
+    vectors: List[List[int]] = []
+    for toks in corpus:
+        vectors.append([toks.count(t) for t in vocab])
+    query_tokens = tokenize(args.query)
+    query_vec = [query_tokens.count(t) for t in vocab]
+    semantic_scores = [cosine_similarity(v, query_vec) for v in vectors]
+    sem_max = max(semantic_scores) or 1
+    sem_norm = [s / sem_max for s in semantic_scores]
+
+    results: List[tuple[int, float, float, float, float]] = []
+    for doc, bm, sem in zip(SAMPLE_DOCS, bm25_norm, sem_norm):
+        final = WEIGHTS[0] * sem + WEIGHTS[1] * bm + WEIGHTS[2] * doc["credibility"]
+        results.append((doc["id"], final, bm, sem, doc["credibility"]))
+
+    results.sort(key=lambda r: r[1], reverse=True)
+    for doc_id, final, bm, sem, cred in results:
+        print(
+            f"id={doc_id} final={final:.2f} bm25={bm:.2f} "
+            f"semantic={sem:.2f} credibility={cred:.2f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_heuristic_properties.py
+++ b/tests/unit/test_heuristic_properties.py
@@ -1,0 +1,32 @@
+import pytest
+from hypothesis import given, strategies as st, assume
+
+from autoresearch.orchestration.metrics import OrchestrationMetrics
+
+
+@pytest.mark.unit
+@given(
+    scores=st.lists(st.floats(min_value=0.0, max_value=1.0), min_size=3, max_size=3),
+    weights=st.lists(st.floats(min_value=0.0, max_value=1.0), min_size=3, max_size=3),
+)
+def test_weighted_score_normalization(scores, weights):
+    total = sum(weights)
+    assume(total > 0)
+    weights = [w / total for w in weights]
+    final = sum(s * w for s, w in zip(scores, weights))
+    assert 0.0 <= final <= 1.0
+
+
+@pytest.mark.unit
+@given(
+    small=st.integers(min_value=0, max_value=50),
+    large=st.integers(min_value=0, max_value=50),
+)
+def test_token_budget_monotonicity(small, large):
+    assume(large >= small)
+    m1, m2 = OrchestrationMetrics(), OrchestrationMetrics()
+    m1.record_tokens("a", small, 0)
+    m2.record_tokens("a", large, 0)
+    b1 = m1.suggest_token_budget(10)
+    b2 = m2.suggest_token_budget(10)
+    assert b2 >= b1


### PR DESCRIPTION
## Summary
- add `simulate_scoring.py` to demonstrate BM25, semantic similarity, and source credibility weighting on sample data
- document combined scoring and token budget formulas with evaluation notes
- validate score normalization and token budget monotonicity via property-based tests

## Testing
- `uv run flake8 scripts/simulate_scoring.py tests/unit/test_heuristic_properties.py`
- `uv run mypy scripts/simulate_scoring.py tests/unit/test_heuristic_properties.py`
- `uv run pytest --override-ini addopts='' tests/unit/test_heuristic_properties.py`
- `uv run mkdocs build` *(fails: mkdocs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5538b3438833398f9718589098093