### PR TITLE
Align API auth tests with 401/403 semantics

### DIFF
--- a/docs/algorithms/api_authentication.md
+++ b/docs/algorithms/api_authentication.md
@@ -11,8 +11,11 @@ model, and why comparisons run in constant time.
    - `Authorization: Bearer <token>` for a bearer token.
 3. The server fetches the expected credential from configuration.
 4. Verification uses a constant-time comparison.
-5. On success the request proceeds; otherwise a **401 Unauthorized** response is
-   returned.
+5. On success the request proceeds. Missing or invalid credentials trigger a
+   **401 Unauthorized** response with messages such as ``Missing API key``,
+   ``Invalid API key``, ``Missing token``, or ``Invalid token``. Authenticated
+   clients lacking required permissions receive **403 Forbidden** with an
+   ``Insufficient permissions`` detail.
 
 ## Configuration
 

--- a/tests/integration/test_api_auth.py
+++ b/tests/integration/test_api_auth.py
@@ -63,6 +63,7 @@ def test_role_assignments(monkeypatch, api_client):
 
     resp_missing = api_client.get("/whoami")
     assert resp_missing.status_code == 401
+    assert resp_missing.json()["detail"] == "Missing API key"
 
 
 def test_rate_limit(monkeypatch, api_client):
@@ -106,6 +107,7 @@ def test_single_api_key(monkeypatch, api_client):
 
     missing = api_client.post("/query", json={"query": "q"})
     assert missing.status_code == 401
+    assert missing.json()["detail"] == "Missing API key"
 
 
 def test_invalid_api_key(monkeypatch, api_client):
@@ -197,6 +199,7 @@ def test_missing_bearer_token(monkeypatch, api_client):
     cfg.api.bearer_token = generate_bearer_token()
     resp = api_client.post("/query", json={"query": "q"})
     assert resp.status_code == 401
+    assert resp.json()["detail"] == "Missing token"
 
 
 def test_permission_denied(monkeypatch, api_client):

--- a/tests/integration/test_api_docs.py
+++ b/tests/integration/test_api_docs.py
@@ -26,7 +26,8 @@ def test_docs_endpoints_require_auth(monkeypatch, api_client):
 
     assert api_client.get("/docs").status_code == 401
     bad = api_client.get("/docs", headers={"X-API-Key": "bad"})
-    assert bad.status_code == 403
+    assert bad.status_code == 401
+    assert bad.json()["detail"] == "Invalid API key"
     ok = api_client.get("/docs", headers={"X-API-Key": "secret"})
     assert ok.status_code == 200
 

--- a/tests/integration/test_api_streaming.py
+++ b/tests/integration/test_api_streaming.py
@@ -128,7 +128,8 @@ def test_api_key_roles_integration(monkeypatch, api_client):
     assert resp.status_code == 200
 
     bad = api_client.post("/query", json={"query": "q"}, headers={"X-API-Key": "bad"})
-    assert bad.status_code == 403
+    assert bad.status_code == 401
+    assert bad.json()["detail"] == "Invalid API key"
 
 
 def test_stream_requires_api_key(monkeypatch, api_client):
@@ -153,7 +154,8 @@ def test_stream_requires_api_key(monkeypatch, api_client):
         assert resp.status_code == 200
 
     bad = api_client.post("/query/stream", json={"query": "q"}, headers={"X-API-Key": "bad"})
-    assert bad.status_code == 403
+    assert bad.status_code == 401
+    assert bad.json()["detail"] == "Invalid API key"
 
 
 def test_batch_query_async_order(monkeypatch, api_client):


### PR DESCRIPTION
## Summary
- Document API auth flow and detail messages for missing/invalid credentials
- Expect 401 Unauthorized for docs and streaming endpoints with bad API keys
- Verify missing API key/token error details in auth tests

## Testing
- `uv run pytest tests/integration/test_api_auth.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68abb417b1188333add2c4f3ee879793