### PR TITLE
Fix token budget rounding with decimal margins

### DIFF
--- a/docs/algorithms/token_budgeting.md
+++ b/docs/algorithms/token_budgeting.md
@@ -13,6 +13,10 @@ and `\bar{a}_t = \max_i \bar{a}_{i,t}`. With margin `m`, the update is
 b_{t+1} = \left\lceil \max(u_t, \bar{u}_t, a_t, \bar{a}_t) (1 + m) \right\rceil.
 \]
 
+Negative margins are clamped to zero to avoid suggesting budgets below
+observed usage. The implementation subtracts a tiny epsilon before the
+ceiling to prevent floating-point drift from inflating the result.
+
 When the new target differs from the current budget the algorithm
 immediately adjusts. If no usage has ever been recorded, the budget is
 left unchanged. Ten consecutive zero-usage samples after activity shrink


### PR DESCRIPTION
## Summary
- avoid floating point inflation in `suggest_token_budget` by subtracting a tiny epsilon before `ceil`
- document margin clamping and rounding safeguard
- test convergence for decimal and negative margins

## Testing
- `uv run pytest tests/unit/test_token_budget_convergence.py -q`
- `uv run mkdocs build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e8a1ffc83339229aea74e2ff8a1