### PR TITLE
feat(api): validate auth before request handling

### DIFF
--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -14,8 +14,12 @@ credentials on every request and assigns a role to the connection. Endpoints
 use a `require_permission` dependency to verify that the role has access to a
 given resource.
 
-Requests without credentials return **401**. Invalid API keys or bearer
-tokens and authenticated clients lacking permission return **403**.
+Requests without credentials return **401** with a descriptive message such as
+`Missing API key`, `Missing token`, or `Missing API key or token` when both
+credentials are configured. Invalid API keys or bearer tokens return **401**
+with `Invalid API key` or `Invalid token`. Authenticated clients lacking
+permission receive **403** `Insufficient permissions`. Streaming and webhook
+requests follow the same rules.
 
 ## Configuration
 
@@ -48,8 +52,9 @@ permissions constrain the impact of a leaked credential.
     - [tests/unit/test_api_auth_middleware.py][t4]
     - [tests/unit/test_api_auth_deps.py][t5]
     - [tests/integration/test_api_auth.py][t6]
-    - [tests/integration/test_api_streaming.py][t7]
-    - [tests/integration/test_api_docs.py][t8]
+    - [tests/integration/test_api_auth_middleware.py][t7]
+    - [tests/integration/test_api_streaming.py][t8]
+    - [tests/integration/test_api_docs.py][t9]
 
 [m1]: ../../src/autoresearch/api/
 [t1]: ../../tests/unit/test_api.py
@@ -58,5 +63,6 @@ permissions constrain the impact of a leaked credential.
 [t4]: ../../tests/unit/test_api_auth_middleware.py
 [t5]: ../../tests/unit/test_api_auth_deps.py
 [t6]: ../../tests/integration/test_api_auth.py
-[t7]: ../../tests/integration/test_api_streaming.py
-[t8]: ../../tests/integration/test_api_docs.py
+[t7]: ../../tests/integration/test_api_auth_middleware.py
+[t8]: ../../tests/integration/test_api_streaming.py
+[t9]: ../../tests/integration/test_api_docs.py

--- a/src/autoresearch/api/middleware.py
+++ b/src/autoresearch/api/middleware.py
@@ -134,6 +134,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         auth_configured = bool(cfg.api_keys or cfg.api_key or cfg.bearer_token)
         if auth_configured and not (key_valid or token_valid):
+            if (cfg.api_keys or cfg.api_key) and cfg.bearer_token:
+                return JSONResponse({"detail": "Missing API key or token"}, status_code=401)
             if cfg.api_keys or cfg.api_key:
                 return JSONResponse({"detail": "Missing API key"}, status_code=401)
             return JSONResponse({"detail": "Missing token"}, status_code=401)

--- a/src/autoresearch/api/streaming.py
+++ b/src/autoresearch/api/streaming.py
@@ -3,20 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+
 from fastapi.responses import StreamingResponse
 
-from .deps import require_permission, create_orchestrator
 from ..config import get_config
-from ..error_utils import get_error_info, format_error_for_api
+from ..error_utils import format_error_for_api, get_error_info
 from ..models import QueryRequest, QueryResponse
 from ..orchestration import ReasoningMode
+from .deps import create_orchestrator
 from .webhooks import notify_webhook
 
 
-async def query_stream_endpoint(
-    request: QueryRequest,
-    _: None = require_permission("query"),
-) -> StreamingResponse:
+async def query_stream_endpoint(request: QueryRequest) -> StreamingResponse:
     """Stream incremental query results as JSON lines."""
     config = get_config()
 

--- a/tests/integration/test_api_auth.py
+++ b/tests/integration/test_api_auth.py
@@ -136,6 +136,7 @@ def test_api_key_or_token(monkeypatch, api_client):
 
     missing = api_client.post("/query", json={"query": "q"})
     assert missing.status_code == 401
+    assert missing.json()["detail"] == "Missing API key or token"
 
 
 def test_invalid_api_key_with_valid_token(monkeypatch, api_client):

--- a/tests/integration/test_api_auth_middleware.py
+++ b/tests/integration/test_api_auth_middleware.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from .test_api_auth import _setup
+
+
+def test_auth_validated_before_body(monkeypatch, api_client):
+    cfg = _setup(monkeypatch)
+    cfg.api.api_key = "secret"
+
+    resp = api_client.post("/query", data="not json", headers={"Content-Type": "application/json"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Missing API key"
+
+
+def test_webhook_auth(monkeypatch, api_client):
+    cfg = _setup(monkeypatch)
+    cfg.api.api_key = "secret"
+    called: list[str] = []
+    monkeypatch.setattr(
+        "autoresearch.api.webhooks.notify_webhook",
+        lambda url, result, timeout=5: called.append(url),
+    )
+
+    resp = api_client.post(
+        "/query",
+        json={"query": "q", "webhook_url": "http://example.com"},
+        headers={"X-API-Key": "secret"},
+    )
+    assert resp.status_code == 200
+    assert called == ["http://example.com"]
+
+    called.clear()
+    resp_bad = api_client.post(
+        "/query",
+        json={"query": "q", "webhook_url": "http://example.com"},
+    )
+    assert resp_bad.status_code == 401
+    assert called == []


### PR DESCRIPTION
## Summary
- verify API key or bearer token is present before processing requests
- enforce auth dependencies at route declaration
- document auth setup and extend integration tests for webhook flows

## Testing
- `task check` *(fails: tests/unit/test_main_cli.py::test_serve_command - assert 1 == 0, etc.)*
- `task verify` *(fails: tests/unit/test_main_cli.py::test_serve_command - assert 1 == 0, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ac7ccc26b883339250b37c555a6e5d