### PR TITLE
Clarify release schedule and track failing metrics/monitor tests

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,8 @@
 # Status
 
-As of **August 25, 2025**, `scripts/codex_setup.sh` installs Go Task and the `dev`
-and `test` extras. Linting and type checks pass, but many unit tests fail.
+As of **August 26, 2025**, `scripts/codex_setup.sh` installs Go Task and the
+`dev` and `test` extras. Linting and type checks pass, but many unit tests
+fail.
 
 ## Lint, type checks, and spec tests
 ```text
@@ -15,8 +16,8 @@ Result: passed
 ```text
 uv run pytest tests/unit -q
 ```
-Result: 33 failed, 626 passed, 26 skipped, 24 deselected, 1 xfailed, 1 xpassed,
-31 warnings, 7 errors
+Result: 34 failed, 625 passed, 26 skipped, 24 deselected, 1 xfailed, 1 xpassed,
+32 warnings, 7 errors
 
 ## Integration tests
 ```text

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,11 +1,10 @@
 # Autoresearch Project - Task Progress
 
 This document tracks the progress of tasks for the Autoresearch project,
-organized by phases from the code complete plan. As of **August 24, 2025**, see
+organized by phases from the code complete plan. As of **August 26, 2025**, see
 [docs/release_plan.md](docs/release_plan.md) for current test and coverage
-status.
-An **0.1.0-alpha.1** preview is scheduled for **2026-03-01**, with
-the final **0.1.0** release targeted for **July 1, 2026**.
+status. An **0.1.0-alpha.1** preview is scheduled for **2026-04-15**, with the
+final **0.1.0** release targeted for **July 1, 2026**.
 
 ## Phase 1: Core System Completion (Weeks 1-2)
 

--- a/issues/fix-metrics-summary-type-errors.md
+++ b/issues/fix-metrics-summary-type-errors.md
@@ -1,0 +1,16 @@
+# Fix metrics summary type errors
+
+## Context
+Unit tests `tests/unit/test_metrics_extra.py::test_cycle_and_agent_metrics` and
+`tests/unit/test_metrics_summary.py::test_metrics_summary` raise `TypeError:
+'types.SimpleNamespace' object is not callable`, indicating the metrics
+utilities return incorrect types.
+
+## Acceptance Criteria
+- Metrics helpers return callable objects and no longer raise `TypeError`.
+- `tests/unit/test_metrics_extra.py::test_cycle_and_agent_metrics` passes.
+- `tests/unit/test_metrics_summary.py::test_metrics_summary` passes.
+- Documentation clarifies expected metrics interfaces.
+
+## Status
+Open

--- a/issues/repair-monitor-serve-command.md
+++ b/issues/repair-monitor-serve-command.md
@@ -1,0 +1,16 @@
+# Repair monitor serve command
+
+## Context
+Unit tests `tests/unit/test_main_monitor_commands.py::test_serve_a2a_command`
+and `tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt`
+fail, showing the monitor CLI `serve` subcommand exits with a non-zero status and
+mishandles interrupts.
+
+## Acceptance Criteria
+- `serve` subcommand exits with status 0 when run normally.
+- `serve` subcommand handles keyboard interrupts gracefully.
+- `tests/unit/test_main_monitor_commands.py` passes.
+- Documentation describes the `monitor serve` workflow.
+
+## Status
+Open

--- a/issues/resolve-test-failures-and-task-tooling.md
+++ b/issues/resolve-test-failures-and-task-tooling.md
@@ -2,10 +2,11 @@
 
 ## Context
 Go Task and `redis` install correctly, and linting and type checks pass. However
-`./.venv/bin/task check` reports 33 failing tests and seven errors. Failures stem
-from DuckDB table creation errors, missing CLI help options, broken backup
-subcommands, and incorrect token budget history logic. Behavior feature
-discovery and API authentication remain unresolved.
+`task check` still reports 34 failing tests and seven errors. Failures include
+DuckDB table creation errors, monitor command failures, TypeErrors in metrics
+tests, missing CLI help options, broken backup subcommands, and incorrect token
+budget history logic. Behavior feature discovery and API authentication remain
+unresolved.
 
 Redis-dependent integration tests skip cleanly when `redis` is missing.
 
@@ -15,10 +16,12 @@ Redis-dependent integration tests skip cleanly when `redis` is missing.
 - [repair-api-authentication-endpoints](repair-api-authentication-endpoints.md)
 - [fix-concurrent-query-interface-behavior](archive/fix-concurrent-query-interface-behavior.md)
 - [add-redis-dependency-for-integration-tests](add-redis-dependency-for-integration-tests.md)
+- [fix-metrics-summary-type-errors](fix-metrics-summary-type-errors.md)
 - [fix-monitor-cli-metrics-failure](archive/fix-monitor-cli-metrics-failure.md)
 - [fix-pytest-bdd-feature-discovery](fix-pytest-bdd-feature-discovery.md)
 - [fix-storage-table-creation-errors](fix-storage-table-creation-errors.md)
 - [repair-cli-help-and-backup-commands](repair-cli-help-and-backup-commands.md)
+- [repair-monitor-serve-command](repair-monitor-serve-command.md)
 - [correct-token-budget-history-logic](correct-token-budget-history-logic.md)
 
 ## Acceptance Criteria


### PR DESCRIPTION
## Summary
- update status and task progress with latest test counts and alpha target
- expand failing-test issue with metrics and monitor failures
- add issues for metrics type errors and monitor serve command

## Testing
- `task check` *(fails: 34 failed, 625 passed, 26 skipped, 24 deselected, 1 xfailed, 1 xpassed, 32 warnings, 7 errors)*
- `task verify` *(fails: 34 failed, 625 passed, 26 skipped, 24 deselected, 2 xfailed, 32 warnings, 7 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7842446c8333af75c30f76bc048d