### PR TITLE
Document cache eviction and add simulation script

### DIFF
--- a/docs/algorithms/README.md
+++ b/docs/algorithms/README.md
@@ -12,3 +12,4 @@
 - [Dialectical Agent Coordination](dialectical_coordination.md)
 - [Token Budget Adaptation](token_budgeting.md)
 - [Error Recovery via Exponential Backoff](error_recovery.md)
+- [Cache Eviction Strategy](cache_eviction.md)

--- a/docs/algorithms/cache_eviction.md
+++ b/docs/algorithms/cache_eviction.md
@@ -1,0 +1,19 @@
+# Cache Eviction Strategy
+
+Autoresearch caches intermediate results until a memory budget is reached. This
+note outlines the policy used to discard entries when space runs low.
+
+## Eviction policy
+- Least Recently Used (LRU): the cache tracks access order and removes the
+  stalest entry first.
+
+## Complexity
+- Insert and access: O(1) using an ordered dictionary.
+- Evict: O(1) per removed entry.
+
+## Assumptions
+- Each item reports its memory footprint on insertion.
+- All entries are independent and eviction has no side effects.
+- The budget is fixed during the simulation.
+
+See [caching](../caching.md) for the storage layer and broader context.

--- a/scripts/simulate_cache_eviction.py
+++ b/scripts/simulate_cache_eviction.py
@@ -1,0 +1,42 @@
+"""Simulate cache eviction under a fixed memory budget.
+
+Usage:
+    uv run python scripts/simulate_cache_eviction.py --budget 1024 --steps 100
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+from collections import OrderedDict
+
+
+def simulate(budget: int, steps: int) -> None:
+    """Run a simple LRU cache simulation."""
+    cache: OrderedDict[str, int] = OrderedDict()
+    total = 0
+    for step in range(steps):
+        size = random.randint(1, max(1, budget // 4))
+        key = f"k{step}"
+        cache[key] = size
+        total += size
+        cache.move_to_end(key)
+        while total > budget and cache:
+            _, evicted = cache.popitem(last=False)
+            total -= evicted
+        print(f"step={step} items={len(cache)} total={total}")
+    print(f"final memory {total}/{budget}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--budget", type=int, default=1024, help="memory budget in bytes")
+    parser.add_argument("--steps", type=int, default=50, help="number of insertions")
+    args = parser.parse_args()
+    if args.budget <= 0 or args.steps <= 0:
+        raise SystemExit("budget and steps must be positive")
+    simulate(args.budget, args.steps)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document cache eviction strategy with policy, complexity, and assumptions
- link cache eviction doc from algorithm index
- add `simulate_cache_eviction.py` script to demonstrate budget convergence

## Testing
- `task check` *(fails: tests - 1 failed, 377 passed, 4 skipped, 24 deselected)*
- `task verify` *(interrupted: tests terminated early)*
- `uv run mkdocs build` *(fails: missing mkdocstrings handler configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a21b14408333a917da74aef94833