### PR TITLE
Improve API auth handling and tests

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -284,8 +284,9 @@ Include the desired key in the `X-API-Key` header. The associated role will be
 available as `request.state.role` inside the application.
 
 If both API keys and a bearer token are configured, either credential grants
-access. The documentation routes `/docs` and `/openapi.json` are also protected
-when authentication is enabled.
+access. When both headers are sent, a valid bearer token overrides an incorrect
+`X-API-Key` value. The documentation routes `/docs` and `/openapi.json` are also
+protected when authentication is enabled.
 
 ### Headers
 
@@ -300,11 +301,11 @@ response. Authenticated clients lacking permission receive **403 Forbidden**.
 ### Role permissions
 
 Use `[api].role_permissions` to restrict which endpoints each role can call.
-Permissions are `query`, `metrics` and `capabilities`.
+Permissions are `query`, `metrics`, `capabilities`, `config` and `health`.
 
 ```toml
 [api.role_permissions]
-admin = ["query", "metrics", "capabilities"]
+admin = ["query", "metrics", "capabilities", "config", "health"]
 user = ["query"]
 ```
 


### PR DESCRIPTION
## Summary
- enforce bearer token auth when no API key is supplied
- expand integration tests for API auth success and failure cases
- document auth configuration and role permissions

## Testing
- `task check` *(fails: command not found)*
- `uv run --with mkdocs-material --with mkdocstrings --with mkdocstrings-python mkdocs build`
- `uv run --with pytest-httpx pytest tests/integration/test_api_auth.py tests/integration/test_api_auth_failure.py`
- `task verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5573597c83338e72a81c28210acf