### PR TITLE
feat(monitor): expose GPU stats in system metrics

### DIFF
--- a/docs/algorithms/resource_monitor.md
+++ b/docs/algorithms/resource_monitor.md
@@ -1,7 +1,8 @@
 # Resource Monitor
 
-The `ResourceMonitor` samples CPU, memory, and GPU usage to expose
-time-series metrics.
+The `ResourceMonitor` samples CPU, memory, GPU, and token counts to expose
+time-series metrics. The `monitor` CLI uses these helpers to print the current
+snapshot in JSON or table form.
 
 ## Sampling Model
 
@@ -13,6 +14,13 @@ With a sampling interval `i` over runtime `T`, the monitor records
 
 Each observation costs `O(1)`, so monitoring overhead grows linearly with
 `n`.
+
+Typical metrics include:
+
+- `cpu_percent` and `memory_percent`
+- `memory_used_mb` and `process_memory_mb`
+- `gpu_percent` and `gpu_memory_mb`
+- `tokens_in_total` and `tokens_out_total`
 
 ## References
 

--- a/src/autoresearch/monitor/__init__.py
+++ b/src/autoresearch/monitor/__init__.py
@@ -61,10 +61,11 @@ def _calculate_health(cpu: float, mem: float) -> str:
 
 
 def _collect_system_metrics() -> Dict[str, Any]:
-    """Collect basic CPU and memory metrics."""
+    """Collect basic CPU, memory, and GPU metrics."""
     metrics: Dict[str, Any] = {}
     try:
         from .system_monitor import SystemMonitor
+        from ..resource_monitor import _get_gpu_stats
 
         if _system_monitor:
             metrics.update(_system_monitor.metrics)
@@ -79,6 +80,9 @@ def _collect_system_metrics() -> Dict[str, Any]:
         metrics.setdefault("memory_percent", mem.percent)
         metrics["memory_used_mb"] = mem.used / (1024 * 1024)
         metrics["process_memory_mb"] = proc.memory_info().rss / (1024 * 1024)
+        gpu_percent, gpu_mem = _get_gpu_stats()
+        metrics["gpu_percent"] = gpu_percent
+        metrics["gpu_memory_mb"] = gpu_mem
     except Exception as e:
         log.warning("Failed to collect system metrics", exc_info=e)
 

--- a/tests/unit/test_monitor_cli.py
+++ b/tests/unit/test_monitor_cli.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, List
 
 from typer.testing import CliRunner
@@ -63,11 +64,9 @@ def test_monitor_prompts_and_passes_callbacks(monkeypatch):
 
 def test_monitor_metrics(monkeypatch):
     runner = CliRunner()
-    monkeypatch.setattr(
-        "autoresearch.monitor._collect_system_metrics",
-        lambda: {"cpu_percent": 1.0, "memory_percent": 2.0},
-    )
+    expected = {"cpu_percent": 1.0, "memory_percent": 2.0}
+    monkeypatch.setattr("autoresearch.monitor._collect_system_metrics", lambda: expected)
     result = runner.invoke(app, ["monitor"])
     assert result.exit_code == 0
-    assert "cpu_percent" in result.stdout
-    assert "memory_percent" in result.stdout
+    assert json.loads(result.stdout) == expected
+    assert result.stdout.strip() == json.dumps(expected)


### PR DESCRIPTION
## Summary
- include GPU utilization and memory in `_collect_system_metrics`
- verify monitor CLI outputs structured metrics
- document expanded metrics collected by the ResourceMonitor

## Testing
- `uv run pytest tests/unit/test_monitor_cli.py -k test_monitor_metrics -q`
- `uv run flake8 src/autoresearch/monitor/__init__.py tests/unit/test_monitor_cli.py`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68aa9e5d8c74833394b6313c9841eb7e