### PR TITLE
chore: drop codex setup references

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,12 +17,10 @@ uv run python scripts/check_env.py
 ```
 
 This sequence installs the minimal development dependencies and checks that
-**uv** and Go Task meet the version requirements. The helper scripts automate
-additional setup:
+**uv** and Go Task meet the version requirements.
+The helper script automates additional setup:
 
 - [`scripts/setup.sh`](../scripts/setup.sh) – full developer bootstrap
-- [`scripts/codex_setup.sh`](../scripts/codex_setup.sh) – agent demo
-  bootstrap
 
 ## Requirements
 
@@ -116,7 +114,6 @@ After installing Go Task, pick a bootstrap method:
 
 - `task install` – minimal setup
 - [`scripts/setup.sh`](../scripts/setup.sh) – full developer toolchain
-- [`scripts/codex_setup.sh`](../scripts/codex_setup.sh) – agent demo bootstrap
 
 Run `uv lock` whenever you change `pyproject.toml` to update `uv.lock`
 before syncing. Selecting Python 3.11 results in an error similar to:
@@ -153,12 +150,9 @@ point the setup script at their locations:
 export WHEELS_DIR=/path/to/wheels
 export ARCHIVES_DIR=/path/to/archives
 ./scripts/setup.sh
-# or
-./scripts/codex_setup.sh
 ```
 
-Both [`scripts/setup.sh`](../scripts/setup.sh) and
-[`scripts/codex_setup.sh`](../scripts/codex_setup.sh) respect these variables.
+[`scripts/setup.sh`](../scripts/setup.sh) respects these variables.
 
 `WHEELS_DIR` should contain wheel files (`*.whl`) and `ARCHIVES_DIR` should
 contain source archives (`*.tar.gz`). The setup script installs these caches
@@ -176,13 +170,10 @@ If you cloned the repository, run the appropriate setup helper:
 
 ```bash
 ./scripts/setup.sh
-# or
-./scripts/codex_setup.sh
 ```
 
 [`scripts/setup.sh`](../scripts/setup.sh) installs every optional extra needed
-for development. [`scripts/codex_setup.sh`](../scripts/codex_setup.sh) targets
-agent demos and omits heavier tooling.
+for development.
 
 The helper ensures the lock file is refreshed and installs every optional
 extra needed for the test suite. Tests normally rely on stubbed versions of

--- a/issues/archive/codex-setup-missing-go-task.md
+++ b/issues/archive/codex-setup-missing-go-task.md
@@ -2,15 +2,18 @@
 
 ## Context
 - Starting environment lacked `task` command and dev packages like `pytest`.
-- Root guidelines expect `scripts/codex_setup.sh` to install Go Task system-wide and dev dependencies.
-- After installing Go Task and running `uv pip install -e '.[dev]'`, `which pytest` resolves to `.venv/bin/pytest` and `uv run pytest -q` executes without missing-module errors.
+- Root guidelines expect the setup script to install Go Task system-wide and
+  dev dependencies.
+- After installing Go Task and running `uv pip install -e '.[dev]'`,
+  `which pytest` resolves to `.venv/bin/pytest` and
+  `uv run pytest -q` executes without missing-module errors.
 
 ## Acceptance Criteria
 - Go Task (`task`) is available after running setup.
 - Dev dependencies including `pytest`, `flake8`, and `typer` are installed in `.venv`.
 - `which pytest` resolves to `.venv/bin/pytest`.
 - `uv run pytest -q` completes without missing-module errors.
-- Update `scripts/codex_setup.sh` and documentation if additional steps are required.
+- Update setup scripts and documentation if additional steps are required.
 
 ## Status
 Archived

--- a/issues/archive/document-environment-bootstrap.md
+++ b/issues/archive/document-environment-bootstrap.md
@@ -4,15 +4,15 @@
 Environment setup instructions are now centralized in
 [docs/installation.md](../../docs/installation.md). Prior to consolidation,
 contributors had to manually install the `task` binary and run `uv sync`.
-`scripts/codex_setup.sh` sometimes aborted during `apt-get update`, leaving
-`task` uninstalled. Clear guidance ensures contributors can reproduce the
-expected setup.
+The previous setup script sometimes aborted during `apt-get update`.
+This left `task` uninstalled. Clear guidance ensures contributors can
+reproduce the expected setup.
 
 ## Acceptance Criteria
 - Consolidate setup steps in
   [docs/installation.md](../../docs/installation.md), including how to install
   `task` and run `task install`.
-- Ensure `scripts/codex_setup.sh` handles package manager failures gracefully
+- Ensure the setup script handles package manager failures gracefully
   and installs required tools.
 - Verify a fresh clone can run `task check` successfully using the documented
   steps.

--- a/issues/archive/environment-setup-gaps.md
+++ b/issues/archive/environment-setup-gaps.md
@@ -34,7 +34,7 @@ documentation specifies Python 3.12 or newer, further complicating
 setup.
 
 ## 2025-08-17
-- Ran `scripts/codex_setup.sh` after removing `.venv`.
+- Ran the setup script after removing `.venv`.
   - Go Task, `flake8`, `mypy`, and `pytest` installed in `.venv`.
   - Setup failed to download the DuckDB VSS extension due to network
     errors but continued with a stub.

--- a/issues/archive/optimize-task-install-dependencies.md
+++ b/issues/archive/optimize-task-install-dependencies.md
@@ -9,7 +9,7 @@ extras would improve setup time while still enabling linting and tests.
 ## Acceptance Criteria
 - `task install` installs only the `dev-minimal` extras by default.
 - Documentation notes how to install heavy extras on demand.
-- scripts/codex_setup.sh reflects the streamlined dependency set.
+- Setup scripts reflect the streamlined dependency set.
 
 ## Status
 Archived

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Usage: ./scripts/setup.sh
 # Full developer bootstrap; see docs/installation.md.
-# For agent demos, use ./scripts/codex_setup.sh instead.
 # Create .venv, install Go Task and development extras using uv.
 # Ensure we are running with Python 3.12 or newer.
 # Run `uv run python scripts/check_env.py` at the end to validate tool versions.


### PR DESCRIPTION
## Summary
- remove codex setup script references from installation guide
- drop codex_setup.sh mention from setup script header
- scrub archived issues of codex setup links

## Testing
- `task check` *(fails: tests/unit/test_download_duckdb_extensions.py::test_download_extension_network_fallback, tests/unit/test_failure_paths.py::test_vector_search_vss_unavailable, tests/unit/test_main_cli.py::test_search_default_output_tty, tests/unit/test_synthesizer_agent_modes.py::test_synthesizer_direct_mode, tests/unit/test_synthesizer_agent_modes.py::test_synthesizer_thesis_and_synthesis)*
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68a7c53b06c8833382aacda3f03f173d