### PR TITLE
Guard pydantic import during startup

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,4 +1,9 @@
-try:
-    import pydantic.root_model  # noqa: F401
-except Exception:
-    pass
+"""Project-wide customizations for Python startup."""
+
+from typing import TYPE_CHECKING
+
+if not TYPE_CHECKING:  # pragma: no cover - runtime import
+    try:
+        import pydantic.root_model  # noqa: F401
+    except Exception:  # pragma: no cover - best effort
+        pass


### PR DESCRIPTION
## Summary
- Avoid importing `pydantic.root_model` when type checking to prevent unnecessary startup work

## Testing
- `uv run mypy src --show-traceback`
- `PATH="$PWD/bin:$PATH" ./bin/task verify` *(fails: tests/unit/test_failure_paths.py::test_vector_search_vss_unavailable – Failed: DID NOT RAISE <class 'autoresearch.errors.VectorSearchUnavailable'>)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f948a8388333a4dde69fafd529bb