### PR TITLE
docs: document manual workflow policy

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,7 @@
+# GitHub Directory Guidelines
+
+- Workflows in `workflows/` must be triggered only via
+  `workflow_dispatch`.
+- Do not enable automatic events such as `push`, `pull_request`, or
+  `schedule`.
+- Update `docs/review_guidelines.md` if workflow policies change.

--- a/docs/review_guidelines.md
+++ b/docs/review_guidelines.md
@@ -1,0 +1,4 @@
+# Review Guidelines
+
+- Confirm that workflows in `.github/workflows/` trigger only via
+  `workflow_dispatch`. Reject push, schedule, or pull request triggers.


### PR DESCRIPTION
## Summary
- document manual-only workflow triggers in `.github/AGENTS.md`
- add review guideline to reject push-triggered workflows

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit -q` *(fails: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ed86cb2483339165d8dfff7dd6e1