### PR TITLE
Raise error when VSS extension missing

### DIFF
--- a/tests/unit/test_synthesizer_agent_modes.py
+++ b/tests/unit/test_synthesizer_agent_modes.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 
 from autoresearch.agents.dialectical.synthesizer import SynthesizerAgent
 from autoresearch.config.models import ConfigModel
+from autoresearch.llm.adapters import LLMAdapter
 from autoresearch.orchestration.reasoning import ReasoningMode
 from autoresearch.orchestration.state import QueryState
 
 
-class DummyAdapter:
+class DummyAdapter(LLMAdapter):
     def __init__(self, output: str) -> None:
         self.output = output
 
-    def generate(self, prompt: str, model: str | None = None) -> str:  # noqa: D401
+    def generate(self, prompt: str, model: str | None = None, **kwargs) -> str:  # noqa: D401
         """Return preset output regardless of prompt."""
         return self.output
 


### PR DESCRIPTION
## Summary
- Raise `StorageError` when vector search is requested without the DuckDB VSS extension
- Use a minimal `LLMAdapter` subclass in synthesizer mode tests

## Testing
- `uv run pytest tests/unit/test_failure_paths.py::test_vector_search_vss_unavailable -vv`
- `uv run pytest tests/unit/test_synthesizer_agent_modes.py -q`
- `./.venv/bin/task check` *(fails: KeyboardInterrupt during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f93ece0c8333812e4f4343dd6ba0