### PR TITLE
feat: install go task and document test status

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 As of **August 24, 2025**, these results reflect attempts to exercise the
 development workflow. Environment provisioning used `scripts/codex_setup.sh`
-to install `task` and required development dependencies. Refer to the
+to install `task` (v3.44.1) and required development dependencies. Refer to the
 [roadmap](ROADMAP.md) and [release plan](docs/release_plan.md) for
 scheduled milestones.
 

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -234,8 +234,9 @@ These behavior test issues remain open until the test suite passes.
 - `uv run flake8 src tests` – passed
 - `uv run mypy src` – passed
 - token budget tests marked xfail
-- `task check` – command not found
-- `task verify` – not run
+- `task check` – failed; `tests/unit/test_monitor_cli.py::test_monitor_metrics`
+  asserted `130 == 0`
+- `task verify` – failed on the same monitor CLI metrics tests
 - `task coverage` – not run
 - `uv run pytest tests/integration -m requires_distributed -q` – skipped 5 tests
   (redis missing)

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -84,6 +84,8 @@ uv sync --extra dev-minimal
 
 # Install Go Task inside the virtual environment
 curl -sL https://taskfile.dev/install.sh | sh -s -- -b ./.venv/bin
+# Verify Task installation by printing its version
+./.venv/bin/task --version
 
 # Install optional extras on demand
 if [ "${AR_INSTALL_UI:-0}" -eq 1 ]; then
@@ -148,7 +150,8 @@ if (( ${#missing_tools[@]} )) || (( ${#missing_pkgs[@]} )); then
 fi
 
 # Post-install version checks
-task --version >/dev/null 2>&1 || { echo 'task is required but missing' >&2; exit 1; }
+# Ensure Task is available and report its version
+task --version || { echo 'task is required but missing' >&2; exit 1; }
 flake8 --version >/dev/null 2>&1 || { echo 'flake8 is required but missing' >&2; exit 1; }
 mypy --version >/dev/null 2>&1 || { echo 'mypy is required but missing' >&2; exit 1; }
 pytest --version >/dev/null 2>&1 || { echo 'pytest is required but missing' >&2; exit 1; }


### PR DESCRIPTION
## Summary
- verify Go Task during codex setup
- record current task test results in status docs

## Testing
- `./.venv/bin/task --version`
- `./.venv/bin/task check` *(fails: tests/unit/test_monitor_cli.py::test_monitor_metrics)*
- `./.venv/bin/task verify` *(fails: tests/unit/test_monitor_cli.py::test_monitor_metrics)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3b70f33883338d546dbc920a7425