### PR TITLE
Fix auth failure status codes

### DIFF
--- a/docs/algorithms/api_authentication.md
+++ b/docs/algorithms/api_authentication.md
@@ -14,6 +14,17 @@ model, and why comparisons run in constant time.
 5. On success the request proceeds; otherwise a **401 Unauthorized** response is
    returned.
 
+## Configuration
+
+API authentication is configured under the `[api]` section of
+`autoresearch.toml` or via environment variables:
+
+- `AUTORESEARCH_API__API_KEY` or `AUTORESEARCH_API__API_KEYS` for API keys.
+- `AUTORESEARCH_API__BEARER_TOKEN` for a bearer token.
+
+Requests with missing or invalid credentials receive **401 Unauthorized**.
+Authenticated clients lacking permission receive **403 Forbidden**.
+
 ## Threat model
 
 - Adversaries may sniff traffic, replay requests, or attempt token guessing.

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,11 +26,10 @@ variables. Common options include:
 
 Setting `AUTORESEARCH_API__API_KEY` enables a single shared key while
 `AUTORESEARCH_API__API_KEYS` maps multiple keys to roles. Use
-`AUTORESEARCH_API__BEARER_TOKEN` to require an `Authorization: Bearer` header.
-Requests without credentials return **401**. Invalid API keys or bearer
-tokens receive **403**. Authenticated clients lacking permission also
-receive **403**. Modify `AUTORESEARCH_API__ROLE_PERMISSIONS` to assign
-actions to roles.
+`AUTORESEARCH_API__BEARER_TOKEN` to require an `Authorization: Bearer`
+header. Requests with missing or invalid credentials return **401**.
+Authenticated clients lacking permission receive **403**. Modify
+`AUTORESEARCH_API__ROLE_PERMISSIONS` to assign actions to roles.
 
 Restart the server after changing these values.
 
@@ -327,9 +326,9 @@ Use these HTTP headers when authentication is enabled:
 - `X-API-Key`: API key from `[api].api_key` or the `[api].api_keys` mapping.
 - `Authorization: Bearer <token>`: bearer token from `[api].bearer_token`.
 
-Requests without credentials receive a **401 Unauthorized** response.
-Invalid credentials or authenticated clients lacking permission receive
-**403 Forbidden**.
+Requests with missing or invalid credentials receive a
+**401 Unauthorized** response. Authenticated clients lacking permission
+receive **403 Forbidden**.
 
 ### Role permissions
 

--- a/src/autoresearch/api/middleware.py
+++ b/src/autoresearch/api/middleware.py
@@ -92,12 +92,16 @@ class AuthMiddleware(BaseHTTPMiddleware):
             if match_role:
                 return match_role, None
             if key:
-                return "anonymous", JSONResponse({"detail": "Invalid API key"}, status_code=403)
+                return "anonymous", JSONResponse(
+                    {"detail": "Invalid API key"}, status_code=401
+                )
             return "anonymous", None
         if cfg.api_key:
             if not (key and secrets.compare_digest(key, cfg.api_key)):
                 if key:
-                    return "anonymous", JSONResponse({"detail": "Invalid API key"}, status_code=403)
+                    return "anonymous", JSONResponse(
+                        {"detail": "Invalid API key"}, status_code=401
+                    )
                 return "anonymous", None
             return "user", None
         return "anonymous", None
@@ -130,9 +134,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
         auth_configured = bool(cfg.api_keys or cfg.api_key or cfg.bearer_token)
         if auth_configured and not (key_valid or token_valid):
             if provided_key:
-                return key_error or JSONResponse({"detail": "Invalid API key"}, status_code=403)
+                return key_error or JSONResponse(
+                    {"detail": "Invalid API key"}, status_code=401
+                )
             if provided_token:
-                return JSONResponse({"detail": "Invalid token"}, status_code=403)
+                return JSONResponse(
+                    {"detail": "Invalid token"}, status_code=401
+                )
             if cfg.api_keys or cfg.api_key:
                 return JSONResponse({"detail": "Missing API key"}, status_code=401)
             return JSONResponse({"detail": "Missing token"}, status_code=401)

--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -10,8 +10,6 @@ if str(ROOT) not in sys.path:
 import os  # noqa: E402
 import pytest  # noqa: E402
 
-import pytest
-
 
 pytest_plugins = ("pytest_bdd",)
 
@@ -20,6 +18,7 @@ pytest_plugins = ("pytest_bdd",)
 def pytest_configure(config):
     """Load step modules after pytest-bdd config."""
     config.pluginmanager.import_plugin("tests.behavior.steps")
+
 
 from autoresearch.api import reset_request_log  # noqa: E402
 from tests.conftest import reset_limiter_state, VSS_AVAILABLE  # noqa: E402

--- a/tests/behavior/features/api_auth.feature
+++ b/tests/behavior/features/api_auth.feature
@@ -16,6 +16,11 @@ Feature: API Authentication and Rate Limiting
     When I send a query "test" with header "Authorization" set to "Bearer bad"
     Then the response status should be 401
 
+  Scenario: Missing API key
+    Given the API requires an API key "secret"
+    When I send a query "test" without credentials
+    Then the response status should be 401
+
   Scenario: Rate limit exceeded
     Given the API rate limit is 1 request per minute
     When I send two queries to the API

--- a/tests/behavior/steps/api_auth_steps.py
+++ b/tests/behavior/steps/api_auth_steps.py
@@ -68,6 +68,13 @@ def send_query_with_header(api_client_factory, test_context, query, header, valu
     test_context["response"] = resp
 
 
+@when(parsers.parse('I send a query "{query}" without credentials'))
+def send_query_without_credentials(api_client_factory, test_context, query):
+    client = api_client_factory()
+    resp = client.post("/query", json={"query": query})
+    test_context["response"] = resp
+
+
 @when("I send two queries to the API")
 def send_two_queries(api_client_factory, test_context):
     client = api_client_factory()
@@ -118,4 +125,9 @@ def test_invalid_bearer_token():
 
 @scenario("../features/api_auth.feature", "Rate limit exceeded")
 def test_rate_limit_exceeded():
+    pass
+
+
+@scenario("../features/api_auth.feature", "Missing API key")
+def test_missing_api_key():
     pass

--- a/tests/integration/test_api_auth.py
+++ b/tests/integration/test_api_auth.py
@@ -34,8 +34,10 @@ def test_http_bearer_token(monkeypatch, api_client):
     )
     assert resp.status_code == 200
 
-    resp = api_client.post("/query", json={"query": "q"}, headers={"Authorization": "Bearer bad"})
-    assert resp.status_code == 403
+    resp = api_client.post(
+        "/query", json={"query": "q"}, headers={"Authorization": "Bearer bad"}
+    )
+    assert resp.status_code == 401
 
 
 def test_role_assignments(monkeypatch, api_client):
@@ -57,7 +59,7 @@ def test_role_assignments(monkeypatch, api_client):
     assert resp_token.json() == {"role": "user"}
 
     resp_bad = api_client.get("/whoami", headers={"X-API-Key": "bad"})
-    assert resp_bad.status_code == 403
+    assert resp_bad.status_code == 401
 
     resp_missing = api_client.get("/whoami")
     assert resp_missing.status_code == 401
@@ -110,8 +112,10 @@ def test_invalid_api_key(monkeypatch, api_client):
     cfg = _setup(monkeypatch)
     cfg.api.api_keys = {"good": "user"}
 
-    bad = api_client.post("/query", json={"query": "q"}, headers={"X-API-Key": "bad"})
-    assert bad.status_code == 403
+    bad = api_client.post(
+        "/query", json={"query": "q"}, headers={"X-API-Key": "bad"}
+    )
+    assert bad.status_code == 401
 
 
 def test_api_key_or_token(monkeypatch, api_client):
@@ -180,11 +184,13 @@ def test_query_status_and_cancel(monkeypatch, api_client):
 
 
 def test_invalid_bearer_token(monkeypatch, api_client):
-    """Invalid bearer token should return 403."""
+    """Invalid bearer token should return 401."""
     cfg = _setup(monkeypatch)
     cfg.api.bearer_token = generate_bearer_token()
-    resp = api_client.post("/query", json={"query": "q"}, headers={"Authorization": "Bearer wrong"})
-    assert resp.status_code == 403
+    resp = api_client.post(
+        "/query", json={"query": "q"}, headers={"Authorization": "Bearer wrong"}
+    )
+    assert resp.status_code == 401
 
 
 def test_missing_bearer_token(monkeypatch, api_client):
@@ -220,7 +226,7 @@ def test_docs_protected(monkeypatch, api_client):
 
 
 def test_invalid_key_and_token(monkeypatch, api_client):
-    """Both credentials invalid results in 403."""
+    """Both credentials invalid results in 401."""
     cfg = _setup(monkeypatch)
     cfg.api.api_key = "secret"
     cfg.api.bearer_token = generate_bearer_token()
@@ -229,7 +235,7 @@ def test_invalid_key_and_token(monkeypatch, api_client):
         json={"query": "q"},
         headers={"X-API-Key": "wrong", "Authorization": "Bearer bad"},
     )
-    assert resp.status_code == 403
+    assert resp.status_code == 401
 
 
 def test_query_status_permission_denied(monkeypatch, api_client):

--- a/tests/unit/test_api_auth_middleware.py
+++ b/tests/unit/test_api_auth_middleware.py
@@ -23,7 +23,7 @@ def test_resolve_role_invalid_key():
     role, err = middleware._resolve_role("bad", cfg.api)
     assert role == "anonymous"
     assert err is not None
-    assert err.status_code == 403
+    assert err.status_code == 401
 
 
 def test_resolve_role_missing_key():
@@ -53,4 +53,4 @@ def test_dispatch_invalid_token(monkeypatch):
         return Response("ok")
 
     resp = asyncio.run(middleware.dispatch(request, call_next))
-    assert resp.status_code == 403
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- return 401 for invalid API keys or bearer tokens
- document API auth configuration and status codes
- add tests for missing credentials and adjust expectations

## Testing
- `task check` *(fails: tests/unit/test_storage_eviction.py::test_enforce_ram_budget_hybrid_policy, tests/unit/test_storage_eviction.py::test_enforce_ram_budget_adaptive_policy, tests/unit/test_token_usage.py::test_budget_considers_agent_history)*
- `uv run mkdocs build` *(fails: `mkdocs` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8d1d2800833393b4ed746325d9bc