### PR TITLE
Clamp negative margins in token budgeting and add property tests

### DIFF
--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -405,10 +405,14 @@ class OrchestrationMetrics:
         non-zero samples. If no usage has been observed, the budget
         remains unchanged. A window of only zero-usage samples drives the
         budget to one token. When usage stabilizes, the update converges to
-        ``ceil(u * (1 + margin))`` for constant usage ``u``. See
-        ``docs/algorithms/token_budgeting.md`` for derivation and
+        ``ceil(u * (1 + margin))`` for constant usage ``u``. Negative
+        ``margin`` values are treated as zero.
+
+        See ``docs/algorithms/token_budgeting.md`` for derivation and
         convergence analysis.
         """
+
+        margin = max(margin, 0.0)
 
         total = self._total_tokens()
         delta = total - self._last_total_tokens


### PR DESCRIPTION
## Summary
- prevent negative `margin` from shrinking token budgets and document the behavior
- add hypothesis tests for negative margin and zero-start boundary cases

## Testing
- `task check` *(fails: command not found)*
- `uv run pre-commit run --files src/autoresearch/orchestration/metrics.py tests/unit/test_token_budgeting_hypothesis.py tests/unit/test_token_budget_convergence.py` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `uv run pytest tests/unit/test_token_budget_convergence.py tests/unit/test_token_budgeting_hypothesis.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab3b546d10833398dfed0300e7e0b0