### PR TITLE
docs: clarify Go Task prerequisite

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,9 +4,10 @@ This guide explains how to install Autoresearch and manage optional features.
 
 Autoresearch requires **Python 3.12 or newer**,
 [**uv**](https://github.com/astral-sh/uv), and
-[**Go Task**](https://taskfile.dev/) for Taskfile commands. Install Go Task
-before running `task`. After cloning, bootstrap the environment and verify
-the toolchain:
+[**Go Task**](https://taskfile.dev/) for Taskfile commands. **Install Go Task
+before running any `task` commands** such as `task install`. After installing
+Go Task and cloning the repository, bootstrap the environment and verify the
+toolchain:
 
 ```bash
 task install

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -56,6 +56,7 @@ def check_python() -> CheckResult:
 
 
 def check_task() -> CheckResult:
+    required = REQUIREMENTS["task"]
     try:
         proc = subprocess.run(
             ["task", "--version"],
@@ -65,13 +66,13 @@ def check_task() -> CheckResult:
         )
     except FileNotFoundError as exc:
         hint = (
-            "Go Task is not installed. Install it from https://taskfile.dev/ "
+            f"Go Task {required}+ is required. Install it from https://taskfile.dev/ "
             "or run scripts/setup.sh"
         )
         raise VersionError(hint) from exc
     if proc.returncode != 0:
         hint = (
-            "Go Task is not installed. Install it from https://taskfile.dev/ "
+            f"Go Task {required}+ is required. Install it from https://taskfile.dev/ "
             "or run scripts/setup.sh"
         )
         raise VersionError(hint)
@@ -79,7 +80,13 @@ def check_task() -> CheckResult:
     if not match:
         raise VersionError("Could not determine Go Task version")
     current = match.group(1)
-    return CheckResult("Go Task", current, REQUIREMENTS["task"])
+    if Version(current) < Version(required):
+        hint = (
+            f"Go Task {current} found, but {required}+ is required. Install it from "
+            "https://taskfile.dev/ or run scripts/setup.sh"
+        )
+        raise VersionError(hint)
+    return CheckResult("Go Task", current, required)
 
 
 def check_uv() -> CheckResult:

--- a/scripts/run_task.py
+++ b/scripts/run_task.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Run Go Task commands with a graceful fallback.
+
+Usage:
+    uv run python scripts/run_task.py [TASK_ARGS...]
+
+This wrapper checks that Go Task is installed before delegating to it.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if shutil.which("task") is None:
+        msg = (
+            "Go Task is not installed. Install it from https://taskfile.dev/ "
+            "or run scripts/setup.sh"
+        )
+        print(f"ERROR: {msg}", file=sys.stderr)
+        return 1
+    result = subprocess.run(["task", *argv])
+    return result.returncode
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- stress Go Task installation before using `task`
- improve `check_env.py` with clearer Task version errors
- add `scripts/run_task.py` wrapper to handle missing Go Task gracefully

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run mkdocs build` *(fails: mkdocs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a78441e3b88333927aa878cd18b9e0