### PR TITLE
feat: standardize API auth status codes

### DIFF
--- a/docs/algorithms/api_authentication.md
+++ b/docs/algorithms/api_authentication.md
@@ -14,6 +14,17 @@ model, and why comparisons run in constant time.
 5. On success the request proceeds; otherwise a **401 Unauthorized** response is
    returned.
 
+## Configuration
+
+Credentials are defined in `autoresearch.toml` under `[api]`:
+
+- `api_key` – single shared key.
+- `api_keys` – mapping of keys to roles.
+- `bearer_token` – value for the `Authorization` header.
+
+Roles gain capabilities via `[api.role_permissions]` with entries such as
+`query` or `docs`.
+
 ## Threat model
 
 - Adversaries may sniff traffic, replay requests, or attempt token guessing.

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,9 +27,9 @@ variables. Common options include:
 Setting `AUTORESEARCH_API__API_KEY` enables a single shared key while
 `AUTORESEARCH_API__API_KEYS` maps multiple keys to roles. Use
 `AUTORESEARCH_API__BEARER_TOKEN` to require an `Authorization: Bearer` header.
-Requests without credentials return **401**. Invalid API keys or bearer
-tokens receive **403**. Authenticated clients lacking permission also
-receive **403**. Modify `AUTORESEARCH_API__ROLE_PERMISSIONS` to assign
+Requests without credentials or with invalid credentials return **401**.
+Authenticated clients lacking permission receive **403**. Modify
+`AUTORESEARCH_API__ROLE_PERMISSIONS` to assign
 actions to roles.
 
 Restart the server after changing these values.

--- a/src/autoresearch/api/middleware.py
+++ b/src/autoresearch/api/middleware.py
@@ -92,12 +92,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
             if match_role:
                 return match_role, None
             if key:
-                return "anonymous", JSONResponse({"detail": "Invalid API key"}, status_code=403)
+                return "anonymous", JSONResponse({"detail": "Invalid API key"}, status_code=401)
             return "anonymous", None
         if cfg.api_key:
             if not (key and secrets.compare_digest(key, cfg.api_key)):
                 if key:
-                    return "anonymous", JSONResponse({"detail": "Invalid API key"}, status_code=403)
+                    return "anonymous", JSONResponse({"detail": "Invalid API key"}, status_code=401)
                 return "anonymous", None
             return "user", None
         return "anonymous", None
@@ -113,11 +113,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         role, key_error = self._resolve_role(api_key, cfg)
         key_valid = bool(api_key) and key_error is None
-        token_valid = (
-            bool(token and verify_bearer_token(token, cfg.bearer_token))
-            if cfg.bearer_token
-            else False
-        )
+        token_valid = verify_bearer_token(token, cfg.bearer_token)
         provided_key = bool(api_key)
         provided_token = bool(token)
 
@@ -130,9 +126,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
         auth_configured = bool(cfg.api_keys or cfg.api_key or cfg.bearer_token)
         if auth_configured and not (key_valid or token_valid):
             if provided_key:
-                return key_error or JSONResponse({"detail": "Invalid API key"}, status_code=403)
+                return key_error or JSONResponse({"detail": "Invalid API key"}, status_code=401)
             if provided_token:
-                return JSONResponse({"detail": "Invalid token"}, status_code=403)
+                return JSONResponse({"detail": "Invalid token"}, status_code=401)
             if cfg.api_keys or cfg.api_key:
                 return JSONResponse({"detail": "Missing API key"}, status_code=401)
             return JSONResponse({"detail": "Missing token"}, status_code=401)

--- a/src/autoresearch/api/utils.py
+++ b/src/autoresearch/api/utils.py
@@ -79,7 +79,7 @@ def generate_bearer_token(length: int = 32) -> str:
     return secrets.token_urlsafe(length)
 
 
-def verify_bearer_token(token: str, expected: str) -> bool:
+def verify_bearer_token(token: str | None, expected: str | None) -> bool:
     """Validate a bearer token using constant-time comparison.
 
     Args:
@@ -87,7 +87,9 @@ def verify_bearer_token(token: str, expected: str) -> bool:
         expected: Reference token from configuration.
 
     Returns:
-        ``True`` if the tokens match, ``False`` otherwise.
+        ``True`` if both values are present and match, ``False`` otherwise.
     """
 
+    if not (token and expected):
+        return False
     return secrets.compare_digest(token, expected)

--- a/tests/behavior/features/api_auth.feature
+++ b/tests/behavior/features/api_auth.feature
@@ -16,6 +16,16 @@ Feature: API Authentication and Rate Limiting
     When I send a query "test" with header "Authorization" set to "Bearer bad"
     Then the response status should be 401
 
+  Scenario: Missing credentials
+    Given the API requires an API key "secret"
+    When I send a query "test" without credentials
+    Then the response status should be 401
+
+  Scenario: Insufficient permission
+    Given the API requires an API key "secret" with role "user" and no permissions
+    When I send a query "test" with header "X-API-Key" set to "secret"
+    Then the response status should be 403
+
   Scenario: Rate limit exceeded
     Given the API rate limit is 1 request per minute
     When I send two queries to the API

--- a/tests/integration/test_api_auth.py
+++ b/tests/integration/test_api_auth.py
@@ -35,7 +35,8 @@ def test_http_bearer_token(monkeypatch, api_client):
     assert resp.status_code == 200
 
     resp = api_client.post("/query", json={"query": "q"}, headers={"Authorization": "Bearer bad"})
-    assert resp.status_code == 403
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid token"
 
 
 def test_role_assignments(monkeypatch, api_client):
@@ -57,7 +58,8 @@ def test_role_assignments(monkeypatch, api_client):
     assert resp_token.json() == {"role": "user"}
 
     resp_bad = api_client.get("/whoami", headers={"X-API-Key": "bad"})
-    assert resp_bad.status_code == 403
+    assert resp_bad.status_code == 401
+    assert resp_bad.json()["detail"] == "Invalid API key"
 
     resp_missing = api_client.get("/whoami")
     assert resp_missing.status_code == 401
@@ -111,7 +113,8 @@ def test_invalid_api_key(monkeypatch, api_client):
     cfg.api.api_keys = {"good": "user"}
 
     bad = api_client.post("/query", json={"query": "q"}, headers={"X-API-Key": "bad"})
-    assert bad.status_code == 403
+    assert bad.status_code == 401
+    assert bad.json()["detail"] == "Invalid API key"
 
 
 def test_api_key_or_token(monkeypatch, api_client):
@@ -180,11 +183,12 @@ def test_query_status_and_cancel(monkeypatch, api_client):
 
 
 def test_invalid_bearer_token(monkeypatch, api_client):
-    """Invalid bearer token should return 403."""
+    """Invalid bearer token should return 401."""
     cfg = _setup(monkeypatch)
     cfg.api.bearer_token = generate_bearer_token()
     resp = api_client.post("/query", json={"query": "q"}, headers={"Authorization": "Bearer wrong"})
-    assert resp.status_code == 403
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid token"
 
 
 def test_missing_bearer_token(monkeypatch, api_client):
@@ -220,7 +224,7 @@ def test_docs_protected(monkeypatch, api_client):
 
 
 def test_invalid_key_and_token(monkeypatch, api_client):
-    """Both credentials invalid results in 403."""
+    """Both credentials invalid results in 401."""
     cfg = _setup(monkeypatch)
     cfg.api.api_key = "secret"
     cfg.api.bearer_token = generate_bearer_token()
@@ -229,7 +233,7 @@ def test_invalid_key_and_token(monkeypatch, api_client):
         json={"query": "q"},
         headers={"X-API-Key": "wrong", "Authorization": "Bearer bad"},
     )
-    assert resp.status_code == 403
+    assert resp.status_code == 401
 
 
 def test_query_status_permission_denied(monkeypatch, api_client):


### PR DESCRIPTION
## Summary
- return 401 for missing or invalid API credentials
- document auth configuration options
- expand auth tests and BDD scenarios

## Testing
- `task check` *(fails: src/autoresearch/orchestration/metrics.py:7:1: F401 'math' imported but unused)*
- `task verify` *(fails: src/autoresearch/orchestration/metrics.py:7:1: F401 'math' imported but unused)*
- `uv run pytest tests/integration/test_api_auth.py tests/behavior -k api_auth`
- `uv run mkdocs build` *(fails: PythonConfig.__init__() got an unexpected keyword argument 'selection')*

------
https://chatgpt.com/codex/tasks/task_e_68ab9942285c83339e5fd2a552df00d4