### PR TITLE
test: isolate storage setup and document fixtures

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -18,6 +18,9 @@ uv run pytest tests/integration -m 'not slow and not requires_ui and not require
   metrics and token counts for comparison.
 - Some tests rely on `owlrl` and `rdflib_sqlalchemy` for RDF reasoning and
   persistence; install these packages to avoid failures during integration runs.
+- Fixtures such as `example_autoresearch_toml` and `example_env_file` provide
+  temporary configuration and environment data. Use `tmp_path` and
+  `monkeypatch` to isolate side effects in tests.
 
 No external databases or network services need to be running. Temporary
 artifacts are created under `tmp_path` and cleaned automatically.

--- a/tests/integration/test_storage_search_link.py
+++ b/tests/integration/test_storage_search_link.py
@@ -11,6 +11,9 @@ from autoresearch import storage
 @pytest.fixture(autouse=True)
 def setup_storage(tmp_path, monkeypatch):
     """Configure isolated in-memory storage and search for each test."""
+    monkeypatch.chdir(tmp_path)
+    ConfigLoader.reset_instance()
+
     cfg = ConfigModel()
     cfg.search.backends = []
     cfg.search.embedding_backends = ["duckdb"]
@@ -20,7 +23,6 @@ def setup_storage(tmp_path, monkeypatch):
     cfg.storage.duckdb_path = str(tmp_path / "kg.duckdb")
 
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
-    ConfigLoader()._config = None
 
     # Avoid ontology reasoning overhead during tests
     monkeypatch.setattr(
@@ -29,19 +31,19 @@ def setup_storage(tmp_path, monkeypatch):
 
     storage.teardown(remove_db=True)
     StorageManager.setup(db_path=cfg.storage.duckdb_path)
-    yield
+    try:
+        yield
+    finally:
+        storage.teardown(remove_db=True)
+        ConfigLoader.reset_instance()
 
 
 def _duckdb_backend_with_citations(query_embedding, max_results=5):
     conn = StorageManager.context.db_backend._conn
-    rows = conn.execute(
-        "SELECT id, content FROM nodes WHERE content ILIKE '%python%'"
-    ).fetchall()
+    rows = conn.execute("SELECT id, content FROM nodes WHERE content ILIKE '%python%'").fetchall()
     results = []
     for node_id, content in rows:
-        citation_rows = conn.execute(
-            "SELECT dst FROM edges WHERE src = ?", [node_id]
-        ).fetchall()
+        citation_rows = conn.execute("SELECT dst FROM edges WHERE src = ?", [node_id]).fetchall()
         citations = [c[0] for c in citation_rows]
         results.append(
             {
@@ -76,9 +78,7 @@ def test_external_lookup_returns_citations(monkeypatch):
         "type": "fact",
         "content": "Python is a programming language.",
         "embedding": [0.1, 0.2],
-        "relations": [
-            {"src": "c1", "dst": source["id"], "rel": "cites"}
-        ],
+        "relations": [{"src": "c1", "dst": source["id"], "rel": "cites"}],
     }
     StorageManager.persist_claim(claim)
     monkeypatch.setattr(StorageManager, "persist_claim", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- ensure storage integration tests use isolated tmp paths and teardown
- document common fixtures for integration tests

## Testing
- `uv run flake8 tests/integration/test_storage_search_link.py`
- `uv run pytest tests/integration -m "not slow and not requires_ui and not requires_vss"` *(fails: AssertionError and StorageError in multiple tests)*


------
https://chatgpt.com/codex/tasks/task_e_68a7b2307918833385c61e4ce9e6a471