### PR TITLE
test: cover search HTTP sessions and confidence scoring

### DIFF
--- a/tests/unit/test_orchestration_utils_module.py
+++ b/tests/unit/test_orchestration_utils_module.py
@@ -43,3 +43,16 @@ def test_calculate_result_confidence():
     )
     score = utils.calculate_result_confidence(resp)
     assert 0.5 <= score <= 1.0
+
+
+def test_calculate_result_confidence_penalties():
+    resp = QueryResponse(
+        answer="a",
+        citations=[],
+        reasoning=[],
+        metrics={
+            "token_usage": {"total": 95, "max_tokens": 100},
+            "errors": ["e1", "e2", "e3", "e4", "e5"],
+        },
+    )
+    assert utils.calculate_result_confidence(resp) == 0.1

--- a/tests/unit/test_pool_sessions.py
+++ b/tests/unit/test_pool_sessions.py
@@ -1,6 +1,7 @@
 from autoresearch.config.models import ConfigModel
 import autoresearch.search as search
 from autoresearch.llm import pool as llm_pool
+import requests
 
 
 def test_search_pool_reuse_and_cleanup(monkeypatch):
@@ -26,3 +27,12 @@ def test_llm_pool_reuse_and_cleanup(monkeypatch):
     llm_pool.close_session()
     s3 = llm_pool.get_session()
     assert s3 is not s1
+
+
+def test_set_http_session(monkeypatch):
+    """Injected session is returned by ``get_http_session``."""
+    search.close_http_session()
+    session = requests.Session()
+    search.set_http_session(session)
+    assert search.get_http_session() is session
+    search.close_http_session()


### PR DESCRIPTION
## Summary
- test: ensure injected HTTP session is reused by search
- test: verify confidence penalties for heavy token usage and errors

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run python scripts/check_spec_tests.py`
- `task coverage` *(fails: exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b23472b48333a8562455b6e17bcd