### PR TITLE
Gracefully handle missing DuckDB extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,5 @@ jobs:
         with:
           name: coverage-data
           path: .coverage
+      - name: Exercise extension download fallback
+        run: uv run pytest tests/unit/test_download_duckdb_extensions.py::test_download_extension_network_failure

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,3 +20,13 @@ Follow these steps to publish a new version of Autoresearch.
   ```bash
   uv run twine upload dist/*
   ```
+
+- If DuckDB extensions fail to download during packaging, the build continues
+  with a warning. Download them manually when needed:
+
+  ```bash
+  uv run python scripts/download_duckdb_extensions.py --output-dir ./extensions
+  ```
+
+  Place the resulting `.duckdb_extension` file in `extensions/vss/` and update
+  `VECTOR_EXTENSION_PATH` if required.

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -238,8 +238,7 @@ uv run python -c "import owlrl" || { echo 'Failed to pre-load ontology reasoner.
 if retry 3 uv run python scripts/download_duckdb_extensions.py --output-dir ./extensions; then
     echo "DuckDB extensions downloaded"
 else
-    echo 'Failed to download DuckDB extensions.' >&2
-    exit 1
+    echo 'Failed to download DuckDB extensions; continuing without them.' >&2
 fi
 # Export the path to the VSS extension for downstream tools. If no real
 # extension is available, fall back to the stub so tests can run without

--- a/tests/unit/test_download_duckdb_extensions.py
+++ b/tests/unit/test_download_duckdb_extensions.py
@@ -1,0 +1,48 @@
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+import duckdb
+
+spec = importlib.util.spec_from_file_location(
+    "download_duckdb_extensions",
+    Path(__file__).resolve().parents[2] / "scripts" / "download_duckdb_extensions.py",
+)
+dde = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(dde)
+
+
+class FailingConn:
+    def __init__(self, path):
+        self.path = path
+
+    def execute(self, *args, **kwargs):
+        return None
+
+    def install_extension(self, name):
+        raise duckdb.IOException("network failure")
+
+    def close(self):
+        pass
+
+
+def test_download_extension_network_failure(monkeypatch, tmp_path, caplog):
+    """Extension downloads warn and continue on network failure."""
+    monkeypatch.setattr(duckdb, "connect", lambda path: FailingConn(path))
+    caplog.set_level(logging.WARNING)
+    result = dde.download_extension("vss", tmp_path, "linux_amd64")
+    assert result is None
+    assert "Error downloading vss extension" in caplog.text
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "download_duckdb_extensions.py",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+    monkeypatch.setattr(dde, "download_extension", lambda *a, **k: None)
+    dde.main()  # Should not raise SystemExit


### PR DESCRIPTION
## Summary
- warn and continue when DuckDB extension downloads fail
- document manual extension installation for releases
- test and exercise extension download fallback in CI

## Testing
- `uv run task check` *(fails: tests/unit/test_monitor_cli.py::test_monitor_metrics - assert 130 == 0)*
- `uv run task verify` *(fails: tests/unit/test_main_monitor_commands.py::test_serve_a2a_command - assert 130 == 0)*
- `uv run pytest tests/unit/test_download_duckdb_extensions.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a67dcf973883339a984088b5062b46