### PR TITLE
Add spec coverage for monitor CLI and API auth errors

### DIFF
--- a/docs/algorithms/README.md
+++ b/docs/algorithms/README.md
@@ -2,6 +2,8 @@
 
 - [BM25 Ranking Formula](bm25.md)
 - [API Rate Limiting](api_rate_limiting.md)
+- [API Authentication](api_authentication.md)
+- [API Auth Error Paths](api_auth_error_paths.md)
 - [Ontology Reasoning](ontology_reasoning.md)
 - [Semantic Similarity](semantic_similarity.md)
 - [Source Credibility](source_credibility.md)
@@ -15,3 +17,4 @@
 - [Error Recovery via Exponential Backoff](error_recovery.md)
 - [Cache Eviction Strategy](cache_eviction.md)
 - [Resource Monitoring](resource_monitor.md)
+- [Monitor CLI](monitor_cli.md)

--- a/docs/algorithms/api_auth_error_paths.md
+++ b/docs/algorithms/api_auth_error_paths.md
@@ -1,0 +1,23 @@
+# API Auth Error Paths
+
+Enumerates failure responses for API credential verification.
+
+## Missing Credential
+
+- Request without `X-API-Key` or `Authorization` header returns **400 Bad
+  Request**.
+
+## Invalid Credential
+
+- Credentials that do not match stored secrets return **401 Unauthorized** and
+  log the failure.
+
+## Rate Limit Exceeded
+
+- Excess requests trigger a **429 Too Many Requests** response via rate limiting
+  middleware.
+
+## References
+
+- [src/autoresearch/api/](../../src/autoresearch/api/)
+- [tests/unit/test_api_error_handling.py](../../tests/unit/test_api_error_handling.py)

--- a/docs/algorithms/api_authentication.md
+++ b/docs/algorithms/api_authentication.md
@@ -67,6 +67,11 @@ Plotting `naive_times` shows longer durations when more prefix characters match,
 while `secure_times` remain flat. This supports the correctness of the
 constant-time strategy.
 
+## Error paths
+
+See [API auth error paths](api_auth_error_paths.md) for failure scenarios and
+responses.
+
 ## Conclusion
 
 By combining explicit handshake steps, a clear threat model, and constant-time

--- a/docs/algorithms/monitor_cli.md
+++ b/docs/algorithms/monitor_cli.md
@@ -1,0 +1,23 @@
+# Monitor CLI
+
+The `autoresearch monitor` commands stream system metrics and resource usage.
+
+## Flow
+
+1. `monitor` prints a single snapshot of CPU, memory, and token counts.
+2. `monitor -w` refreshes the snapshot every second.
+3. `monitor resources` collects samples for a duration and reports
+   aggregates.
+4. `monitor start --prometheus` launches a Prometheus metrics endpoint.
+
+## Error Handling
+
+- If metrics collection fails, a friendly message is printed and exit code 1
+  is returned.
+- When the endpoint fails to start, the command stops gracefully without
+  leaving background threads.
+
+## References
+
+- [src/autoresearch/monitor/](../../src/autoresearch/monitor/)
+- [tests/unit/test_monitor_cli.py](../../tests/unit/test_monitor_cli.py)

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1,6 +1,9 @@
 # Api
 
-FastAPI app aggregator for Autoresearch. See [API rate limiting
+FastAPI app aggregator for Autoresearch. See [API authentication
+algorithm](../algorithms/api_authentication.md) and
+[error paths](../algorithms/api_auth_error_paths.md) for credential handling
+details, and [API rate limiting
 model](../algorithms/api_rate_limiting.md) for load control guidance.
 
 ## Authentication flow

--- a/docs/specs/monitor.md
+++ b/docs/specs/monitor.md
@@ -1,6 +1,8 @@
 # Monitor
 
-Interactive monitoring commands for Autoresearch.
+Interactive monitoring commands for Autoresearch. See
+[monitor CLI algorithm](../algorithms/monitor_cli.md) for command flow and
+error handling.
 
 The metrics command reports system statistics without changing the
 `autoresearch_queries_total` counter. Monitor commands now skip storage

--- a/scripts/api_auth_simulation.py
+++ b/scripts/api_auth_simulation.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Simulate API authentication flows.
+
+Usage:
+    uv run scripts/api_auth_simulation.py --token <TOKEN>
+"""
+
+import argparse
+import secrets
+
+EXPECTED_TOKEN = "secret-token"
+
+
+def authenticate(token: str | None) -> tuple[int, str]:
+    """Verify the provided token.
+
+    Args:
+        token: Token from the request.
+
+    Returns:
+        Tuple of status code and message describing result.
+    """
+    if not token:
+        return 400, "missing credential"
+    if secrets.compare_digest(token, EXPECTED_TOKEN):
+        return 200, "authorized"
+    return 401, "unauthorized"
+
+
+def main() -> None:
+    """Parse arguments and run the simulation."""
+    parser = argparse.ArgumentParser(description="Simulate API authentication")
+    parser.add_argument("--token", help="token to validate")
+    args = parser.parse_args()
+    code, msg = authenticate(args.token)
+    print(f"{code}: {msg}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document monitor CLI execution and error handling
- explain API auth failure paths and index algorithms
- simulate API auth flows and link new algorithms in specs

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run scripts/check_spec_tests.py`
- `uv run pytest tests/unit/test_monitor_cli.py tests/unit/test_api_error_handling.py tests/unit/test_api.py -q`
- `uv run pytest tests/integration/test_monitor_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7a0f90148333a13b474ded9ca41a