### PR TITLE
test: add orchestrator search storage and behavior scenarios

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -25,6 +25,9 @@ These instructions apply to files in the `tests/` directory.
   categorize behavior scenarios.
 - Register any new markers in `pytest.ini`.
 - Include extras corresponding to any other markers as needed.
+- Scenarios tagged `error_recovery` or `reasoning_modes` run with the base
+  `.[test]` extra; add `[nlp]`, `[ui]`, or `[vss]` only when combining with
+  their respective `requires_*` markers.
 - Remove temporary files such as `kg.duckdb` and `rdf_store`.
 - Prefer fixtures like `tmp_path` and `monkeypatch` to isolate side effects.
 - Run `task clean` if tests generate build artifacts.

--- a/tests/behavior/features/error_recovery.feature
+++ b/tests/behavior/features/error_recovery.feature
@@ -1,4 +1,4 @@
-@behavior
+@behavior @error_recovery
 # Feature covers reasoning modes: direct, chain-of-thought, dialectical, unsupported
 # Recovery paths: retry_with_backoff, fail_gracefully, fallback_agent
 Feature: Error Recovery
@@ -86,6 +86,19 @@ Feature: Error Recovery
     And the system state should be restored
     And the logs should include "recovery"
     And the response should list a timeout error
+
+  Scenario: Recovery after critical agent failure
+    Given an agent that fails during execution
+    When I run the orchestrator on query "recover test"
+    Then the reasoning mode selected should be "dialectical"
+    And the loops used should be 1
+    And the agent groups should be "Faulty"
+    And the agents executed should be "Faulty"
+    And a recovery strategy "fail_gracefully" should be recorded
+    And error category "critical" should be recorded
+    And recovery should be applied
+    And the logs should include "recovery"
+    And the response should list an agent execution error
 
   Scenario: Recovery after agent failure with fallback
     Given an agent that fails triggering fallback

--- a/tests/behavior/features/reasoning_mode.feature
+++ b/tests/behavior/features/reasoning_mode.feature
@@ -1,4 +1,5 @@
 # Feature covers reasoning modes: direct, chain-of-thought, dialectical, unsupported
+@behavior @reasoning_modes
 Feature: Reasoning Mode Selection
   As a user
   I want to choose how the system reasons
@@ -49,6 +50,15 @@ Feature: Reasoning Mode Selection
     And the reasoning mode selected should be "dialectical"
     And the agent groups should be "Synthesizer; Contrarian; FactChecker"
     And the agents executed should be "Synthesizer, Contrarian, FactChecker"
+
+  Scenario: Direct reasoning with a realistic query
+    Given loops is set to 1 in configuration
+    And reasoning mode is "direct"
+    When I run the orchestrator on query "Why is the sky blue?"
+    Then the loops used should be 1
+    And the reasoning mode selected should be "direct"
+    And the agent groups should be "Synthesizer"
+    And the agents executed should be "Synthesizer"
 
   Scenario: Direct mode agent failure triggers fallback
     Given reasoning mode is "direct"

--- a/tests/behavior/steps/error_recovery_steps.py
+++ b/tests/behavior/steps/error_recovery_steps.py
@@ -75,6 +75,14 @@ def test_error_recovery_timeout():
 
 @scenario(
     "../features/error_recovery.feature",
+    "Recovery after critical agent failure",
+)
+def test_error_recovery_agent_failure():
+    pass
+
+
+@scenario(
+    "../features/error_recovery.feature",
     "Unsupported reasoning mode during recovery fails gracefully",
 )
 def test_error_recovery_unsupported_mode():

--- a/tests/behavior/steps/reasoning_mode_steps.py
+++ b/tests/behavior/steps/reasoning_mode_steps.py
@@ -44,6 +44,13 @@ def test_dialectical_real_query():
 
 
 @scenario(
+    "../features/reasoning_mode.feature", "Direct reasoning with a realistic query"
+)
+def test_direct_real_query():
+    pass
+
+
+@scenario(
     "../features/reasoning_mode.feature",
     "Unsupported reasoning mode fails gracefully",
 )


### PR DESCRIPTION
## Summary
- add integration test for orchestrator search + storage when no results
- expand behavior tests with critical agent failure and direct reasoning scenarios
- document test extras for recovery and reasoning markers

## Testing
- `uv run pytest tests/integration/test_orchestrator_search_storage.py::test_orchestrator_handles_empty_search_results -q`
- `uv run pytest tests/integration/test_orchestrator_search_storage.py::test_orchestrator_handles_empty_search_results tests/behavior -k "error_recovery_agent_failure or direct_real_query" -q` *(fails: Failed to load VSS extension: IO Error: Failed to download extension "vss")*

------
https://chatgpt.com/codex/tasks/task_e_68a8bde0b19c8333acff7e9862a8da86