### PR TITLE
Reset monitor metrics between runs

### DIFF
--- a/docs/algorithms/resource_monitor.md
+++ b/docs/algorithms/resource_monitor.md
@@ -2,7 +2,9 @@
 
 The `ResourceMonitor` samples CPU, memory, GPU, and token counts to expose
 time-series metrics. The `monitor` CLI uses these helpers to print the current
-snapshot in JSON or table form.
+snapshot in JSON or table form. Gauges reset to zero on startup so repeated
+runs begin with clean metrics. Reset global counters between tests to avoid
+cross-test contamination.
 
 ## Sampling Model
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,13 +45,14 @@ from autoresearch.agents.registry import (  # noqa: E402
     AgentRegistry,
 )
 from autoresearch.api import SLOWAPI_STUB  # noqa: E402
-from autoresearch.api import app as api_app  # noqa: E402
 from autoresearch.api import reset_request_log  # noqa: E402
+from autoresearch.api import app as api_app  # noqa: E402
 from autoresearch.config.loader import ConfigLoader  # noqa: E402
 from autoresearch.config.models import ConfigModel  # noqa: E402, F401
 from autoresearch.extensions import VSSExtensionLoader  # noqa: E402
 from autoresearch.llm.registry import LLMFactory  # noqa: E402
 from autoresearch.models import QueryResponse  # noqa: E402, F401
+from autoresearch.orchestration import metrics  # noqa: E402
 from autoresearch.storage import (  # noqa: E402
     StorageContext,
     StorageManager,
@@ -248,6 +249,14 @@ def reset_rate_limiting():
     yield
     reset_limiter_state()
     reset_request_log()
+
+
+@pytest.fixture(autouse=True)
+def reset_orchestration_metrics():
+    """Reset global orchestration counters before and after each test."""
+    metrics.reset_metrics()
+    yield
+    metrics.reset_metrics()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,9 +1,8 @@
-import pytest
-from types import SimpleNamespace
 from typing import Callable
 
+import pytest
+
 from autoresearch.orchestration.orchestrator import Orchestrator
-from autoresearch.orchestration import metrics
 
 
 @pytest.fixture
@@ -21,44 +20,3 @@ def orchestrator(orchestrator_factory: Callable[[], Orchestrator]) -> Orchestrat
     """Provide a fresh ``Orchestrator`` instance for each test."""
 
     return orchestrator_factory()
-
-
-@pytest.fixture(autouse=True)
-def reset_orchestration_metrics():
-    """Reset global metrics counters before and after each test."""
-
-    class DummyCounter:
-        def __init__(self) -> None:
-            self._value = SimpleNamespace(value=0)
-            self._value.get = lambda ns=self._value: ns.value
-            self._value.set = lambda v, ns=self._value: setattr(ns, "value", v)
-
-        def inc(self, n: int = 1) -> None:
-            self._value.value += n
-
-    def _fresh_value(counter: DummyCounter) -> None:
-        ns = SimpleNamespace(value=0)
-        ns.get = lambda ns=ns: ns.value
-        ns.set = lambda v, ns=ns: setattr(ns, "value", v)
-        counter._value = ns
-
-    names = [
-        "QUERY_COUNTER",
-        "ERROR_COUNTER",
-        "TOKENS_IN_COUNTER",
-        "TOKENS_OUT_COUNTER",
-    ]
-    for name in names:
-        counter = getattr(metrics, name, None)
-        if not hasattr(counter, "_value") or not hasattr(counter, "inc"):
-            counter = DummyCounter()
-            setattr(metrics, name, counter)
-        if not hasattr(counter._value, "set"):
-            _fresh_value(counter)
-        counter._value.set(0)
-    yield
-    for name in names:
-        counter = getattr(metrics, name)
-        if not hasattr(counter._value, "set"):
-            _fresh_value(counter)
-        counter._value.set(0)


### PR DESCRIPTION
## Summary
- ensure Prometheus gauges in monitor components are reused and reset
- reset orchestration counters before each test
- document that monitor gauges start at zero on startup

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run mkdocs build` *(fails: No such file or directory)*
- `uv run pytest tests/unit/test_metrics.py tests/unit/test_monitor_cli.py tests/integration/test_monitor_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab8d190cf48333ae21b1db7767be22