### PR TITLE
test: add config reload and monitor scenarios

### DIFF
--- a/docs/user_flows.md
+++ b/docs/user_flows.md
@@ -41,6 +41,12 @@ This document describes the typical user flows for all interface modalities of t
    autoresearch config reasoning --show
    ```
 
+4. **Ignore Invalid Changes**
+   - If `autoresearch.toml` contains invalid syntax, the last valid configuration
+     remains active until the file is fixed.
+   - See `tests/behavior/features/configuration_hot_reload.feature`
+     for automated coverage.
+
 ### Monitoring Flow
 
 1. **Display System Metrics**
@@ -54,10 +60,17 @@ This document describes the typical user flows for all interface modalities of t
    autoresearch monitor run
    ```
 
-3. **View Agent Activity**
+3. **Record Resource Usage**
+   ```bash
+   autoresearch monitor resources -d 60
+   ```
+   - Captures CPU and memory metrics for the specified duration.
+   - Verified by `tests/behavior/features/monitor_cli.feature`.
+
+4. **View Agent Activity**
    - The monitor shows which agents are active and their current status
 
-4. **Exit Monitor**
+5. **Exit Monitor**
    - Press Ctrl+C to exit the monitor
 
 ### Local Directory and Git Repository Search Flow

--- a/tests/behavior/features/configuration_hot_reload.feature
+++ b/tests/behavior/features/configuration_hot_reload.feature
@@ -16,3 +16,8 @@ Feature: Configuration & Hot Reload
     When I modify "autoresearch.toml" to enable a new agent
     Then the orchestrator should reload the configuration automatically
     And the new agent should be visible in the next iteration cycle
+
+  Scenario: Ignore invalid configuration changes
+    Given the application is running
+    When I modify "autoresearch.toml" with invalid content
+    Then the orchestrator should keep the previous configuration

--- a/tests/behavior/features/monitor_cli.feature
+++ b/tests/behavior/features/monitor_cli.feature
@@ -22,3 +22,8 @@ Feature: Monitor CLI
     Then the monitor command should exit with an error
     And the monitor output should include a friendly metrics backend error message
 
+  Scenario: Resource monitoring for a duration
+    When I run `autoresearch monitor resources -d 1`
+    Then the monitor command should exit successfully
+    And the monitor output should show CPU and memory usage
+

--- a/tests/behavior/steps/configuration_hot_reload_steps.py
+++ b/tests/behavior/steps/configuration_hot_reload_steps.py
@@ -51,6 +51,29 @@ def check_agent_visible(check_hot_reload: ConfigModel):
     assert "NewAgent" in check_hot_reload.agents
 
 
+@when(
+    parsers.parse('I modify "{file}" with invalid content'),
+    target_fixture="modify_config_invalid",
+)
+def modify_config_invalid(file, tmp_path):
+    ConfigLoader.reset_instance()
+    loader = ConfigLoader()
+    cfg_before = loader.load_config()
+    with open(file, "w") as f:
+        f.write("invalid = [this is not valid toml]")
+    try:
+        loader.load_config()
+    except Exception:
+        pass
+    return cfg_before
+
+
+@then("the orchestrator should keep the previous configuration")
+def config_unchanged(modify_config_invalid: ConfigModel):
+    cfg_after = ConfigLoader().load_config()
+    assert cfg_after == modify_config_invalid
+
+
 @when("I start the application", target_fixture="start_application")
 def start_application():
     ConfigLoader.reset_instance()
@@ -80,4 +103,12 @@ def test_load_config_startup():
 
 @scenario("../features/configuration_hot_reload.feature", "Hot-reload on config change")
 def test_hot_reload_config():
+    pass
+
+
+@scenario(
+    "../features/configuration_hot_reload.feature",
+    "Ignore invalid configuration changes",
+)
+def test_ignore_invalid_config():
     pass

--- a/tests/behavior/steps/monitor_cli_steps.py
+++ b/tests/behavior/steps/monitor_cli_steps.py
@@ -121,3 +121,33 @@ def test_monitor_watch():
 def test_monitor_backend_unavailable():
     """Scenario: Metrics backend unavailable."""
     pass
+
+
+@when("I run `autoresearch monitor resources -d 1`")
+def run_monitor_resources(
+    monkeypatch,
+    bdd_context,
+    cli_runner,
+    dummy_query_response,
+    reset_global_registries,
+):
+    """Execute resource monitoring for a short duration."""
+
+    def fake_record(self):
+        self.resource_usage.append((time.time(), 10.0, 5.0, 0.0, 0.0))
+
+    monkeypatch.setattr(
+        "autoresearch.orchestration.metrics.OrchestrationMetrics.record_system_resources",
+        fake_record,
+    )
+    monkeypatch.setattr("autoresearch.monitor.time.sleep", lambda *_: None)
+    result = cli_runner.invoke(cli_app, ["monitor", "resources", "-d", "1"])
+    bdd_context["monitor_result"] = result
+
+
+@scenario(
+    "../features/monitor_cli.feature", "Resource monitoring for a duration"
+)
+def test_monitor_resources_duration():
+    """Scenario: Resource monitoring for a duration."""
+    pass


### PR DESCRIPTION
## Summary
- cover invalid configuration reloads with new behavior scenario
- exercise resource monitoring CLI for a duration
- document configuration reload and resource monitoring flows

## Testing
- `uv run task check` *(fails: interrupted)*
- `uv run task verify` *(fails: interrupted)*
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68a8be0aec1c833397dfd7dc97ec6b8d