### PR TITLE
Add coverage threshold and token regression check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Run task verify
         run: uv run task verify
       - name: Run tests with coverage
-        run: uv run pytest --cov=src
+        run: uv run pytest --cov=src --cov-report=xml --cov-fail-under=90
+      - name: Check token regression
+        run: uv run python scripts/check_token_regression.py --threshold 5
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,7 +84,8 @@ tasks:
     cmds:
       - uv run pytest tests/unit --cov=src --cov-report=term-missing --cov-append
       - uv run pytest tests/integration --cov=src --cov-report=term-missing --cov-append
-      - uv run pytest tests/behavior --cov=src --cov-report=xml --cov-report=term-missing
+      - uv run pytest tests/behavior --cov=src --cov-report=xml --cov-report=term-missing \
+          --cov-append --cov-fail-under=90
     desc: "Run full test suite with coverage reporting"
 
   verify:
@@ -98,7 +99,8 @@ tasks:
       - uv run pytest tests/unit --cov=src --cov-report=term-missing --cov-append
       - uv run pytest tests/integration -m "not slow and not requires_ui and not requires_vss" \
           --cov=src --cov-report=term-missing --cov-append
-      - uv run pytest tests/behavior --cov=src --cov-report=xml --cov-report=term-missing
+      - uv run pytest tests/behavior --cov=src --cov-report=xml --cov-report=term-missing \
+          --cov-append --cov-fail-under=90
     desc: "Run linting, type checks and fast tests with coverage"
 
   clean:


### PR DESCRIPTION
## Summary
- enforce 90% coverage threshold in Taskfile and CI workflow
- run token regression check during CI

## Testing
- `uv run task check` *(fails: assert 130 == 0 in tests/unit/test_main_monitor_commands.py::test_monitor_command)*
- `uv run task verify` *(fails: assert 130 == 0 in tests/unit/test_main_monitor_commands.py::test_serve_a2a_command)*
- `uv run python scripts/check_token_regression.py --threshold 5`


------
https://chatgpt.com/codex/tasks/task_e_68a67ddba68c8333ab66c9715306d5c1