### PR TITLE
feat: fallback to offline VSS extension

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -4,16 +4,17 @@ Follow these steps to publish a new version of Autoresearch.
 
 - Update the version in `pyproject.toml` and
   `src/autoresearch/__init__.py`. Commit the change and tag the release.
-- Build the distribution files.
+- Build the distribution files with the `build` extra.
 
   ```bash
-  uv run python -m build
+  uv run --extra build python -m build
   ```
 - Upload the build to TestPyPI for validation.
 
   ```bash
-  uv run python scripts/publish_dev.py --dry-run
-  uv run python scripts/publish_dev.py
+  UV_INSTALL_ARGS="--extra build" \
+    uv run scripts/publish_dev.py --dry-run
+  uv run scripts/publish_dev.py
   ```
 - Release to PyPI once the TestPyPI upload is verified.
 
@@ -28,5 +29,8 @@ Follow these steps to publish a new version of Autoresearch.
   uv run python scripts/download_duckdb_extensions.py --output-dir ./extensions
   ```
 
-  Place the resulting `.duckdb_extension` file in `extensions/vss/` and update
-  `VECTOR_EXTENSION_PATH` if required.
+    Place the resulting `.duckdb_extension` file in `extensions/vss/` and update
+    `VECTOR_EXTENSION_PATH` if required. At runtime, if the extension remains
+    unavailable, the storage backend reads `.env.offline` for a
+    `VECTOR_EXTENSION_PATH` fallback before continuing without vector
+    search.


### PR DESCRIPTION
## Summary
- add offline fallback for DuckDB VSS extension loading
- document build and dry-run steps and offline extension fallback

## Testing
- `uv run --extra build python -m build`
- `UV_INSTALL_ARGS="--extra build" uv run scripts/publish_dev.py --dry-run`
- `uv run mkdocs build`
- `uv run flake8 src/autoresearch/storage_backends.py`
- `uv run pytest tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::test_verify_extension_success -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78420b1748333898b5e1291a6340e