### PR TITLE
Track access frequency for eviction policies

### DIFF
--- a/docs/algorithms/cache_eviction.md
+++ b/docs/algorithms/cache_eviction.md
@@ -7,6 +7,10 @@ note outlines the policy used to discard entries when space runs low.
 - Least Recently Used (LRU): the cache tracks access order and removes the
   stalest entry first.
 
+## Metrics
+- Each eviction increments an `EVICTION_COUNTER` metric for observability.
+- Accesses update a frequency table that hybrid and adaptive policies use.
+
 ## Complexity
 - Insert and access: O(1) using an ordered dictionary.
 - Evict: O(1) per removed entry.

--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -1246,10 +1246,11 @@ class StorageManager(metaclass=StorageManagerMeta):
 
         This method updates the access timestamp for a node in the LRU (Least
         Recently Used) cache and moves it to the end of the cache order,
-        marking it as most recently used.  The implementation relies on the
-        ordering properties of :class:`collections.OrderedDict`, meaning older
-        entries remain at the beginning and are evicted first when the RAM
-        budget is exceeded.
+        marking it as most recently used.  It also increments an access
+        counter used by hybrid and adaptive eviction policies.  The
+        implementation relies on the ordering properties of
+        :class:`collections.OrderedDict`, meaning older entries remain at the
+        beginning and are evicted first when the RAM budget is exceeded.
 
         If a custom implementation is set via set_delegate(), the call is
         delegated to that implementation.
@@ -1266,6 +1267,9 @@ class StorageManager(metaclass=StorageManagerMeta):
             lru[node_id] = state.lru_counter
             # ``move_to_end`` maintains the deque order for faster popping
             lru.move_to_end(node_id)
+            StorageManager._access_frequency[node_id] = (
+                StorageManager._access_frequency.get(node_id, 0) + 1
+            )
 
     @staticmethod
     def get_duckdb_conn() -> duckdb.DuckDBPyConnection:

--- a/tests/unit/test_storage_persistence_eviction.py
+++ b/tests/unit/test_storage_persistence_eviction.py
@@ -1,9 +1,9 @@
 import pytest
 
-from autoresearch.storage import StorageManager
-from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel
 from autoresearch.orchestration import metrics
+from autoresearch.storage import StorageManager
 
 
 @pytest.mark.parametrize("policy", ["lru", "score", "hybrid"])
@@ -17,7 +17,6 @@ def test_persistence_and_eviction(storage_manager, tmp_path, monkeypatch, policy
     claim = {"id": "p1", "type": "fact", "content": "c"}
     db_file = tmp_path / "kg.duckdb"
     monkeypatch.setenv("DUCKDB_PATH", str(db_file))
-    StorageManager._access_frequency["p1"] = 1
     StorageManager.persist_claim(claim)
     assert StorageManager.context.db_backend._path == str(db_file)
     assert "p1" not in StorageManager.get_graph().nodes


### PR DESCRIPTION
## Summary
- track node access frequency in `StorageManager.touch_node` to support hybrid/adaptive eviction
- verify persistence-triggered eviction across LRU, score, and hybrid policies
- document eviction metrics and frequency tracking

## Testing
- ⚠️ `task check` *(command not found)*
- ⚠️ `task verify` *(command not found)*
- ✅ `uv run pytest tests/unit/test_storage_persistence_eviction.py -q`
- ✅ `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68aa9e6549288333842c74399431a8bc