### PR TITLE
doc: record integration test failures

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -237,6 +237,9 @@ and several tests fail.
 - `uv sync --extra dev-minimal --extra test` – success
 - `uv run task verify` – fails: configuration command tests fail
 - `uv run --extra dev-minimal pytest -q` – fails: configuration command tests, ~67% coverage
+- `uv run pytest tests/integration -m "not slow and not requires_ui and not requires_vss" -q`
+  – fails: missing `pytest_httpx`; earlier run showed 39 integration failures
+- `task check` – command unavailable (`task` utility missing in environment)
 
 ### Performance Baselines
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,6 +16,8 @@ uv run pytest tests/integration -m 'not slow and not requires_ui and not require
 - Configuration tests write temporary TOML files via `tomli-w`.
 - Baseline JSON files in `tests/integration/baselines/` hold expected
   metrics and token counts for comparison.
+- Some tests rely on `owlrl` for RDF reasoning; install this package to
+  avoid failures during integration runs.
 
 No external databases or network services need to be running. Temporary
 artifacts are created under `tmp_path` and cleaned automatically.


### PR DESCRIPTION
## Summary
- note `owlrl` requirement for integration tests
- log failing integration test run and missing `task` utility in task progress

## Testing
- `uv run pytest tests/integration -m "not slow and not requires_ui and not requires_vss" -q`
- `task check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a73b9934a88333bed8e152389b072a