### PR TITLE
feat: print metrics on monitor default

### DIFF
--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -18,3 +18,14 @@ The monitor runs an HTTP server that serves `/metrics` and performs checks
 at a fixed interval. Gauges include `autoresearch_redis_up`,
 `autoresearch_ray_up`, and `autoresearch_node_health`. Use Prometheus to
 scrape the metrics and set alerts when values drop to `0`.
+
+## CLI usage
+
+Run the monitor command to print current CPU and memory usage:
+
+```bash
+uv run autoresearch monitor
+```
+
+This displays a JSON object containing `cpu_percent`, `memory_percent`, and
+other counters. Pass `--watch` to refresh continuously.

--- a/src/autoresearch/monitor/__init__.py
+++ b/src/autoresearch/monitor/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 import time
 from typing import Any, Dict, List, Union
@@ -40,7 +41,10 @@ def default_callback(
 ) -> None:
     """Display system metrics when no subcommand is provided."""
     if ctx.invoked_subcommand is None:
-        metrics(watch=watch)
+        if watch:
+            metrics(watch=True)
+        else:
+            typer.echo(json.dumps(_collect_system_metrics()))
 
 
 def _calculate_health(cpu: float, mem: float) -> str:
@@ -71,6 +75,7 @@ def _collect_system_metrics() -> Dict[str, Any]:
 
         mem = psutil.virtual_memory()
         proc = psutil.Process()
+        metrics.setdefault("cpu_percent", psutil.cpu_percent(interval=None))
         metrics.setdefault("memory_percent", mem.percent)
         metrics["memory_used_mb"] = mem.used / (1024 * 1024)
         metrics["process_memory_mb"] = proc.memory_info().rss / (1024 * 1024)

--- a/tests/unit/test_monitor_cli.py
+++ b/tests/unit/test_monitor_cli.py
@@ -70,3 +70,4 @@ def test_monitor_metrics(monkeypatch):
     result = runner.invoke(app, ["monitor"])
     assert result.exit_code == 0
     assert "cpu_percent" in result.stdout
+    assert "memory_percent" in result.stdout


### PR DESCRIPTION
## Summary
- print JSON metrics when `autoresearch monitor` runs without a subcommand
- ensure `_collect_system_metrics` always reports CPU usage
- document monitor CLI usage and cover with regression tests

## Testing
- `uv run pytest tests/unit/test_monitor_cli.py::test_monitor_metrics -q`
- `task check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa555a86d0833389c1be05e203a49e