### PR TITLE
fix: stabilize config CLI tests

### DIFF
--- a/issues/archive/fix-config-cli-command-tests.md
+++ b/issues/archive/fix-config-cli-command-tests.md
@@ -1,0 +1,11 @@
+# Fix config CLI command tests
+
+## Context
+`config` subcommands were initializing storage and tests used Click's runner, causing failures.
+
+## Acceptance Criteria
+- Config initialization and validation run without storage setup.
+- Unit tests for config commands pass using Typer's `CliRunner`.
+
+## Status
+Archived

--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -140,9 +140,7 @@ def start_watcher(
 
         print_info("Available Commands:", symbol=False)
         print_command_example("search", "Run a search query")
-        print_command_example(
-            "monitor", "Start interactive resource and metrics monitor"
-        )
+        print_command_example("monitor", "Start interactive resource and metrics monitor")
         print_command_example("config", "Configuration management commands")
         print_command_example("backup", "Backup and restore operations")
         print_command_example("serve", "Start an MCP server")
@@ -153,17 +151,16 @@ def start_watcher(
         console.print("")
 
         # Suggest initializing configuration
-        if typer.confirm(
-            "Would you like to initialize the configuration now?", default=True
-        ):
+        if typer.confirm("Would you like to initialize the configuration now?", default=True):
             ctx.invoke(config_init)
             return
 
-    try:
-        StorageManager.setup()
-    except StorageError as e:
-        typer.echo(f"Storage initialization failed: {e}")
-        raise typer.Exit(code=1)
+    if ctx.invoked_subcommand != "config":
+        try:
+            StorageManager.setup()
+        except StorageError as e:
+            typer.echo(f"Storage initialization failed: {e}")
+            raise typer.Exit(code=1)
 
     watch_ctx = _config_loader.watching()
     watch_ctx.__enter__()
@@ -341,12 +338,8 @@ def search(
     # Check if query is empty or missing (this shouldn't happen with typer, but just in case)
     if not query or query.strip() == "":
         print_warning("You need to provide a query to search for.")
-        print_command_example(
-            'autoresearch search "What is quantum computing?"', "Example query"
-        )
-        print_command_example(
-            "autoresearch search --help", "Show help for search command"
-        )
+        print_command_example('autoresearch search "What is quantum computing?"', "Example query")
+        print_command_example("autoresearch search --help", "Show help for search command")
         return
 
     try:
@@ -454,12 +447,8 @@ app.add_typer(monitor_app, name="monitor")
 
 @app.command()
 def serve(
-    host: str = typer.Option(
-        "127.0.0.1", "--host", help="Host to bind the MCP server to"
-    ),
-    port: int = typer.Option(
-        8080, "--port", "-p", help="Port to bind the MCP server to"
-    ),
+    host: str = typer.Option("127.0.0.1", "--host", help="Host to bind the MCP server to"),
+    port: int = typer.Option(8080, "--port", "-p", help="Port to bind the MCP server to"),
 ) -> None:
     """Start an MCP server that exposes Autoresearch as a tool.
 
@@ -496,12 +485,8 @@ def serve(
 
 @app.command()
 def serve_a2a(
-    host: str = typer.Option(
-        "127.0.0.1", "--host", help="Host to bind the A2A server to"
-    ),
-    port: int = typer.Option(
-        8765, "--port", "-p", help="Port to bind the A2A server to"
-    ),
+    host: str = typer.Option("127.0.0.1", "--host", help="Host to bind the A2A server to"),
+    port: int = typer.Option(8765, "--port", "-p", help="Port to bind the A2A server to"),
 ) -> None:
     """Start an A2A server that exposes Autoresearch as an agent.
 
@@ -791,15 +776,9 @@ def capabilities(
 
 @app.command("test_mcp")
 def test_mcp(
-    host: str = typer.Option(
-        "127.0.0.1", "--host", help="Host where the MCP server is running"
-    ),
-    port: int = typer.Option(
-        8080, "--port", "-p", help="Port where the MCP server is running"
-    ),
-    query: Optional[str] = typer.Option(
-        None, "--query", "-q", help="Query to test with"
-    ),
+    host: str = typer.Option("127.0.0.1", "--host", help="Host where the MCP server is running"),
+    port: int = typer.Option(8080, "--port", "-p", help="Port where the MCP server is running"),
+    query: Optional[str] = typer.Option(None, "--query", "-q", help="Query to test with"),
     output: Optional[str] = typer.Option(
         None, "-o", "--output", help="Output format: json|markdown|plain"
     ),
@@ -854,15 +833,9 @@ def test_mcp(
 
 @app.command("test_a2a")
 def test_a2a(
-    host: str = typer.Option(
-        "127.0.0.1", "--host", help="Host where the A2A server is running"
-    ),
-    port: int = typer.Option(
-        8765, "--port", "-p", help="Port where the A2A server is running"
-    ),
-    query: Optional[str] = typer.Option(
-        None, "--query", "-q", help="Query to test with"
-    ),
+    host: str = typer.Option("127.0.0.1", "--host", help="Host where the A2A server is running"),
+    port: int = typer.Option(8765, "--port", "-p", help="Port where the A2A server is running"),
+    query: Optional[str] = typer.Option(None, "--query", "-q", help="Query to test with"),
     output: Optional[str] = typer.Option(
         None, "-o", "--output", help="Output format: json|markdown|plain"
     ),
@@ -920,9 +893,7 @@ def test_a2a(
 @app.command("visualize")
 def visualize(
     query: str = typer.Argument(..., help="Query to visualize"),
-    output: str = typer.Argument(
-        "query_graph.png", help="Output PNG path for the visualization"
-    ),
+    output: str = typer.Argument("query_graph.png", help="Output PNG path for the visualization"),
     layout: str = typer.Option(
         "spring",
         "--layout",
@@ -974,12 +945,8 @@ def sparql_query(
 
 @app.command("gui")
 def gui(
-    port: int = typer.Option(
-        8501, "--port", "-p", help="Port to run the Streamlit app on"
-    ),
-    browser: bool = typer.Option(
-        True, "--browser/--no-browser", help="Open browser automatically"
-    ),
+    port: int = typer.Option(8501, "--port", "-p", help="Port to run the Streamlit app on"),
+    browser: bool = typer.Option(True, "--browser/--no-browser", help="Open browser automatically"),
 ) -> None:
     """Launch the Streamlit GUI.
 

--- a/src/autoresearch/main/config_cli.py
+++ b/src/autoresearch/main/config_cli.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 from typing import Optional, Any
 
-import typer
-import tomllib
+import importlib.resources as importlib_resources
 import tomli_w
+import tomllib
+import typer
 
-from ..config.models import ConfigModel
-from ..config.loader import ConfigLoader
-from ..errors import ConfigError
-from ..config_utils import validate_config
-from .app import _config_loader
 from ..cli_backup import backup_app
+from ..config.loader import ConfigLoader
+from ..config.models import ConfigModel
+from ..config_utils import validate_config
+from ..errors import ConfigError
+from .app import _config_loader
 
 config_app = typer.Typer(help="Configuration management commands")
 
@@ -41,23 +42,18 @@ def config_init(
 ) -> None:
     """Initialize configuration files with default values."""
     from pathlib import Path
-    from importlib.resources import files
 
     target_dir = Path(config_dir) if config_dir else Path.cwd()
     target_dir.mkdir(parents=True, exist_ok=True)
     toml_path = target_dir / "autoresearch.toml"
     env_path = target_dir / ".env"
     if toml_path.exists() and not force:
-        typer.echo(
-            f"Configuration file already exists at {toml_path}. Use --force to overwrite."
-        )
+        typer.echo(f"Configuration file already exists at {toml_path}. Use --force to overwrite.")
         return
     if env_path.exists() and not force:
-        typer.echo(
-            f"Environment file already exists at {env_path}. Use --force to overwrite."
-        )
+        typer.echo(f"Environment file already exists at {env_path}. Use --force to overwrite.")
         return
-    example_dir = files("autoresearch.examples")
+    example_dir = importlib_resources.files("autoresearch.examples")
     example_toml = example_dir / "autoresearch.toml"
     example_env = example_dir / ".env.example"
 
@@ -116,13 +112,9 @@ def config_reasoning(
         None, help="Index of starting agent for dialectical mode"
     ),
     mode: Optional[str] = typer.Option(None, help="Reasoning mode to use"),
-    token_budget: Optional[int] = typer.Option(
-        None, help="Token budget for a single run"
-    ),
+    token_budget: Optional[int] = typer.Option(None, help="Token budget for a single run"),
     max_errors: Optional[int] = typer.Option(None, help="Abort after this many errors"),
-    show: bool = typer.Option(
-        False, "--show", help="Display current reasoning configuration"
-    ),
+    show: bool = typer.Option(False, "--show", help="Display current reasoning configuration"),
 ) -> None:
     """Get or update reasoning configuration options."""
     cfg = _config_loader.load_config()

--- a/tests/unit/test_main_config_commands.py
+++ b/tests/unit/test_main_config_commands.py
@@ -1,10 +1,9 @@
 import shutil
 from importlib import resources as importlib_resources
-from importlib.resources import files
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-from click.testing import CliRunner
+from typer.testing import CliRunner
 
 from autoresearch.main import app
 
@@ -18,7 +17,7 @@ def mock_config_loader():
 @pytest.fixture
 def example_resources(tmp_path, monkeypatch):
     """Provide temporary example config files."""
-    src_dir = files("autoresearch.examples")
+    src_dir = importlib_resources.files("autoresearch.examples")
     temp_dir = tmp_path / "examples"
     shutil.copytree(src_dir, temp_dir)
 
@@ -41,9 +40,7 @@ def test_config_init_command(tmp_path, example_resources):
     assert "Configuration initialized successfully." in result.stdout
 
 
-def test_config_init_command_force(
-    example_autoresearch_toml, example_env_file, example_resources
-):
+def test_config_init_command_force(example_autoresearch_toml, example_env_file, example_resources):
     """Test the config init command with force flag."""
     runner = CliRunner()
     cfg = example_autoresearch_toml
@@ -55,9 +52,9 @@ def test_config_init_command_force(
     )
     assert result.exit_code == 0
     example_dir = example_resources
-    assert cfg.read_text(encoding="utf-8") == (
-        example_dir / "autoresearch.toml"
-    ).read_text(encoding="utf-8")
+    assert cfg.read_text(encoding="utf-8") == (example_dir / "autoresearch.toml").read_text(
+        encoding="utf-8"
+    )
     assert env.read_text(encoding="utf-8") == (example_dir / ".env.example").read_text(
         encoding="utf-8"
     )
@@ -80,9 +77,7 @@ def test_config_validate_command_valid(
             "autoresearch.main.config_cli.validate_config", return_value=(True, [])
         ) as mock_validate,
     ):
-        result = runner.invoke(
-            app, ["config", "validate"], prog_name="autoresearch"
-        )
+        result = runner.invoke(app, ["config", "validate"], prog_name="autoresearch")
     assert result.exit_code == 0
     mock_loader_class.assert_called_once()
     mock_validate.assert_called_once_with(mock_config_loader)
@@ -106,9 +101,7 @@ def test_config_validate_command_invalid(
             return_value=(False, ["Error 1", "Error 2"]),
         ) as mock_validate,
     ):
-        result = runner.invoke(
-            app, ["config", "validate"], prog_name="autoresearch"
-        )
+        result = runner.invoke(app, ["config", "validate"], prog_name="autoresearch")
     assert result.exit_code == 1
     mock_loader_class.assert_called_once()
     mock_validate.assert_called_once_with(mock_config_loader)


### PR DESCRIPTION
## Summary
- prevent storage setup when running `config` subcommands
- load example resources via `importlib.resources` for easy patching
- use Typer's `CliRunner` in config command tests

## Testing
- `uv run pytest tests/unit/test_main_config_commands.py`
- `uv run task verify` *(fails: KeyboardInterrupt after tests complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f9801a88833386d3cf702becff11