### PR TITLE
Verify Go Task installation during setup

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,6 +19,9 @@ Run a bootstrap command immediately:
 task install        # minimal environment
 ```
 
+`./scripts/setup.sh` installs Go Task when missing and exits if `task --version`
+fails.
+
 If you see errors like `task: command not found` or `uv: command not found`,
 diagnose the environment with
 [`scripts/check_env.py`](../scripts/check_env.py):

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -35,18 +35,22 @@ if sys.version_info < (3, 12):
     raise SystemExit(f"uv venv created Python {sys.version.split()[0]}, but >=3.12 is required")
 EOF
 
-# Install Go Task inside the virtual environment if missing
-if [ ! -x .venv/bin/task ]; then
-    echo "Installing Go Task..."
-    curl -sL https://taskfile.dev/install.sh | sh -s -- -b ./.venv/bin
-fi
-
 # Install locked dependencies and development extras
 echo "Installing development extras via uv sync --extra dev"
 uv sync --extra dev
 
 # Link the project in editable mode so tools are available
 uv pip install -e .
+
+# Ensure Go Task is installed after bootstrapping
+if [ ! -x .venv/bin/task ]; then
+    echo "Go Task missing; installing..."
+    curl -sL https://taskfile.dev/install.sh | sh -s -- -b ./.venv/bin
+fi
+if ! .venv/bin/task --version >/dev/null 2>&1; then
+    echo "task --version failed; Go Task is required but was not installed" >&2
+    exit 1
+fi
 
 # Create extensions directory if it doesn't exist
 mkdir -p extensions


### PR DESCRIPTION
## Summary
- ensure `scripts/setup.sh` installs Go Task if missing and validates `task --version`
- document automatic Task check in installation guide

## Testing
- `.venv/bin/task check` *(fails: No module named 'flake8')*
- `uv run mkdocs build` *(fails: No such file or directory: mkdocs)*
- `.venv/bin/task verify` *(fails: No module named 'flake8')*

------
https://chatgpt.com/codex/tasks/task_e_68a8bdd4163c8333a55626cc0b3adcc2