### PR TITLE
Configure pytest-bdd features and document test setup

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -320,6 +320,14 @@ Behavior tests in `tests/behavior/` use **pytest-bdd**. Steps share
 state via the `bdd_context` fixture and scenarios end with assertions
 that validate this context. When writing scenario functions:
 
+The base directory for feature files is set in `pytest.ini`:
+
+```ini
+bdd_features_base_dir = tests/behavior/features
+```
+
+The `pytest-bdd` plugin is provided through the `.[test]` extra.
+
 * Use `@scenario` to map a Gherkin scenario to the test.
 * Accept `bdd_context` (and other fixtures if needed) and assert that
   steps populated expected values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ test = [
     "psutil >=7.0.0",
     "redis >=6.2",
     "pytest-httpx >=0.35.0",
+    "pytest-bdd >=8.1.0",
     "tomli-w >=1.2.0",
 ]
 # Full install: all features for power users and development
@@ -199,6 +200,7 @@ autoresearch = "autoresearch.main:app"
 minversion = "6.0"
 addopts = "-m 'not slow and not requires_ui and not requires_vss and not requires_distributed'"
 testpaths = ["tests/unit", "tests/integration", "tests/behavior"]
+bdd_features_base_dir = "tests/behavior/features"
 python_files = ["test_*.py", "*_steps.py"]
 markers = [
     "behavior: mark behavior (BDD) tests",

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 minversion = 6.0
 addopts = -m 'not slow and not requires_ui and not requires_vss and not requires_distributed'
 testpaths = tests/unit tests/integration tests/behavior
+bdd_features_base_dir = tests/behavior/features
 python_files = test_*.py *_steps.py
 markers =
     behavior: mark behavior (BDD) tests


### PR DESCRIPTION
## Summary
- set `bdd_features_base_dir` so pytest-bdd locates features
- expose pytest-bdd in the `[test]` extra and mirror config in pyproject
- document BDD configuration in testing guidelines

## Testing
- `task check` *(fails: command not found)*
- `uv run pytest tests/behavior -q --maxfail=1`
- `uv run mkdocs build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3b46c42883338bd0739b0fb78864