### PR TITLE
feat: provide single monitor snapshot

### DIFF
--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -27,5 +27,6 @@ Run the monitor command to print current CPU and memory usage:
 uv run autoresearch monitor
 ```
 
-This displays a JSON object containing `cpu_percent`, `memory_percent`, and
-other counters. Pass `--watch` to refresh continuously.
+The command outputs a single JSON object containing `cpu_percent`,
+`memory_percent`, token counters, and more, then exits with status code 0.
+Pass `--watch` to refresh the metrics continuously.

--- a/src/autoresearch/monitor/__init__.py
+++ b/src/autoresearch/monitor/__init__.py
@@ -44,7 +44,9 @@ def default_callback(
         if watch:
             metrics(watch=True)
         else:
-            typer.echo(json.dumps(_collect_system_metrics()))
+            data = _collect_system_metrics()
+            typer.echo(json.dumps(data))
+            raise typer.Exit(code=0)
 
 
 def _calculate_health(cpu: float, mem: float) -> str:
@@ -64,8 +66,8 @@ def _collect_system_metrics() -> Dict[str, Any]:
     """Collect basic CPU, memory, and GPU metrics."""
     metrics: Dict[str, Any] = {}
     try:
-        from .system_monitor import SystemMonitor
         from ..resource_monitor import _get_gpu_stats
+        from .system_monitor import SystemMonitor
 
         if _system_monitor:
             metrics.update(_system_monitor.metrics)


### PR DESCRIPTION
## Summary
- ensure `autoresearch monitor` prints metrics once and exits cleanly
- document one-shot and watch modes for monitor CLI

## Testing
- `uv run flake8 src/autoresearch/monitor/__init__.py`
- `uv run mypy src/autoresearch/monitor/__init__.py`
- `uv run pytest tests/unit/test_monitor_cli.py::test_monitor_metrics -q`
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68aaa8977bd083338748cdfbbaa58a23