### PR TITLE
Harden API auth middleware and expand tests

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -284,6 +284,14 @@ curl -H "Authorization: Bearer $AUTORESEARCH_API__BEARER_TOKEN" \
   -d '{"query": "test"}' http://localhost:8000/query
 ```
 
+Credentials may also be specified directly in `autoresearch.toml`:
+
+```toml
+[api]
+api_key = "mysecret"
+bearer_token = "mytoken"
+```
+
 Generate random tokens with `generate_bearer_token`:
 
 ```python


### PR DESCRIPTION
## Summary
- enforce constant-time API key comparison and set role before returning 401s
- test role assignment and invalid credential paths in API auth integration tests
- document API authentication with config file examples

## Testing
- ⚠️ `./.venv/bin/task check` *(interrupted: exit status 2)*
- ⚠️ `./.venv/bin/task verify` *(interrupted by KeyboardInterrupt)*
- ✅ `uv run pytest tests/integration/test_api_auth.py -q`
- ✅ `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68ab4e9a9378833383ff5037b69c4cfc