### PR TITLE
Prevent monitoring command from inflating query metrics

### DIFF
--- a/docs/specs/monitor.md
+++ b/docs/specs/monitor.md
@@ -2,8 +2,8 @@
 
 Interactive monitoring commands for Autoresearch.
 
-The metrics command increments the `autoresearch_queries_total` counter each
-time system statistics are collected. Monitor commands now skip storage
+The metrics command reports system statistics without changing the
+`autoresearch_queries_total` counter. Monitor commands now skip storage
 initialization so metrics can be displayed without a configured database.
 
 ## Traceability

--- a/src/autoresearch/monitor/__init__.py
+++ b/src/autoresearch/monitor/__init__.py
@@ -65,7 +65,6 @@ def _calculate_health(cpu: float, mem: float) -> str:
 def _collect_system_metrics() -> Dict[str, Any]:
     """Collect basic CPU, memory, and GPU metrics."""
     metrics: Dict[str, Any] = {}
-    orch_metrics.QUERY_COUNTER.inc()
     try:
         from ..resource_monitor import _get_gpu_stats
         from .system_monitor import SystemMonitor

--- a/tests/unit/test_monitor_cli.py
+++ b/tests/unit/test_monitor_cli.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Dict, List
 
+import psutil  # type: ignore
 from typer.testing import CliRunner
 
 try:
@@ -12,6 +13,7 @@ from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.main import app
 from autoresearch.models import QueryResponse
+from autoresearch.orchestration import metrics as orch_metrics
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.search import Search
 
@@ -64,9 +66,35 @@ def test_monitor_prompts_and_passes_callbacks(monkeypatch):
 
 def test_monitor_metrics(monkeypatch):
     runner = CliRunner()
-    expected = {"cpu_percent": 1.0, "memory_percent": 2.0}
-    monkeypatch.setattr("autoresearch.monitor._collect_system_metrics", lambda: expected)
+
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: type("C", (), {})())
+    orch_metrics.reset_metrics()
+    orch_metrics.QUERY_COUNTER._value.set(5)
+    orch_metrics.TOKENS_IN_COUNTER._value.set(7)
+    orch_metrics.TOKENS_OUT_COUNTER._value.set(9)
+
+    class Mem:
+        percent = 2.0
+        used = 2 * 1024 * 1024
+
+    class Proc:
+        def memory_info(self):
+            return type("I", (), {"rss": 3 * 1024 * 1024})()
+
+    monkeypatch.setattr(psutil, "cpu_percent", lambda interval=None: 1.0)
+    monkeypatch.setattr(psutil, "virtual_memory", lambda: Mem)
+    monkeypatch.setattr(psutil, "Process", lambda: Proc())
+    monkeypatch.setattr("autoresearch.resource_monitor._get_gpu_stats", lambda: (4.0, 5.0))
+
     result = runner.invoke(app, ["monitor"])
     assert result.exit_code == 0
-    assert json.loads(result.stdout) == expected
-    assert result.stdout.strip() == json.dumps(expected)
+    data = json.loads(result.stdout)
+    assert data["cpu_percent"] == 1.0
+    assert data["memory_percent"] == 2.0
+    assert data["memory_used_mb"] == 2.0
+    assert data["process_memory_mb"] == 3.0
+    assert data["gpu_percent"] == 4.0
+    assert data["gpu_memory_mb"] == 5.0
+    assert data["queries_total"] == 5
+    assert data["tokens_in_total"] == 7
+    assert data["tokens_out_total"] == 9


### PR DESCRIPTION
## Summary
- avoid incrementing query counter when collecting system metrics
- expand CLI test to assert system and counter values
- document that metrics command is read-only for query totals

## Testing
- `uv run flake8 src/autoresearch/monitor/__init__.py tests/unit/test_monitor_cli.py`
- `uv run black src/autoresearch/monitor/__init__.py tests/unit/test_monitor_cli.py`
- `uv run pytest tests/unit/test_monitor_cli.py`
- `PYTHONPATH=src uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68ab4e9616b88333800c1281beac5cc1