### PR TITLE
Add property-based token tests and expand BDD coverage

### DIFF
--- a/tests/behavior/features/error_recovery_workflow.feature
+++ b/tests/behavior/features/error_recovery_workflow.feature
@@ -8,3 +8,8 @@ Feature: Error recovery workflow
     Given a transient error occurs
     When the orchestrator executes the query "fail once"
     Then bdd_context should record "recovery_applied" as true
+
+  Scenario: Persistent error fails without recovery
+    Given a persistent error occurs
+    When the orchestrator executes the query "fail always"
+    Then bdd_context should record "recovery_applied" as false

--- a/tests/behavior/features/user_workflows.feature
+++ b/tests/behavior/features/user_workflows.feature
@@ -8,3 +8,8 @@ Feature: User workflows
     Given the Autoresearch application is running
     When I run `autoresearch search "workflow test"`
     Then the CLI should exit successfully
+
+  Scenario: CLI search with invalid backend reports error
+    Given the Autoresearch application is running
+    When I run `autoresearch search --backend missing "workflow test"`
+    Then the CLI should report an error

--- a/tests/behavior/steps/user_workflows_steps.py
+++ b/tests/behavior/steps/user_workflows_steps.py
@@ -6,3 +6,11 @@ pytest_plugins = ["tests.behavior.steps.common_steps"]
 @scenario("../features/user_workflows.feature", "CLI search completes successfully")
 def test_cli_workflow(bdd_context):
     assert bdd_context["result"].exit_code == 0
+
+
+@scenario(
+    "../features/user_workflows.feature",
+    "CLI search with invalid backend reports error",
+)
+def test_cli_workflow_invalid_backend(bdd_context):
+    assert bdd_context["result"].exit_code != 0

--- a/tests/integration/test_config_hot_reload.py
+++ b/tests/integration/test_config_hot_reload.py
@@ -28,6 +28,8 @@ class Search:
 
 
 pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
     pytest.mark.requires_git,
     pytest.mark.skipif(not GITPYTHON_INSTALLED, reason="GitPython not installed"),
 ]

--- a/tests/unit/test_property_token_counting.py
+++ b/tests/unit/test_property_token_counting.py
@@ -1,0 +1,31 @@
+from hypothesis import given, strategies as st, settings, HealthCheck
+import string
+
+from autoresearch.llm.token_counting import compress_prompt, prune_context
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture])
+@given(
+    words=st.lists(st.text(alphabet=string.ascii_letters, min_size=1, max_size=5), min_size=3, max_size=20),
+    budget=st.integers(min_value=1, max_value=20),
+)
+def test_compress_prompt_preserves_edges(words, budget):
+    prompt = " ".join(words)
+    compressed = compress_prompt(prompt, budget)
+    c_tokens = compressed.split()
+    assert c_tokens[0] == words[0]
+    assert c_tokens[-1] == words[-1]
+    assert len(c_tokens) <= max(budget, 3)
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture])
+@given(
+    messages=st.lists(st.text(alphabet=string.ascii_letters, min_size=1, max_size=5), min_size=0, max_size=10),
+    budget=st.integers(min_value=0, max_value=20),
+)
+def test_prune_context_respects_budget(messages, budget):
+    pruned = prune_context(messages, budget)
+    total = sum(len(m.split()) for m in pruned)
+    assert total <= budget
+    if sum(len(m.split()) for m in messages) <= budget:
+        assert pruned == messages

--- a/tests/unit/test_token_counting_utils.py
+++ b/tests/unit/test_token_counting_utils.py
@@ -14,3 +14,17 @@ def test_prune_context_drops_old_messages():
     pruned = prune_context(msgs, 4)
     assert sum(len(m.split()) for m in pruned) <= 4
     assert pruned == msgs[-4:]
+
+
+def test_compress_prompt_zero_budget_handles_ellipsis():
+    prompt = "one two three four"
+    compressed = compress_prompt(prompt, 0)
+    tokens = compressed.split()
+    assert tokens[0] == "one"
+    assert tokens[-1] == "four"
+    assert "..." in tokens
+
+
+def test_prune_context_zero_budget_returns_empty():
+    msgs = ["a", "b"]
+    assert prune_context(msgs, 0) == []


### PR DESCRIPTION
## Summary
- add edge-case tests and property-based checks for token counting utilities
- mark config hot-reload test as integration and slow for automatic execution
- expand user workflow and error recovery BDD scenarios with step definitions

## Testing
- `task check` *(fails: Failed tests/unit/test_failure_paths.py::test_vector_search_vss_unavailable)*
- `task verify` *(fails: exit status 2 before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e58e81dc83338d515977879fe6b3