### PR TITLE
Align token budget heuristic with spec

### DIFF
--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -427,7 +427,7 @@ class OrchestrationMetrics:
         if all(u == 0 for u in recent_usage):
             if self._ever_used_tokens:
                 return 1
-            return max(current_budget, 1)
+            return current_budget
 
         avg_used = _mean_last_nonzero(self.token_usage_history)
         latest = recent_usage[-1]
@@ -453,6 +453,6 @@ class OrchestrationMetrics:
         # rounding that would otherwise inflate budgets (e.g. ``55.0000000001``
         # becoming ``56``).
         scaled = max(usage_candidates) * (1 + margin)
-        desired = max(math.ceil(scaled - 1e-9), 1)
+        desired = math.ceil(scaled - 1e-9)
 
-        return desired
+        return max(desired, 1)

--- a/tests/unit/test_token_budgeting_hypothesis.py
+++ b/tests/unit/test_token_budgeting_hypothesis.py
@@ -79,7 +79,7 @@ def test_negative_margin_treated_as_zero(start: int, usage: int, margin: float) 
 
 
 @given(margin=st.floats(min_value=-1.0, max_value=2.0, allow_nan=False))
-def test_budget_floor_with_zero_start(margin: float) -> None:
-    """A zero starting budget is elevated to one token."""
+def test_zero_start_remains_zero_without_usage(margin: float) -> None:
+    """A zero starting budget stays zero until usage occurs."""
     metrics = OrchestrationMetrics()
-    assert metrics.suggest_token_budget(0, margin=margin) == 1
+    assert metrics.suggest_token_budget(0, margin=margin) == 0


### PR DESCRIPTION
## Summary
- fix `suggest_token_budget` to keep zero budgets unchanged until usage is recorded and apply ceiling with epsilon before enforcing a floor of one
- expand token budget convergence tests to cover zero-start and lower-bound cases
- update hypothesis property tests for zero starting budgets

## Testing
- `uv run black --check src/autoresearch/orchestration/metrics.py tests/unit/test_token_budget_convergence.py tests/unit/test_token_budgeting_hypothesis.py`
- `uv run flake8 src/autoresearch/orchestration/metrics.py tests/unit/test_token_budget_convergence.py tests/unit/test_token_budgeting_hypothesis.py`
- `uv run pytest tests/unit/test_token_budget_convergence.py`
- `uv run pytest tests/unit/test_token_budgeting_hypothesis.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab79e79e848333bea8da2397079058