### PR TITLE
refactor: expose callable time interface for metrics

### DIFF
--- a/docs/specs/orchestration.md
+++ b/docs/specs/orchestration.md
@@ -13,6 +13,8 @@ and error handling while providing detailed logging and token counting.
   state.
 - Run agent groups in parallel and synthesize their results.
 - Record token usage and emit structured debug logs.
+- Metrics helpers depend on callables (e.g., `time.time`) so tests can swap
+  implementations without using `types.SimpleNamespace`.
 
 ## Traceability
 

--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -1,12 +1,12 @@
 """Metrics collection for orchestration system."""
 
 import logging
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from decimal import ROUND_HALF_EVEN, Decimal
 from os import getenv
 from pathlib import Path
-from time import time
 from typing import Any
 
 from prometheus_client import Counter, Histogram
@@ -208,12 +208,12 @@ class OrchestrationMetrics:
 
     def start_cycle(self) -> None:
         """Mark the start of a new cycle."""
-        self.last_cycle_start = time()
+        self.last_cycle_start = time.time()
 
     def end_cycle(self) -> None:
         """Mark the end of a cycle and record duration."""
         if self.last_cycle_start:
-            duration = time() - self.last_cycle_start
+            duration = time.time() - self.last_cycle_start
             self.cycle_durations.append(duration)
             self.last_cycle_start = None
 
@@ -226,7 +226,7 @@ class OrchestrationMetrics:
     def record_system_resources(self) -> None:
         """Record current CPU, memory, and GPU usage."""
         cpu, mem, gpu, gpu_mem = _get_system_usage()
-        self.resource_usage.append((time(), cpu, mem, gpu, gpu_mem))
+        self.resource_usage.append((time.time(), cpu, mem, gpu, gpu_mem))
 
     def record_tokens(self, agent_name: str, tokens_in: int, tokens_out: int) -> None:
         """Record token usage for an agent."""

--- a/tests/unit/test_metrics_extra.py
+++ b/tests/unit/test_metrics_extra.py
@@ -1,11 +1,12 @@
-import types
-
 from autoresearch.orchestration import metrics
 
 
 def test_cycle_and_agent_metrics(monkeypatch, tmp_path):
-    fake_time = types.SimpleNamespace(time=lambda: 1.0)
-    monkeypatch.setattr(metrics, "time", fake_time)
+    def fake_time() -> float:
+        return 1.0
+
+    monkeypatch.setattr(metrics.time, "time", fake_time)
+    assert callable(metrics.time.time)
     path = tmp_path / "dir" / "release.json"
     monkeypatch.setenv("AUTORESEARCH_RELEASE_METRICS", str(path))
     m = metrics.OrchestrationMetrics()

--- a/tests/unit/test_metrics_summary.py
+++ b/tests/unit/test_metrics_summary.py
@@ -1,14 +1,15 @@
-import types
 import pytest
+
 from autoresearch.orchestration import metrics
 
 
 def _fake_time_gen():
-    t = {'v': 0}
+    t = {"v": 0}
 
-    def fake():
-        t['v'] += 1
-        return t['v']
+    def fake() -> int:
+        t["v"] += 1
+        return t["v"]
+
     return fake
 
 
@@ -21,7 +22,8 @@ def _fake_time_gen():
 )
 def test_metrics_summary(monkeypatch, records):
     fake_time = _fake_time_gen()
-    monkeypatch.setattr(metrics, "time", types.SimpleNamespace(time=fake_time))
+    monkeypatch.setattr(metrics.time, "time", fake_time)
+    assert callable(metrics.time.time)
 
     m = metrics.OrchestrationMetrics()
     total_in = total_out = 0


### PR DESCRIPTION
## Summary
- refactor metrics to import time module and use callable interface
- update tests to patch time providers with callables
- document callable metrics helpers in orchestration spec

## Testing
- `task check` *(fails: command not found)*
- `uv run black --check src/autoresearch/orchestration/metrics.py tests/unit/test_metrics_extra.py tests/unit/test_metrics_summary.py`
- `uv run isort --check-only src/autoresearch/orchestration/metrics.py tests/unit/test_metrics_extra.py tests/unit/test_metrics_summary.py`
- `uv run pytest tests/unit/test_metrics_extra.py tests/unit/test_metrics_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac7caf2c5c833382774c6eb8d3b04d