### PR TITLE
docs: add token budget convergence proof

### DIFF
--- a/docs/algorithms/token_budgeting.md
+++ b/docs/algorithms/token_budgeting.md
@@ -22,15 +22,32 @@ the budget to a minimum of one token.
 
 When usage stabilizes at `u`, the sequence `{b_t}` converges to
 `ceil(u * (1 + m))`. Averaging the last ten non-zero samples prevents
-spikes or idle cycles from skewing the estimate. Let `b* = ceil(u * (1 +
-m))`. Each step sets `b_{t+1}` exactly to `b*`, so convergence occurs in
-one iteration once the usage statistics stabilize.
+spikes or idle cycles from skewing the estimate.
+
+### Proof of Convergence
+
+Assume there exists `T` such that for all `t \ge T` each agent consumes
+exactly `u > 0` tokens. After at most ten cycles the histories examined
+by the algorithm contain only `u`, so for all `t \ge T + 9`
+
+```
+u_t = u,  \bar{u}_t = u,  a_t = u,  \bar{a}_t = u.
+```
+
+Let `b* = ceil(u * (1 + m))`. For all `t \ge T + 9`,
+
+```
+b_{t+1} = \lceil \max(u, u, u, u) (1 + m) \rceil = b*.
+```
+
+Thus the sequence `{b_t}` becomes constant at `b*` and converges within
+ten iterations of usage stabilizing.
 
 ## Simulation
 
-Run `uv run scripts/token_budget_convergence.py` to observe convergence
-for synthetic workloads. As an example,
-`uv run scripts/token_budget_convergence.py --steps 5 --usage 50 --margin 0.2`
+Run [`token_budget_convergence.py`](../../scripts/token_budget_convergence.py)
+to observe convergence for synthetic workloads. As an example,
+`uv run scripts/token_budget_convergence.py --steps 10 --usage 50 --margin 0.2`
 produces
 ```
 step 1: 60
@@ -38,6 +55,11 @@ step 2: 60
 step 3: 60
 step 4: 60
 step 5: 60
+step 6: 60
+step 7: 60
+step 8: 60
+step 9: 60
+step 10: 60
 final budget: 60
 ```
 

--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -399,15 +399,22 @@ class OrchestrationMetrics:
     def suggest_token_budget(self, current_budget: int, *, margin: float = 0.1) -> int:
         """Return an adjusted token budget based on recorded usage.
 
-        ``margin`` controls how aggressively the budget adapts. The
-        calculation considers the most recent per-cycle usage, per-agent
-        historical averages, and the overall average across the last ten
-        non-zero samples. If no usage has been observed, the budget
-        remains unchanged. A window of only zero-usage samples drives the
-        budget to one token. When usage stabilizes, the update converges to
-        ``ceil(u * (1 + margin))`` for constant usage ``u``. See
-        ``docs/algorithms/token_budgeting.md`` for derivation and
-        convergence analysis.
+        Args:
+            current_budget: Current allowance for tokens.
+            margin: Fractional buffer used to inflate the estimated usage.
+
+        Returns:
+            int: Updated budget that tracks recent token usage.
+
+        ``margin`` controls how aggressively the budget adapts. The calculation
+        considers the most recent per-cycle usage, per-agent historical
+        averages, and the overall average across the last ten non-zero samples.
+        If no usage has been observed, the budget remains unchanged. A window of
+        only zero-usage samples drives the budget to one token. When usage
+        stabilizes, the update converges to ``ceil(u * (1 + margin))`` for
+        constant usage ``u``. See
+        ``docs/algorithms/token_budgeting.md#proof-of-convergence`` for a formal
+        proof.
         """
 
         total = self._total_tokens()

--- a/tests/unit/test_token_budget_convergence.py
+++ b/tests/unit/test_token_budget_convergence.py
@@ -1,3 +1,9 @@
+"""Convergence tests for ``suggest_token_budget``.
+
+See ``docs/algorithms/token_budgeting.md#proof-of-convergence`` for the
+mathematical justification.
+"""
+
 import math
 from typing import List
 
@@ -16,7 +22,11 @@ def _run_cycles(metrics: OrchestrationMetrics, usage: List[int], margin: float, 
 
 
 def test_suggest_token_budget_converges() -> None:
-    """Repeated updates reach ceil(u * (1 + m)) for constant usage."""
+    """Repeated updates reach ``ceil(u * (1 + m))`` for constant usage.
+
+    See ``docs/algorithms/token_budgeting.md#proof-of-convergence`` for the
+    full proof.
+    """
     m = OrchestrationMetrics()
     budget = _run_cycles(m, [50] * 8, margin=0.2, start=50)
     assert budget == math.ceil(50 * 1.2)


### PR DESCRIPTION
## Summary
- add formal convergence proof for token budgeting
- reference proof in docstrings and tests

## Testing
- `uv run scripts/token_budget_convergence.py --steps 10 --usage 50 --margin 0.2`
- `uv run --with pytest-httpx --with hypothesis pytest tests/unit/test_token_budget_convergence.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*
- `task check` *(fails: command not found: task)*
- `uv run --with mkdocs --with mkdocs-material --with mkdocstrings mkdocs build` *(fails: No module named 'mkdocstrings_handlers')*
- `uv run --with pre-commit pre-commit run --files docs/algorithms/token_budgeting.md src/autoresearch/orchestration/metrics.py tests/unit/test_token_budget_convergence.py` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3b807ba08333835f9958ad6f7c8c