### PR TITLE
Harden API auth and expand coverage

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -20,6 +20,8 @@ machine.
   [search backends](search_backends.md) and [storage](storage.md)).
 - Quickstart and advanced guides help explore features (see [quickstart
   guides](quickstart_guides.md) and [advanced usage](advanced_usage.md)).
+- HTTP API authenticates using configured API keys or bearer tokens. Any
+  provided credential must be valid or the request receives a 401 response.
 
 ### Known Limitations
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -23,6 +23,10 @@ Follow these steps to publish a new version of Autoresearch.
   uv run twine upload dist/*
   ```
 
+- Configure authentication in `config.yml` using `api.api_key`,
+  `api.api_keys`, or `api.bearer_token`. Any supplied credential must be valid
+  or the server returns a 401 error.
+
 - If DuckDB extensions fail to download during packaging, the build
   continues with a warning. The download script falls back to
   `VECTOR_EXTENSION_PATH` defined in `.env.offline` and copies the

--- a/tests/integration/test_api_auth_streaming.py
+++ b/tests/integration/test_api_auth_streaming.py
@@ -1,0 +1,69 @@
+import pytest
+
+from autoresearch.api.utils import generate_bearer_token
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.state import QueryState
+
+from .test_api_auth import _setup
+
+
+def _setup_stream(monkeypatch):
+    cfg = _setup(monkeypatch)
+
+    def dummy_run_query(query, config, callbacks=None, **kwargs):
+        state = QueryState(query=query)
+        if callbacks and "on_cycle_end" in callbacks:
+            callbacks["on_cycle_end"](0, state)
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+
+    monkeypatch.setattr(Orchestrator, "run_query", dummy_run_query)
+    return cfg
+
+
+@pytest.mark.slow
+def test_streaming_with_api_key(monkeypatch, api_client):
+    cfg = _setup_stream(monkeypatch)
+    cfg.api.api_key = "secret"
+
+    with api_client.stream(
+        "POST", "/query?stream=true", json={"query": "q"}, headers={"X-API-Key": "secret"}
+    ) as resp:
+        assert resp.status_code == 200
+        _ = [line for line in resp.iter_lines()]
+
+    bad = api_client.post("/query?stream=true", json={"query": "q"}, headers={"X-API-Key": "bad"})
+    assert bad.status_code == 401
+    assert bad.json()["detail"] == "Invalid API key"
+
+    missing = api_client.post("/query?stream=true", json={"query": "q"})
+    assert missing.status_code == 401
+    assert missing.json()["detail"] == "Missing API key"
+
+
+@pytest.mark.slow
+def test_streaming_with_bearer_token(monkeypatch, api_client):
+    cfg = _setup_stream(monkeypatch)
+    token = generate_bearer_token()
+    cfg.api.bearer_token = token
+
+    with api_client.stream(
+        "POST",
+        "/query?stream=true",
+        json={"query": "q"},
+        headers={"Authorization": f"Bearer {token}"},
+    ) as resp:
+        assert resp.status_code == 200
+        _ = [line for line in resp.iter_lines()]
+
+    bad = api_client.post(
+        "/query?stream=true",
+        json={"query": "q"},
+        headers={"Authorization": "Bearer bad"},
+    )
+    assert bad.status_code == 401
+    assert bad.json()["detail"] == "Invalid token"
+
+    missing = api_client.post("/query?stream=true", json={"query": "q"})
+    assert missing.status_code == 401
+    assert missing.json()["detail"] == "Missing token"


### PR DESCRIPTION
## Summary
- require every supplied API key or bearer token to be valid
- add auth tests for invalid credentials and streaming endpoints
- document auth configuration in release notes and release guide

## Testing
- `task check` *(fails: command not found)*
- `uv run flake8 src/autoresearch/api/middleware.py tests/integration/test_api_auth.py tests/integration/test_api_auth_streaming.py`
- `uv run pytest tests/integration/test_api_auth.py tests/integration/test_api_auth_streaming.py` *(fails: Failed to create tables)*
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68abca2ef1a8833383058040500f15a7