### PR TITLE
docs: add orchestrator state diagrams

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+# Summary
+- 
+
+# Testing
+- [ ] `task check`
+- [ ] `task verify`
+
+# Spec References
+- docs/orchestrator_state.md#state-transitions
+- docs/orchestrator_state.md#api-contract

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ CLI utilities are provided via Typer and the HTTP API is powered by FastAPI.
 **Note:** [docs/installation.md](docs/installation.md) is the authoritative
 source for environment setup and optional features.
 
+For orchestrator state transitions and API contracts see
+[docs/orchestrator_state.md](docs/orchestrator_state.md).
+
 ## Prerequisites
 
 Autoresearch requires **Python 3.12+**,

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,9 @@ uvicorn autoresearch.api:app --reload
 
 Once the server is running you can interact with the endpoints described below.
 
+For details on orchestrator state transitions and the API contract see
+[orchestrator_state.md](orchestrator_state.md).
+
 ## Endpoints
 
 ### `POST /query`

--- a/docs/diagrams/api_contract.puml
+++ b/docs/diagrams/api_contract.puml
@@ -1,0 +1,16 @@
+@startuml
+skinparam dpi 150
+skinparam monochrome true
+
+participant Client
+participant API
+participant Orchestrator
+participant Agent
+
+Client -> API : submitQuery()
+API -> Orchestrator : dispatch(request)
+Orchestrator -> Agent : runTask()
+Agent --> Orchestrator : result
+Orchestrator --> API : respond(result)
+API --> Client : deliver(response)
+@enduml

--- a/docs/diagrams/orchestrator_state.puml
+++ b/docs/diagrams/orchestrator_state.puml
@@ -1,0 +1,12 @@
+@startuml
+skinparam dpi 150
+skinparam monochrome true
+
+[*] --> Idle
+Idle --> Preparing : start()
+Preparing --> Running : launch()
+Running --> Complete : finish()
+Running --> Error : fail()
+Complete --> [*]
+Error --> [*]
+@enduml

--- a/docs/orchestrator_state.md
+++ b/docs/orchestrator_state.md
@@ -1,0 +1,12 @@
+# Orchestrator State and API Contracts
+
+The orchestrator follows a predictable set of state transitions and interacts
+with the API through a simple contract.
+
+## State Transitions
+
+![Orchestrator states](diagrams/orchestrator_state.puml)
+
+## API Contract
+
+![API contract](diagrams/api_contract.puml)

--- a/tests/behavior/features/api_orchestrator_integration.feature
+++ b/tests/behavior/features/api_orchestrator_integration.feature
@@ -7,6 +7,7 @@ Feature: API and Orchestrator Integration
     Given the API server is running
     And the orchestrator is configured with test agents
 
+  # Spec: docs/orchestrator_state.md#api-contract - Forward queries through orchestrator
   Scenario: API forwards queries to the orchestrator
     When I send a query "What is artificial intelligence?" to the API
     Then the orchestrator should receive the query
@@ -15,6 +16,7 @@ Feature: API and Orchestrator Integration
     And the response should include citations
     And the response should include reasoning
 
+  # Spec: docs/orchestrator_state.md#api-contract - Surface orchestrator failures via API
   Scenario: API handles orchestrator errors gracefully
     Given the orchestrator is configured to raise an error
     When I send a query "Test query" to the API

--- a/tests/behavior/features/orchestration_system.feature
+++ b/tests/behavior/features/orchestration_system.feature
@@ -6,28 +6,38 @@ Feature: Orchestration System
   Background:
     Given the system is configured with default settings
 
-  # Spec: docs/specs/orchestration.md#key-behaviors - Record token usage and emit structured debug logs
+  # Spec: docs/specs/orchestration.md#key-behaviors - Record token usage and
+  # emit structured debug logs
   Scenario: Token counting without monkey patching
     When I run a query with token counting enabled
     Then token usage should be recorded correctly
     And no global state should be modified
 
-  # Spec: docs/specs/orchestration.md#key-behaviors - Integrate multiple agents, propagating state and capturing errors
+  # Spec: docs/specs/orchestration.md#key-behaviors - Integrate multiple agents,
+  # propagating state and capturing errors
   Scenario: Extracting complex methods
     When I run a query with multiple agents
     Then the orchestration should handle agent execution in smaller focused methods
     And the code should be more maintainable
 
-  # Spec: docs/specs/orchestration.md#key-behaviors - Integrate multiple agents, propagating state and capturing errors
+  # Spec: docs/specs/orchestration.md#key-behaviors - Integrate multiple agents,
+  # propagating state and capturing errors
   Scenario: Improved error handling
     When an agent fails during execution
     Then the error should be properly captured and categorized
     And the system should recover gracefully
     And detailed error information should be logged
 
-  # Spec: docs/specs/orchestration.md#key-behaviors - Record token usage and emit structured debug logs
+  # Spec: docs/specs/orchestration.md#key-behaviors - Record token usage and
+  # emit structured debug logs
   Scenario: Better logging for debugging
     When I run a query with debug logging enabled
     Then each step of the orchestration process should be logged
     And log messages should include relevant context
     And log levels should be appropriate for the message content
+
+  # Spec: docs/orchestrator_state.md#state-transitions - Log each orchestrator phase
+  Scenario: State transition flow
+    When I run a query with debug logging enabled
+    Then each step of the orchestration process should be logged
+    And log messages should include relevant context


### PR DESCRIPTION
## Summary
- document orchestrator state transitions and API contract
- cross-link new specs from README, API guide, and BDD scenarios
- add PR template referencing spec sections

## Testing
- `uv run mkdocs build`
- `task check` *(fails: KeyboardInterrupt)*
- `task verify` *(fails: tests/unit/test_failure_paths.py::test_vector_search_vss_unavailable, tests/unit/test_monitor_cli.py::test_monitor_prompts_and_passes_callbacks)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f99d53b88333bddc0d6e4558afd7