### PR TITLE
ci: build wheels in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,24 @@ jobs:
         with:
           path: current/coverage.xml
           key: coverage-${{ github.ref }}
+
+  build-wheels:
+    needs: verify
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, macos-14]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        run: python -m pip install uv
+      - name: Build wheel
+        run: uv run python -m build
+      - name: Install wheel in fresh venv
+        run: |
+          python -m venv wheel
+          wheel/bin/pip install dist/*.whl
+          wheel/bin/python -c "import autoresearch"


### PR DESCRIPTION
## Summary
- build project wheel and install it in fresh venvs on Linux and macOS

## Testing
- `uv run task check` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a2156ab48333b9c56bcd7d103518