### PR TITLE
Add API auth error simulation and probabilistic docs

### DIFF
--- a/docs/algorithms/api_auth_error_paths.md
+++ b/docs/algorithms/api_auth_error_paths.md
@@ -17,7 +17,28 @@ Enumerates failure responses for API credential verification.
 - Excess requests trigger a **429 Too Many Requests** response via rate limiting
   middleware.
 
+## Probabilistic Modeling
+
+Credential checks can be described by probabilities for missing, invalid, and
+rate limited requests. Let `p_m`, `p_i`, and `p_r` denote those values.
+
+- **400 Bad Request:** `p_m`
+- **401 Unauthorized:** `p_i`
+- **429 Too Many Requests:** `p_r`
+
+Expected response rates follow from the chosen distribution. The simulation
+script illustrates outcome frequencies:
+
+```
+uv run scripts/simulate_api_auth_errors.py --requests 1000 \
+    --missing 0.2 --invalid 0.3 --rate-limit 0.1 --seed 0
+```
+
 ## References
 
 - [src/autoresearch/api/](../../src/autoresearch/api/)
-- [tests/unit/test_api_error_handling.py](../../tests/unit/test_api_error_handling.py)
+- [tests/unit/test_api_error_handling.py][test-auth]
+- [scripts/simulate_api_auth_errors.py][sim-script]
+
+[test-auth]: ../../tests/unit/test_api_error_handling.py
+[sim-script]: ../../scripts/simulate_api_auth_errors.py

--- a/scripts/simulate_api_auth_errors.py
+++ b/scripts/simulate_api_auth_errors.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Simulate API auth errors with configurable credential distributions.
+
+Usage:
+    uv run scripts/simulate_api_auth_errors.py --requests 1000 \
+        --missing 0.2 --invalid 0.3 --rate-limit 0.1 --seed 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+from collections import Counter
+
+
+def simulate(
+    requests: int,
+    missing_prob: float,
+    invalid_prob: float,
+    rate_limit_prob: float,
+    seed: int | None = None,
+) -> dict[int, int]:
+    """Return frequency of status codes for simulated requests."""
+    if min(missing_prob, invalid_prob, rate_limit_prob) < 0:
+        raise ValueError("probabilities must be non-negative")
+    total = missing_prob + invalid_prob + rate_limit_prob
+    if total > 1:
+        raise ValueError("probabilities sum to more than 1")
+    rng = random.Random(seed)
+    counts: Counter[int] = Counter()
+    for _ in range(requests):
+        r = rng.random()
+        if r < missing_prob:
+            counts[400] += 1
+        elif r < missing_prob + invalid_prob:
+            counts[401] += 1
+        elif r < total:
+            counts[429] += 1
+        else:
+            counts[200] += 1
+    return dict(counts)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Simulate API auth error responses",
+    )
+    parser.add_argument(
+        "--requests",
+        type=int,
+        default=1000,
+        help="number of simulated requests",
+    )
+    parser.add_argument(
+        "--missing",
+        type=float,
+        default=0.1,
+        help="probability of missing credential",
+    )
+    parser.add_argument(
+        "--invalid",
+        type=float,
+        default=0.1,
+        help="probability of invalid credential",
+    )
+    parser.add_argument(
+        "--rate-limit",
+        dest="rate_limit",
+        type=float,
+        default=0.1,
+        help="probability of rate limiting",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="random seed for reproducibility",
+    )
+    args = parser.parse_args()
+    counts = simulate(
+        args.requests,
+        args.missing,
+        args.invalid,
+        args.rate_limit,
+        seed=args.seed,
+    )
+    for code in sorted(counts):
+        freq = counts[code]
+        pct = freq / args.requests * 100
+        print(f"{code}: {freq} ({pct:.1f}%)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- model credential failure probabilities in API auth docs
- add `simulate_api_auth_errors.py` to explore 400/401/429 rates
- cover deterministic simulation outcomes in regression test

## Testing
- `task check` *(fails: 33 failed, 7 errors)*
- `task verify` *(fails: 33 failed, 7 errors)*
- `uvx --from mkdocs-material --with mkdocstrings mkdocs build` *(missing mkdocstrings_handlers)*
- `uv run flake8 scripts/simulate_api_auth_errors.py tests/unit/test_api_error_handling.py`
- `uv run mypy scripts/simulate_api_auth_errors.py tests/unit/test_api_error_handling.py`
- `uv run pytest tests/unit/test_api_error_handling.py::test_simulate_api_auth_error_rates -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7ce4185c8333b1f52d065233d351