### PR TITLE
docs: centralize test status references

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ preparing for the upcoming **0.1.0** release. The version is defined in
 planned for **July 20, 2025**, but the schedule slipped. An
 **0.1.0-alpha.1** preview is scheduled for **2026-03-01**, with
 the final **0.1.0** milestone targeted for **July 1, 2026**. See
+
 [ROADMAP.md](ROADMAP.md) for feature milestones and
 [docs/release_plan.md](docs/release_plan.md) for the full schedule,
 outstanding tasks, and current test and coverage status. The release
 workflow is detailed in [docs/releasing.md](docs/releasing.md).
 
-Current checks show `uv run --extra dev-minimal flake8 src tests` and
-`uv run --extra dev-minimal mypy src` passing. `uv run --extra
-dev-minimal pytest -q --cov=src --cov-report=term` returns failing tests
-with total coverage around 67%.
+## Status
+
+See [STATUS.md](STATUS.md) for current test and coverage results.
 
 See [docs/release_plan.md](docs/release_plan.md#alpha-release-checklist) for the
 alpha release checklist.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,8 +3,12 @@
 This roadmap summarizes planned features for upcoming releases. Dates and
 milestones align with the [release plan](docs/release_plan.md). Installation and
 environment details are covered in the [README](README.md). Last updated
-**August 22, 2025**. For current test and coverage status, see
-[docs/release_plan.md](docs/release_plan.md). Use Python 3.12+ with:
+**August 22, 2025**.
+
+## Status
+
+See [STATUS.md](STATUS.md) for current test and coverage results. Use Python
+3.12+ with:
 
 ```
 uv venv && uv sync --all-extras &&
@@ -59,12 +63,12 @@ The final 0.1.0 release focuses on making the project installable and providing
 complete documentation once the open issues are resolved. Key activities
 include:
 
-- Running all unit, integration and behavior tests.
+- Running all unit, integration and behavior tests (see [STATUS.md](STATUS.md)).
 - Finalizing API reference and user guides.
 - Verifying packaging metadata and TestPyPI uploads.
 
-Type checking and tests still fail, so integration and behavior suites remain
-blocked. The release was originally planned for **July 20, 2025**, but the
+Type checking and unit tests currently fail; see [STATUS.md](STATUS.md) for
+details. The release was originally planned for **July 20, 2025**, but the
 schedule slipped. The **0.1.0** milestone is now targeted for **July 1, 2026**
 while packaging tasks are resolved.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,9 @@
+# Status
+
+These results reflect the latest development state.
+
+- `task verify` – flake8 and mypy pass. pytest fails during collection in
+  `tests/unit/test_main_config_commands.py`.
+- `task coverage` – fails during collection in `tests/unit/test_main_config_commands.py`,
+  so coverage is not reported.
+

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -13,17 +13,12 @@ reflects the fact that the codebase currently sits at the **unreleased 0.1.0a1**
 version defined in `autoresearch.__version__`. Phase 3
 (stabilization/testing/documentation) and Phase 4 activities remain planned.
 
-## Test and Coverage Status
+## Status
 
 The dependency pins for `fastapi` (>=0.115.12) and `slowapi` (==0.1.9) are
 confirmed in `pyproject.toml` and [installation.md](installation.md).
-
-Current checks show:
-
-- `uv run --extra dev-minimal flake8 src tests` passes.
-- `uv run --extra dev-minimal mypy src` reports no issues.
-- `uv run --extra dev-minimal pytest -q --cov=src --cov-report=term`
-  passes with total coverage around 90%.
+Current test and coverage results are tracked in
+[../STATUS.md](../STATUS.md).
 
 ## Milestones
 


### PR DESCRIPTION
## Summary
- add STATUS.md with current `task verify` and `task coverage` results
- point README, release plan, and roadmap to the shared Status section
- standardize status references across docs

## Testing
- `./bin/task verify` *(fails: tests/unit/test_main_config_commands.py)*
- `./bin/task coverage` *(fails: tests/unit/test_main_config_commands.py)*
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68a7e57fbba08333bfab848b5331ab31