### PR TITLE
Gracefully handle missing Redis dependency

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -18,6 +18,9 @@ Before running any tests ensure the project is installed with the
 these groups so both local and CI environments have every optional dependency
 available.
 
+Redis is an optional dependency but required for distributed tests. The
+integration suite skips those tests automatically when Redis is missing.
+
 Use [Go Task](https://taskfile.dev/#/) to run specific suites inside the project's virtual environment:
 
 ```bash

--- a/src/autoresearch/distributed/broker.py
+++ b/src/autoresearch/distributed/broker.py
@@ -48,7 +48,13 @@ class RedisBroker:
     """Message broker backed by Redis."""
 
     def __init__(self, url: str | None = None, queue_name: str = "autoresearch") -> None:
-        import redis
+        try:
+            import redis
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "RedisBroker requires the 'redis' package. Install it via the"
+                " '[distributed]' extra."
+            ) from exc
 
         self.client = redis.Redis.from_url(url or "redis://localhost:6379/0")
         self.queue = RedisQueue(self.client, queue_name)

--- a/tests/integration/test_distributed_node_health.py
+++ b/tests/integration/test_distributed_node_health.py
@@ -1,9 +1,13 @@
+import importlib.util
 import sys
 import types
 from pathlib import Path
 
 import pytest
 from prometheus_client import CollectorRegistry
+
+if importlib.util.find_spec("redis") is None:
+    pytest.skip("redis not installed", allow_module_level=True)
 
 package = types.ModuleType("autoresearch.monitor")
 package.__path__ = [str(Path(__file__).resolve().parents[2] / "src" / "autoresearch" / "monitor")]

--- a/tests/integration/test_distributed_redis_broker.py
+++ b/tests/integration/test_distributed_redis_broker.py
@@ -1,8 +1,12 @@
+import importlib.util
+
 import pytest
 
 from autoresearch.distributed.broker import RedisBroker
 
-redis = pytest.importorskip("redis")
+if importlib.util.find_spec("redis") is None:
+    pytest.skip("redis not installed", allow_module_level=True)
+import redis
 
 pytestmark = pytest.mark.slow
 

--- a/tests/unit/test_distributed_redis.py
+++ b/tests/unit/test_distributed_redis.py
@@ -22,20 +22,22 @@ class _FakeRedisClient:
 
 
 def test_get_message_broker_redis_roundtrip(monkeypatch):
+    """Round trip messages through the Redis broker."""
+
     client = _FakeRedisClient()
-    dummy_module = types.SimpleNamespace(
-        Redis=types.SimpleNamespace(from_url=lambda url: client)
-    )
+    dummy_module = types.SimpleNamespace(Redis=types.SimpleNamespace(from_url=lambda url: client))
     monkeypatch.setitem(sys.modules, "redis", dummy_module)
 
     broker = get_message_broker("redis")
     broker.publish({"a": 1})
     assert client.entries[0][0] == "autoresearch"
-    assert client.entries[0][1] == "{\"a\": 1}"
+    assert client.entries[0][1] == '{"a": 1}'
     broker.shutdown()
 
 
 def test_get_message_broker_redis_missing(monkeypatch):
-    sys.modules.pop("redis", None)
+    """Raise an error when the Redis module cannot be imported."""
+
+    monkeypatch.setitem(sys.modules, "redis", None)
     with pytest.raises(ModuleNotFoundError):
         get_message_broker("redis")


### PR DESCRIPTION
## Summary
- raise a clear error when `redis` module is absent
- skip Redis integration tests when `redis` isn't installed
- document that Redis is optional but required for distributed tests

## Testing
- `uv run pytest tests/unit/test_distributed_redis.py tests/integration/test_distributed_redis_broker.py tests/integration/test_distributed_node_health.py`
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68aa55555224833396f8e1e4f45ba9ee