### PR TITLE
chore: initialize counters for monitor metrics

### DIFF
--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -28,5 +28,6 @@ uv run autoresearch monitor
 ```
 
 The command outputs a single JSON object containing `cpu_percent`,
-`memory_percent`, token counters, and more, then exits with status code 0.
-Pass `--watch` to refresh the metrics continuously.
+`memory_percent`, token counters, and more. Query and token counters are
+initialised to `0` when no queries have been executed so they always appear
+in the output. Pass `--watch` to refresh the metrics continuously.

--- a/src/autoresearch/monitor/__init__.py
+++ b/src/autoresearch/monitor/__init__.py
@@ -88,6 +88,7 @@ def _collect_system_metrics() -> Dict[str, Any]:
     except Exception as e:
         log.warning("Failed to collect system metrics", exc_info=e)
 
+    orch_metrics.ensure_counters_initialized()
     metrics["queries_total"] = int(orch_metrics.QUERY_COUNTER._value.get())
     metrics["tokens_in_total"] = int(orch_metrics.TOKENS_IN_COUNTER._value.get())
     metrics["tokens_out_total"] = int(orch_metrics.TOKENS_OUT_COUNTER._value.get())

--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -35,6 +35,13 @@ KUZU_QUERY_TIME = Histogram(
 )
 
 
+def ensure_counters_initialized() -> None:
+    """Ensure global counters are registered without changing their values."""
+    QUERY_COUNTER.inc(0)
+    TOKENS_IN_COUNTER.inc(0)
+    TOKENS_OUT_COUNTER.inc(0)
+
+
 def reset_metrics() -> None:
     """Reset all Prometheus counters to zero."""
     counters = [


### PR DESCRIPTION
## Summary
- ensure Prometheus counters are initialized before monitor CLI reads them
- verify CLI reports zero-valued counters when no queries have run
- document that monitor command always outputs query/token counters

## Testing
- `uv run pytest tests/unit/test_monitor_cli.py::test_monitor_metrics tests/unit/test_monitor_cli.py::test_monitor_metrics_default_counters -q`
- `uv run black src/autoresearch/orchestration/metrics.py src/autoresearch/monitor/__init__.py tests/unit/test_monitor_cli.py`
- `uv run isort src/autoresearch/orchestration/metrics.py src/autoresearch/monitor/__init__.py tests/unit/test_monitor_cli.py`
- `task check` *(fails: command not found)*
- `uv run pre-commit run --files src/autoresearch/orchestration/metrics.py src/autoresearch/monitor/__init__.py tests/unit/test_monitor_cli.py docs/monitor.md` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab79f0f5a883339b6435731a1ff7b2