### PR TITLE
feat(logging): add env-based configuration helper

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -31,7 +31,7 @@ documented behaviour.
 | `src/autoresearch/extensions.py` | [extensions.md](extensions.md) | `../../tests/unit/test_vss_extension_loader.py<br>../../tests/unit/test_duckdb_storage_backend.py` |
 | `src/autoresearch/kg_reasoning.py` | [kg-reasoning.md](kg-reasoning.md) | `../../tests/unit/test_kg_reasoning.py` |
 | `src/autoresearch/llm/` | [llm.md](llm.md) | `../../tests/unit/test_agents_llm.py<br>../../tests/unit/test_llm_adapter.py<br>../../tests/unit/test_llm_capabilities.py` |
-| `src/autoresearch/logging_utils.py` | [logging-utils.md](logging-utils.md) | `../../tests/unit/test_logging_utils.py` |
+| `src/autoresearch/logging_utils.py` | [logging-utils.md](logging-utils.md) | `../../tests/unit/test_logging_utils.py`<br>`../../tests/unit/test_logging_utils_env.py` |
 | `src/autoresearch/main/` | [main.md](main.md) | `../../tests/unit/test_main_backup_commands.py<br>../../tests/unit/test_main_cli.py<br>../../tests/unit/test_main_config_commands.py` |
 | `src/autoresearch/mcp_interface.py` | [mcp-interface.md](mcp-interface.md) | `../../tests/unit/test_mcp_interface.py<br>../../tests/behavior/features/mcp_interface.feature` |
 | `src/autoresearch/models.py` | [models.md](models.md) | `../../tests/unit/test_models_docstrings.py` |

--- a/docs/specs/logging-utils.md
+++ b/docs/specs/logging-utils.md
@@ -1,8 +1,17 @@
 # Logging Utils
 
 Logging utilities that combine loguru and structlog for structured JSON
-logging.
+logging. Includes helpers to configure logging and obtain structured
+loggers.
+
+## Features
+
+- Unified JSON logging via `configure_logging`.
+- `configure_logging_from_env` reads `AUTORESEARCH_LOG_LEVEL` to set the
+  log level.
+- `get_logger` returns a structured logger for modules.
 
 ## Traceability
 
 - `../../tests/unit/test_logging_utils.py`
+- `../../tests/unit/test_logging_utils_env.py`

--- a/tests/unit/test_logging_utils_env.py
+++ b/tests/unit/test_logging_utils_env.py
@@ -1,0 +1,27 @@
+"""Tests for configure_logging_from_env helper."""
+
+import logging
+import pytest
+
+from autoresearch import logging_utils
+
+
+def test_configure_logging_from_env(monkeypatch):
+    captured = {}
+
+    def fake_configure_logging(*, level: int) -> None:
+        captured["level"] = level
+
+    monkeypatch.setenv("AUTORESEARCH_LOG_LEVEL", "DEBUG")
+    monkeypatch.setattr(logging_utils, "configure_logging", fake_configure_logging)
+
+    logging_utils.configure_logging_from_env()
+
+    assert captured["level"] == logging.DEBUG
+
+
+def test_configure_logging_from_env_invalid(monkeypatch):
+    monkeypatch.setenv("AUTORESEARCH_LOG_LEVEL", "INVALID")
+
+    with pytest.raises(ValueError):
+        logging_utils.configure_logging_from_env()


### PR DESCRIPTION
## Summary
- add `configure_logging_from_env` to derive log level from `AUTORESEARCH_LOG_LEVEL`
- document logging helpers and traceability
- test environment-based logging configuration

## Testing
- `uv run mkdocs build` *(fails: Config value 'theme': Unrecognised theme name: 'material')*
- `uv run task verify` *(fails: KeyboardInterrupt after tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a61187b2b88333a7e17190ead8923f