### PR TITLE
Use dev-minimal extras and document optional extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ the full developer bootstrap or `task install` for a minimal environment. See
 [docs/installation.md#after-cloning](docs/installation.md#after-cloning) for
 details.
 
-To bootstrap a Python 3.12+ environment with development and test extras run:
+To bootstrap a Python 3.12+ environment with the lightweight development and test
+extras run:
 
 ```bash
 task install
 ```
 
-This installs tools like `pytest-httpx`, `duckdb`, and `networkx` needed for
-local testing.
+This syncs the `dev-minimal` and `test` extras to install tools like
+`pytest-httpx`, `duckdb`, and `networkx` needed for local testing.
 
 For current capabilities and known limitations see
 [docs/release_notes.md](docs/release_notes.md).
@@ -70,6 +71,23 @@ See [docs/installation.md](docs/installation.md) for the authoritative
 installation guide, including environment setup, optional features and
 upgrade instructions.
 
+### Optional extras
+
+Autoresearch exposes optional extras to enable additional features:
+
+- `nlp` – language processing via spaCy and BERTopic
+- `llm` – heavy LLM libraries like `sentence-transformers`
+- `parsers` – PDF and DOCX document ingestion
+- `ui` – reference Streamlit interface
+- `vss` – DuckDB VSS extension for vector search
+- `distributed` – Ray and Redis for distributed processing
+- `analysis` – Polars-based data analysis utilities
+- `git` – local Git repository search
+- `full` – installs `nlp`, `ui`, `vss`, `distributed`, and `analysis`
+
+Install extras with `uv sync --extra nlp` or
+`pip install "autoresearch[nlp]"`.
+
 ## Building the documentation
 
 Install MkDocs and generate the static site:
@@ -83,4 +101,6 @@ Use `mkdocs serve` to preview the documentation locally.
 
 ## Accessibility
 
-CLI output uses Markdown headings and plain-text lists so screen readers can navigate sections. Help messages avoid color-only cues and respect the `NO_COLOR` environment variable for ANSI-free output.
+CLI output uses Markdown headings and plain-text lists so screen readers can
+navigate sections. Help messages avoid color-only cues and respect the
+`NO_COLOR` environment variable for ANSI-free output.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,7 +9,7 @@ vars:
 tasks:
   install:
     cmds:
-      - uv sync --extra dev --extra test
+      - uv sync --extra dev-minimal --extra test
     desc: "Initialize development environment"
   check-env:
     cmds:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,9 +17,10 @@ Run a bootstrap command immediately:
 ```bash
 ./scripts/setup.sh  # full developer bootstrap
 # or
-task install        # developer environment
+task install        # lightweight dev-minimal and test extras
 ```
 
+`task install` syncs the `dev-minimal` and `test` extras for a quick setup.
 `./scripts/setup.sh` installs Go Task when missing, syncs the `dev` and `test`
 extras (including packages such as `pytest_httpx`, `tomli_w`, `freezegun`,
 `hypothesis`, and `redis`), and exits if `task --version` fails.
@@ -143,13 +144,13 @@ Use `uv` to manage the environment when working from a clone:
 
 ```bash
 # Install pinned dependencies for development
-uv sync --extra dev
+uv sync --extra dev-minimal --extra test
 # Activate the environment
 source .venv/bin/activate
 ```
 
-Run `task install` or `uv sync --extra dev` before executing tests to ensure
-the development dependencies are available.
+Run `task install` or `uv sync --extra dev-minimal --extra test` before
+executing tests to ensure the development dependencies are available.
 
 Add heavy extras on demand:
 

--- a/duckdb/__init__.py
+++ b/duckdb/__init__.py
@@ -1,8 +1,21 @@
 """Minimal stub of duckdb for tests."""
 
 
+class Error(Exception):
+    """Placeholder DuckDB exception."""
+
+
 class DuckDBPyConnection:  # pragma: no cover - placeholder
-    pass
+    """Minimal DuckDB connection stub."""
+
+    def execute(self, *args, **kwargs):
+        return self
+
+    def fetchall(self):
+        return []
+
+    def close(self):
+        return None
 
 
 def connect(*args, **kwargs):  # pragma: no cover - placeholder

--- a/src/autoresearch/extensions.py
+++ b/src/autoresearch/extensions.py
@@ -7,12 +7,16 @@ particularly the VSS extension used for vector similarity search.
 
 import os
 from pathlib import Path
+from typing import Any
 
 import duckdb
 
 from .config import ConfigLoader
 from .errors import StorageError
 from .logging_utils import get_logger
+
+# Use "Any" for DuckDB connections due to incomplete upstream type hints.
+DuckDBConnection = Any
 
 log = get_logger(__name__)
 
@@ -28,7 +32,7 @@ class VSSExtensionLoader:
     """
 
     @staticmethod
-    def load_extension(conn: duckdb.DuckDBPyConnection) -> bool:
+    def load_extension(conn: DuckDBConnection) -> bool:
         """Load the VSS extension into the provided DuckDB connection.
 
         This method attempts to load the VSS extension using the following strategy:
@@ -65,13 +69,9 @@ class VSSExtensionLoader:
                         log.info("VSS extension loaded successfully from filesystem")
                         extension_loaded = True
                     else:
-                        log.warning(
-                            "VSS extension failed verification after filesystem load"
-                        )
-                except duckdb.Error as e:
-                    log.warning(
-                        "Failed to load VSS extension from filesystem: %s", e
-                    )
+                        log.warning("VSS extension failed verification after filesystem load")
+                except duckdb.Error as e:  # type: ignore[attr-defined]
+                    log.warning("Failed to load VSS extension from filesystem: %s", e)
 
         if not extension_loaded:
             try:
@@ -84,7 +84,7 @@ class VSSExtensionLoader:
                     extension_loaded = True
                 else:
                     log.warning("VSS extension may not be fully loaded")
-            except duckdb.Error as e:
+            except duckdb.Error as e:  # type: ignore[attr-defined]
                 log.error(f"Failed to load VSS extension: {e}")
                 if os.getenv("AUTORESEARCH_STRICT_EXTENSIONS", "").lower() == "true":
                     raise StorageError("Failed to load VSS extension", cause=e)
@@ -92,7 +92,7 @@ class VSSExtensionLoader:
         return extension_loaded
 
     @staticmethod
-    def verify_extension(conn: duckdb.DuckDBPyConnection, verbose: bool = True) -> bool:
+    def verify_extension(conn: DuckDBConnection, verbose: bool = True) -> bool:
         """
         Verify that the VSS extension is loaded and functioning correctly.
 
@@ -118,7 +118,7 @@ class VSSExtensionLoader:
                 if verbose:
                     log.warning("VSS extension is not loaded")
                 return False
-        except duckdb.Error as e:
+        except duckdb.Error as e:  # type: ignore[attr-defined]
             if verbose:
                 log.warning(f"VSS extension verification failed: {e}")
             return False

--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -29,7 +29,6 @@ from dataclasses import dataclass, field
 from threading import RLock
 from typing import Any, ClassVar, Iterator, Optional, cast
 
-import duckdb
 import networkx as nx
 import rdflib
 
@@ -39,6 +38,9 @@ from .kg_reasoning import run_ontology_reasoner
 from .logging_utils import get_logger
 from .orchestration.metrics import EVICTION_COUNTER
 from .storage_backends import DuckDBStorageBackend, KuzuStorageBackend
+
+# Use "Any" for DuckDB connections due to incomplete upstream type hints.
+DuckDBConnection = Any
 
 
 @dataclass
@@ -1274,7 +1276,7 @@ class StorageManager(metaclass=StorageManagerMeta):
             )
 
     @staticmethod
-    def get_duckdb_conn() -> duckdb.DuckDBPyConnection:
+    def get_duckdb_conn() -> DuckDBConnection:
         """Get the DuckDB connection used for relational storage.
 
         This method returns the global DuckDB connection used for relational
@@ -1285,7 +1287,7 @@ class StorageManager(metaclass=StorageManagerMeta):
         delegated to that implementation.
 
         Returns:
-            duckdb.DuckDBPyConnection: The DuckDB connection instance.
+            DuckDBConnection: The DuckDB connection instance.
 
         Raises:
             NotFoundError: If the connection cannot be initialized or remains None after initialization.
@@ -1304,7 +1306,7 @@ class StorageManager(metaclass=StorageManagerMeta):
 
     @staticmethod
     @contextmanager
-    def connection() -> Iterator[duckdb.DuckDBPyConnection]:
+    def connection() -> Iterator[DuckDBConnection]:
         """Borrow a DuckDB connection from the pool."""
         if _delegate and _delegate is not StorageManager:
             with _delegate.connection() as conn:

--- a/tests/behavior/__init__.py
+++ b/tests/behavior/__init__.py
@@ -2,4 +2,3 @@
 
 # Ensure the pytest-bdd plugin loads for feature collection
 pytest_plugins = ["pytest_bdd"]
-


### PR DESCRIPTION
## Summary
- Default `task install` to lightweight `dev-minimal` extras
- Document optional extras like `nlp`, `llm`, and `ui` in README and docs
- Stub DuckDB module for testing

## Testing
- `task install`
- `task verify` *(fails: tests/behavior/__init__.py:5:1: W391 blank line at end of file)*

------
https://chatgpt.com/codex/tasks/task_e_68abbc10b0448333a0b72f831ab708f8