### PR TITLE
chore: update issues based on latest tests

### DIFF
--- a/issues/archive/correct-token-budget-convergence-logic.md
+++ b/issues/archive/correct-token-budget-convergence-logic.md
@@ -10,5 +10,5 @@
 - Add property-based tests for boundary cases.
 
 ## Status
-Open
+Archived
 

--- a/issues/archive/fix-monitor-cli-metrics-failure.md
+++ b/issues/archive/fix-monitor-cli-metrics-failure.md
@@ -12,4 +12,5 @@ The monitor CLI is not producing the expected metrics and needs investigation.
 - Update documentation if monitor behavior changes.
 
 ## Status
-Open
+Archived
+

--- a/issues/fix-pytest-bdd-feature-discovery.md
+++ b/issues/fix-pytest-bdd-feature-discovery.md
@@ -3,9 +3,8 @@
 ## Context
 Running `uv run pytest tests/behavior/features/api_orchestrator_integration.feature -q`
 reports `ERROR: not found: ... (no match in any of [<Dir features>])` because
-`pytest-bdd` cannot discover the feature directory. Behavior tests cannot
-execute reliably. This was reproduced on **August 24, 2025** after manually
-installing `pytest-bdd`.
+`pytest-bdd` cannot discover the feature directory even with the plugin
+installed. Behavior tests cannot execute reliably.
 
 ## Acceptance Criteria
 - `uv run pytest tests/behavior/features/api_orchestrator_integration.feature -q`

--- a/issues/improve-test-coverage-and-streamline-dependencies.md
+++ b/issues/improve-test-coverage-and-streamline-dependencies.md
@@ -1,9 +1,8 @@
 # Improve test coverage and streamline dependencies
 
 ## Context
-Attempts to run `task install` and `task verify` stalled when large GPU and
-machine learning packages like `torch` and CUDA began downloading. Without a
-successful install, the test suite and `coverage html` could not run to
+Current `task install` completes with minimal dependencies, but `task verify`
+fails due to `flake8` errors, preventing `coverage html` from running to
 identify low-coverage modules. The existing baseline at
 `baseline/coverage.xml` shows roughly twenty-two percent coverage, leaving most
 modules untested.

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -1,14 +1,13 @@
 # Prepare first alpha release
 
 ## Context
-Version 0.1.0a1 will be the project's first public alpha. A fresh clone on
-**August 24, 2025** lacked the Go Task binary and dev extras such as
-`tomli_w`, `freezegun`, and `hypothesis`, so `task check` and `task verify`
-could not run. After manually installing `pytest-httpx` and `pytest-bdd`, unit
-tests still aborted during collection with `ModuleNotFoundError: tomli_w`, and
+Version 0.1.0a1 will be the project's first public alpha. Go Task and dev
+extras now install via the setup script, but `task check` fails on `flake8`
+warnings in `src/autoresearch/orchestration/metrics.py` and
+`tests/behavior/features/conftest.py`. Running
 `uv run pytest tests/behavior/features/api_orchestrator_integration.feature -q`
-reported "no match in any of [<Dir features>]". Integration tests execute with
-`redis` installed, but coverage remains at **24%**, far below the **90%**
+still reports "no match in any of [<Dir features>]". Integration tests execute
+with `redis` installed, but coverage remains at **24%**, far below the **90%**
 target. The TestPyPI upload returns HTTP 403, and release notes and packaging
 steps are incomplete.
 

--- a/issues/resolve-test-failures-and-task-tooling.md
+++ b/issues/resolve-test-failures-and-task-tooling.md
@@ -1,29 +1,25 @@
 # Resolve test failures and task tooling
 
 ## Context
- Go Task now installs correctly, and `redis` is installed, but `task check`
- reports new unit test failures. With minimal development extras, `flake8`,
- `mypy`, spec checks, and most unit tests pass. Running the full test suite
- reveals failures in storage persistence eviction, token budget convergence,
- API authentication, concurrent query handling, Redis broker detection, and
- monitor CLI metrics. Integration and behavior test suites remain unreliable.
+Go Task and `redis` are installed, yet `task check` fails with `flake8`
+warnings for an unused import in
+`src/autoresearch/orchestration/metrics.py` and import order in
+`tests/behavior/features/conftest.py`. Targeted unit tests such as
+`test_monitor_cli.py::test_monitor_metrics` and
+`test_token_budget_convergence.py::test_suggest_token_budget_converges`
+now pass, but API authentication, concurrent query handling, Redis broker
+detection, and behavior feature discovery remain unresolved.
 
- A fresh clone on **August 24, 2025** lacked Go Task and several dev
- dependencies. Manual installs of `pytest-httpx` and `pytest-bdd` succeeded, yet
- `uv run pytest` still exited during collection with
- `ModuleNotFoundError` for `tomli_w`, `freezegun`, and `hypothesis`.
-
- Redis-dependent integration tests skip cleanly when `redis` is missing
- (verified 2025-08-24).
+Redis-dependent integration tests skip cleanly when `redis` is missing.
 
 ## Dependencies
 
 - [address-storage-persistence-eviction-failure](archive/address-storage-persistence-eviction-failure.md)
-- [correct-token-budget-convergence-logic](correct-token-budget-convergence-logic.md)
+- [correct-token-budget-convergence-logic](archive/correct-token-budget-convergence-logic.md)
 - [repair-api-authentication-endpoints](repair-api-authentication-endpoints.md)
 - [fix-concurrent-query-interface-behavior](archive/fix-concurrent-query-interface-behavior.md)
 - [add-redis-dependency-for-integration-tests](add-redis-dependency-for-integration-tests.md)
-- [fix-monitor-cli-metrics-failure](fix-monitor-cli-metrics-failure.md)
+- [fix-monitor-cli-metrics-failure](archive/fix-monitor-cli-metrics-failure.md)
 - [fix-pytest-bdd-feature-discovery](fix-pytest-bdd-feature-discovery.md)
 
 ## Acceptance Criteria


### PR DESCRIPTION
## Summary
- refresh open issue context to reflect current test failures
- archive resolved tickets for token budget convergence and monitor CLI metrics

## Testing
- `task check` *(fails: src/autoresearch/orchestration/metrics.py:7:1: F401 'math' imported but unused; tests/behavior/features/conftest.py:11:1: E402 module level import not at top of file)*
- `task verify` *(fails: src/autoresearch/orchestration/metrics.py:7:1: F401 'math' imported but unused; tests/behavior/features/conftest.py:11:1: E402 module level import not at top of file)*
- `uv run pytest tests/unit/test_token_budget_convergence.py::test_suggest_token_budget_converges -q`
- `uv run pytest tests/unit/test_monitor_cli.py::test_monitor_metrics tests/unit/test_monitor_cli.py::test_monitor_prompts_and_passes_callbacks -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab9f7f0f00833393ea4293133fb013