### PR TITLE
Track coverage blockers and add follow-up issue

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -227,17 +227,15 @@ These behavior test issues remain open until the test suite passes.
 
 ### Coverage Report
 
-`task coverage` could not complete in this environment; coverage metrics are unavailable.
+Attempts to run `task install` and `task verify` stalled when large GPU and ML
+packages like `torch` and CUDA began downloading. As a result, `task check`,
+`task verify`, and `coverage html` could not run to generate updated metrics.
+The `baseline/coverage.xml` file still reports roughly twenty-two percent
+coverage.
 
 ### Latest Test Results
 
-- `uv run flake8 src tests` – passed
-- `uv run mypy src` – passed
-- `uv run python scripts/check_spec_tests.py` – passed
-- `uv run pytest tests/unit -q` – 639 passed, 5 failed, 26 skipped, 24 deselected, 2 xfailed
-- `uv run pytest tests/integration -m 'not slow and not requires_ui and not requires_vss and not requires_distributed' -q` – 192 passed, 1 failed, 4 skipped, 86 deselected
-- `uv run pytest tests/behavior -q` – numerous failures; run interrupted
-- Coverage collection reports **24%** overall
+No tests ran in this environment.
 
 ### Performance Baselines
 

--- a/issues/improve-test-coverage-and-streamline-dependencies.md
+++ b/issues/improve-test-coverage-and-streamline-dependencies.md
@@ -1,0 +1,21 @@
+# Improve test coverage and streamline dependencies
+
+## Context
+Attempts to run `task install` and `task verify` stalled when large GPU and
+machine learning packages like `torch` and CUDA began downloading. Without a
+successful install, the test suite and `coverage html` could not run to
+identify low-coverage modules. The existing baseline at
+`baseline/coverage.xml` shows roughly twenty-two percent coverage, leaving most
+modules untested.
+
+## Acceptance Criteria
+- `task install` completes without heavyweight GPU or ML dependencies by
+default.
+- `task verify` and `coverage html` run to completion on a fresh clone.
+- Unit tests in `tests/unit` cover previously untested modules.
+- Integration and behavior scenarios exercise uncovered workflows.
+- `baseline/coverage.xml` updates once overall coverage meets at least ninety
+percent.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- Record that `task install` and `task verify` stall on heavyweight GPU/ML packages, leaving coverage around twenty-two percent with no tests run.
- Add an issue to improve test coverage and streamline dependencies so coverage can reach ninety percent.

## Testing
- `task check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab97becc3c8333ae85c3b969b40a96