### PR TITLE
Register pytest-bdd features directory

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -327,7 +327,9 @@ The base directory for feature files is set in `pytest.ini`:
 bdd_features_base_dir = tests/behavior/features
 ```
 
-The `pytest-bdd` plugin is provided through the `.[test]` extra.
+The `pytest-bdd` plugin is provided through the `.[test]` extra and registered
+in `tests/behavior/conftest.py` so `bdd_features_base_dir` is honored when
+loading Gherkin files.
 
 * Use `@scenario` to map a Gherkin scenario to the test.
 * Accept `bdd_context` (and other fixtures if needed) and assert that

--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -10,6 +10,8 @@ if str(ROOT) not in sys.path:
 import os  # noqa: E402
 import pytest  # noqa: E402
 
+pytest_plugins = ("pytest_bdd",)
+
 from autoresearch.api import reset_request_log  # noqa: E402
 from tests.conftest import reset_limiter_state, VSS_AVAILABLE  # noqa: E402
 from autoresearch.orchestration.state import QueryState  # noqa: E402


### PR DESCRIPTION
## Summary
- ensure pytest-bdd plugin is registered for behavior tests
- document behavior test plugin setup in testing guidelines

## Testing
- `uv run pytest tests/behavior -k ""` *(fails: AttributeError: 'NoneType' object...)*
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68ab4ea03fc48333b5bb9c1e1d01a81d