### PR TITLE
Document visualization pipeline and performance sampling

### DIFF
--- a/docs/algorithms/README.md
+++ b/docs/algorithms/README.md
@@ -18,3 +18,4 @@
 - [Cache Eviction Strategy](cache_eviction.md)
 - [Resource Monitoring](resource_monitor.md)
 - [Monitor CLI](monitor_cli.md)
+- [Graph Visualization Pipeline](visualization.md)

--- a/docs/algorithms/visualization.md
+++ b/docs/algorithms/visualization.md
@@ -1,0 +1,49 @@
+# Graph Visualization Pipeline
+
+Autoresearch renders knowledge graphs with NetworkX and a force-directed
+layout. The pipeline:
+
+1. build a graph from query results,
+2. compute positions with the Fruchterman–Reingold algorithm,
+3. draw nodes, edges, and labels with Matplotlib.
+
+The layout minimizes the energy function
+
+\[
+E = \sum_{(u,v) \in E} \frac{\|p_u - p_v\|^2}{k}
+    + \sum_{u \ne v} \frac{k^2}{\|p_u - p_v\|}
+\]
+
+ensuring edges remain straight segments between node positions.
+
+## Complexity
+
+Each iteration computes attractive and repulsive forces for every pair of nodes.
+With `n` nodes and `i` iterations, time is
+
+\[
+T(n) = O(i n^2), \qquad S(n) = O(n).
+\]
+
+## Performance
+
+The script [visualization_performance.py][perf] samples layout times:
+
+| nodes | seconds |
+| ----- | ------- |
+| 10 | 0.0025 |
+| 50 | 0.0163 |
+| 100 | 0.0234 |
+| 200 | 0.1233 |
+| 500 | 4.5152 |
+
+Rendering remains interactive for graphs under 200 nodes on typical hardware.
+
+[perf]: ../../scripts/visualization_performance.py
+
+## References
+
+- Thomas M. J. Fruchterman and Edward M. Reingold. "Graph drawing by
+  force-directed placement." *Software: Practice and Experience*, 1991.
+  <https://doi.org/10.1002/spe.4380211102>
+- NetworkX documentation. <https://networkx.org/>

--- a/docs/specs/visualization.md
+++ b/docs/specs/visualization.md
@@ -10,6 +10,10 @@ Utilities for generating graphical representations of query results.
   - [tests/behavior/features/visualization_cli.feature][t1]
   - [tests/unit/test_visualization.py][t2]
 
+## Algorithms
+
+- [Graph Visualization Pipeline](../algorithms/visualization.md)
+
 [m1]: ../../src/autoresearch/visualization.py
 [t1]: ../../tests/behavior/features/visualization_cli.feature
 [t2]: ../../tests/unit/test_visualization.py

--- a/scripts/visualization_performance.py
+++ b/scripts/visualization_performance.py
@@ -1,0 +1,45 @@
+"""Sample layout times for varying node counts.
+
+Usage:
+    uv run --with scipy scripts/visualization_performance.py [COUNTS ...]
+
+The script prints a table of node counts and seconds required to compute
+spring layout. Counts default to 10 50 100 200 500.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import networkx as nx
+
+
+def measure(counts: list[int]) -> list[tuple[int, float]]:
+    results: list[tuple[int, float]] = []
+    nx.spring_layout(nx.empty_graph(2), seed=42)
+    for n in counts:
+        graph = nx.gnm_random_graph(n, n * 2, seed=42)
+        start = time.perf_counter()
+        nx.spring_layout(graph, seed=42)
+        duration = time.perf_counter() - start
+        results.append((n, duration))
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sample layout times for node counts.")
+    parser.add_argument(
+        "counts",
+        nargs="*",
+        type=int,
+        default=[10, 50, 100, 200, 500],
+        help="Node counts to sample.",
+    )
+    args = parser.parse_args()
+    for n, secs in measure(args.counts):
+        print(f"{n} {secs:.6f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `docs/algorithms/visualization.md` explaining rendering steps, layout complexity, and performance notes
- link visualization spec to new algorithm doc
- provide `visualization_performance.py` to sample layout times for different node counts

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run --with flake8 flake8 scripts/visualization_performance.py`
- `uv run --with mkdocs-material --with mkdocstrings mkdocs build` *(fails: No module named 'mkdocstrings_handlers')*
- `uv run --with scipy scripts/visualization_performance.py`


------
https://chatgpt.com/codex/tasks/task_e_68abb4d1605483338d1ce7bc4960d0e8