### PR TITLE
Add coverage regression check and document local coverage workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         run: uv run task verify
       - name: Run tests with coverage
         run: uv run pytest --cov=src --cov-report=xml
+      - name: Enforce coverage threshold
+        run: uv run coverage report --fail-under=90
       - name: Upload coverage
         if: always()
         uses: actions/upload-artifact@v4
@@ -46,7 +48,37 @@ jobs:
             coverage.xml
       - name: Check token regression
         run: uv run python scripts/check_token_regression.py --threshold 5
-      - name: Enforce coverage threshold
-        run: uv run coverage report --fail-under=90
       - name: Exercise extension download fallback
         run: uv run pytest tests/unit/test_download_duckdb_extensions.py::test_download_extension_network_failure
+
+  coverage-regression:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        run: python -m pip install uv
+      - name: Restore coverage baseline
+        id: coverage-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: baseline/coverage.xml
+          key: coverage-${{ github.ref }}
+      - name: Download current coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-data
+          path: current
+      - name: Check coverage regression
+        run: |
+          uv run python scripts/check_token_regression.py \
+            --coverage-baseline baseline/coverage.xml \
+            --coverage-current current/coverage.xml
+      - name: Save coverage baseline
+        uses: actions/cache/save@v4
+        with:
+          path: current/coverage.xml
+          key: coverage-${{ github.ref }}

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -28,6 +28,10 @@ task test:fast         # unit, integration, and behavior tests (no slow)
 task test:slow         # only tests marked as slow
 task test:all          # entire suite including slow tests
 ```
+
+Run `task coverage` before committing to execute the full suite with coverage
+and token regression checks.
+
 You can also invoke the slow suite directly with:
 
 ```bash

--- a/scripts/check_token_regression.py
+++ b/scripts/check_token_regression.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Compare token metrics with baselines and enforce a threshold."""
+"""Compare token metrics or coverage against baselines and enforce thresholds."""
 
 from __future__ import annotations
 
@@ -7,19 +7,25 @@ import argparse
 import json
 import os
 from pathlib import Path
+import xml.etree.ElementTree as ET
 
 
 def _total(tokens: dict[str, dict[str, int]]) -> int:
     return sum(v.get("in", 0) + v.get("out", 0) for v in tokens.values())
 
 
+def _coverage_percent(path: Path) -> float:
+    tree = ET.fromstring(path.read_text())
+    return float(tree.get("line-rate", "0")) * 100
+
+
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Check token usage regression")
+    parser = argparse.ArgumentParser(description="Check token or coverage regression")
     parser.add_argument(
         "--threshold",
         type=int,
         default=0,
-        help="Allowed increase in total tokens compared to baseline",
+        help="Allowed change in metric compared to baseline",
     )
     parser.add_argument(
         "--baseline",
@@ -35,7 +41,26 @@ def main() -> int:
         "--release",
         default=os.getenv("AUTORESEARCH_RELEASE", "development"),
     )
+    parser.add_argument("--coverage-baseline", type=Path)
+    parser.add_argument("--coverage-current", type=Path)
     args = parser.parse_args()
+
+    if args.coverage_baseline or args.coverage_current:
+        if not args.coverage_baseline or not args.coverage_current:
+            parser.error("Both --coverage-baseline and --coverage-current are required")
+        if not args.coverage_baseline.exists():
+            print(f"No baseline coverage at {args.coverage_baseline}")
+            return 0
+        baseline_cov = _coverage_percent(args.coverage_baseline)
+        current_cov = _coverage_percent(args.coverage_current)
+        if current_cov + args.threshold < baseline_cov:
+            print(
+                f"Coverage {current_cov:.2f}% below baseline "
+                f"{baseline_cov:.2f}% - {args.threshold}% allowed"
+            )
+            return 1
+        print("Coverage within threshold")
+        return 0
 
     baseline = json.loads(args.baseline.read_text())
     metrics_data = json.loads(args.release_metrics.read_text())
@@ -48,9 +73,7 @@ def main() -> int:
     latest_total = _total(metrics)
 
     if latest_total > baseline_total + args.threshold:
-        print(
-            f"Token usage {latest_total} exceeds baseline {baseline_total} + {args.threshold}"
-        )
+        print(f"Token usage {latest_total} exceeds baseline {baseline_total} + {args.threshold}")
         return 1
 
     print("Token usage within threshold")


### PR DESCRIPTION
## Summary
- enforce coverage threshold after tests and upload coverage data
- add coverage regression job comparing with previous run
- extend token regression script to check coverage
- document running `task coverage` locally before commits

## Testing
- `uv run mkdocs build`
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit -q` *(fails: DID NOT RAISE <class 'autoresearch.errors.VSSNotInstalled'>)*


------
https://chatgpt.com/codex/tasks/task_e_68a768bcf9208333ac93fc2ad7fa317b