### PR TITLE
Enforce API permission semantics and document auth handshake

### DIFF
--- a/docs/algorithms/api_authentication.md
+++ b/docs/algorithms/api_authentication.md
@@ -11,11 +11,11 @@ model, and why comparisons run in constant time.
    - `Authorization: Bearer <token>` for a bearer token.
 3. The server fetches the expected credential from configuration.
 4. Verification uses a constant-time comparison.
-5. On success the request proceeds. Missing or invalid credentials trigger a
-   **401 Unauthorized** response with messages such as ``Missing API key``,
-   ``Invalid API key``, ``Missing token``, or ``Invalid token``. Authenticated
-   clients lacking required permissions receive **403 Forbidden** with an
-   ``Insufficient permissions`` detail.
+5. The resolved role is checked against ``[api].role_permissions``.
+   Missing or invalid credentials trigger **401 Unauthorized** with messages
+   such as ``Missing API key``, ``Invalid API key``, ``Missing token``, or
+   ``Invalid token``. Authenticated clients lacking required permissions
+   receive **403 Forbidden** with an ``Insufficient permissions`` detail.
 
 ## Configuration
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,10 +27,15 @@ variables. Common options include:
 Setting `AUTORESEARCH_API__API_KEY` enables a single shared key while
 `AUTORESEARCH_API__API_KEYS` maps multiple keys to roles. Use
 `AUTORESEARCH_API__BEARER_TOKEN` to require an `Authorization: Bearer` header.
-Requests without credentials or with invalid credentials return **401**.
-Authenticated clients lacking permission receive **403**. Modify
-`AUTORESEARCH_API__ROLE_PERMISSIONS` to assign
-actions to roles.
+
+Authentication follows a two-step handshake:
+
+1. Credentials are validated against configured keys or the bearer token.
+2. The resolved role is checked against `[api].role_permissions`.
+
+Missing or invalid credentials yield **401 Unauthorized**. Authenticated
+clients without the required permission receive **403 Forbidden**. Adjust
+`AUTORESEARCH_API__ROLE_PERMISSIONS` to assign actions to roles.
 
 Restart the server after changing these values.
 

--- a/src/autoresearch/api/__init__.py
+++ b/src/autoresearch/api/__init__.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 from . import routing
 from .middleware import (
     SLOWAPI_STUB,
-    RateLimitExceeded as _RateLimitExceeded,
+)
+from .middleware import Limiter as _Limiter
+from .middleware import RateLimitExceeded as _RateLimitExceeded
+from .middleware import (
     dynamic_limit,
     get_remote_address,
-    Limiter as _Limiter,
     parse,
 )
 from .utils import (
     RequestLogger,
     create_request_logger,
+    enforce_permission,
     get_request_logger,
     reset_request_log,
 )
@@ -40,6 +43,7 @@ __all__ = [
     "RateLimitExceeded",
     "Limiter",
     "query_endpoint",
+    "enforce_permission",
     "create_request_logger",
     "get_request_logger",
     "RequestLogger",

--- a/src/autoresearch/api/deps.py
+++ b/src/autoresearch/api/deps.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends, Request
 
 from ..orchestration.orchestrator import Orchestrator
+from .utils import enforce_permission
 
 
 def require_permission(permission: str):
@@ -16,10 +17,7 @@ def require_permission(permission: str):
 
     async def checker(request: Request) -> None:
         permissions = getattr(request.state, "permissions", None)
-        if permissions is None:
-            raise HTTPException(status_code=401, detail="Authentication required")
-        if permission not in permissions:
-            raise HTTPException(status_code=403, detail="Insufficient permissions")
+        enforce_permission(permissions, permission)
 
     return Depends(checker)
 

--- a/tests/integration/test_api_auth_permissions.py
+++ b/tests/integration/test_api_auth_permissions.py
@@ -1,0 +1,42 @@
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import APIConfig, ConfigModel
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import Orchestrator
+
+
+def _setup(monkeypatch):
+    cfg = ConfigModel(api=APIConfig())
+    ConfigLoader.reset_instance()
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setattr(
+        Orchestrator,
+        "run_query",
+        lambda q, c, callbacks=None, **k: QueryResponse(
+            answer="ok", citations=[], reasoning=[], metrics={}
+        ),
+    )
+    return cfg
+
+
+def test_permission_success(monkeypatch, api_client):
+    cfg = _setup(monkeypatch)
+    cfg.api.api_keys = {"adm": "admin"}
+    cfg.api.role_permissions = {"admin": ["metrics"]}
+    resp = api_client.get("/metrics", headers={"X-API-Key": "adm"})
+    assert resp.status_code == 200
+
+
+def test_permission_forbidden(monkeypatch, api_client):
+    cfg = _setup(monkeypatch)
+    cfg.api.api_keys = {"usr": "user"}
+    cfg.api.role_permissions = {"user": []}
+    resp = api_client.get("/metrics", headers={"X-API-Key": "usr"})
+    assert resp.status_code == 403
+
+
+def test_permission_unauthenticated(monkeypatch, api_client):
+    cfg = _setup(monkeypatch)
+    cfg.api.api_key = "secret"
+    resp = api_client.get("/metrics")
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Missing API key"


### PR DESCRIPTION
## Summary
- add `enforce_permission` helper and export it through `autoresearch.api`
- rely on the new helper inside `require_permission`
- document two-step auth handshake and role-based 401/403 behavior
- cover auth success and failure paths with new integration tests

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit -q` *(fails: ModuleNotFoundError: No module named 'tomli_w')*
- `uv run pytest tests/integration/test_api_auth_permissions.py -q` *(fails: autoresearch.errors.StorageError: Failed to create tables)*
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68abe0dec93083339ca51323666d87ae