### PR TITLE
fix: ensure in-memory storage initializes tables

### DIFF
--- a/docs/algorithms/storage_eviction.md
+++ b/docs/algorithms/storage_eviction.md
@@ -9,6 +9,13 @@ policies. We model two strategies:
 Both policies operate in constant time per update and require memory
 linear in cache size.
 
+## DuckDB Initialization
+
+Use `initialize_storage()` when the DuckDB path is `:memory:`. In-memory
+databases start empty on each run, so the helper recreates the `nodes`,
+`edges`, `embeddings`, and `metadata` tables before eviction logic is
+evaluated.
+
 ## Verification
 
 Simulation tests


### PR DESCRIPTION
## Summary
- ensure initialize_storage creates DuckDB tables for in-memory databases
- add regression test covering in-memory storage initialization
- document in-memory DuckDB initialization requirements

## Testing
- `task check tests/unit/test_eviction.py src/autoresearch/storage.py docs/algorithms/storage_eviction.md` *(fails: command not found)*
- `uv run pytest tests/unit/test_eviction.py -k initialize_storage_in_memory -q`
- `uv run mkdocs build` *(fails: Config value 'plugins': The "mkdocstrings" plugin is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7cb3833083338d1e7f9600eb6ca3