### PR TITLE
docs: track pytest-bdd feature discovery issue

### DIFF
--- a/issues/fix-pytest-bdd-feature-discovery.md
+++ b/issues/fix-pytest-bdd-feature-discovery.md
@@ -1,0 +1,16 @@
+# Fix pytest-bdd feature discovery
+
+## Context
+Running `uv run pytest tests/integration/test_concurrent_queries.py \
+ tests/behavior/features/api_orchestrator_integration.feature -q` fails
+with "not found" because `pytest-bdd` cannot discover the feature
+directory. Behavior tests cannot execute reliably.
+
+## Acceptance Criteria
+- `uv run pytest tests/behavior/features/api_orchestrator_integration.feature -q`
+  collects and runs the feature.
+- Behavior tests run without manually configuring feature paths.
+- Documentation reflects any required `pytest` configuration.
+
+## Status
+Open

--- a/issues/resolve-test-failures-and-task-tooling.md
+++ b/issues/resolve-test-failures-and-task-tooling.md
@@ -16,6 +16,7 @@
 - [fix-concurrent-query-interface-behavior](archive/fix-concurrent-query-interface-behavior.md)
 - [add-redis-dependency-for-integration-tests](add-redis-dependency-for-integration-tests.md)
 - [fix-monitor-cli-metrics-failure](fix-monitor-cli-metrics-failure.md)
+- [fix-pytest-bdd-feature-discovery](fix-pytest-bdd-feature-discovery.md)
 
 ## Acceptance Criteria
 - Go Task installed in `.venv` and available on `PATH`.


### PR DESCRIPTION
## Summary
- add issue to document pytest-bdd feature discovery failure
- link new issue from overarching test failure tracker

## Testing
- `uv run pytest tests/integration/test_concurrent_queries.py -q`
- `uv run pytest tests/integration/test_concurrent_queries.py tests/behavior/features/api_orchestrator_integration.feature -q` (fails: feature file not found)
- `task check` (fails: 29 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68aaa89f78148333a0f10ff88c50a13a