### PR TITLE
Add examples spec and tests

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -28,6 +28,7 @@ documented behaviour.
 | `src/autoresearch/distributed/` | [distributed.md](distributed.md) | `../../tests/unit/test_distributed.py<br>../../tests/unit/test_distributed_extra.py<br>../../tests/integration/test_distributed_agent_storage.py` |
 | `src/autoresearch/error_utils.py` | [error-utils.md](error-utils.md) | `../../tests/unit/test_error_utils_additional.py` |
 | `src/autoresearch/errors.py` | [errors.md](errors.md) | `../../tests/unit/test_config_errors.py<br>../../tests/unit/test_config_validation_errors.py<br>../../tests/unit/test_errors.py` |
+| `src/autoresearch/examples/` | [examples.md](examples.md) | `../../tests/unit/test_examples_package.py` |
 | `src/autoresearch/extensions.py` | [extensions.md](extensions.md) | `../../tests/unit/test_vss_extension_loader.py<br>../../tests/unit/test_duckdb_storage_backend.py` |
 | `src/autoresearch/kg_reasoning.py` | [kg-reasoning.md](kg-reasoning.md) | `../../tests/unit/test_kg_reasoning.py` |
 | `src/autoresearch/llm/` | [llm.md](llm.md) | `../../tests/unit/test_agents_llm.py<br>../../tests/unit/test_llm_adapter.py<br>../../tests/unit/test_llm_capabilities.py` |

--- a/docs/specs/examples.md
+++ b/docs/specs/examples.md
@@ -1,0 +1,13 @@
+# Examples
+
+Sample configuration resources for quick-start setups.
+
+## Sample configuration
+
+- Provide `autoresearch.toml` with local-first defaults.
+- Load the file via `importlib.resources` from `autoresearch.examples`.
+
+## Traceability
+
+- `src/autoresearch/examples/`
+- `../../tests/unit/test_examples_package.py`

--- a/src/autoresearch/examples/__init__.py
+++ b/src/autoresearch/examples/__init__.py
@@ -1,0 +1,4 @@
+"""Example resources for Autoresearch.
+
+Spec: docs/specs/examples.md#sample-configuration
+"""

--- a/tests/unit/test_examples_package.py
+++ b/tests/unit/test_examples_package.py
@@ -1,0 +1,13 @@
+"""Tests for the `examples` package."""
+
+from importlib import resources
+import tomllib
+
+
+def test_sample_configuration() -> None:
+    """Spec: docs/specs/examples.md#sample-configuration"""
+    config_path = resources.files("autoresearch.examples") / "autoresearch.toml"
+    data = tomllib.loads(config_path.read_text())
+    core = data["core"]
+    assert core["llm_backend"] == "lmstudio"
+    assert core["loops"] == 3


### PR DESCRIPTION
## Summary
- document examples package with sample configuration spec
- cover examples config via unit test and link spec in index

## Testing
- `uv run pytest tests/unit/test_examples_package.py -q`
- `uv run mkdocs build`
- `task check` *(fails: process interrupted)*
- `task verify` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a67e12bcf88333b8ab86de8769b934