### PR TITLE
link milestones to issues and trim completed items

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,14 +18,19 @@ before running tests.
 - 0.1.0a1 (2026-03-01, status: open): Alpha preview to collect feedback while
   aligning environment requirements ([prepare-alpha-release]).
 - 0.1.0 (2026-07-01, status: planned): Finalize packaging, docs and CI checks
-  with all tests passing ([update-release-documentation]).
-- 0.1.1 (2026-09-15, status: planned): Bug fixes and documentation updates.
+  with all tests passing
+  ([finalize-first-public-preview-release]).
+- 0.1.1 (2026-09-15, status: planned): Bug fixes and documentation updates
+  ([deliver-bug-fixes-and-docs-update]).
 - 0.2.0 (2026-12-01, status: planned): API stabilization, configuration
-  hot-reload, improved search backends.
-- 0.3.0 (2027-03-01, status: planned): Distributed execution support,
-  monitoring utilities.
+  hot-reload and improved search backends
+  ([stabilize-api-and-improve-search]).
+- 0.3.0 (2027-03-01, status: planned): Distributed execution support and
+  monitoring utilities
+  ([support-distributed-execution-and-monitoring]).
 - 1.0.0 (2027-06-01, status: planned): Full feature set, performance tuning
-  and stable interfaces.
+  and stable interfaces
+  ([reach-stable-performance-and-interfaces]).
 
 See [docs/release_plan.md](docs/release_plan.md#alpha-release-checklist) for the
 alpha release checklist.
@@ -36,15 +41,17 @@ This pre-release provides an early package for testing while packaging tasks
 remain open. Related issue ([prepare-alpha-release]) tracks outstanding
 environment work. Key activities include:
 
-- [x] Environment bootstrap in place.
-- [ ] Packaging verification with DuckDB fallback.
-- [ ] Integration tests stabilized.
-- [ ] Coverage gates enforce 90% threshold.
-- [ ] Algorithm validation for ranking and coordination.
+- [ ] Packaging verification with DuckDB fallback
+  ([packaging-fallback]).
+- [ ] Integration tests stabilized
+  ([stabilize-integration-tests]).
+- [ ] Coverage gates enforce 90% threshold
+  ([coverage-gates]).
+- [ ] Algorithm validation for ranking and coordination ([ranking]).
 
 These steps depend on one another:
-environment bootstrap → packaging verification → integration tests →
-coverage gates → algorithm validation.
+packaging verification → integration tests → coverage gates → algorithm
+validation.
 
 ## 0.1.0 – First public preview
 
@@ -110,5 +117,13 @@ The 1.0.0 milestone aims for a polished, production-ready system:
   lines 178-186; TASK_PROGRESS lines 206-216).
 - Optimize performance across all components and finalize documentation.
 
-[update-release-documentation]: issues/archive/update-release-documentation.md
 [prepare-alpha-release]: issues/prepare-alpha-release.md
+[finalize-first-public-preview-release]: issues/finalize-first-public-preview-release.md
+[deliver-bug-fixes-and-docs-update]: issues/deliver-bug-fixes-and-docs-update.md
+[stabilize-api-and-improve-search]: issues/stabilize-api-and-improve-search.md
+[support-distributed-execution-and-monitoring]: issues/support-distributed-execution-and-monitoring.md
+[reach-stable-performance-and-interfaces]: issues/reach-stable-performance-and-interfaces.md
+[packaging-fallback]: issues/verify-packaging-workflow-and-duckdb-fallback.md
+[stabilize-integration-tests]: issues/stabilize-integration-tests.md
+[coverage-gates]: issues/add-coverage-gates-and-regression-checks.md
+[ranking]: issues/validate-ranking-algorithms-and-agent-coordination.md

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -30,14 +30,19 @@ Current checks show:
 - **0.1.0a1** (2026-03-01, status: open): Alpha preview to collect feedback
   ([prepare-alpha-release]).
 - **0.1.0** (2026-07-01, status: planned): Finalize packaging, docs and CI
-  checks with all tests passing.
-- **0.1.1** (2026-09-15, status: planned): Bug fixes and documentation updates.
+  checks with all tests passing
+  ([finalize-first-public-preview-release]).
+- **0.1.1** (2026-09-15, status: planned): Bug fixes and documentation updates
+  ([deliver-bug-fixes-and-docs-update]).
 - **0.2.0** (2026-12-01, status: planned): API stabilization, configuration
-  hot-reload, improved search backends.
-- **0.3.0** (2027-03-01, status: planned): Distributed execution support,
-  monitoring utilities.
+  hot-reload and improved search backends
+  ([stabilize-api-and-improve-search]).
+- **0.3.0** (2027-03-01, status: planned): Distributed execution support and
+  monitoring utilities
+  ([support-distributed-execution-and-monitoring]).
 - **1.0.0** (2027-06-01, status: planned): Full feature set, performance
-  tuning and stable interfaces.
+  tuning and stable interfaces
+  ([reach-stable-performance-and-interfaces]).
 
 The project originally targeted **0.1.0** for **July 20, 2025**, but the
 schedule slipped. To gather early feedback, an alpha **0.1.0a1** release is
@@ -46,8 +51,6 @@ now set for **July 1, 2026** while packaging tasks are resolved.
 
 ### Alpha release checklist
 
-- [x] Document development environment bootstrap
-  ([document-environment-bootstrap.md][env-bootstrap])
 - [ ] Packaging verification with DuckDB fallback
   ([verify-packaging-workflow-and-duckdb-fallback.md][packaging-fallback])
 - [ ] Integration test suite passes
@@ -56,11 +59,9 @@ now set for **July 1, 2026** while packaging tasks are resolved.
   see [add-coverage-gates-and-regression-checks.md][coverage-gates])
 - [ ] Validate ranking algorithms and agent coordination (see
   [ranking])
-- [x] Assemble preliminary release notes and confirm README instructions
-  ([assemble-release-notes-and-validate-readme.md][release-notes])
 
-These tasks depend on each other in order: environment bootstrap → packaging
-verification → integration tests → coverage gates → algorithm validation.
+These tasks depend on each other in order: packaging verification → integration
+tests → coverage gates → algorithm validation.
 
 Resolving these items will determine the new completion date for **0.1.0**.
 
@@ -100,6 +101,9 @@ optional extras):
 [stabilize-integration-tests]: ../issues/stabilize-integration-tests.md
 [packaging-fallback]: ../issues/verify-packaging-workflow-and-duckdb-fallback.md
 [ranking]: ../issues/validate-ranking-algorithms-and-agent-coordination.md
-[env-bootstrap]: ../issues/archive/document-environment-bootstrap.md
-[release-notes]: ../issues/archive/assemble-release-notes-and-validate-readme.md
 [prepare-alpha-release]: ../issues/prepare-alpha-release.md
+[finalize-first-public-preview-release]: ../issues/finalize-first-public-preview-release.md
+[deliver-bug-fixes-and-docs-update]: ../issues/deliver-bug-fixes-and-docs-update.md
+[stabilize-api-and-improve-search]: ../issues/stabilize-api-and-improve-search.md
+[support-distributed-execution-and-monitoring]: ../issues/support-distributed-execution-and-monitoring.md
+[reach-stable-performance-and-interfaces]: ../issues/reach-stable-performance-and-interfaces.md

--- a/issues/deliver-bug-fixes-and-docs-update.md
+++ b/issues/deliver-bug-fixes-and-docs-update.md
@@ -1,0 +1,13 @@
+# Deliver bug fixes and docs update
+
+## Context
+After the first public preview, follow-up fixes and documentation updates
+are required to address outstanding issues.
+
+## Acceptance Criteria
+- Apply high-priority bug fixes discovered after the 0.1.0 release.
+- Update documentation to reflect resolved issues and new behaviors.
+- Ensure tests and coverage remain stable.
+
+## Status
+Open

--- a/issues/finalize-first-public-preview-release.md
+++ b/issues/finalize-first-public-preview-release.md
@@ -1,0 +1,14 @@
+# Finalize first public preview release
+
+## Context
+The project targets a 0.1.0 release with complete packaging, documentation
+and continuous integration checks. An open ticket tracks remaining work
+required to finalize this milestone.
+
+## Acceptance Criteria
+- Package builds verified and published to TestPyPI.
+- Documentation and release notes finalized.
+- All CI checks pass with required coverage thresholds.
+
+## Status
+Open

--- a/issues/reach-stable-performance-and-interfaces.md
+++ b/issues/reach-stable-performance-and-interfaces.md
@@ -1,0 +1,13 @@
+# Reach stable performance and interfaces
+
+## Context
+The 1.0.0 milestone aims to provide a polished, production-ready system with
+stable interfaces and tuned performance.
+
+## Acceptance Criteria
+- Complete cross-platform packaging with containerization support.
+- Deliver deployment scripts and configuration validation.
+- Optimize performance across all components and finalize documentation.
+
+## Status
+Open

--- a/issues/stabilize-api-and-improve-search.md
+++ b/issues/stabilize-api-and-improve-search.md
@@ -1,0 +1,13 @@
+# Stabilize API and improve search
+
+## Context
+The 0.2.0 milestone targets API stabilization, configuration hot reload and
+enhanced search capabilities.
+
+## Acceptance Criteria
+- Provide stable API endpoints with streaming and webhook support.
+- Implement hybrid search with ranking across backends.
+- Document configuration hot reload behavior.
+
+## Status
+Open

--- a/issues/support-distributed-execution-and-monitoring.md
+++ b/issues/support-distributed-execution-and-monitoring.md
@@ -1,0 +1,13 @@
+# Support distributed execution and monitoring
+
+## Context
+The 0.3.0 release introduces distributed agent execution and expanded
+monitoring utilities.
+
+## Acceptance Criteria
+- Coordinate agents across processes and storage backends.
+- Expose real-time metrics including GPU usage.
+- Document deployment patterns for distributed execution.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- link release and roadmap milestones to new issue trackers
- drop completed alpha checklist entries and note remaining dependency order

## Testing
- `uv run mkdocs build` *(fails: No such file or directory)*
- `task check` *(fails: No module named 'flake8')*
- `task verify` *(fails: No module named 'flake8')*

------
https://chatgpt.com/codex/tasks/task_e_68a78cbc04fc83339b5315074e180f3d