### PR TITLE
Refine API auth responses

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -27,9 +27,10 @@ variables. Common options include:
 Setting `AUTORESEARCH_API__API_KEY` enables a single shared key while
 `AUTORESEARCH_API__API_KEYS` maps multiple keys to roles. Use
 `AUTORESEARCH_API__BEARER_TOKEN` to require an `Authorization: Bearer` header.
-Requests missing valid credentials return **401**. If a key is valid but lacks
-the required permission, the server responds with **403**. Modify
-`AUTORESEARCH_API__ROLE_PERMISSIONS` to assign actions to roles.
+Requests without credentials return **401**. Invalid API keys or bearer
+tokens receive **403**. Authenticated clients lacking permission also
+receive **403**. Modify `AUTORESEARCH_API__ROLE_PERMISSIONS` to assign
+actions to roles.
 
 Restart the server after changing these values.
 
@@ -326,8 +327,9 @@ Use these HTTP headers when authentication is enabled:
 - `X-API-Key`: API key from `[api].api_key` or the `[api].api_keys` mapping.
 - `Authorization: Bearer <token>`: bearer token from `[api].bearer_token`.
 
-Requests with missing or invalid credentials receive a **401 Unauthorized**
-response. Authenticated clients lacking permission receive **403 Forbidden**.
+Requests without credentials receive a **401 Unauthorized** response.
+Invalid credentials or authenticated clients lacking permission receive
+**403 Forbidden**.
 
 ### Role permissions
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -11,6 +11,9 @@ credentials on every request and assigns a role to the connection. Endpoints
 use a `require_permission` dependency to verify that the role has access to a
 given resource.
 
+Requests without credentials return **401**. Invalid API keys or bearer
+tokens and authenticated clients lacking permission return **403**.
+
 ## Configuration
 
 Authentication settings live in `autoresearch.toml` under `[api]` or via
@@ -35,12 +38,22 @@ permissions constrain the impact of a leaked credential.
 
 - Modules
   - [src/autoresearch/api/][m1]
-- Tests
-  - [tests/unit/test_api.py][t1]
-  - [tests/unit/test_api_error_handling.py][t2]
-  - [tests/unit/test_api_imports.py][t3]
+  - Tests
+    - [tests/unit/test_api.py][t1]
+    - [tests/unit/test_api_error_handling.py][t2]
+    - [tests/unit/test_api_imports.py][t3]
+    - [tests/unit/test_api_auth_middleware.py][t4]
+    - [tests/unit/test_api_auth_deps.py][t5]
+    - [tests/integration/test_api_auth.py][t6]
+    - [tests/integration/test_api_streaming.py][t7]
+    - [tests/integration/test_api_docs.py][t8]
 
 [m1]: ../../src/autoresearch/api/
 [t1]: ../../tests/unit/test_api.py
 [t2]: ../../tests/unit/test_api_error_handling.py
 [t3]: ../../tests/unit/test_api_imports.py
+[t4]: ../../tests/unit/test_api_auth_middleware.py
+[t5]: ../../tests/unit/test_api_auth_deps.py
+[t6]: ../../tests/integration/test_api_auth.py
+[t7]: ../../tests/integration/test_api_streaming.py
+[t8]: ../../tests/integration/test_api_docs.py

--- a/src/autoresearch/api/middleware.py
+++ b/src/autoresearch/api/middleware.py
@@ -91,10 +91,14 @@ class AuthMiddleware(BaseHTTPMiddleware):
                         match_role = role
             if match_role:
                 return match_role, None
-            return "anonymous", JSONResponse({"detail": "Invalid API key"}, status_code=401)
+            if key:
+                return "anonymous", JSONResponse({"detail": "Invalid API key"}, status_code=403)
+            return "anonymous", None
         if cfg.api_key:
             if not (key and secrets.compare_digest(key, cfg.api_key)):
-                return "anonymous", JSONResponse({"detail": "Invalid API key"}, status_code=401)
+                if key:
+                    return "anonymous", JSONResponse({"detail": "Invalid API key"}, status_code=403)
+                return "anonymous", None
             return "user", None
         return "anonymous", None
 
@@ -114,6 +118,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
             if cfg.bearer_token
             else False
         )
+        provided_key = bool(api_key)
+        provided_token = bool(token)
 
         if token_valid and not key_valid:
             role = "user"
@@ -123,9 +129,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         auth_configured = bool(cfg.api_keys or cfg.api_key or cfg.bearer_token)
         if auth_configured and not (key_valid or token_valid):
+            if provided_key:
+                return key_error or JSONResponse({"detail": "Invalid API key"}, status_code=403)
+            if provided_token:
+                return JSONResponse({"detail": "Invalid token"}, status_code=403)
             if cfg.api_keys or cfg.api_key:
-                return key_error or JSONResponse({"detail": "Invalid API key"}, status_code=401)
-            return JSONResponse({"detail": "Invalid token"}, status_code=401)
+                return JSONResponse({"detail": "Missing API key"}, status_code=401)
+            return JSONResponse({"detail": "Missing token"}, status_code=401)
 
         return await call_next(request)
 

--- a/tests/integration/test_api_auth.py
+++ b/tests/integration/test_api_auth.py
@@ -35,7 +35,7 @@ def test_http_bearer_token(monkeypatch, api_client):
     assert resp.status_code == 200
 
     resp = api_client.post("/query", json={"query": "q"}, headers={"Authorization": "Bearer bad"})
-    assert resp.status_code == 401
+    assert resp.status_code == 403
 
 
 def test_role_assignments(monkeypatch, api_client):
@@ -57,7 +57,7 @@ def test_role_assignments(monkeypatch, api_client):
     assert resp_token.json() == {"role": "user"}
 
     resp_bad = api_client.get("/whoami", headers={"X-API-Key": "bad"})
-    assert resp_bad.status_code == 401
+    assert resp_bad.status_code == 403
 
     resp_missing = api_client.get("/whoami")
     assert resp_missing.status_code == 401
@@ -111,7 +111,7 @@ def test_invalid_api_key(monkeypatch, api_client):
     cfg.api.api_keys = {"good": "user"}
 
     bad = api_client.post("/query", json={"query": "q"}, headers={"X-API-Key": "bad"})
-    assert bad.status_code == 401
+    assert bad.status_code == 403
 
 
 def test_api_key_or_token(monkeypatch, api_client):
@@ -180,11 +180,11 @@ def test_query_status_and_cancel(monkeypatch, api_client):
 
 
 def test_invalid_bearer_token(monkeypatch, api_client):
-    """Invalid bearer token should return 401."""
+    """Invalid bearer token should return 403."""
     cfg = _setup(monkeypatch)
     cfg.api.bearer_token = generate_bearer_token()
     resp = api_client.post("/query", json={"query": "q"}, headers={"Authorization": "Bearer wrong"})
-    assert resp.status_code == 401
+    assert resp.status_code == 403
 
 
 def test_missing_bearer_token(monkeypatch, api_client):
@@ -220,7 +220,7 @@ def test_docs_protected(monkeypatch, api_client):
 
 
 def test_invalid_key_and_token(monkeypatch, api_client):
-    """Both credentials invalid results in 401."""
+    """Both credentials invalid results in 403."""
     cfg = _setup(monkeypatch)
     cfg.api.api_key = "secret"
     cfg.api.bearer_token = generate_bearer_token()
@@ -229,7 +229,7 @@ def test_invalid_key_and_token(monkeypatch, api_client):
         json={"query": "q"},
         headers={"X-API-Key": "wrong", "Authorization": "Bearer bad"},
     )
-    assert resp.status_code == 401
+    assert resp.status_code == 403
 
 
 def test_query_status_permission_denied(monkeypatch, api_client):

--- a/tests/integration/test_api_docs.py
+++ b/tests/integration/test_api_docs.py
@@ -25,12 +25,12 @@ def test_docs_endpoints_require_auth(monkeypatch, api_client):
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
 
     assert api_client.get("/docs").status_code == 401
+    bad = api_client.get("/docs", headers={"X-API-Key": "bad"})
+    assert bad.status_code == 403
     ok = api_client.get("/docs", headers={"X-API-Key": "secret"})
     assert ok.status_code == 200
 
-    openapi = api_client.get(
-        "/openapi.json", headers={"X-API-Key": "secret"}
-    )
+    openapi = api_client.get("/openapi.json", headers={"X-API-Key": "secret"})
     assert openapi.status_code == 200
 
 

--- a/tests/integration/test_api_streaming.py
+++ b/tests/integration/test_api_streaming.py
@@ -1,4 +1,3 @@
-
 import asyncio
 import json
 import time
@@ -45,7 +44,9 @@ def test_config_webhooks(monkeypatch, api_client, httpx_mock):
     monkeypatch.setattr(
         Orchestrator,
         "run_query",
-        lambda q, c, callbacks=None, **k: QueryResponse(answer="ok", citations=[], reasoning=[], metrics={}),
+        lambda q, c, callbacks=None, **k: QueryResponse(
+            answer="ok", citations=[], reasoning=[], metrics={}
+        ),
     )
 
     httpx_mock.add_response(method="POST", url="http://hook", status_code=200)
@@ -70,7 +71,9 @@ def test_batch_query_pagination(monkeypatch, api_client):
     monkeypatch.setattr(
         Orchestrator,
         "run_query",
-        lambda q, c, callbacks=None, **k: QueryResponse(answer=q, citations=[], reasoning=[], metrics={}),
+        lambda q, c, callbacks=None, **k: QueryResponse(
+            answer=q, citations=[], reasoning=[], metrics={}
+        ),
     )
 
     payload = {"queries": [{"query": "q1"}, {"query": "q2"}, {"query": "q3"}, {"query": "q4"}]}
@@ -93,7 +96,9 @@ def test_batch_query_defaults(monkeypatch, api_client):
     monkeypatch.setattr(
         Orchestrator,
         "run_query",
-        lambda q, c, callbacks=None, **k: QueryResponse(answer=q, citations=[], reasoning=[], metrics={}),
+        lambda q, c, callbacks=None, **k: QueryResponse(
+            answer=q, citations=[], reasoning=[], metrics={}
+        ),
     )
 
     payload = {"queries": [{"query": "a"}, {"query": "b"}, {"query": "c"}]}
@@ -114,14 +119,16 @@ def test_api_key_roles_integration(monkeypatch, api_client):
     monkeypatch.setattr(
         Orchestrator,
         "run_query",
-        lambda q, c, callbacks=None, **k: QueryResponse(answer="ok", citations=[], reasoning=[], metrics={}),
+        lambda q, c, callbacks=None, **k: QueryResponse(
+            answer="ok", citations=[], reasoning=[], metrics={}
+        ),
     )
 
     resp = api_client.post("/query", json={"query": "q"}, headers={"X-API-Key": "secret"})
     assert resp.status_code == 200
 
     bad = api_client.post("/query", json={"query": "q"}, headers={"X-API-Key": "bad"})
-    assert bad.status_code == 401
+    assert bad.status_code == 403
 
 
 def test_stream_requires_api_key(monkeypatch, api_client):
@@ -144,6 +151,9 @@ def test_stream_requires_api_key(monkeypatch, api_client):
         "POST", "/query/stream", json={"query": "q"}, headers={"X-API-Key": "secret"}
     ) as resp:
         assert resp.status_code == 200
+
+    bad = api_client.post("/query/stream", json={"query": "q"}, headers={"X-API-Key": "bad"})
+    assert bad.status_code == 403
 
 
 def test_batch_query_async_order(monkeypatch, api_client):

--- a/tests/unit/test_api_auth_middleware.py
+++ b/tests/unit/test_api_auth_middleware.py
@@ -1,4 +1,11 @@
+import asyncio
+from types import SimpleNamespace
+
+from fastapi import Request
+from starlette.responses import Response
+
 from autoresearch.api.middleware import AuthMiddleware
+from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import APIConfig, ConfigModel
 
 
@@ -16,4 +23,34 @@ def test_resolve_role_invalid_key():
     role, err = middleware._resolve_role("bad", cfg.api)
     assert role == "anonymous"
     assert err is not None
-    assert err.status_code == 401
+    assert err.status_code == 403
+
+
+def test_resolve_role_missing_key():
+    cfg = ConfigModel(api=APIConfig(api_keys={"good": "user"}))
+    middleware = AuthMiddleware(lambda *_: None)
+    role, err = middleware._resolve_role(None, cfg.api)
+    assert role == "anonymous"
+    assert err is None
+
+
+def test_dispatch_invalid_token(monkeypatch):
+    cfg = ConfigModel(api=APIConfig(bearer_token="secret"))
+    ConfigLoader.reset_instance()
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    app = SimpleNamespace(state=SimpleNamespace(config_loader=ConfigLoader()))
+    scope = {
+        "type": "http",
+        "path": "/",
+        "method": "GET",
+        "headers": [(b"authorization", b"Bearer bad")],
+        "app": app,
+    }
+    request = Request(scope)
+    middleware = AuthMiddleware(lambda *_: None)
+
+    async def call_next(_):
+        return Response("ok")
+
+    resp = asyncio.run(middleware.dispatch(request, call_next))
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- distinguish missing versus invalid credentials in API middleware
- document auth configuration and status codes
- broaden unit and integration tests for auth

## Testing
- `task check` *(fails: command not found)*
- `uv run black --check src/autoresearch/api/middleware.py tests/integration/test_api_auth.py tests/integration/test_api_streaming.py tests/integration/test_api_docs.py tests/unit/test_api_auth_middleware.py`
- `uv run flake8 src/autoresearch/api/middleware.py tests/integration/test_api_auth.py tests/integration/test_api_streaming.py tests/integration/test_api_docs.py tests/unit/test_api_auth_middleware.py`
- `uv run pytest tests/unit/test_api_auth_middleware.py tests/unit/test_api_auth_deps.py tests/integration/test_api_auth.py tests/integration/test_api_streaming.py tests/integration/test_api_docs.py`
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68ab79eb8db4833396a9fc42682e176a