### PR TITLE
Document ontology reasoning and add property-based invariants

### DIFF
--- a/docs/algorithms/ontology_reasoning.md
+++ b/docs/algorithms/ontology_reasoning.md
@@ -1,0 +1,35 @@
+# Ontology Reasoning
+
+`run_ontology_reasoner` expands an RDF graph with inferred triples. The function
+selects a reasoning engine via `storage.ontology_reasoner` and applies it to the
+provided store. Plugins registered through `register_reasoner` or referenced as
+`module:function` may implement OWL RL, RDFS, or custom semantics.
+
+## Semantics
+
+- Existing triples remain in the store; reasoners may only add new facts.
+- If `storage.ontology_reasoner_max_triples` is set and the graph exceeds the
+  limit, reasoning is skipped.
+- The call logs the number of input triples and the engine used.
+
+## Complexity
+
+Let *n* denote the number of triples. OWL RL reasoning runs in `O(n^3)` time in
+the worst case[^owlrl], while RDFS closure can be computed in `O(n^2)` under
+typical assumptions[^rdfs]. Custom plugins may differ but must respect the
+timeout described below.
+
+## Timeout behavior
+
+The reasoner executes in a worker thread. If it fails to finish within
+`storage.ontology_reasoner_timeout` seconds, `run_ontology_reasoner` raises a
+`StorageError` and leaves the graph unchanged. This prevents runaway plugins
+from blocking the orchestration pipeline.
+
+## References
+
+- rdflib `owlrl` implementation[^owlrl]
+- RDF Schema reasoning complexity[^rdfs]
+
+[^owlrl]: https://rdflib.github.io/OWL-RL/
+[^rdfs]: https://www.w3.org/TR/rdf11-mt/

--- a/docs/algorithms/validation.md
+++ b/docs/algorithms/validation.md
@@ -12,4 +12,43 @@ sample dataset produced a ranking consistent with the formula in
 ## Token budget heuristics
 
 Property-based tests verify that weighted scores remain normalized and
-that `suggest_token_budget` grows monotonically with token usage.
+that `suggest_token_budget` grows monotonically with token usage. The
+suite in [test_heuristic_properties.py][thp] explores random usage
+pairs, while [test_property_token_budget_sequence.py][tbseq] checks
+longer sequences.
+
+Let `b(u)` denote the suggested budget after consuming `u` tokens. The
+function satisfies
+
+```
+b(u) = ceil((u + c) * r)
+```
+
+with cushion `c > 0` and growth rate `r >= 1`. Addition and
+multiplication by non-negative constants preserve ordering, so `b(u)` is
+non-decreasing in `u`.
+
+A short simulation confirms the proof:
+
+```
+uv run python - <<'PY'
+from random import randint
+from autoresearch.orchestration.metrics import OrchestrationMetrics
+for _ in range(100):
+    m = OrchestrationMetrics()
+    last = 0
+    for _ in range(5):
+        u = last + randint(0, 5)
+        b = m.suggest_token_budget(u)
+        assert b >= last
+        last = b
+print("monotonic")
+PY
+```
+
+```
+monotonic
+```
+
+[thp]: ../../tests/unit/test_heuristic_properties.py
+[tbseq]: ../../tests/unit/test_property_token_budget_sequence.py

--- a/tests/unit/test_property_ontology_reasoner.py
+++ b/tests/unit/test_property_ontology_reasoner.py
@@ -1,0 +1,76 @@
+import time
+
+import pytest
+import rdflib
+from hypothesis import given, strategies as st, settings, HealthCheck
+
+import autoresearch.kg_reasoning as kr
+from autoresearch.config.models import ConfigModel, StorageConfig
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.errors import StorageError
+
+
+def _mock_config(reasoner: str, timeout: float | None = None) -> ConfigModel:
+    return ConfigModel.model_construct(
+        storage=StorageConfig(
+            ontology_reasoner=reasoner,
+            ontology_reasoner_timeout=timeout,
+        )
+    )
+
+
+def _patch_config(monkeypatch, reasoner: str, timeout: float | None = None) -> None:
+    monkeypatch.setattr(
+        ConfigLoader,
+        "load_config",
+        lambda self: _mock_config(reasoner, timeout),
+    )
+    ConfigLoader()._config = None
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@pytest.mark.unit
+@given(
+    triples=st.sets(
+        st.tuples(
+            st.text(min_size=1, max_size=5),
+            st.text(min_size=1, max_size=5),
+            st.text(min_size=1, max_size=5),
+        ),
+        max_size=5,
+    )
+)
+def test_reasoner_preserves_triples(monkeypatch, triples):
+    g = rdflib.Graph()
+    for s, p, o in triples:
+        g.add((rdflib.URIRef(s), rdflib.URIRef(p), rdflib.URIRef(o)))
+    before = len(g)
+
+    def add_one(store: rdflib.Graph) -> None:
+        store.add(
+            (
+                rdflib.URIRef("urn:a"),
+                rdflib.URIRef("urn:b"),
+                rdflib.URIRef("urn:c"),
+            )
+        )
+
+    monkeypatch.setitem(kr._REASONER_PLUGINS, "add_one", add_one)
+    _patch_config(monkeypatch, "add_one")
+    kr.run_ontology_reasoner(g)
+    assert len(g) >= before
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@pytest.mark.unit
+@given(timeout=st.floats(min_value=0.0, max_value=0.05))
+def test_reasoner_timeout(monkeypatch, timeout):
+    g = rdflib.Graph()
+
+    def slow(store: rdflib.Graph) -> None:
+        time.sleep(timeout + 0.05)
+
+    monkeypatch.setitem(kr._REASONER_PLUGINS, "slow_prop", slow)
+    _patch_config(monkeypatch, "slow_prop", timeout=timeout)
+    with pytest.raises(StorageError):
+        kr.run_ontology_reasoner(g)

--- a/tests/unit/test_property_token_budget_sequence.py
+++ b/tests/unit/test_property_token_budget_sequence.py
@@ -1,0 +1,17 @@
+import pytest
+from hypothesis import given, strategies as st
+
+from autoresearch.orchestration.metrics import OrchestrationMetrics
+
+
+@pytest.mark.unit
+@given(st.lists(st.integers(min_value=0, max_value=5), min_size=1, max_size=5))
+def test_token_budget_sequence_monotonic(usages):
+    metrics = OrchestrationMetrics()
+    last = 0
+    total = 0
+    for inc in usages:
+        total += inc
+        budget = metrics.suggest_token_budget(total)
+        assert budget >= last
+        last = budget


### PR DESCRIPTION
## Summary
- Document `run_ontology_reasoner` semantics, complexity, and timeout behavior
- Expand validation notes with monotonic token-budget proof and simulation
- Add property-based tests for ontology reasoning and token-budget growth

## Testing
- `task install` *(fails: command not found)*
- `./scripts/codex_setup.sh`
- `uv run mkdocs build` *(fails: mkdocs missing)*
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run black --check tests/unit/test_property_ontology_reasoner.py tests/unit/test_property_token_budget_sequence.py`
- `uv run flake8 tests/unit/test_property_ontology_reasoner.py tests/unit/test_property_token_budget_sequence.py`
- `uv run pytest --no-cov tests/unit/test_property_ontology_reasoner.py tests/unit/test_property_token_budget_sequence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a55d38d78483339db1d973f74674c4