### PR TITLE
Enforce 90% coverage and test error recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ name: CI
 on:
   workflow_dispatch:
 
+env:
+  COVERAGE_THRESHOLD: 90
+
 jobs:
   verify:
     runs-on: ${{ matrix.os }}
@@ -38,7 +41,7 @@ jobs:
         run: uv run task coverage
       - name: Enforce coverage threshold
         run: |
-          uv run coverage report --fail-under=90
+          uv run coverage report --fail-under=${{ env.COVERAGE_THRESHOLD }}
       - name: Upload coverage
         if: always()
         uses: actions/upload-artifact@v4

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,6 +3,9 @@ version: '3'
 set:
   - e
 
+vars:
+  COVERAGE_THRESHOLD: 90
+
 tasks:
   install:
     cmds:
@@ -114,7 +117,7 @@ tasks:
           --cov-append
       - uv run pytest tests/behavior --cov=src --cov-report=xml --cov-report=term-missing \
           --cov-append
-      - uv run coverage report --fail-under=90
+      - uv run coverage report --fail-under={{.COVERAGE_THRESHOLD}}
       - uv run python scripts/check_token_regression.py --threshold 5
     desc: "Run full test suite with coverage reporting"
 
@@ -134,7 +137,7 @@ tasks:
           --cov=src --cov-report=term-missing --cov-append
       - uv run pytest tests/behavior --cov=src --cov-report=xml --cov-report=term-missing \
           --cov-append
-      - uv run coverage report --fail-under=90
+      - uv run coverage report --fail-under={{.COVERAGE_THRESHOLD}}
       - uv run python scripts/check_token_regression.py --threshold 5
     desc: "Run linting, type checks and fast tests with coverage"
 

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -35,8 +35,9 @@ task coverage          # full suite with coverage and regression checks
 
 Run `task coverage` before committing to execute the full suite with
 coverage and token regression checks. The command fails if line coverage
-drops below 90%. CI stores a baseline `coverage.xml` in
-`baseline/coverage.xml` and compares future runs against it to detect
+drops below 90%. The threshold is controlled by the `COVERAGE_THRESHOLD`
+variable, set to `90` in the Taskfile and CI workflow. CI stores a baseline
+`coverage.xml` in `baseline/coverage.xml` and compares future runs against it to detect
 regressions. To perform the comparison locally, run:
 
 ```bash

--- a/tests/unit/test_error_recovery.py
+++ b/tests/unit/test_error_recovery.py
@@ -1,0 +1,49 @@
+"""Unit tests for :mod:`autoresearch.error_recovery`."""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from autoresearch.error_recovery import retry_with_backoff
+
+
+def test_retry_with_backoff_succeeds_on_first_try(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return after a single attempt when the action succeeds immediately."""
+    attempts: list[int] = []
+
+    def action() -> bool:
+        attempts.append(1)
+        return True
+
+    monkeypatch.setattr(time, "sleep", lambda _delay: None)
+
+    count = retry_with_backoff(action, max_retries=3, base_delay=0.01)
+
+    assert count == 1
+    assert len(attempts) == 1
+
+
+def test_retry_with_backoff_retries_until_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry until the action succeeds before reaching the retry limit."""
+    responses = iter([False, False, True])
+
+    def action() -> bool:
+        return next(responses)
+
+    monkeypatch.setattr(time, "sleep", lambda _delay: None)
+
+    count = retry_with_backoff(action, max_retries=5, base_delay=0.01)
+
+    assert count == 3
+
+
+def test_retry_with_backoff_raises_after_max_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Raise ``RuntimeError`` when the action never succeeds."""
+    monkeypatch.setattr(time, "sleep", lambda _delay: None)
+
+    def action() -> bool:
+        return False
+
+    with pytest.raises(RuntimeError):
+        retry_with_backoff(action, max_retries=2, base_delay=0.01)


### PR DESCRIPTION
## Summary
- enforce shared 90% coverage threshold in Taskfile and CI workflow
- document coverage task and threshold configuration
- add tests for `retry_with_backoff` error recovery helper

## Testing
- `task verify` *(fails: command interrupted)*
- `uv run mkdocs build` *(fails: command not found)*
- `uv run coverage report src/autoresearch/error_recovery.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab3b74ee588333afa41e1b07561aa9