### PR TITLE
Install Go Task with retry and document Task troubleshooting

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,6 +79,15 @@ After installation, initialize the environment:
 task install
 ```
 
+#### Troubleshooting
+
+- If the install script completes but `task` is missing, ensure the install
+  directory (often `~/.local/bin`) appears in your `PATH`.
+- Network failures during installation are usually transient. Rerun the
+  command or download the installer and execute it locally.
+- For permission errors, run the installer with a writable `-b` path or use a
+  package manager such as `brew` or `apt`.
+
 ### Core dependencies
 
 The following packages are required at the minimum versions listed. Each has

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -83,7 +83,10 @@ rm -rf /var/lib/apt/lists/*
 uv sync --extra dev-minimal
 
 # Install Go Task inside the virtual environment and expose it on PATH
-curl -sL https://taskfile.dev/install.sh | sh -s -- -b ./.venv/bin
+if ! retry 3 bash -c "curl -sL https://taskfile.dev/install.sh | sh -s -- -b ./.venv/bin"; then
+    echo 'task installation failed; see https://taskfile.dev/#/installation' >&2
+    exit 1
+fi
 export PATH=".venv/bin:$PATH"
 command -v task >/dev/null 2>&1 || {
     echo 'task installation failed; not on PATH' >&2


### PR DESCRIPTION
## Summary
- Install Go Task in `codex_setup.sh` with retry logic and clear failure guidance
- Add troubleshooting tips for Go Task installation in documentation

## Testing
- ⚠️ `task install` (partial; aborted after large downloads began)
- ❌ `task check` (flake8 errors in tests/behavior/conftest.py)
- ❌ `task verify` (flake8 errors in tests/behavior/conftest.py)


------
https://chatgpt.com/codex/tasks/task_e_68ab8d09845c8333a40017837b046352