### PR TITLE
docs: highlight env prerequisites and checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,20 @@ data in local databases so that searches and knowledge graphs remain on your mac
 The project is built around a modular Python package located under `src/autoresearch/`.
 CLI utilities are provided via Typer and the HTTP API is powered by FastAPI.
 
-Autoresearch requires **Python 3.12 or newer**.
+## Prerequisites
 
-For current capabilities and known limitations see [docs/release_notes.md](docs/release_notes.md).
+Autoresearch requires **Python 3.12 or newer**,
+[**uv**](https://github.com/astral-sh/uv), and
+[**Go Task**](https://taskfile.dev/) for running Taskfile commands. After
+cloning the repository, initialize the environment and validate tool versions:
+
+```bash
+task install
+uv run python scripts/check_env.py
+```
+
+For current capabilities and known limitations see
+[docs/release_notes.md](docs/release_notes.md).
 
 ## Roadmap
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,10 @@ tasks:
     cmds:
       - uv sync --extra dev-minimal
     desc: "Initialize development environment"
+  check-env:
+    cmds:
+      - uv run python scripts/check_env.py
+    desc: "Validate required tool versions"
   check:
     deps: [check-env]
     # Minimal validation for quick feedback. Skips slow tests and scenarios
@@ -96,11 +100,6 @@ tasks:
           --cov=src --cov-report=term-missing --cov-append
       - uv run pytest tests/behavior --cov=src --cov-report=xml --cov-report=term-missing
     desc: "Run linting, type checks and fast tests with coverage"
-
-  check-env:
-    cmds:
-      - uv run python scripts/check_env.py
-    desc: "Validate required tool versions"
 
   clean:
     cmds:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,13 +2,21 @@
 
 This guide explains how to install Autoresearch and manage optional features.
 
-Autoresearch uses **uv** for dependency management. The examples below use `uv`.
+Autoresearch requires **Python 3.12 or newer**,
+[**uv**](https://github.com/astral-sh/uv), and
+[**Go Task**](https://taskfile.dev/) for Taskfile commands. After cloning,
+initialize the environment and verify the toolchain:
 
-Autoresearch requires **Python 3.12 or newer**.
+```bash
+task install
+uv run python scripts/check_env.py
+```
 
 ## Requirements
 
 - Python 3.12 or newer (but below 4.0)
+- `uv`
+- Go Task
 - `git` and build tools if compiling optional packages
 
 ### Go Task

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Usage: ./scripts/setup.sh
 # Create .venv and install all extras using uv.
-# Ensure we are running with Python 3.12 or newer
+# Ensure we are running with Python 3.12 or newer.
+# Run scripts/check_env.py after setup to validate tool versions.
 set -euo pipefail
 
 # Abort if python3 is not available
@@ -136,6 +137,8 @@ for cmd in task flake8 pytest mypy; do
 done
 deactivate
 
+# For a comprehensive toolchain check see scripts/check_env.py
+# or run `uv run python scripts/check_env.py`.
 # Run mypy to ensure type hints are valid and stubs are picked up
 echo "Running mypy..."
 uv run mypy src


### PR DESCRIPTION
## Summary
- emphasize Python 3.12+, `uv`, and Go Task prerequisites in README and installation guide
- remind developers to run `task install` and `scripts/check_env.py` after cloning
- reference `scripts/check_env.py` from setup script and surface `check-env` task early in the Taskfile

## Testing
- `task install`
- `task check` *(fails: tests fail and task interrupted)*
- `uv run mkdocs build` *(passes with warnings: missing links, missing type annotations)*

------
https://chatgpt.com/codex/tasks/task_e_68a5536bafb8833380dd8f2750439ef2