### PR TITLE
refactor: lighten dev-minimal extras

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,6 +21,13 @@ task install        # lightweight dev-minimal and test extras
 ```
 
 `task install` syncs the `dev-minimal` and `test` extras for a quick setup.
+Install heavier groups only when needed:
+
+```bash
+uv sync --extra nlp  # spaCy and BERTopic
+uv sync --extra llm  # sentence-transformers and transformers
+```
+
 `./scripts/setup.sh` installs Go Task when missing, syncs the `dev` and `test`
 extras (including packages such as `pytest_httpx`, `tomli_w`, `freezegun`,
 `hypothesis`, and `redis`), and exits if `task --version` fails.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,9 +181,6 @@ dev-minimal = [
     "types-tabulate >=0.9.0",
     "freezegun >=1.5.0",
     "responses >=0.25.7",
-    "uvicorn >=0.35.0",
-    "psutil >=7.0.0",
-    "redis >=6.2",
 ]
 
 # Packaging utilities for building and publishing distributions


### PR DESCRIPTION
## Summary
- drop server/runtime deps from `dev-minimal` optional group
- document how to install heavier NLP/LLM extras on demand
- confirm `task install` syncs only `dev-minimal` and `test` extras

## Testing
- `uv run mkdocs build`
- `task check` *(fails: 34 failed, 7 errors)*
- `task verify` *(fails: 34 failed, 7 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abca4d53e483339ef95fc026d0ec89