### PR TITLE
Expose interactive search flags and harden backup CLI

### DIFF
--- a/src/autoresearch/cli_backup.py
+++ b/src/autoresearch/cli_backup.py
@@ -1,4 +1,5 @@
 """Typer commands for managing database backups."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -74,6 +75,14 @@ def backup_create(
             console.print(f"[yellow]Suggestion:[/yellow] {e.context['suggestion']}")
         raise typer.Exit(code=1)
 
+    except KeyboardInterrupt:
+        console.print("[bold yellow]Backup creation cancelled.[/bold yellow]")
+        raise typer.Exit(code=1)
+
+    except Exception as e:  # pragma: no cover - defensive
+        console.print(f"[bold red]Unexpected error creating backup:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
 
 @backup_app.command("restore")
 def backup_restore(
@@ -100,7 +109,8 @@ def backup_restore(
     try:
         if not force:
             console.print(
-                "[bold yellow]Warning:[/bold yellow] Restoring a backup will create new database files."
+                "[bold yellow]Warning:[/bold yellow] "
+                "Restoring a backup will create new database files."
             )
             console.print("The original files will not be modified, but you will need to configure")
             console.print("the application to use the restored files if you want to use them.")
@@ -131,6 +141,14 @@ def backup_restore(
         console.print(f"[bold red]Error restoring backup:[/bold red] {str(e)}")
         if hasattr(e, "context") and "suggestion" in e.context:
             console.print(f"[yellow]Suggestion:[/yellow] {e.context['suggestion']}")
+        raise typer.Exit(code=1)
+
+    except KeyboardInterrupt:
+        console.print("[bold yellow]Restore cancelled by user.[/bold yellow]")
+        raise typer.Exit(code=1)
+
+    except Exception as e:  # pragma: no cover - defensive
+        console.print(f"[bold red]Unexpected error restoring backup:[/bold red] {e}")
         raise typer.Exit(code=1)
 
 
@@ -175,14 +193,20 @@ def backup_list(
         console.print(table)
 
         if len(backups) > limit:
-            console.print(
-                f"Showing {limit} of {len(backups)} backups. Use --limit to show more."
-            )
+            console.print(f"Showing {limit} of {len(backups)} backups. Use --limit to show more.")
 
     except BackupError as e:
         console.print(f"[bold red]Error listing backups:[/bold red] {str(e)}")
         if hasattr(e, "context") and "suggestion" in e.context:
             console.print(f"[yellow]Suggestion:[/yellow] {e.context['suggestion']}")
+        raise typer.Exit(code=1)
+
+    except KeyboardInterrupt:
+        console.print("[bold yellow]Listing cancelled by user.[/bold yellow]")
+        raise typer.Exit(code=1)
+
+    except Exception as e:  # pragma: no cover - defensive
+        console.print(f"[bold red]Unexpected error listing backups:[/bold red] {e}")
         raise typer.Exit(code=1)
 
 
@@ -239,6 +263,14 @@ def backup_schedule(
             console.print(f"[yellow]Suggestion:[/yellow] {e.context['suggestion']}")
         raise typer.Exit(code=1)
 
+    except KeyboardInterrupt:
+        console.print("[bold yellow]Scheduling cancelled by user.[/bold yellow]")
+        raise typer.Exit(code=1)
+
+    except Exception as e:  # pragma: no cover - defensive
+        console.print(f"[bold red]Unexpected error scheduling backups:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
 
 @backup_app.command("recover")
 def backup_recover(
@@ -279,7 +311,8 @@ def backup_recover(
 
         if not force:
             console.print(
-                "[bold yellow]Warning:[/bold yellow] Point-in-time recovery will create new database files."
+                "[bold yellow]Warning:[/bold yellow] "
+                "Point-in-time recovery will create new database files."
             )
             console.print("The original files will not be modified, but you will need to configure")
             console.print("the application to use the recovered files if you want to use them.")
@@ -293,9 +326,7 @@ def backup_recover(
                 return
 
         with Progress() as progress:
-            task = progress.add_task(
-                "[green]Performing point-in-time recovery...", total=1
-            )
+            task = progress.add_task("[green]Performing point-in-time recovery...", total=1)
             restored_paths = BackupManager.restore_point_in_time(
                 backup_dir=backup_dir or "backups",
                 target_time=target_time,
@@ -303,9 +334,7 @@ def backup_recover(
             )
             progress.update(task, completed=1)
 
-        console.print(
-            "[bold green]Point-in-time recovery completed successfully:[/bold green]"
-        )
+        console.print("[bold green]Point-in-time recovery completed successfully:[/bold green]")
         console.print(f"  Target time: {target_time}")
         console.print(f"  DuckDB database: {restored_paths['db_path']}")
         console.print(f"  RDF store: {restored_paths['rdf_path']}")
@@ -314,11 +343,19 @@ def backup_recover(
         )
 
     except BackupError as e:
-        console.print(
-            f"[bold red]Error performing point-in-time recovery:[/bold red] {str(e)}"
-        )
+        console.print(f"[bold red]Error performing point-in-time recovery:[/bold red] {str(e)}")
         if hasattr(e, "context") and "suggestion" in e.context:
             console.print(f"[yellow]Suggestion:[/yellow] {e.context['suggestion']}")
+        raise typer.Exit(code=1)
+
+    except KeyboardInterrupt:
+        console.print("[bold yellow]Recovery cancelled by user.[/bold yellow]")
+        raise typer.Exit(code=1)
+
+    except Exception as e:  # pragma: no cover - defensive
+        console.print(
+            f"[bold red]Unexpected error performing point-in-time recovery:[/bold red] {e}"
+        )
         raise typer.Exit(code=1)
 
 

--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -128,7 +128,8 @@ def start_watcher(
     if is_first_run and ctx.invoked_subcommand is None:
         console.print("\n" + format_success("Welcome to Autoresearch!", symbol=False))
         console.print(
-            "A local-first research assistant that coordinates multiple agents to produce evidence-backed answers.\n"
+            "A local-first research assistant that coordinates multiple agents "
+            "to produce evidence-backed answers.\n"
         )
 
         print_info("Getting Started:", symbol=False)
@@ -301,7 +302,8 @@ def search(
         autoresearch search --agents Synthesizer,Contrarian "What is quantum computing?"
 
         # Run agent groups in parallel
-        autoresearch search --parallel --agent-groups "Synthesizer,Contrarian" "FactChecker" "Impacts of AI"
+        autoresearch search --parallel --agent-groups "Synthesizer,Contrarian" \
+            "FactChecker" "Impacts of AI"
     """
     config = _config_loader.load_config()
 
@@ -494,9 +496,9 @@ def serve_a2a(
 ) -> None:
     """Start an A2A server that exposes Autoresearch as an agent.
 
-    This allows other A2A-compatible agents to interact with Autoresearch via the Agent-to-Agent protocol.
-    The server exposes Autoresearch's capabilities as an agent that can process queries, manage configuration,
-    and discover capabilities.
+    This allows other A2A-compatible agents to interact with Autoresearch via the
+    Agent-to-Agent protocol. The server exposes Autoresearch's capabilities as an
+    agent that can process queries, manage configuration, and discover capabilities.
 
     Examples:
         # Start the A2A server on the default host and port
@@ -846,8 +848,9 @@ def test_a2a(
 ) -> None:
     """Test the A2A interface.
 
-    This command tests the A2A interface by sending test requests and displaying the responses.
-    It can test the connection to the A2A server, the capabilities endpoint, and the query functionality.
+    This command tests the A2A interface by sending test requests and displaying the
+    responses. It can test the connection to the A2A server, the capabilities
+    endpoint, and the query functionality.
 
     Examples:
         # Run a test suite with default queries
@@ -903,10 +906,33 @@ def visualize(
         "--layout",
         help="Graph layout algorithm (spring or circular)",
     ),
+    interactive: bool = typer.Option(
+        False,
+        "--interactive",
+        "-i",
+        help="Refine the query interactively between agent cycles",
+    ),
+    loops: int | None = typer.Option(
+        None,
+        "--loops",
+        help="Number of reasoning cycles to run",
+    ),
+    ontology: str | None = typer.Option(
+        None,
+        "--ontology",
+        help="Load an ontology file before executing the query",
+    ),
 ) -> None:
     """Run a query and render a knowledge graph."""
     try:
-        _cli_visualize_query(query, output, layout=layout)
+        _cli_visualize_query(
+            query,
+            output,
+            layout=layout,
+            interactive=interactive,
+            loops=loops,
+            ontology=ontology,
+        )
     except Exception:
         raise typer.Exit(1)
 

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -11,9 +11,7 @@ def test_cli_help_no_ansi(monkeypatch, dummy_storage):
     def _load(self):
         return ConfigModel.model_construct(loops=1)
 
-    monkeypatch.setattr(
-        ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False
-    )
+    monkeypatch.setattr(ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False)
     monkeypatch.setattr(ConfigLoader, "env_path", Path("dummy.env"), raising=False)
     monkeypatch.setattr(ConfigLoader, "load_config", _load)
     main = importlib.import_module("autoresearch.main")
@@ -31,9 +29,7 @@ def test_search_help_includes_interactive(monkeypatch, dummy_storage):
     def _load(self):
         return ConfigModel.model_construct(loops=1)
 
-    monkeypatch.setattr(
-        ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False
-    )
+    monkeypatch.setattr(ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False)
     monkeypatch.setattr(ConfigLoader, "env_path", Path("dummy.env"), raising=False)
     monkeypatch.setattr(ConfigLoader, "load_config", _load)
     main = importlib.import_module("autoresearch.main")
@@ -51,9 +47,7 @@ def test_search_help_includes_visualize(monkeypatch, dummy_storage):
     def _load(self):
         return ConfigModel.model_construct(loops=1)
 
-    monkeypatch.setattr(
-        ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False
-    )
+    monkeypatch.setattr(ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False)
     monkeypatch.setattr(ConfigLoader, "env_path", Path("dummy.env"), raising=False)
     monkeypatch.setattr(ConfigLoader, "load_config", _load)
     main = importlib.import_module("autoresearch.main")
@@ -75,9 +69,7 @@ def test_search_loops_option(monkeypatch, dummy_storage):
         loaded["loops"] = cfg.loops
         return cfg
 
-    monkeypatch.setattr(
-        ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False
-    )
+    monkeypatch.setattr(ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False)
     monkeypatch.setattr(ConfigLoader, "env_path", Path("dummy.env"), raising=False)
     monkeypatch.setattr(ConfigLoader, "load_config", _load)
 
@@ -106,15 +98,16 @@ def test_search_help_includes_ontology_flags(monkeypatch, dummy_storage):
     def _load(self):
         return ConfigModel.model_construct(loops=1)
 
-    monkeypatch.setattr(
-        ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False
-    )
+    monkeypatch.setattr(ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False)
     monkeypatch.setattr(ConfigLoader, "env_path", Path("dummy.env"), raising=False)
     monkeypatch.setattr(ConfigLoader, "load_config", _load)
     main = importlib.import_module("autoresearch.main")
     runner = CliRunner()
     result = runner.invoke(main.app, ["search", "--help"])
     assert result.exit_code == 0
+    assert "--ontology" in result.stdout
+    assert "--ontology-reasoner" in result.stdout
+    assert "--infer-relations" in result.stdout
 
 
 def test_visualize_help_includes_layout(monkeypatch, dummy_storage):
@@ -124,9 +117,7 @@ def test_visualize_help_includes_layout(monkeypatch, dummy_storage):
     def _load(self):
         return ConfigModel.model_construct(loops=1)
 
-    monkeypatch.setattr(
-        ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False
-    )
+    monkeypatch.setattr(ConfigLoader, "search_paths", [Path("dummy.toml")], raising=False)
     monkeypatch.setattr(ConfigLoader, "env_path", Path("dummy.env"), raising=False)
     monkeypatch.setattr(ConfigLoader, "load_config", _load)
     main = importlib.import_module("autoresearch.main")
@@ -134,3 +125,6 @@ def test_visualize_help_includes_layout(monkeypatch, dummy_storage):
     result = runner.invoke(main.app, ["visualize", "--help"])
     assert result.exit_code == 0
     assert "--layout" in result.stdout
+    assert "--interactive" in result.stdout
+    assert "--loops" in result.stdout
+    assert "--ontology" in result.stdout


### PR DESCRIPTION
## Summary
- Expand `visualize` command with `--interactive`, `--loops`, and `--ontology` options
- Add interactive, loops, and ontology support to graph visualization helper
- Improve backup CLI error handling and cover new flags/subcommands in unit tests

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run pytest tests/unit/test_cli_help.py tests/unit/test_main_backup_commands.py -q` *(fails: storage initialization and configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7cbb6d988333931329d88444d3f8