### PR TITLE
Improve token budget convergence and add property tests

### DIFF
--- a/docs/algorithms/token_budgeting.md
+++ b/docs/algorithms/token_budgeting.md
@@ -4,15 +4,17 @@ The orchestrator adjusts its token allowance using
 `suggest_token_budget` from
 [`orchestration.metrics`](../../src/autoresearch/orchestration/metrics.py).
 Let `u_t` denote tokens consumed in cycle `t`, `\bar{u}_t` the mean usage
-across the last ten cycles, and `b_t` the budget before adaptation. With
-margin `m`, the update sets
+across the last ten **non-zero** cycles, and `b_t` the budget before
+adaptation. With margin `m`, the update sets
 
 \[
 b_{t+1} = \left\lceil \max(u_t, \bar{u}_t) (1 + m) \right\rceil.
 \]
 
 When the new target differs from the current budget the algorithm
-immediately adjusts, expanding or shrinking to the computed value.
+immediately adjusts, expanding or shrinking to the computed value. If no
+usage has been observed, the budget is left unchanged. A window composed
+only of zeros drives the budget to a minimum of one token.
 
 ## Convergence
 


### PR DESCRIPTION
## Summary
- handle empty and zero-usage histories in `suggest_token_budget`
- document updated token budgeting formula
- add Hypothesis tests for initial state and margin extremes

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run pytest tests/unit/test_token_budget_convergence.py`
- `uv run mkdocs build` *(warnings: many missing links)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5565883c83338c7cc6b9cb2ea641