### PR TITLE
chore: plan alpha release and tidy issues

### DIFF
--- a/issues/document-environment-bootstrap.md
+++ b/issues/document-environment-bootstrap.md
@@ -1,12 +1,18 @@
 # Document environment bootstrap
 
 ## Context
-Setting up the development environment currently requires manually installing the `task` binary and running `uv sync`. The `scripts/codex_setup.sh` script aborted during `apt-get update`, leaving `task` uninstalled. Clear instructions are needed so contributors can reproduce the expected setup.
+Setting up the development environment currently requires manually installing the
+`task` binary and running `uv sync`. The `scripts/codex_setup.sh` script aborted
+during `apt-get update`, leaving `task` uninstalled. Clear instructions are
+needed so contributors can reproduce the expected setup.
 
 ## Acceptance Criteria
-- Update README and setup docs with explicit steps to install `task` and run `task install`.
-- Ensure `scripts/codex_setup.sh` handles package manager failures gracefully and installs required tools.
-- Verify a fresh clone can run `task check` successfully using the documented steps.
+- Update README and setup docs with explicit steps to install `task` and run
+  `task install`.
+- Ensure `scripts/codex_setup.sh` handles package manager failures gracefully
+  and installs required tools.
+- Verify a fresh clone can run `task check` successfully using the documented
+  steps.
 
 ## Status
 Open

--- a/issues/prepare-alpha-release.md
+++ b/issues/prepare-alpha-release.md
@@ -1,0 +1,22 @@
+# Prepare alpha release
+
+## Context
+The project targets an initial alpha release, but foundational pieces remain
+incomplete. Environment reproducibility is fragile, tests are unstable, and
+packaging steps lack verification. A consolidated plan is needed to coordinate
+these efforts.
+
+## Acceptance Criteria
+- Record the following PR-sized tasks with linked issues and dependency notes:
+  - Clarify environment bootstrap (see `document-environment-bootstrap.md`).
+  - Stabilize the integration test suite (see `stabilize-integration-tests.md`).
+  - Verify packaging workflow and add fallback when DuckDB extensions cannot be
+    downloaded.
+  - Add coverage gates and regression checks in CI.
+  - Provide proofs or simulations for ranking algorithms and agent
+    coordination.
+- Ensure roadmap and release plan capture the updated sequencing and
+  requirements.
+
+## Status
+Open

--- a/issues/stabilize-integration-tests.md
+++ b/issues/stabilize-integration-tests.md
@@ -1,12 +1,19 @@
 # Stabilize integration test suite
 
 ## Context
-Recent runs of `uv run pytest tests/integration -m "not slow and not requires_ui and not requires_vss" -q` show numerous failing tests and inconsistent process teardown, preventing a reliable `task check` or `task verify` run. This blocks the 0.1.0-alpha.1 release and obscures regression detection.
+Recent runs of
+`uv run pytest tests/integration -m "not slow and not requires_ui and not requires_vss" -q`
+show numerous failing tests and inconsistent process teardown, preventing a
+reliable `task check` or `task verify` run. This blocks the 0.1.0-alpha.1
+release and obscures regression detection.
 
 ## Acceptance Criteria
-- Identify and resolve the failing integration tests so that the above command completes with zero failures.
-- Ensure the test run terminates cleanly without hanging or leaving stray processes.
-- Update documentation to outline any required services or data for integration tests.
+- Identify and resolve the failing integration tests so that the above command
+  completes with zero failures.
+- Ensure the test run terminates cleanly without hanging or leaving stray
+  processes.
+- Update documentation to outline any required services or data for integration
+  tests.
 
 ## Status
 Open


### PR DESCRIPTION
## Summary
- Rewrap existing issue tickets for environment bootstrap and integration tests to respect line-length and style guidelines
- Add new `prepare-alpha-release` issue outlining PR-sized tasks for the first alpha release

## Testing
- `timeout 100 ./.venv/bin/task check` *(failed: interrupted with failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a66dba6d688333b6149732bec1c967