### PR TITLE
docs: highlight bootstrap after clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ source for environment setup and optional features.
 
 Autoresearch requires **Python 3.12+**,
 [uv](https://github.com/astral-sh/uv), and
-[Go Task](https://taskfile.dev/). For detailed setup instructions, see
-[docs/installation.md](docs/installation.md).
+[Go Task](https://taskfile.dev/). After cloning, run `./scripts/setup.sh` for
+the full developer bootstrap or `task install` for a minimal environment. See
+[docs/installation.md#after-cloning](docs/installation.md#after-cloning) for
+details.
 
 For current capabilities and known limitations see
 [docs/release_notes.md](docs/release_notes.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,21 +6,28 @@ environments.
 
 Autoresearch requires **Python 3.12 or newer**,
 [**uv**](https://github.com/astral-sh/uv), and
-[**Go Task**](https://taskfile.dev/) for Taskfile commands. **Install Go Task
-before running any `task` commands** such as `task install`. After installing
-Go Task and cloning the repository, bootstrap the environment and verify the
-toolchain:
+[**Go Task**](https://taskfile.dev/) for Taskfile commands. Install Go Task
+before running any `task` commands.
+
+## After cloning
+
+Run a bootstrap command immediately:
 
 ```bash
-task install
+./scripts/setup.sh  # full developer bootstrap
+# or
+task install        # minimal environment
+```
+
+If you see errors like `task: command not found` or `uv: command not found`,
+diagnose the environment with
+[`scripts/check_env.py`](../scripts/check_env.py):
+
+```bash
 uv run python scripts/check_env.py
 ```
 
-This sequence installs the minimal development dependencies and checks that
-**uv** and Go Task meet the version requirements.
-The helper script automates additional setup:
-
-- [`scripts/setup.sh`](../scripts/setup.sh) – full developer bootstrap
+The script reports missing tools and version mismatches.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- emphasize running `./scripts/setup.sh` or `task install` right after cloning
- add diagnostics note for missing tool errors via `scripts/check_env.py`
- link README prerequisites to the new installation quick-start

## Testing
- `task check` *(fails: tests/unit/test_failure_paths.py::test_vector_search_vss_unavailable, tests/unit/test_monitor_cli.py::test_monitor_metrics)*
- `task verify` *(fails: interrupted)*
- `uv run mkdocs build` *(fails: numerous missing file warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a222bcd08333a992d4a03f5efb4a