### PR TITLE
docs: clarify setup scripts and task prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ For orchestrator state transitions and API contracts see
 Autoresearch requires **Python 3.12+**,
 [uv](https://github.com/astral-sh/uv), and
 [Go Task](https://taskfile.dev/). After cloning, run `./scripts/setup.sh` for
-the full developer bootstrap or `task install` for a minimal environment. See
+typical development or `task install` for a minimal environment. Use
+`scripts/codex_setup.sh` **only** when preparing a Codex evaluation
+environment. See
 [docs/installation.md#after-cloning](docs/installation.md#after-cloning) for
 details.
 
@@ -61,6 +63,13 @@ See [docs/installation.md](docs/installation.md) for the authoritative
 installation guide, including environment setup, optional features and
 upgrade instructions.
 
+## Troubleshooting
+
+Taskfile targets depend on Go Task and the project's development extras. If you
+encounter `task: command not found` or missing package errors, run
+`./scripts/setup.sh` (or `task install`) to install Go Task and sync the dev
+dependencies before invoking any `task` commands.
+
 ## Building the documentation
 
 Install MkDocs and generate the static site:
@@ -74,4 +83,6 @@ Use `mkdocs serve` to preview the documentation locally.
 
 ## Accessibility
 
-CLI output uses Markdown headings and plain-text lists so screen readers can navigate sections. Help messages avoid color-only cues and respect the `NO_COLOR` environment variable for ANSI-free output.
+CLI output uses Markdown headings and plain-text lists so screen readers can
+navigate sections. Help messages avoid color-only cues and respect the
+`NO_COLOR` environment variable for ANSI-free output.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,6 +4,9 @@ This guide is the canonical bootstrap reference for Autoresearch. It covers
 the minimal developer workflow and links to helper scripts for specific
 environments.
 
+Use `./scripts/setup.sh` for day-to-day development. Reserve
+`scripts/codex_setup.sh` for Codex evaluation containers.
+
 Autoresearch requires **Python 3.12 or newer**,
 [**uv**](https://github.com/astral-sh/uv), and
 [**Go Task**](https://taskfile.dev/) for Taskfile commands. Install Go Task
@@ -17,6 +20,8 @@ Run a bootstrap command immediately:
 ./scripts/setup.sh  # full developer bootstrap
 # or
 task install        # developer environment
+# Codex evaluation only
+# ./scripts/codex_setup.sh
 ```
 
 `./scripts/setup.sh` installs Go Task when missing, syncs the `dev` extras
@@ -40,6 +45,13 @@ uv run python scripts/check_env.py
 ```
 
 The script reports missing tools and version mismatches.
+
+## Troubleshooting
+
+Taskfile commands depend on Go Task and the project's `dev` extras. If
+`task` targets fail or packages are missing, ensure `./scripts/setup.sh` (or
+`task install`) has installed Go Task and synced the development extras before
+invoking any Taskfile target.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- clarify setup script usage: run `scripts/setup.sh` for development, reserve `scripts/codex_setup.sh` for Codex evaluations
- add troubleshooting guidance noting Go Task and dev extras are required before using Taskfile commands

## Testing
- `task check` *(fails: 36 errors during collection)*
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68aa55a960f883339b72c9a0766e69af