### PR TITLE
Add storage teardown helper for integration tests

### DIFF
--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -299,6 +299,22 @@ class StorageManager(metaclass=StorageManagerMeta):
         return ctx
 
     @staticmethod
+    def teardown(
+        remove_db: bool = False,
+        context: StorageContext | None = None,
+        state: StorageState | None = None,
+    ) -> None:
+        """Close storage connections and optionally remove database files."""
+        st = state or StorageManager.state
+        ctx = context or st.context
+        if _delegate and _delegate is not StorageManager:
+            _delegate.teardown(remove_db, ctx, st)  # type: ignore[attr-defined]
+            return
+        StorageManager.state = st
+        StorageManager.context = ctx
+        teardown(remove_db, ctx, st)
+
+    @staticmethod
     def _current_ram_mb() -> float:
         """Calculate the approximate RAM usage of the current process in MB.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,8 +16,8 @@ uv run pytest tests/integration -m 'not slow and not requires_ui and not require
 - Configuration tests write temporary TOML files via `tomli-w`.
 - Baseline JSON files in `tests/integration/baselines/` hold expected
   metrics and token counts for comparison.
-- Some tests rely on `owlrl` for RDF reasoning; install this package to
-  avoid failures during integration runs.
+- Some tests rely on `owlrl` and `rdflib_sqlalchemy` for RDF reasoning and
+  persistence; install these packages to avoid failures during integration runs.
 
 No external databases or network services need to be running. Temporary
 artifacts are created under `tmp_path` and cleaned automatically.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,10 +54,10 @@ from autoresearch.llm.registry import LLMFactory  # noqa: E402
 from autoresearch.models import QueryResponse  # noqa: E402, F401
 from autoresearch.storage import (  # noqa: E402
     StorageContext,
+    StorageManager,
 )
 from autoresearch.storage import set_delegate as set_storage_delegate  # noqa: E402
 from autoresearch.storage import setup as storage_setup  # noqa: E402
-from autoresearch.storage import teardown as storage_teardown  # noqa: E402
 
 _orig_option = typer.Option
 
@@ -253,9 +253,9 @@ def reset_rate_limiting():
 @pytest.fixture(autouse=True)
 def cleanup_storage():
     """Remove any persistent storage state between tests."""
-    storage_teardown(remove_db=True)
+    StorageManager.teardown(remove_db=True)
     yield
-    storage_teardown(remove_db=True)
+    StorageManager.teardown(remove_db=True)
 
 
 @pytest.fixture(autouse=True)
@@ -373,7 +373,7 @@ def storage_context_factory(tmp_path):
         try:
             yield ctx
         finally:
-            storage_teardown(remove_db=True, context=ctx)
+            StorageManager.teardown(remove_db=True, context=ctx)
 
     return _make
 


### PR DESCRIPTION
## Summary
- add `StorageManager.teardown` to close connections and remove temp DBs
- call `StorageManager.teardown` in `cleanup_storage` fixture
- document RDF test dependencies in `tests/README.md`

## Testing
- `uv run pytest tests/integration -m "not slow and not requires_ui and not requires_vss" -q` *(fails: assert 1 == 3)*

------
https://chatgpt.com/codex/tasks/task_e_68a768c274d083338d14c0c5bd4c360f