### PR TITLE
Add critic agent test coverage

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -1,17 +1,17 @@
+"""Shared fixtures and hooks for behavior tests."""
+
+import os
 import sys
 from pathlib import Path
+
+import pytest
+
 
 # Ensure the repository root is on the import path so ``tests.conftest`` can be
 # imported reliably when running behavior tests directly.
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))  # noqa: E402
-
-import os  # noqa: E402
-import pytest  # noqa: E402
-
-import pytest
-
+    sys.path.insert(0, str(ROOT))
 
 pytest_plugins = ("pytest_bdd",)
 
@@ -20,6 +20,7 @@ pytest_plugins = ("pytest_bdd",)
 def pytest_configure(config):
     """Load step modules after pytest-bdd config."""
     config.pluginmanager.import_plugin("tests.behavior.steps")
+
 
 from autoresearch.api import reset_request_log  # noqa: E402
 from tests.conftest import reset_limiter_state, VSS_AVAILABLE  # noqa: E402

--- a/tests/behavior/features/critic_agent.feature
+++ b/tests/behavior/features/critic_agent.feature
@@ -1,0 +1,6 @@
+@user_workflows
+Feature: Critic agent evaluation
+  Scenario: Critic agent produces critique for research findings
+    Given a query with findings
+    When the critic agent evaluates the query
+    Then a critique is produced

--- a/tests/behavior/steps/critic_agent_steps.py
+++ b/tests/behavior/steps/critic_agent_steps.py
@@ -1,0 +1,43 @@
+"""Steps for critic agent behavior tests."""
+
+from pytest_bdd import given, when, then, scenarios
+
+from autoresearch.agents.specialized.critic import CriticAgent
+from autoresearch.config.models import ConfigModel
+from autoresearch.orchestration.state import QueryState
+
+
+scenarios("../features/critic_agent.feature")
+
+
+@given("a query with findings")
+def given_query_with_findings(test_context):
+    test_context["state"] = QueryState(
+        query="q",
+        claims=[{"id": "1", "type": "research_findings", "content": "data"}],
+    )
+    test_context["config"] = ConfigModel()
+
+
+@when("the critic agent evaluates the query")
+def when_critic_executes(test_context, monkeypatch):
+    agent = CriticAgent()
+
+    class DummyAdapter:
+        def generate(self, prompt, model=None):
+            return "critique text"
+
+    monkeypatch.setattr(
+        CriticAgent, "get_adapter", lambda self, cfg: DummyAdapter()
+    )
+    monkeypatch.setattr(
+        CriticAgent, "generate_prompt", lambda self, name, **kw: "prompt"
+    )
+    test_context["result"] = agent.execute(
+        test_context["state"], test_context["config"]
+    )
+
+
+@then("a critique is produced")
+def then_critique_produced(test_context):
+    assert test_context["result"]["results"]["critique"] == "critique text"

--- a/tests/unit/test_critic_agent.py
+++ b/tests/unit/test_critic_agent.py
@@ -1,0 +1,37 @@
+from autoresearch.agents.specialized.critic import CriticAgent
+from autoresearch.config.models import ConfigModel
+from autoresearch.orchestration.state import QueryState
+
+
+def test_can_execute_requires_claims():
+    agent = CriticAgent()
+    config = ConfigModel()
+    assert not agent.can_execute(QueryState(query=""), config)
+    state = QueryState(query="q", claims=[{"content": "data"}])
+    assert agent.can_execute(state, config)
+
+
+def test_execute_generates_critique(monkeypatch):
+    state = QueryState(
+        query="q",
+        claims=[{"id": "1", "type": "research_findings", "content": "data"}],
+    )
+    config = ConfigModel()
+    agent = CriticAgent()
+
+    class DummyAdapter:
+        def generate(self, prompt, model=None):
+            assert prompt == "prompt"
+            return "critique text"
+
+    monkeypatch.setattr(
+        CriticAgent, "get_adapter", lambda self, cfg: DummyAdapter()
+    )
+    monkeypatch.setattr(
+        CriticAgent, "generate_prompt", lambda self, name, **kw: "prompt"
+    )
+
+    result = agent.execute(state, config)
+
+    assert result["results"]["critique"] == "critique text"
+    assert result["claims"][0]["type"] == "critique"


### PR DESCRIPTION
## Summary
- refactor behavior test setup imports
- add unit tests for `CriticAgent`
- add BDD scenario exercising critic workflow

## Testing
- `uv run pytest tests/unit/test_critic_agent.py -q`
- `uv run pytest --rootdir=. tests/behavior -k critic_agent -q`
- `task check` *(fails: command interrupted due to environment/time)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8d1019e88333b5a10fa1ac61b8cb