### PR TITLE
docs: add rate limiting and config hot reload algorithms

### DIFF
--- a/docs/algorithms/README.md
+++ b/docs/algorithms/README.md
@@ -1,10 +1,12 @@
 # Algorithms
 
 - [BM25 Ranking Formula](bm25.md)
+- [API Rate Limiting](api_rate_limiting.md)
 - [Ontology Reasoning](ontology_reasoning.md)
 - [Semantic Similarity](semantic_similarity.md)
 - [Source Credibility](source_credibility.md)
 - [Validation](validation.md)
 - [Distributed Coordination](distributed_coordination.md)
 - [Weight Tuning](weight_tuning.md)
+- [Config Hot Reload](config_hot_reload.md)
 - [Dialectical Agent Coordination](dialectical_coordination.md)

--- a/docs/algorithms/api_rate_limiting.md
+++ b/docs/algorithms/api_rate_limiting.md
@@ -1,0 +1,17 @@
+# API Rate Limiting
+
+Rate limiting protects the API from abuse and spreads capacity across
+clients. The token bucket model grants each client a bucket with a
+maximum capacity ``C`` and refill rate ``R`` tokens per second. Each
+request removes one token; requests are denied when the bucket is empty.
+
+## Complexity
+
+Token checks and refills operate in constant time per request. Memory
+usage is linear in the number of tracked clients.
+
+## Edge Cases
+
+- Distributed clocks can drift, causing inconsistent refill times.
+- Buckets must expire for idle clients to avoid unbounded memory use.
+- Bursty traffic may need jitter or leaky bucket smoothing.

--- a/docs/algorithms/config_hot_reload.md
+++ b/docs/algorithms/config_hot_reload.md
@@ -1,0 +1,16 @@
+# Config Hot Reload
+
+Hot reload updates configuration without restarting the system. A file or
+service watcher emits events when the source changes. The application
+validates the new content and swaps it into the active state atomically.
+
+## Complexity
+
+Watchers poll or receive events in constant time. Parsing updated content
+runs in ``O(n)`` where ``n`` is file size.
+
+## Edge Cases
+
+- Partial writes can surface invalid configuration snapshots.
+- Race conditions may arise when multiple writers update the source.
+- Fallback logic is needed when reload validation fails.

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1,6 +1,7 @@
 # Api
 
-FastAPI app aggregator for Autoresearch.
+FastAPI app aggregator for Autoresearch. See [API rate limiting
+model](../algorithms/api_rate_limiting.md) for load control guidance.
 
 ## Traceability
 

--- a/docs/specs/config.md
+++ b/docs/specs/config.md
@@ -1,6 +1,7 @@
 # Config
 
-Specification for config module.
+Specification for config module. See [config hot reload
+algorithm](../algorithms/config_hot_reload.md) for reload behavior.
 
 ## Traceability
 

--- a/scripts/simulate_config_reload.py
+++ b/scripts/simulate_config_reload.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""Demonstrate configuration hot reload by watching a file.
+
+Usage:
+    uv run scripts/simulate_config_reload.py /tmp/cfg.txt --updates 3
+
+The script prints a message every time the file changes and simulates
+updates by rewriting it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import threading
+import time
+from pathlib import Path
+
+
+def watch(path: Path, interval: float, stop: threading.Event) -> None:
+    """Poll ``path`` and print its contents when it changes."""
+    last = path.stat().st_mtime
+    while not stop.is_set():
+        current = path.stat().st_mtime
+        if current != last:
+            last = current
+            print(f"reload: {path.read_text().strip()}")
+        time.sleep(interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Simulate hot reload via file polling",
+    )
+    parser.add_argument("path", type=Path, help="path to config file")
+    parser.add_argument(
+        "--updates",
+        type=int,
+        default=3,
+        help="number of simulated updates",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=0.5,
+        help="poll interval in seconds",
+    )
+    args = parser.parse_args()
+    if args.updates <= 0 or args.interval <= 0:
+        parser.error("updates and interval must be positive")
+    if not args.path.exists():
+        args.path.write_text("0\n")
+    stop = threading.Event()
+    watcher = threading.Thread(
+        target=watch,
+        args=(args.path, args.interval, stop),
+        daemon=True,
+    )
+    watcher.start()
+    for i in range(args.updates):
+        args.path.write_text(f"{i + 1}\n")
+        time.sleep(args.interval / 2)
+    stop.set()
+    watcher.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/simulate_rate_limit.py
+++ b/scripts/simulate_rate_limit.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+"""Simulate token bucket API rate limiting under load.
+
+Usage:
+    uv run scripts/simulate_rate_limit.py --requests 20 --rate 5 --burst 10
+
+The ``--requests`` flag sets the total requests. ``--rate`` is the refill
+rate in tokens per second. ``--burst`` defines the bucket capacity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+
+def simulate(reqs: int, rate: float, burst: int) -> None:
+    """Print whether each request is allowed or throttled."""
+    tokens = float(burst)
+    last = time.monotonic()
+    allowed = 0
+    for i in range(reqs):
+        now = time.monotonic()
+        tokens = min(burst, tokens + (now - last) * rate)
+        last = now
+        if tokens >= 1:
+            tokens -= 1
+            allowed += 1
+            status = "allowed"
+        else:
+            status = "throttled"
+        print(f"request {i + 1:03d}: {status}")
+    print(f"{allowed}/{reqs} requests allowed")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Simulate API rate limiting with a token bucket",
+    )
+    parser.add_argument(
+        "--requests",
+        type=int,
+        default=20,
+        help="total number of requests to send",
+    )
+    parser.add_argument(
+        "--rate",
+        type=float,
+        default=5.0,
+        help="refill rate in tokens per second",
+    )
+    parser.add_argument(
+        "--burst",
+        type=int,
+        default=10,
+        help="bucket capacity",
+    )
+    args = parser.parse_args()
+    if args.requests <= 0 or args.rate <= 0 or args.burst <= 0:
+        parser.error("all arguments must be positive")
+    simulate(args.requests, args.rate, args.burst)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document API rate limiting and configuration hot reload algorithms
- add scripts to simulate rate limiting and config reload behavior under load
- reference new algorithms from API and config specs

## Testing
- `uv run mkdocs build`
- `task check` *(fails: Failed tests: tests/unit/test_failure_paths.py::test_vector_search_vss_unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e5a593e883338a73c3418b9c8b08