### PR TITLE
chore: tidy imports

### DIFF
--- a/tests/behavior/features/conftest.py
+++ b/tests/behavior/features/conftest.py
@@ -1,11 +1,12 @@
 """Load behavior fixtures when running feature files directly."""
+
 import sys
 from pathlib import Path
+
+# Import behavior-level fixtures and plugin registrations
+from tests.behavior.conftest import *  # noqa: F401,F403
 
 # Ensure repository root on sys.path for imports
 ROOT = Path(__file__).resolve().parents[3]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
-
-# Import behavior-level fixtures and plugin registrations
-from tests.behavior.conftest import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- remove unused imports in orchestration metrics module and sort remaining
- sort test fixture imports and position constants after imports

## Testing
- `uv run flake8 src tests`


------
https://chatgpt.com/codex/tasks/task_e_68abb40544848333abc3cacc8270cba7