### PR TITLE
docs: log redis integration test behavior

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -23,7 +23,8 @@ failures. `task verify` and `task coverage` attempted but terminated
 early in this environment.
 
 ## Integration tests
-Not executed.
+Redis not installed; `uv run pytest tests/integration -m requires_distributed -q`
+skipped all `requires_distributed` scenarios.
 
 ## Spec tests
 ```text

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -231,12 +231,14 @@ These behavior test issues remain open until the test suite passes.
 
 ### Latest Test Results
 
- - `uv run flake8 src tests` – passed
- - `uv run mypy src` – passed
- - token budget tests marked xfail
- - `task check` – terminated early
- - `task verify` – terminated early
- - `task coverage` – terminated early
+- `uv run flake8 src tests` – passed
+- `uv run mypy src` – passed
+- token budget tests marked xfail
+- `task check` – command not found
+- `task verify` – not run
+- `task coverage` – not run
+- `uv run pytest tests/integration -m requires_distributed -q` – skipped 5 tests
+  (redis missing)
 
 ### Performance Baselines
 

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -10,6 +10,9 @@ Coverage sits at **24%**, far below the **90%** target, and the TestPyPI
 upload currently returns HTTP 403. Release notes and packaging steps are
 incomplete.
 
+Redis-dependent integration tests now skip cleanly when `redis` is missing
+(verified 2025-08-24).
+
 ## Milestone
 
 - 0.1.0a1 (2026-04-15)

--- a/issues/resolve-test-failures-and-task-tooling.md
+++ b/issues/resolve-test-failures-and-task-tooling.md
@@ -8,6 +8,9 @@
  API authentication, concurrent query handling, Redis broker detection, and
  monitor CLI metrics. Integration and behavior test suites remain unreliable.
 
+ Redis-dependent integration tests skip cleanly when `redis` is missing
+ (verified 2025-08-24).
+
 ## Dependencies
 
 - [address-storage-persistence-eviction-failure](archive/address-storage-persistence-eviction-failure.md)


### PR DESCRIPTION
## Summary
- Record that redis-marked integration tests skip cleanly when the redis package is missing
- Note redis skip behavior in alpha-release planning and test-failure resolution issues
- Update task progress with latest lint, type check, and redis test results

## Testing
- `uv pip show redis`
- `uv run flake8 src tests && echo flake8-ok`
- `uv run mypy src`
- `task check` *(fails: command not found)*
- `uv run pytest tests/integration -m requires_distributed -q`
- `uv run pytest tests/integration/test_distributed_redis_broker.py -vv -rs`


------
https://chatgpt.com/codex/tasks/task_e_68aaa8a26b80833398ccf4b771771176