### PR TITLE
docs: record failing test environment

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,10 +1,12 @@
 # Status
 
-As of **August 24, 2025**, these results reflect the current development
-workflow. Dependencies were installed with `uv sync --extra dev --extra test`.
-The `task` CLI was unavailable, so commands ran directly via `uv run`.
-Refer to the [roadmap](ROADMAP.md) and [release plan](docs/release_plan.md) for
-scheduled milestones.
+As of **August 24, 2025**, a fresh clone was brought up with `uv sync`, but the
+Go Task binary was missing and had to be skipped. Manual installation of
+`pytest-httpx` and `pytest-bdd` allowed initial collection, yet several dev
+dependencies (`tomli_w`, `freezegun`, `hypothesis`) were absent and caused test
+collection to fail. These results capture the current state; see the
+[roadmap](ROADMAP.md) and [release plan](docs/release_plan.md) for scheduled
+milestones.
 
 ## Lint, type checks, and spec tests
 ```text
@@ -12,26 +14,28 @@ uv run flake8 src tests
 uv run mypy src
 uv run python scripts/check_spec_tests.py
 ```
-Result: all passed
+Result: not run; environment validation failed before checks completed
 
 ## Unit tests
 ```text
 uv run pytest tests/unit -q
 ```
-Result: 1 failed, 405 passed, 4 skipped, 24 deselected, 2 xfailed,
-31 warnings. Failure: `tests/unit/test_metrics_token_budget_spec.py::test_token_budget_expands_then_shrinks`
+Result: exited during collection with `ModuleNotFoundError` for `tomli_w`,
+`freezegun`, and `hypothesis`
 
 ## Integration tests
 ```text
 uv run pytest tests/integration -m "not slow and not requires_ui and not requires_vss and not requires_distributed" -q
 ```
-Result: 193 passed, 4 skipped, 86 deselected, 5 warnings
+Result: collection aborted with `ModuleNotFoundError: tomli_w`
 
 ## Behavior tests
 ```text
 uv run pytest tests/behavior -q
 ```
-Result: numerous failures; suite requires stabilization
+Result: feature discovery fails; running
+`uv run pytest tests/behavior/features/api_orchestrator_integration.feature -q`
+reports `ERROR: not found: ... (no match in any of [<Dir features>])`
 
 ## Coverage
-Coverage not collected in this run
+Coverage not collected; tests did not run to completion

--- a/issues/fix-pytest-bdd-feature-discovery.md
+++ b/issues/fix-pytest-bdd-feature-discovery.md
@@ -4,7 +4,8 @@
 Running `uv run pytest tests/behavior/features/api_orchestrator_integration.feature -q`
 reports `ERROR: not found: ... (no match in any of [<Dir features>])` because
 `pytest-bdd` cannot discover the feature directory. Behavior tests cannot
-execute reliably.
+execute reliably. This was reproduced on **August 24, 2025** after manually
+installing `pytest-bdd`.
 
 ## Acceptance Criteria
 - `uv run pytest tests/behavior/features/api_orchestrator_integration.feature -q`

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -1,15 +1,16 @@
 # Prepare first alpha release
 
 ## Context
-Version 0.1.0a1 will be the project's first public alpha. After running
-`scripts/codex_setup.sh`, `task check` and `task verify` execute but both
-fail at `tests/unit/test_monitor_cli.py` asserting `130 == 0`. Behavior
-tests still cannot collect because `pytest-bdd` does not discover the
-feature directory. Integration tests now run with `redis` installed, and
-required extras such as `pytest_httpx` and `tomli_w` are available.
-Coverage remains at **24%**, far below the **90%** target, the TestPyPI
-upload returns HTTP 403, and release notes and packaging steps are
-incomplete.
+Version 0.1.0a1 will be the project's first public alpha. A fresh clone on
+**August 24, 2025** lacked the Go Task binary and dev extras such as
+`tomli_w`, `freezegun`, and `hypothesis`, so `task check` and `task verify`
+could not run. After manually installing `pytest-httpx` and `pytest-bdd`, unit
+tests still aborted during collection with `ModuleNotFoundError: tomli_w`, and
+`uv run pytest tests/behavior/features/api_orchestrator_integration.feature -q`
+reported "no match in any of [<Dir features>]". Integration tests execute with
+`redis` installed, but coverage remains at **24%**, far below the **90%**
+target. The TestPyPI upload returns HTTP 403, and release notes and packaging
+steps are incomplete.
 
 ## Milestone
 

--- a/issues/resolve-test-failures-and-task-tooling.md
+++ b/issues/resolve-test-failures-and-task-tooling.md
@@ -8,6 +8,11 @@
  API authentication, concurrent query handling, Redis broker detection, and
  monitor CLI metrics. Integration and behavior test suites remain unreliable.
 
+ A fresh clone on **August 24, 2025** lacked Go Task and several dev
+ dependencies. Manual installs of `pytest-httpx` and `pytest-bdd` succeeded, yet
+ `uv run pytest` still exited during collection with
+ `ModuleNotFoundError` for `tomli_w`, `freezegun`, and `hypothesis`.
+
  Redis-dependent integration tests skip cleanly when `redis` is missing
  (verified 2025-08-24).
 


### PR DESCRIPTION
## Summary
- document missing tooling and dev dependencies in STATUS.md
- refresh issue tickets with current environment details

## Testing
- `task check` *(fails: command not found)*
- `uv run pytest tests/unit/test_config_reload.py -q` *(fails: ModuleNotFoundError: tomli_w)*
- `uv run pytest tests/behavior/features/api_orchestrator_integration.feature -q` *(fails: feature not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab734eea0c833394541493ee3b1026