### PR TITLE
docs: align 0.1.x roadmap and release plan

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,6 +45,8 @@ This pre-release provided an early package for testing after packaging tasks
 were verified. Related issue ([prepare-alpha-release]) tracks remaining
 environment work. Key activities included:
 
+- [x] Environment bootstrap documented and installation instructions
+  consolidated ([environment-bootstrap]).
 - [x] Packaging verification with DuckDB fallback
   ([packaging-fallback]).
 - [x] Integration tests stabilized
@@ -53,9 +55,8 @@ environment work. Key activities included:
   ([coverage-gates]).
 - [x] Algorithm validation for ranking and coordination ([ranking]).
 
-These steps completed in sequence:
-packaging verification → integration tests → coverage gates → algorithm
-validation.
+These steps completed in sequence: environment bootstrap → packaging
+verification → integration tests → coverage gates → algorithm validation.
 
 ## 0.1.0 – First public preview
 
@@ -121,7 +122,8 @@ The 1.0.0 milestone aims for a polished, production-ready system:
   lines 178-186; TASK_PROGRESS lines 206-216).
 - Optimize performance across all components and finalize documentation.
 
-[prepare-alpha-release]: issues/prepare-alpha-release.md
+[environment-bootstrap]: issues/archive/document-environment-bootstrap.md
+[prepare-alpha-release]: issues/archive/prepare-alpha-release.md
 [finalize-first-public-preview-release]: issues/finalize-first-public-preview-release.md
 [deliver-bug-fixes-and-docs-update]: issues/deliver-bug-fixes-and-docs-update.md
 [stabilize-api-and-improve-search]: issues/stabilize-api-and-improve-search.md

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -46,6 +46,8 @@ now set for **July 1, 2026** while packaging tasks are resolved.
 
 ### Alpha release checklist
 
+- [x] Environment bootstrap documented and installation instructions
+  consolidated ([document-environment-bootstrap.md][environment-bootstrap])
 - [x] Packaging verification with DuckDB fallback
   ([verify-packaging-workflow-and-duckdb-fallback.md][packaging-fallback])
 - [x] Integration test suite passes
@@ -54,8 +56,8 @@ now set for **July 1, 2026** while packaging tasks are resolved.
   (see [add-coverage-gates-and-regression-checks.md][coverage-gates])
 - [x] Validate ranking algorithms and agent coordination (see [ranking])
 
-These tasks completed in order: packaging verification → integration tests →
-coverage gates → algorithm validation.
+These tasks completed in order: environment bootstrap → packaging verification
+→ integration tests → coverage gates → algorithm validation.
 
 Completion of these items confirms the alpha baseline for **0.1.0**.
 
@@ -95,7 +97,8 @@ optional extras):
 [stabilize-integration-tests]: ../issues/archive/stabilize-integration-tests.md
 [packaging-fallback]: ../issues/archive/verify-packaging-workflow-and-duckdb-fallback.md
 [ranking]: ../issues/archive/validate-ranking-algorithms-and-agent-coordination.md
-[prepare-alpha-release]: ../issues/prepare-alpha-release.md
+[environment-bootstrap]: ../issues/archive/document-environment-bootstrap.md
+[prepare-alpha-release]: ../issues/archive/prepare-alpha-release.md
 [finalize-first-public-preview-release]: ../issues/finalize-first-public-preview-release.md
 [deliver-bug-fixes-and-docs-update]: ../issues/deliver-bug-fixes-and-docs-update.md
 [stabilize-api-and-improve-search]: ../issues/stabilize-api-and-improve-search.md

--- a/issues/archive/prepare-alpha-release.md
+++ b/issues/archive/prepare-alpha-release.md
@@ -37,4 +37,4 @@ verification, so a consolidated plan is needed to coordinate these efforts.
    coverage gates and integration tests.
 
 ## Status
-Open
+Archived

--- a/issues/deliver-bug-fixes-and-docs-update.md
+++ b/issues/deliver-bug-fixes-and-docs-update.md
@@ -4,6 +4,10 @@
 After the first public preview, follow-up fixes and documentation updates
 are required to address outstanding issues.
 
+## Milestone
+
+- 0.1.1 (2026-09-15)
+
 ## Acceptance Criteria
 - Apply high-priority bug fixes discovered after the 0.1.0 release.
 - Update documentation to reflect resolved issues and new behaviors.

--- a/issues/finalize-first-public-preview-release.md
+++ b/issues/finalize-first-public-preview-release.md
@@ -5,6 +5,10 @@ The project targets a 0.1.0 release with complete packaging, documentation
 and continuous integration checks. An open ticket tracks remaining work
 required to finalize this milestone.
 
+## Milestone
+
+- 0.1.0 (2026-07-01)
+
 ## Acceptance Criteria
 - Package builds verified and published to TestPyPI.
 - Documentation and release notes finalized.

--- a/tests/test_dependency_versions.py
+++ b/tests/test_dependency_versions.py
@@ -40,4 +40,3 @@ def _parse_docs() -> dict[str, str]:
 def test_dependency_versions_match() -> None:
     """CI guardrail verifying docs align with pyproject dependencies."""
     assert _parse_pyproject() == _parse_docs()
-


### PR DESCRIPTION
## Summary
- add environment bootstrap task and ordered dependencies to the 0.1.0a1 checklist
- record milestones for pending 0.1.0 and 0.1.1 issues
- archive the completed prepare-alpha-release issue

## Testing
- `uv run flake8 src tests`
- `uv run mypy src` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68a884fbaedc833399931bee5fefb8fc