### PR TITLE
feat(ci): enforce coverage gate and regression check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,18 @@ jobs:
       - name: Run task verify
         run: uv run task verify
       - name: Run tests with coverage
-        run: uv run pytest --cov=src --cov-report=xml --cov-fail-under=90
-      - name: Check token regression
-        run: uv run python scripts/check_token_regression.py --threshold 5
+        run: uv run pytest --cov=src --cov-report=xml
       - name: Upload coverage
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-data
-          path: .coverage
+          path: |
+            .coverage
+            coverage.xml
+      - name: Check token regression
+        run: uv run python scripts/check_token_regression.py --threshold 5
+      - name: Enforce coverage threshold
+        run: uv run coverage report --fail-under=90
       - name: Exercise extension download fallback
         run: uv run pytest tests/unit/test_download_duckdb_extensions.py::test_download_extension_network_failure

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,6 +86,7 @@ tasks:
       - uv run pytest tests/integration --cov=src --cov-report=term-missing --cov-append
       - uv run pytest tests/behavior --cov=src --cov-report=xml --cov-report=term-missing \
           --cov-append --cov-fail-under=90
+      - uv run python scripts/check_token_regression.py --threshold 5
     desc: "Run full test suite with coverage reporting"
 
   verify:
@@ -101,6 +102,7 @@ tasks:
           --cov=src --cov-report=term-missing --cov-append
       - uv run pytest tests/behavior --cov=src --cov-report=xml --cov-report=term-missing \
           --cov-append --cov-fail-under=90
+      - uv run python scripts/check_token_regression.py --threshold 5
     desc: "Run linting, type checks and fast tests with coverage"
 
   clean:

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -240,6 +240,14 @@ Aim for high test coverage:
 3. Use parameterization to test multiple inputs
 4. Test both positive and negative scenarios
 
+Use `task coverage` to run the full suite with coverage and enforce the
+90% threshold. The command also invokes
+`scripts/check_token_regression.py` to detect token usage regressions. For
+a quicker pre-commit check run `task verify`, which executes a reduced
+suite with coverage and the same regression guard. If legitimate changes
+exceed the threshold, update `tests/integration/baselines/token_usage.json`
+and commit the new baseline.
+
 ## Template
 
 A template for unit tests is available at `tests/unit/test_template.py`. Use this template as a starting point for new test files.


### PR DESCRIPTION
## Summary
- gate coverage in CI and always upload coverage artifacts
- run token regression check from coverage and verify tasks
- document local coverage workflow and regression expectations

## Testing
- `task check` *(fails: tests/unit/test_main_cli.py::test_search_primus_start_option, tests/unit/test_monitor_cli.py::test_monitor_prompts_and_passes_callbacks, tests/unit/test_synthesizer_agent_modes.py::test_synthesizer_direct_mode, tests/unit/test_synthesizer_agent_modes.py::test_synthesizer_thesis_and_synthesis)*
- `task coverage` *(fails: exit status 2)*


------
https://chatgpt.com/codex/tasks/task_e_68a73b9ed55c8333a3ddec921f6d4856