### PR TITLE
Document alpha release blockers and fix roadmap link

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,9 @@
 # Status
 
-These results reflect running `task check` after installing development
-dependencies. Refer to the [roadmap](ROADMAP.md) and
+These results reflect attempts to run `task check` after installing
+development dependencies. The `task` utility was not pre-installed and
+required manual installation, and several Python extras were missing.
+Refer to the [roadmap](ROADMAP.md) and
 [release plan](docs/release_plan.md) for scheduled milestones.
 
 ## Lint and type checks
@@ -9,13 +11,16 @@ dependencies. Refer to the [roadmap](ROADMAP.md) and
 uv run flake8 src tests
 uv run mypy src
 ```
-Result: both commands completed without issues.
+Result: both commands completed without issues after installing
+`flake8`, `mypy`, and related dependencies.
 
 ## Unit tests
 ```text
-uv run pytest tests/unit -q
+uv run pytest tests/unit/test_monitor_cli.py -k test_monitor_metrics -q
 ```
-Result: 391 passed, 4 skipped, 24 deselected, 31 warnings.
+Result: initial run failed due to missing `pytest_httpx` and `tomli_w`.
+After installing the packages, the targeted test passed. The full unit
+suite has not been executed.
 
 ## Integration tests
 Not executed.
@@ -24,7 +29,7 @@ Not executed.
 ```text
 uv run scripts/check_spec_tests.py
 ```
-Result: no spec files missing test references.
+Result: not executed.
 
 ## Behavior tests
 Not executed.

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -3,13 +3,22 @@
 ## Context
 Version 0.1.0a1 will be the project's first public alpha. The environment
 provisions via `scripts/setup.sh`, yet `task check` stalls during unit tests
-and integration tests require the `redis` package. Behavior tests remain
-unreliable. Release notes and packaging steps are incomplete.
+and `task verify` hangs during `mypy`. Integration tests require the
+`redis` package, behavior tests remain unreliable, and several unit tests
+need additional dependencies such as `pytest_httpx` and `tomli_w`.
+Coverage sits at **24%**, far below the **90%** target, and the TestPyPI
+upload currently returns HTTP 403. Release notes and packaging steps are
+incomplete.
 
 ## Acceptance Criteria
-- `task check` and `task verify` complete on a fresh clone.
+- `task check` and `task verify` complete on a fresh clone without
+  hanging during `mypy`.
+- Unit tests install required extras (`pytest_httpx`, `tomli_w`) and pass
+  consistently.
 - Integration tests run with `redis` available or skip cleanly when absent.
 - Behavior suite passes or scenarios are updated.
+- Coverage meets the **90%** threshold.
+- TestPyPI upload succeeds without authorization errors.
 - Release notes and packaging instructions drafted.
 - Backlog prioritized for post-alpha milestones.
 

--- a/issues/reach-stable-performance-and-interfaces.md
+++ b/issues/reach-stable-performance-and-interfaces.md
@@ -10,8 +10,8 @@ stable interfaces and tuned performance.
 
 ## Dependencies
 
-- [support-distributed-execution-and-monitoring](archive/support-distributed-execution-and-monitoring.md)
-- [formalize-algorithm-proofs-for-research-modules](formalize-algorithm-proofs-for-research-modules.md)
+ - [support-distributed-execution-and-monitoring](archive/support-distributed-execution-and-monitoring.md)
+ - [formalize-algorithm-proofs-for-research-modules](archive/formalize-algorithm-proofs-for-research-modules.md)
 
 ## Acceptance Criteria
 - Complete cross-platform packaging with containerization support.


### PR DESCRIPTION
## Summary
- detail outstanding tasks for 0.1.0a1 in `prepare-first-alpha-release`
- note missing test extras and partial results in `STATUS`
- fix broken dependency link in `reach-stable-performance-and-interfaces`

## Testing
- `uv run flake8 STATUS.md issues/prepare-first-alpha-release.md`
- `uv run flake8 issues/reach-stable-performance-and-interfaces.md`
- `uv run mypy src`
- `uv run pytest tests/unit/test_monitor_cli.py -k test_monitor_metrics -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa5e6ee3048333acd6d3c1c6e513ef