### PR TITLE
Restrict documentation endpoints to authenticated roles

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -298,8 +298,8 @@ available as `request.state.role` inside the application.
 
 If both API keys and a bearer token are configured, either credential grants
 access. When both headers are sent, a valid bearer token overrides an incorrect
-`X-API-Key` value. The documentation routes `/docs` and `/openapi.json` are also
-protected when authentication is enabled.
+`X-API-Key` value. The documentation routes `/docs` and `/openapi.json` require
+the `docs` permission and are protected when authentication is enabled.
 
 ### Headers
 
@@ -314,16 +314,17 @@ response. Authenticated clients lacking permission receive **403 Forbidden**.
 ### Role permissions
 
 Use `[api].role_permissions` to restrict which endpoints each role can call.
-Permissions are `query`, `metrics`, `capabilities`, `config` and `health`.
+Permissions are `query`, `docs`, `metrics`, `capabilities`, `config` and
+`health`.
 
 ```toml
 [api.role_permissions]
-admin = ["query", "metrics", "capabilities", "config", "health"]
-user = ["query"]
+admin = ["query", "docs", "metrics", "capabilities", "config", "health"]
+user = ["query", "docs"]
 ```
 
-By default `user` can only submit queries while `admin` has access to all
-endpoints.
+By default `user` can submit queries and view documentation, while `admin`
+has access to all endpoints.
 
 ## Throttling
 

--- a/src/autoresearch/api/streaming.py
+++ b/src/autoresearch/api/streaming.py
@@ -14,7 +14,8 @@ from .webhooks import notify_webhook
 
 
 async def query_stream_endpoint(
-    request: QueryRequest, _=require_permission("query")
+    request: QueryRequest,
+    _: None = require_permission("query"),
 ) -> StreamingResponse:
     """Stream incremental query results as JSON lines."""
     config = get_config()

--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -143,9 +143,16 @@ class APIConfig(BaseModel):
     )
     role_permissions: Dict[str, List[str]] = Field(
         default_factory=lambda: {
-            "anonymous": ["query"],
-            "user": ["query"],
-            "admin": ["query", "metrics", "capabilities", "config", "health"],
+            "anonymous": ["query", "docs"],
+            "user": ["query", "docs"],
+            "admin": [
+                "query",
+                "docs",
+                "metrics",
+                "capabilities",
+                "config",
+                "health",
+            ],
         },
         description="Mapping of roles to allowed actions",
     )


### PR DESCRIPTION
## Summary
- Require `docs` permission on `/docs` and `/openapi.json`
- Include `docs` in default role permissions
- Clarify authentication docs and tighten streaming auth typing

## Testing
- `uv run pytest tests/integration/test_api_auth.py tests/integration/test_api_docs.py tests/integration/test_api_streaming.py -q`
- `task check` *(fails: command not found)*
- `uv run mkdocs build` *(fails: mkdocstrings plugin configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa88cc7108333b9904e30ab8ab769