### PR TITLE
Add resource monitor stats and simulation

### DIFF
--- a/docs/algorithms/resource_monitor.md
+++ b/docs/algorithms/resource_monitor.md
@@ -12,6 +12,23 @@ With a sampling interval `i` over runtime `T`, the monitor records
 - `C = (1/n) \sum_{k=1}^{n} c_k`
 - `M = (1/n) \sum_{k=1}^{n} m_k`
 
+Variance captures spread in the observations. For CPU `S_C^2` and memory
+`S_M^2` the unbiased estimators are
+
+- `S_C^2 = (1/(n - 1)) \sum_{k=1}^{n} (c_k - C)^2`
+- `S_M^2 = (1/(n - 1)) \sum_{k=1}^{n} (m_k - M)^2`
+
+The `p`-quantile `Q_p` is approximated by sorting values and selecting
+`x_{\lceil pn \rceil}`.
+
+Sampling error of the mean decreases with more observations. The standard
+error (expected deviation from the true mean) is
+
+- `SE(C) = \sqrt{S_C^2 / n}`
+- `SE(M) = \sqrt{S_M^2 / n}`
+
+A 95% confidence interval for the CPU mean is `C \pm 1.96 * SE(C)`.
+
 Each observation costs `O(1)`, so monitoring overhead grows linearly with
 `n`.
 
@@ -24,6 +41,12 @@ Typical metrics include:
 
 ## References
 
-- [Prometheus Metrics Overview](https://prometheus.io/docs/concepts/metric_types/)
-- [tests/integration/test_monitor_metrics.py](../../tests/integration/test_monitor_metrics.py)
+- [Prometheus Metrics Overview]
+- [tests/integration/test_monitor_metrics.py]
+- [Sample Variance](https://en.wikipedia.org/wiki/Variance#Sample_variance)
+- [Quantile](https://en.wikipedia.org/wiki/Quantile)
+- [Standard Error](https://en.wikipedia.org/wiki/Standard_error)
+
+[Prometheus Metrics Overview]: https://prometheus.io/docs/concepts/metric_types/
+[tests/integration/test_monitor_metrics.py]: ../../tests/integration/test_monitor_metrics.py
 

--- a/scripts/resource_monitor_simulation.py
+++ b/scripts/resource_monitor_simulation.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Simulate resource metrics and verify sampling error bounds.
+
+Usage:
+    uv run python scripts/resource_monitor_simulation.py --samples 50
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import random
+import statistics
+from typing import Iterable, List
+
+
+def quantile(values: Iterable[float], q: float) -> float:
+    """Return the linear-interpolated ``q``-quantile of ``values``."""
+    data = sorted(values)
+    k = (len(data) - 1) * q
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return data[int(k)]
+    return data[f] * (c - k) + data[c] * (k - f)
+
+
+def simulate(samples: int, mu: float, sigma: float, q: float) -> None:
+    """Generate ``samples`` values and print stats after each draw."""
+    data: List[float] = []
+    for i in range(samples):
+        data.append(random.gauss(mu, sigma))
+        mean = statistics.mean(data)
+        var = statistics.variance(data)
+        q_val = quantile(data, q)
+        se = math.sqrt(var / len(data))
+        print(f"{i+1:3d} mean={mean:6.2f} var={var:6.2f} " f"q{q:.2f}={q_val:6.2f} se={se:6.2f}")
+    error = abs(statistics.mean(data) - mu)
+    bound = 1.96 * math.sqrt(statistics.variance(data) / len(data))
+    print(f"error={error:.2f} bound={bound:.2f} within={error <= bound}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simulate monitor statistics")
+    parser.add_argument("--samples", type=int, default=50, help="number of draws")
+    parser.add_argument("--mu", type=float, default=50.0, help="true mean")
+    parser.add_argument("--sigma", type=float, default=10.0, help="true std dev")
+    parser.add_argument("--quantile", type=float, default=0.95, help="quantile")
+    args = parser.parse_args()
+    simulate(args.samples, args.mu, args.sigma, args.quantile)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/unit/test_property_resource_monitor_stats.py
+++ b/tests/unit/test_property_resource_monitor_stats.py
@@ -1,0 +1,46 @@
+"""Property tests for resource monitor statistical formulas."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from hypothesis import HealthCheck, given, settings, strategies as st
+
+
+def stats(values: list[float], q: float) -> tuple[float, float, float, float]:
+    """Return mean, variance, quantile, and standard error."""
+    n = len(values)
+    mean = sum(values) / n
+    var = sum((x - mean) ** 2 for x in values) / (n - 1)
+    data = sorted(values)
+    k = (n - 1) * q
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        q_val = data[int(k)]
+    else:
+        q_val = data[f] * (c - k) + data[c] * (k - f)
+    se = math.sqrt(var / n)
+    return mean, var, q_val, se
+
+
+@given(
+    st.lists(
+        st.floats(min_value=0.0, max_value=100.0, allow_nan=False, allow_infinity=False),
+        min_size=2,
+        max_size=50,
+    )
+)
+@settings(max_examples=50, suppress_health_check=[HealthCheck.too_slow])
+def test_statistics_match_numpy(values: list[float]) -> None:
+    """Ensure custom stats align with NumPy implementations."""
+    mean, var, q_val, se = stats(values, 0.95)
+    np_mean = float(np.mean(values))
+    np_var = float(np.var(values, ddof=1))
+    np_q = float(np.quantile(values, 0.95))
+    np_se = float(np.std(values, ddof=1) / math.sqrt(len(values)))
+    assert math.isclose(mean, np_mean, rel_tol=1e-7, abs_tol=1e-7)
+    assert math.isclose(var, np_var, rel_tol=1e-7, abs_tol=1e-7)
+    assert math.isclose(q_val, np_q, rel_tol=1e-7, abs_tol=1e-7)
+    assert math.isclose(se, np_se, rel_tol=1e-7, abs_tol=1e-7)


### PR DESCRIPTION
## Summary
- document variance, quantile, and sampling error formulas for ResourceMonitor
- add simulation script demonstrating statistical bounds over time
- introduce property-based test to validate statistical calculations

## Testing
- `uv run black scripts/resource_monitor_simulation.py tests/unit/test_property_resource_monitor_stats.py`
- `uv run flake8 scripts/resource_monitor_simulation.py tests/unit/test_property_resource_monitor_stats.py`
- `uv run pytest tests/unit/test_property_resource_monitor_stats.py`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68aaa29b994083339baceaca37e2bf7a