### PR TITLE
Ensure behavior feature paths resolve directly

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -333,15 +333,14 @@ respect the configured base directory.
 
 The `pytest-bdd` plugin is provided through the `.[test]` extra, loaded via
 ``-p pytest_bdd`` in ``pytest.ini``, and registered in
-``tests/behavior/__init__.py``. This combination ensures the
-``bdd_features_base_dir`` setting is honored when feature files are targeted
-directly.
+``tests/behavior/__init__.py``. ``tests/behavior/conftest.py`` also configures
+``bdd_features_base_dir`` so paths like
+``tests/behavior/features/<feature>.feature`` resolve when invoked directly.
 
 ``tests/behavior/features/__init__.py`` marks the directory as a package so
-pytest can discover scenarios when feature files are invoked directly.
+pytest can discover scenarios when feature files are targeted by path.
 
-To execute a single feature file, reference it directly from the repository
-root:
+To execute a single feature file, run from the repository root:
 
 ```
 uv run pytest tests/behavior/features/api_orchestrator_integration.feature -q

--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -14,6 +14,15 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+# Make the ``features`` package importable so feature files can be targeted by
+# their direct paths. This mirrors ``bdd_features_base_dir`` in ``pytest.ini``
+# and ensures ``pytest`` resolves paths like
+# ``tests/behavior/features/<feature>.feature``.
+FEATURES_DIR = Path(__file__).resolve().parent / "features"
+FEATURES_PARENT = FEATURES_DIR.parent
+if str(FEATURES_PARENT) not in sys.path:
+    sys.path.insert(0, str(FEATURES_PARENT))
+
 from autoresearch.api import reset_request_log  # noqa: E402
 from autoresearch.config.loader import ConfigLoader  # noqa: E402
 from autoresearch.config.models import ConfigModel  # noqa: E402
@@ -26,7 +35,8 @@ pytest_plugins = ("pytest_bdd",)
 
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config: pytest.Config) -> None:
-    """Load step modules after pytest-bdd config."""
+    """Load step modules and configure feature base directory."""
+    config.option.bdd_features_base_dir = str(FEATURES_DIR)
     config.pluginmanager.import_plugin("tests.behavior.steps")
 
 

--- a/tests/integration/test_behavior_feature_path.py
+++ b/tests/integration/test_behavior_feature_path.py
@@ -1,0 +1,27 @@
+"""Regression test for invoking a single feature file by path."""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def test_direct_feature_invocation() -> None:
+    """Run a behavior feature file via its direct path.
+
+    This ensures ``bdd_features_base_dir`` configuration resolves step
+    definitions when a feature file is targeted explicitly.
+    """
+
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "pytest",
+            "tests/behavior/features/api_orchestrator_integration.feature",
+            "-q",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+


### PR DESCRIPTION
## Summary
- configure behavior test conftest to expose `tests/behavior/features` on `sys.path` and set `bdd_features_base_dir`
- document direct feature execution in testing guidelines
- add regression test invoking a feature file via its path

## Testing
- `uv run pytest tests/integration/test_behavior_feature_path.py -q` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7cc5ec9c8333af8b0a38b9d52a1e