### PR TITLE
docs: add monitor reliability simulation and timing attack demo

### DIFF
--- a/docs/algorithms/api_authentication.md
+++ b/docs/algorithms/api_authentication.md
@@ -61,11 +61,20 @@ naive_times = [
 secure_times = [
     timeit.timeit(lambda: compare_digest(token, w), number=1000) for w in wrong
 ]
+
+naive_range = max(naive_times) - min(naive_times)
+secure_range = max(secure_times) - min(secure_times)
+print(f"naive range: {naive_range:.6f}")
+print(f"secure range: {secure_range:.6f}")
 ```
 
 Plotting `naive_times` shows longer durations when more prefix characters match,
 while `secure_times` remain flat. This supports the correctness of the
 constant-time strategy.
+
+The `secure_range` output approaches zero, showing constant-time behavior even
+when token prefixes overlap. Integration coverage lives in
+[tests/integration/test_api_auth.py](../../tests/integration/test_api_auth.py).
 
 ## Error paths
 

--- a/docs/algorithms/monitor_cli.md
+++ b/docs/algorithms/monitor_cli.md
@@ -17,7 +17,22 @@ The `autoresearch monitor` commands stream system metrics and resource usage.
 - When the endpoint fails to start, the command stops gracefully without
   leaving background threads.
 
+## Reliability analysis
+
+A Monte Carlo model estimates how often metrics collection fails and the
+latency of successful samples. Run the simulation to explore different
+failure rates and observe average latency:
+
+```bash
+uv run scripts/monitor_cli_reliability.py --runs 1000 --fail-rate 0.05
+```
+
+This informs retry budgets and helps tune sampling intervals.
+
 ## References
 
 - [src/autoresearch/monitor/](../../src/autoresearch/monitor/)
+- [scripts/monitor_cli_reliability.py](../../scripts/monitor_cli_reliability.py)
 - [tests/unit/test_monitor_cli.py](../../tests/unit/test_monitor_cli.py)
+- [tests/integration/test_monitor_metrics.py](../../tests/integration/test_monitor_metrics.py)
+- [tests/behavior/steps/monitor_cli_steps.py](../../tests/behavior/steps/monitor_cli_steps.py)

--- a/scripts/monitor_cli_reliability.py
+++ b/scripts/monitor_cli_reliability.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Simulate monitor CLI latency and failure rates.
+
+Usage:
+    uv run scripts/monitor_cli_reliability.py --runs 1000 --fail-rate 0.05
+
+Runs a Monte Carlo model of metrics collection. Each simulated run may fail
+with a configured probability and records a latency sample. Results include
+average latency and success rate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import statistics
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Simulate monitor CLI reliability and latency.")
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=1000,
+        help="number of simulated runs",
+    )
+    parser.add_argument(
+        "--fail-rate",
+        type=float,
+        default=0.02,
+        help="probability a run fails to collect metrics",
+    )
+    return parser.parse_args()
+
+
+def simulate(runs: int, fail_rate: float) -> tuple[float, float]:
+    failures = 0
+    latencies: list[float] = []
+    for _ in range(runs):
+        if random.random() < fail_rate:
+            failures += 1
+            continue
+        latencies.append(random.gauss(100, 15))
+    success_rate = 1 - failures / runs
+    avg_latency = statistics.mean(latencies) if latencies else float("nan")
+    return avg_latency, success_rate
+
+
+def main() -> None:
+    args = parse_args()
+    if args.runs <= 0 or not (0.0 <= args.fail_rate <= 1.0):
+        print(
+            "runs must be positive and fail-rate between 0 and 1",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    avg_latency, success_rate = simulate(args.runs, args.fail_rate)
+    print(f"average_latency_ms={avg_latency:.1f}")
+    print(f"success_rate={success_rate:.3f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document monitor CLI reliability analysis and provide a simulation script
- expand API authentication timing-attack simulation and link integration tests

## Testing
- `uvx --with mkdocs-material --with 'mkdocstrings[python]' mkdocs build` *(fails: PythonConfig.__init__() got an unexpected keyword argument 'selection')*
- `uvx --with pytest-httpx --with duckdb --with networkx pytest tests/unit/test_monitor_cli.py tests/integration/test_monitor_metrics.py tests/integration/test_api_auth.py` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_68ab8d2bcf5c83339dd18899547a7214