### PR TITLE
Add simulations for ranking correctness and coordination

### DIFF
--- a/docs/algorithms/validation.md
+++ b/docs/algorithms/validation.md
@@ -40,6 +40,12 @@ sequences and show the ranked output matches the original order. A simulation,
 stability `1.0` in
 [ranking_tie_metrics.json](../../tests/analysis/ranking_tie_metrics.json).
 
+## Ranking correctness
+
+The simulation [`ranking_correctness_analysis.py`][rca] draws random relevance
+scores and confirms that sorting by score yields a non-increasing sequence.
+Results show correctness `1.0` in [`ranking_correctness_metrics.json`][rcm].
+
 ## Token budget heuristics
 
 Property-based tests verify that weighted scores remain normalized and
@@ -85,6 +91,8 @@ monotonic
 [tbseq]: ../../tests/unit/test_property_token_budget_sequence.py
 [tpbn]: ../../tests/unit/test_property_bm25_normalization.py
 [tpwt]: ../../tests/unit/test_property_weight_tuning.py
+[rca]: ../../tests/analysis/ranking_correctness_analysis.py
+[rcm]: ../../tests/analysis/ranking_correctness_metrics.json
 
 ## Coordination policies
 
@@ -111,6 +119,14 @@ and confirms the invariant.
 [tpcs]: ../../tests/unit/test_property_coordination_stability.py
 [tprt]: ../../tests/unit/test_property_ranking_ties.py
 [tpcfp]: ../../tests/unit/test_property_coordination_fixed_point.py
+[aca]: ../../tests/analysis/agent_coordination_analysis.py
+[acm]: ../../tests/analysis/agent_coordination_metrics.json
+
+## Agent coordination
+
+[`agent_coordination_analysis.py`][aca] spawns locked processes that increment a
+shared counter. The final value matches the expected total, recorded in
+[`agent_coordination_metrics.json`][acm], demonstrating proper synchronization.
 
 ## Summary
 

--- a/tests/analysis/agent_coordination_analysis.py
+++ b/tests/analysis/agent_coordination_analysis.py
@@ -1,0 +1,41 @@
+"""Simulate agents incrementing a shared counter with locking."""
+
+from __future__ import annotations
+
+import json
+from multiprocessing import Lock, Process, Value
+from pathlib import Path
+
+
+def _worker(counter: Value, lock: Lock, increments: int) -> None:
+    """Increment ``counter`` safely using ``lock``."""
+    for _ in range(increments):
+        with lock:
+            counter.value += 1
+
+
+def simulate(workers: int = 4, increments: int = 1000) -> dict[str, int | bool]:
+    """Run workers and validate the final counter value."""
+    counter = Value("i", 0)
+    lock = Lock()
+    procs = [Process(target=_worker, args=(counter, lock, increments)) for _ in range(workers)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join()
+    expected = workers * increments
+    success = counter.value == expected
+    out_path = Path(__file__).with_name("agent_coordination_metrics.json")
+    out_path.write_text(
+        json.dumps({"final": counter.value, "expected": expected, "success": success}, indent=2) + "\n"
+    )
+    return {"final": counter.value, "expected": expected, "success": success}
+
+
+def run() -> dict[str, int | bool]:
+    """Entry point for running the simulation."""
+    return simulate()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print(json.dumps(run(), indent=2))

--- a/tests/analysis/agent_coordination_metrics.json
+++ b/tests/analysis/agent_coordination_metrics.json
@@ -1,0 +1,5 @@
+{
+  "final": 4000,
+  "expected": 4000,
+  "success": true
+}

--- a/tests/analysis/ranking_correctness_analysis.py
+++ b/tests/analysis/ranking_correctness_analysis.py
@@ -1,0 +1,38 @@
+"""Simulate ranking by score to confirm descending ordering."""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+
+def rank_results(results: list[dict]) -> list[dict]:
+    """Sort results by ``relevance_score`` descending."""
+    return sorted(results, key=lambda r: r["relevance_score"], reverse=True)
+
+
+def simulate(trials: int = 100, items: int = 5) -> dict[str, float]:
+    """Generate random scores and verify the sorted order."""
+    correct = 0
+    for _ in range(trials):
+        results = [
+            {"title": str(i), "relevance_score": random.random()} for i in range(items)
+        ]
+        ranked = rank_results(results)
+        scores = [r["relevance_score"] for r in ranked]
+        if all(scores[i] >= scores[i + 1] for i in range(len(scores) - 1)):
+            correct += 1
+    ratio = correct / trials
+    out_path = Path(__file__).with_name("ranking_correctness_metrics.json")
+    out_path.write_text(json.dumps({"correctness": ratio}, indent=2) + "\n")
+    return {"correctness": ratio}
+
+
+def run() -> dict[str, float]:
+    """Entry point for running the simulation."""
+    return simulate()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print(json.dumps(run(), indent=2))

--- a/tests/analysis/ranking_correctness_metrics.json
+++ b/tests/analysis/ranking_correctness_metrics.json
@@ -1,0 +1,3 @@
+{
+  "correctness": 1.0
+}

--- a/tests/analysis/test_agent_coordination.py
+++ b/tests/analysis/test_agent_coordination.py
@@ -1,0 +1,9 @@
+"""Tests for agent coordination simulation."""
+
+from tests.analysis.agent_coordination_analysis import run
+
+
+def test_agent_coordination() -> None:
+    metrics = run()
+    assert metrics["final"] == metrics["expected"]
+    assert metrics["success"]

--- a/tests/analysis/test_ranking_correctness.py
+++ b/tests/analysis/test_ranking_correctness.py
@@ -1,0 +1,8 @@
+"""Tests for ranking correctness simulation."""
+
+from tests.analysis.ranking_correctness_analysis import run
+
+
+def test_ranking_correctness() -> None:
+    metrics = run()
+    assert metrics["correctness"] == 1.0


### PR DESCRIPTION
## Summary
- add ranking correctness simulation and test to ensure sorting by score
- add agent coordination simulation with shared counter and associated test
- document validation results for ranking correctness and agent coordination

## Testing
- `uv run flake8 tests/analysis/ranking_correctness_analysis.py tests/analysis/agent_coordination_analysis.py tests/analysis/test_ranking_correctness.py tests/analysis/test_agent_coordination.py`
- `uv run pytest tests/analysis/test_ranking_correctness.py tests/analysis/test_agent_coordination.py`
- `task check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78cb59a7083339a4ff8e0f5b9b4c9