### PR TITLE
feat: add duckdb extension fallback

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -4,33 +4,36 @@ Follow these steps to publish a new version of Autoresearch.
 
 - Update the version in `pyproject.toml` and
   `src/autoresearch/__init__.py`. Commit the change and tag the release.
-- Build the distribution files with the `build` extra.
+- Validate the package builds.
 
   ```bash
-  uv run --extra build python -m build
+  uv run python -m build
+  uv run scripts/publish_dev.py --dry-run
   ```
-- Upload the build to TestPyPI for validation.
+
+- Upload the validated build to TestPyPI.
 
   ```bash
-  UV_INSTALL_ARGS="--extra build" \
-    uv run scripts/publish_dev.py --dry-run
   uv run scripts/publish_dev.py
   ```
+
 - Release to PyPI once the TestPyPI upload is verified.
 
   ```bash
   uv run twine upload dist/*
   ```
 
-- If DuckDB extensions fail to download during packaging, the build continues
-  with a warning. Download them manually when needed:
+- If DuckDB extensions fail to download during packaging, the build
+  continues with a warning. The download script falls back to
+  `VECTOR_EXTENSION_PATH` defined in `.env.offline` and copies the
+  referenced file into `extensions/vss/`. Run the script manually when
+  needed:
 
   ```bash
   uv run python scripts/download_duckdb_extensions.py --output-dir ./extensions
   ```
 
-    Place the resulting `.duckdb_extension` file in `extensions/vss/` and update
-    `VECTOR_EXTENSION_PATH` if required. At runtime, if the extension remains
-    unavailable, the storage backend reads `.env.offline` for a
-    `VECTOR_EXTENSION_PATH` fallback before continuing without vector
-    search.
+  At runtime, if the extension remains unavailable, the storage backend
+  reads `.env.offline` for a `VECTOR_EXTENSION_PATH` fallback before
+  continuing without vector search.
+


### PR DESCRIPTION
## Summary
- fallback to VECTOR_EXTENSION_PATH when DuckDB extension download fails
- document packaging workflow and offline extension instructions

## Testing
- `task check` *(command not found)*
- `uv run pytest` *(missing pytest_httpx)*
- `uv run mkdocs build` *(command not found)*
- `uv run python -m build`
- `uv run scripts/publish_dev.py --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68a78cadc2b083338d5ae0fef803caa2