### PR TITLE
Refine token budget adaptation and convergence tests

### DIFF
--- a/docs/algorithms/token_budgeting.md
+++ b/docs/algorithms/token_budgeting.md
@@ -3,18 +3,20 @@
 The orchestrator adjusts its token allowance using
 `suggest_token_budget` from
 [`orchestration.metrics`](../../src/autoresearch/orchestration/metrics.py).
-Let `u_t` denote tokens consumed in cycle `t`, `\bar{u}_t` the mean usage
-across the last ten **non-zero** cycles, and `b_t` the budget before
-adaptation. With margin `m`, the update sets
+Let `u_t` denote tokens consumed in cycle `t` and `\bar{u}_t` the mean
+usage across the last ten **non-zero** cycles. For each agent `i`, let
+`a_{i,t}` be the tokens it used in cycle `t` and `\bar{a}_{i,t}` the
+mean across its last ten non-zero samples. Define `a_t = \max_i a_{i,t}`
+and `\bar{a}_t = \max_i \bar{a}_{i,t}`. With margin `m`, the update is
 
 \[
-b_{t+1} = \left\lceil \max(u_t, \bar{u}_t) (1 + m) \right\rceil.
+b_{t+1} = \left\lceil \max(u_t, \bar{u}_t, a_t, \bar{a}_t) (1 + m) \right\rceil.
 \]
 
 When the new target differs from the current budget the algorithm
-immediately adjusts, expanding or shrinking to the computed value. If no
-usage has been observed, the budget is left unchanged. A window composed
-only of zeros drives the budget to a minimum of one token.
+immediately adjusts. If no usage has ever been recorded, the budget is
+left unchanged. Ten consecutive zero-usage samples after activity shrink
+the budget to a minimum of one token.
 
 ## Convergence
 

--- a/docs/token_budget_spec.md
+++ b/docs/token_budget_spec.md
@@ -1,47 +1,39 @@
 # Token Budget Helpers Specification
 
-This specification outlines expected behaviors for the token budgeting helpers in `autoresearch.orchestration.metrics`.
+This specification outlines expected behaviors for the token budgeting
+helpers in `autoresearch.orchestration.metrics`.
 
 ## `compress_prompt_if_needed`
 - Records each prompt length to track a running average.
 - Computes an adjusted threshold:
   - Starts with the provided `threshold` (default `1.0`).
-  - If the average length exceeds the `token_budget`, the threshold becomes `min(threshold, token_budget / avg_length)`.
-- Returns the original prompt when `tokens <= token_budget * adjusted_threshold`.
-- Otherwise invokes `llm.token_counting.compress_prompt` to produce text whose token count does not exceed `token_budget`.
-- The historical average allows later prompts to be compressed earlier when recent prompts were long.
+  - If the average length exceeds the `token_budget`, the threshold becomes
+    `min(threshold, token_budget / avg_length)`.
+- Returns the original prompt when
+  `tokens <= token_budget * adjusted_threshold`.
+- Otherwise invokes `llm.token_counting.compress_prompt` to produce text
+  whose token count does not exceed `token_budget`.
+- The historical average allows later prompts to be compressed earlier when
+  recent prompts were long.
 
 ## `suggest_token_budget`
 - Tracks total tokens and per-agent usage between calls.
-- Computes `delta` as tokens used since the last invocation and maintains historical averages.
-- Defines thresholds from the current budget:
-  - `expand_threshold = current_budget * (1 + margin)`
-  - `shrink_threshold = current_budget * (1 - margin)`
-- Expands the budget to `max(int(max(delta, avg_used) * (1 + margin)), 1)` when `delta > expand_threshold` **or** `avg_used > current_budget`.
-- Shrinks the budget to `max(int(avg_used * (1 + margin)), 1)` when `delta < shrink_threshold` **and** `avg_used < shrink_threshold`.
-- Otherwise returns `max(current_budget, 1)`.
-- Budgets are never allowed to drop below `1` token.
-
-Expressed as equations, the suggested budget :math:`B'` is:
-
-\[
-\begin{aligned}
-\text{expand\_threshold} &= B (1 + m)\\
-\text{shrink\_threshold} &= B (1 - m)\\
-B' &=
-  \begin{cases}
-    \max(\lfloor \max(\delta, \bar{u})(1+m) \rfloor, 1), & \delta > \text{expand\_threshold}\ \text{or}\ \bar{u} > B \\
-    \max(\lfloor \bar{u}(1+m) \rfloor, 1), & \delta < \text{shrink\_threshold}\ \text{and}\ \bar{u} < \text{shrink\_threshold} \\
-    \max(B, 1), & \text{otherwise}
-  \end{cases}
-\end{aligned}
-\]
-
-The function is monotonic in :math:`\delta`: for identical histories,
-if :math:`\delta_1 \le \delta_2` then :math:`B'(\delta_1) \le B'(\delta_2)`.
+- Computes `delta` as tokens used since the last invocation and appends it
+  to the usage history. A flag records whether any positive usage has been
+  seen.
+- Maintains per-agent histories and extracts the maximum per-agent
+  delta `a_t` and mean `\bar{a}_t` over the last ten non-zero samples.
+- From the global history it derives the latest usage `u_t` and the mean
+  `\bar{u}_t` over the last ten non-zero samples.
+- If the most recent ten deltas are all zero, the function returns `1` when
+  positive usage was seen previously and otherwise leaves the budget
+  unchanged.
+- Otherwise it sets the new budget to
+  `max(ceil(max(u_t, \bar{u}_t, a_t, \bar{a}_t) * (1 + margin)), 1)`.
+- Budgets never drop below one token.
 
 ## Tests
 Unit tests in `tests/unit/test_metrics_token_budget_spec.py` exercise:
 - Threshold adaptation based on prompt history.
-- Budget expansion after a spike and shrinkage when usage falls.
-- Enforcement of the minimum budget of one token.
+- Convergence to `ceil(u * (1 + margin))` for constant workloads.
+- Enforcement of the minimum budget of one token after idle periods.

--- a/scripts/token_budget_convergence.py
+++ b/scripts/token_budget_convergence.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-"""Demonstrate convergence of suggest_token_budget.
+"""Demonstrate convergence of ``suggest_token_budget``.
 
 Usage:
-    uv run scripts/token_budget_convergence.py --steps 10 --usage 50
+    uv run scripts/token_budget_convergence.py --steps 10 --usage 50 --margin 0.2
 """
 
 from __future__ import annotations
@@ -13,13 +13,14 @@ from typing import List
 from autoresearch.orchestration.metrics import OrchestrationMetrics
 
 
-def simulate(steps: int, usage: int) -> List[int]:
+def simulate(steps: int, usage: int, margin: float) -> List[int]:
+    """Return budgets produced for ``steps`` cycles of constant ``usage``."""
     m = OrchestrationMetrics()
     budget = usage
     budgets: List[int] = []
     for _ in range(steps):
-        m.token_usage_history.append(usage)
-        budget = m.suggest_token_budget(budget)
+        m.record_tokens("agent", usage, 0)
+        budget = m.suggest_token_budget(budget, margin=margin)
         budgets.append(budget)
     return budgets
 
@@ -28,8 +29,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Simulate token budget convergence")
     parser.add_argument("--steps", type=int, default=10)
     parser.add_argument("--usage", type=int, default=50)
+    parser.add_argument("--margin", type=float, default=0.1)
     args = parser.parse_args()
-    budgets = simulate(args.steps, args.usage)
+    budgets = simulate(args.steps, args.usage, args.margin)
     for i, b in enumerate(budgets, start=1):
         print(f"step {i}: {b}")
     print(f"final budget: {budgets[-1]}")


### PR DESCRIPTION
## Summary
- incorporate agent-level histories into `suggest_token_budget` and stabilize convergence to ceil(u * (1 + margin))
- update token budgeting docs and spec to match revised algorithm and add CLI simulation
- expand property-based tests for token budget convergence and zero-usage behaviour

## Testing
- `uv run ruff check src/autoresearch/orchestration/metrics.py scripts/token_budget_convergence.py tests/unit/test_token_budget_convergence.py`
- `uv run pytest tests/unit/test_token_budget_convergence.py`
- `uv run mkdocs build`
- `uv run scripts/token_budget_convergence.py --steps 5 --usage 50 --margin 0.2`


------
https://chatgpt.com/codex/tasks/task_e_68aa9e5a09988333a51a837e28f2a57b