### PR TITLE
docs: add token budget convergence proof

### DIFF
--- a/docs/algorithms/token_budgeting.md
+++ b/docs/algorithms/token_budgeting.md
@@ -20,11 +20,25 @@ the budget to a minimum of one token.
 
 ## Convergence
 
-When usage stabilizes at `u`, the sequence `{b_t}` converges to
-`ceil(u * (1 + m))`. Averaging the last ten non-zero samples prevents
-spikes or idle cycles from skewing the estimate. Let `b* = ceil(u * (1 +
-m))`. Each step sets `b_{t+1}` exactly to `b*`, so convergence occurs in
-one iteration once the usage statistics stabilize.
+Let usage settle at a constant value `u` and define
+`b* = ceil(u * (1 + m))`. Averaging the last ten non-zero samples blocks
+isolated spikes from influencing the limit.
+
+### Proof
+
+Assume there exists `T` such that for all `t >= T`, every agent consumes
+`u` tokens. Because `\bar{u}_t` and each `\bar{a}_{i,t}` average the last
+ten non-zero values, for `t >= T + 10` these statistics equal `u`. At that
+point the update becomes
+
+\[
+b_{t+1} = \left\lceil \max(u, u, u, u) (1 + m) \right\rceil = b*.
+\]
+
+Since `b*` is a fixed point of the update rule, the sequence `{b_t}` is
+constant for `t > T + 10`. Thus `{b_t}` converges to `b*`. Ten consecutive
+zero-usage cycles after activity similarly force all candidates to zero,
+yielding the fixed point `b_t = 1`.
 
 ## Simulation
 

--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -408,8 +408,8 @@ class OrchestrationMetrics:
         ``ceil(u * (1 + margin))`` for constant usage ``u``. Negative
         ``margin`` values are treated as zero.
 
-        See ``docs/algorithms/token_budgeting.md`` for derivation and
-        convergence analysis.
+        See ``docs/algorithms/token_budgeting.md`` for derivation and a
+        formal proof of convergence.
         """
 
         margin = max(margin, 0.0)

--- a/tests/unit/test_token_budget_convergence.py
+++ b/tests/unit/test_token_budget_convergence.py
@@ -1,3 +1,8 @@
+"""Convergence checks for ``suggest_token_budget``.
+
+The mathematical proof appears in ``docs/algorithms/token_budgeting.md``.
+"""
+
 import math
 from typing import List
 
@@ -16,7 +21,10 @@ def _run_cycles(metrics: OrchestrationMetrics, usage: List[int], margin: float, 
 
 
 def test_suggest_token_budget_converges() -> None:
-    """Repeated updates reach ceil(u * (1 + m)) for constant usage."""
+    """Repeated updates reach ``ceil(u * (1 + m))`` for constant usage.
+
+    See ``docs/algorithms/token_budgeting.md`` for the formal proof.
+    """
     m = OrchestrationMetrics()
     budget = _run_cycles(m, [50] * 8, margin=0.2, start=50)
     assert budget == math.ceil(50 * 1.2)


### PR DESCRIPTION
## Summary
- add formal convergence proof for token budget adaptation
- cite convergence proof in `suggest_token_budget` docstring
- reference proof in token budget convergence tests

## Testing
- `uv run scripts/token_budget_convergence.py --steps 5 --usage 50 --margin 0.2`
- `task check` *(fails: command not found)*
- `uv run pre-commit run --files docs/algorithms/token_budgeting.md src/autoresearch/orchestration/metrics.py tests/unit/test_token_budget_convergence.py` *(fails: .pre-commit-config.yaml is not a file)*
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'tomli_w')*


------
https://chatgpt.com/codex/tasks/task_e_68ab3eee2654833396a94cde8347305c