### PR TITLE
Ensure Go Task and dev tools are installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
           EOF
       - name: Install uv
         run: python -m pip install uv
-      - name: Check environment
-        run: uv run task check-env
       - name: Install dependencies
         run: uv pip sync uv.lock
       - name: Install extras
         run: uv pip install -e '.[full,parsers,git,llm,dev]'
+      - name: Validate tool versions
+        run: uv run python scripts/check_env.py
       - name: Run task verify
         run: uv run task verify
       - name: Run tests with coverage

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ CLI utilities are provided via Typer and the HTTP API is powered by FastAPI.
 
 Autoresearch requires **Python 3.12 or newer**,
 [**uv**](https://github.com/astral-sh/uv), and
-[**Go Task**](https://taskfile.dev/) for running Taskfile commands. After
-cloning the repository, initialize the environment and validate tool versions:
+[**Go Task**](https://taskfile.dev/). Install Go Task before invoking any
+`task` commands. After cloning the repository, initialize the environment and
+validate tool versions:
 
 ```bash
 task install
@@ -55,26 +56,26 @@ without renaming.
 ## Installation
 
 Autoresearch requires **Python 3.12 or newer**. The `scripts/setup.sh` helper
-installs all optional extras and invokes `python3.12` directly when checking
-the interpreter version, so make
-sure it is available on your `PATH`. On Debian/Ubuntu systems install it with
-`sudo apt-get install python3.12 python3.12-venv`. If you manage multiple
-interpreters via pyenv or another tool, specify the path when creating the
-environment, e.g. `uv venv -p python3.12`.
-Both setup scripts abort if `python3.12` cannot be located.
+installs Go Task and the development extras, invoking `python3.12` directly
+when checking the interpreter version, so make sure it is available on your
+`PATH`. On Debian/Ubuntu systems install it with `sudo apt-get install
+python3.12 python3.12-venv`. If you manage multiple interpreters via pyenv or
+another tool, specify the path when creating the environment, e.g. `uv venv -p
+python3.12`. Both setup scripts abort if `python3.12` cannot be located.
 The project recently transitioned from **Poetry** to
 [**uv**](https://github.com/astral-sh/uv) for dependency management. The `uv.lock`
 file is the authoritative source of pinned dependencies, replacing the old
 `poetry.lock`. You can install the project using `uv` or plain **pip**.
 See [docs/installation.md](docs/installation.md) for details on optional features
 and upgrade instructions.
-The `scripts/setup.sh` helper ensures `uv.lock` is current and installs
-all optional extras so development and runtime dependencies are available for testing.
-Run `task install` to install only the `dev-minimal` extras for linting and
-tests. Use `scripts/setup.sh` when the full dependency set is required. CI
-environments install every extra with `uv sync --all-extras && uv pip install -e .`.
-After editing `pyproject.toml`, regenerate `uv.lock` with `uv lock` and reinstall
-with the needed extras to apply updates.
+The `scripts/setup.sh` helper ensures `uv.lock` is current and installs the
+development extras so tooling is available for testing. Run `task install` to
+install only the `dev-minimal` extras for linting and tests. Use
+`scripts/setup.sh` when the full toolchain is required. CI environments install
+every extra with `uv sync --all-extras && uv pip install -e .`. After editing
+`pyproject.toml`, regenerate `uv.lock` with `uv lock` and reinstall with the
+needed extras to apply updates. After either setup path, run `uv run python
+scripts/check_env.py` to confirm the tool versions meet the requirements.
 The `task` commands rely on [Go Task](https://taskfile.dev/). Install it
 with your package manager (for example `brew install go-task/tap/go-task` on
 macOS) or use the official install script:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,8 +4,9 @@ This guide explains how to install Autoresearch and manage optional features.
 
 Autoresearch requires **Python 3.12 or newer**,
 [**uv**](https://github.com/astral-sh/uv), and
-[**Go Task**](https://taskfile.dev/) for Taskfile commands. After cloning,
-initialize the environment and verify the toolchain:
+[**Go Task**](https://taskfile.dev/) for Taskfile commands. Install Go Task
+before running `task`. After cloning, initialize the environment and verify
+the toolchain:
 
 ```bash
 task install
@@ -113,15 +114,7 @@ Because autoresearch requires Python >=3.12,<4.0 and the current Python is
 Verify the environment by running:
 
 ```bash
-task --version
-uv pip list | grep flake8
-uv run flake8 src tests
-uv run mypy src
-uv run pytest --version
-uv run python -c "import importlib.metadata; print(importlib.metadata.version('pytest-bdd'))"
-uv run python -c "import pydantic; print(pydantic.__version__)"
-uv run pytest -q
-uv run pytest tests/behavior
+uv run python scripts/check_env.py
 ```
 
 ### Offline installation

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Usage: ./scripts/setup.sh
-# Create .venv and install all extras using uv.
+# Create .venv, install Go Task and development extras using uv.
 # Ensure we are running with Python 3.12 or newer.
-# Run scripts/check_env.py after setup to validate tool versions.
+# Run `uv run python scripts/check_env.py` at the end to validate tool versions.
 set -euo pipefail
 
 # Abort if python3 is not available
@@ -40,9 +40,9 @@ if [ ! -x .venv/bin/task ]; then
     curl -sL https://taskfile.dev/install.sh | sh -s -- -b ./.venv/bin
 fi
 
-# Install all locked dependencies and extras
-echo "Installing all extras via uv sync --all-extras"
-uv sync --all-extras
+# Install locked dependencies and development extras
+echo "Installing development extras via uv sync --extra dev"
+uv sync --extra dev
 
 # Link the project in editable mode so tools are available
 uv pip install -e .
@@ -137,8 +137,10 @@ for cmd in task flake8 pytest mypy; do
 done
 deactivate
 
-# For a comprehensive toolchain check see scripts/check_env.py
-# or run `uv run python scripts/check_env.py`.
+# Validate required tool versions
+echo "Validating tool versions..."
+uv run python scripts/check_env.py
+
 # Run mypy to ensure type hints are valid and stubs are picked up
 echo "Running mypy..."
 uv run mypy src


### PR DESCRIPTION
## Summary
- install Go Task and development extras in setup.sh
- document Go Task and check_env.py in README and installation guide
- run check_env.py during CI to verify tool versions

## Testing
- `uv run python scripts/check_env.py`
- `uv run mkdocs build` *(fails: No such file or directory)*
- `task check` *(fails: 4 failed, 253 passed, 2 skipped, 24 deselected)*
- `task verify` *(fails: 5 failed, 307 passed, 3 skipped, 24 deselected)*

------
https://chatgpt.com/codex/tasks/task_e_68a55d25bdb8833396a0c5bd00a76840