### PR TITLE
Use dev-minimal extras by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,18 @@ For orchestrator state transitions and API contracts see
 Autoresearch requires **Python 3.12+**,
 [uv](https://github.com/astral-sh/uv), and
 [Go Task](https://taskfile.dev/). After cloning, run `./scripts/setup.sh` for
-the full developer bootstrap or `task install` for a minimal environment. See
-[docs/installation.md#after-cloning](docs/installation.md#after-cloning) for
-details.
+the full developer bootstrap or `task install` for a lightweight environment.
+See [docs/installation.md#after-cloning](docs/installation.md#after-cloning)
+for details.
 
-To bootstrap a Python 3.12+ environment with development and test extras run:
+To bootstrap a Python 3.12+ environment with minimal development extras run:
 
 ```bash
 task install
 ```
 
-This installs tools like `pytest-httpx`, `duckdb`, and `networkx` needed for
-local testing.
+This uses the `dev-minimal` extras to install tools like `pytest-httpx`,
+`duckdb`, and `networkx` needed for local testing.
 
 For current capabilities and known limitations see
 [docs/release_notes.md](docs/release_notes.md).
@@ -69,6 +69,28 @@ without renaming.
 See [docs/installation.md](docs/installation.md) for the authoritative
 installation guide, including environment setup, optional features and
 upgrade instructions.
+
+### Optional extras
+
+Autoresearch exposes optional features via pip extras:
+
+- `nlp` – language processing via spaCy and BERTopic
+- `llm` – heavy model dependencies like `sentence-transformers` and
+  `transformers`
+- `parsers` – PDF and DOCX document ingestion
+- `ui` – the reference Streamlit interface
+- `vss` – DuckDB vector search extension
+- `distributed` – distributed processing with Ray and Redis
+- `analysis` – Polars-based data analysis utilities
+- `git` – local Git repository search support
+- `full` – installs most extras (nlp, ui, vss, distributed, analysis) but omits
+  `parsers` and `git`
+
+Install extras with pip:
+
+```bash
+pip install "autoresearch[nlp,ui]"
+```
 
 ## Building the documentation
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,20 +9,20 @@ vars:
 tasks:
   install:
     cmds:
-      - uv sync --extra dev --extra test
+      - uv sync --extra dev-minimal
     desc: "Initialize development environment"
   check-env:
     cmds:
       - uv run python scripts/check_env.py
       - >
           uv run python -c "import pytest_httpx" 2>/dev/null ||
-          echo "Warning: pytest-httpx missing; install with 'task install' or 'uv sync --extra dev'."
+          echo "Warning: pytest-httpx missing; install with 'task install' or 'uv sync --extra dev-minimal'."
       - >
           uv run python -c "import tomli_w" 2>/dev/null ||
-          echo "Warning: tomli-w missing; install with 'task install' or 'uv sync --extra dev'."
+          echo "Warning: tomli-w missing; install with 'task install' or 'uv sync --extra dev-minimal'."
       - >
           uv run python -c "import redis" 2>/dev/null ||
-          echo "Warning: redis missing; install with 'task install' or 'uv sync --extra dev'."
+          echo "Warning: redis missing; install with 'task install' or 'uv sync --extra dev-minimal'."
     desc: "Validate required tool versions"
   check:
     deps: [check-env]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,9 +17,10 @@ Run a bootstrap command immediately:
 ```bash
 ./scripts/setup.sh  # full developer bootstrap
 # or
-task install        # developer environment
+task install        # lightweight developer environment
 ```
 
+`task install` syncs only the `dev-minimal` extras for a faster setup.
 `./scripts/setup.sh` installs Go Task when missing, syncs the `dev` and `test`
 extras (including packages such as `pytest_httpx`, `tomli_w`, `freezegun`,
 `hypothesis`, and `redis`), and exits if `task --version` fails.
@@ -143,13 +144,13 @@ Use `uv` to manage the environment when working from a clone:
 
 ```bash
 # Install pinned dependencies for development
-uv sync --extra dev
+uv sync --extra dev-minimal
 # Activate the environment
 source .venv/bin/activate
 ```
 
-Run `task install` or `uv sync --extra dev` before executing tests to ensure
-the development dependencies are available.
+Run `task install` or `uv sync --extra dev-minimal` before executing tests to
+ensure the development dependencies are available.
 
 Add heavy extras on demand:
 
@@ -160,7 +161,7 @@ uv sync --extra nlp
 
 After installing Go Task, pick a bootstrap method:
 
-- `task install` – developer setup
+- `task install` – lightweight developer setup
 - [`scripts/setup.sh`](../scripts/setup.sh) – full developer toolchain
 
 Run `uv lock` whenever you change `pyproject.toml` to update `uv.lock`

--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -4,11 +4,10 @@ Metrics collection for orchestration system.
 
 import json
 import logging
-import math
 import os
 import time
 from contextlib import contextmanager
-from decimal import Decimal, ROUND_HALF_EVEN
+from decimal import ROUND_HALF_EVEN, Decimal
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Tuple
 
@@ -458,9 +457,7 @@ class OrchestrationMetrics:
         # Round using ``Decimal`` to avoid floating-point drift that could
         # otherwise inflate the budget (e.g. ``14.5000000001`` rounding to
         # ``15``).
-        scaled = Decimal(str(max(usage_candidates))) * (
-            Decimal("1") + Decimal(str(margin))
-        )
+        scaled = Decimal(str(max(usage_candidates))) * (Decimal("1") + Decimal(str(margin)))
         desired = int(scaled.quantize(Decimal("1"), rounding=ROUND_HALF_EVEN))
 
         return max(desired, 1)

--- a/tests/behavior/features/conftest.py
+++ b/tests/behavior/features/conftest.py
@@ -1,4 +1,5 @@
 """Load behavior fixtures when running feature files directly."""
+
 import sys
 from pathlib import Path
 
@@ -8,4 +9,4 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 # Import behavior-level fixtures and plugin registrations
-from tests.behavior.conftest import *  # noqa: F401,F403
+from tests.behavior.conftest import *  # noqa: F401,F403,E402

--- a/tests/unit/test_api_auth_middleware.py
+++ b/tests/unit/test_api_auth_middleware.py
@@ -23,7 +23,7 @@ def test_resolve_role_invalid_key():
     role, err = middleware._resolve_role("bad", cfg.api)
     assert role == "anonymous"
     assert err is not None
-    assert err.status_code == 403
+    assert err.status_code == 401
 
 
 def test_resolve_role_missing_key():
@@ -53,4 +53,4 @@ def test_dispatch_invalid_token(monkeypatch):
         return Response("ok")
 
     resp = asyncio.run(middleware.dispatch(request, call_next))
-    assert resp.status_code == 403
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- Default `task install` to the lightweight `dev-minimal` extras and update helper warnings
- Document optional pip extras and lightweight install path in README and installation guide
- Align API auth middleware tests with current 401 responses

## Testing
- `task install` *(pass)*
- `uv run mkdocs build` *(pass)*
- `task verify` *(fail: KeyboardInterrupt after tests completed)*

------
https://chatgpt.com/codex/tasks/task_e_68abb4a422f08333b295ea1ccd002219