### PR TITLE
docs: retarget alpha release milestones

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 This roadmap summarizes planned features for upcoming releases.
 Dates and milestones align with the [release plan](docs/release_plan.md).
 Installation and environment details are covered in the [README](README.md).
-Last updated **August 23, 2025**.
+Last updated **August 24, 2025**.
 
 ## Status
 
@@ -19,9 +19,9 @@ before running tests.
 
 ## Milestones
 
-- 0.1.0a1 (2026-03-01, status: completed): Alpha preview to collect feedback
-  while aligning environment requirements
-  ([prepare-initial-alpha-release](issues/archive/prepare-initial-alpha-release.md)).
+- 0.1.0a1 (2026-04-15, status: in progress): Alpha preview to collect
+  feedback while aligning environment requirements
+  ([prepare-first-alpha-release](issues/prepare-first-alpha-release.md)).
 - 0.1.0 (2026-07-01, status: planned): Finalize packaging, docs and CI checks
   with all tests passing
   ([finalize-first-public-preview-release](
@@ -47,10 +47,12 @@ for the alpha release checklist.
 
 ## 0.1.0a1 – Alpha preview
 
-This pre-release provided an early package for testing after packaging tasks
-were verified. Related issue
-([prepare-initial-alpha-release](issues/archive/prepare-initial-alpha-release.md))
-captured the environment work. Key activities included:
+This pre-release will provide an early package for testing once packaging tasks
+are verified. Related issue
+([prepare-first-alpha-release](issues/prepare-first-alpha-release.md)) tracks
+the work. Tagging **0.1.0a1** requires `task verify` to complete, coverage to
+reach **90%**, and a successful TestPyPI upload. The release is re-targeted for
+**April 15, 2026**. Key activities include:
 
 - [x] Environment bootstrap documented and installation instructions
   consolidated
@@ -64,7 +66,7 @@ captured the environment work. Key activities included:
 - [x] Algorithm validation for ranking and coordination
   ([ranking](issues/archive/validate-ranking-algorithms-and-agent-coordination.md)).
 
-These steps completed in sequence: environment bootstrap → packaging
+These steps proceed in sequence: environment bootstrap → packaging
 verification → integration tests → coverage gates → algorithm validation.
 
 ## 0.1.0 – First public preview

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -9,7 +9,7 @@ The publishing workflow follows the steps in
 [ROADMAP.md](../ROADMAP.md) for high-level milestones.
 
 The project kicked off in **May 2025** (see the initial commit dated
-`2025-05-18`). This schedule was last updated on **August 23, 2025** and
+`2025-05-18`). This schedule was last updated on **August 24, 2025** and
 reflects that the codebase currently sits at the **unreleased 0.1.0a1** version
 defined in `autoresearch.__version__`. Phase 3
 (stabilization/testing/documentation) and Phase 4 activities remain planned.
@@ -23,10 +23,10 @@ Current test and coverage results are tracked in
 
 ## Milestones
 
-- **0.1.0a1** (2026-03-01, status: in progress): Alpha preview to collect
+- **0.1.0a1** (2026-04-15, status: in progress): Alpha preview to collect
   feedback
-  ([prepare-alpha-release](
-  ../issues/archive/prepare-alpha-release.md)).
+  ([prepare-first-alpha-release](
+  ../issues/prepare-first-alpha-release.md)).
 - **0.1.0** (2026-07-01, status: planned): Finalize packaging, docs and CI
   checks with all tests passing
   ([finalize-first-public-preview-release](
@@ -49,8 +49,8 @@ Current test and coverage results are tracked in
 
 The project originally targeted **0.1.0** for **July 20, 2025**, but the
 schedule slipped. To gather early feedback, an alpha **0.1.0a1** release is
-scheduled for **2026-03-01**. The final **0.1.0** milestone is
-now set for **July 1, 2026** while packaging tasks are resolved.
+now re-targeted for **April 15, 2026**. The final **0.1.0** milestone is set
+for **July 1, 2026** while packaging tasks are resolved.
 
 ### Alpha release checklist
 
@@ -76,11 +76,14 @@ now set for **July 1, 2026** while packaging tasks are resolved.
 These tasks completed in order: environment bootstrap → packaging verification
 → integration tests → coverage gates → algorithm validation.
 
-### Remaining blockers before tagging 0.1.0a1
+### Prerequisites for tagging 0.1.0a1
 
 - `task verify` stalls during `mypy`; type checking must complete.
 - Total coverage is **24%**, short of the **90%** gate.
 - TestPyPI upload returns HTTP 403, so packaging needs a retry.
+
+The **0.1.0a1** date is re-targeted for **April 15, 2026** and the release
+remains in progress until these prerequisites are satisfied.
 
 Completion of these items confirms the alpha baseline for **0.1.0**.
 

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -10,6 +10,23 @@ Coverage sits at **24%**, far below the **90%** target, and the TestPyPI
 upload currently returns HTTP 403. Release notes and packaging steps are
 incomplete.
 
+## Milestone
+
+- 0.1.0a1 (2026-04-15)
+
+## Dependencies
+
+- [document-environment-bootstrap](
+  archive/document-environment-bootstrap.md)
+- [verify-packaging-workflow-and-duckdb-fallback](
+  archive/verify-packaging-workflow-and-duckdb-fallback.md)
+- [stabilize-integration-tests](
+  archive/stabilize-integration-tests.md)
+- [add-coverage-gates-and-regression-checks](
+  archive/add-coverage-gates-and-regression-checks.md)
+- [validate-ranking-algorithms-and-agent-coordination](
+  archive/validate-ranking-algorithms-and-agent-coordination.md)
+
 ## Acceptance Criteria
 - `task check` and `task verify` complete on a fresh clone without
   hanging during `mypy`.


### PR DESCRIPTION
## Summary
- mark 0.1.0a1 as in progress and move target to 2026-04-15
- note prerequisites for tagging the alpha release
- align issue links and dependencies with the release plan

## Testing
- `task check` *(fails: No module named 'flake8')*
- `uv run mkdocs build` *(fails: mkdocs not installed)*
- `task verify` *(fails: No module named 'flake8')*

------
https://chatgpt.com/codex/tasks/task_e_68aaa5d1355083339ef4aa18accad51c