### PR TITLE
test: import required modules for config CLI tests

### DIFF
--- a/tests/unit/test_main_config_commands.py
+++ b/tests/unit/test_main_config_commands.py
@@ -1,7 +1,7 @@
 import shutil
-from importlib import resources as importlib_resources
 from unittest.mock import MagicMock, patch
 
+import importlib_resources
 import pytest
 from typer.testing import CliRunner
 


### PR DESCRIPTION
## Summary
- explicitly import `importlib_resources` and `shutil` in `test_main_config_commands`

## Testing
- `pytest tests/unit/test_main_config_commands.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7c549e8ec83338f56086ba3ff8802