### PR TITLE
Clarify Codex-only setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,10 @@
   hooks or dependencies.
 - Use **uv** for package management; prefix standalone Python commands with
   `uv run`.
-- If provisioning fails, consult `scripts/codex_setup.sh`.
+- For provisioning issues within this evaluation, `scripts/codex_setup.sh`
+  bootstraps the Codex environment. It is Codex-specific, non-generic, and
+  must not be referenced outside AGENTS.md files or the script itself. Use
+  `scripts/setup.sh` for any other environment.
 
 ## Testing
 - `task check` – run early for linting, type checks, and a fast test suite.
@@ -38,7 +41,8 @@
 
 ## AGENTS.md Compliance
 - Only `scripts/codex_setup.sh` may mention `AGENTS.md`; keep it aligned with
-  these instructions.
+  these instructions. Do not reference `scripts/codex_setup.sh` outside this
+  AGENTS.md system or the script itself.
 - This file's scope is the entire repository; nested `AGENTS.md` files override
   these rules.
 - This AGENTS.md follows the [AGENTS.md spec](https://gist.github.com) and acts
@@ -46,6 +50,8 @@
 - For extensive details, consult docs under `docs/` as required.
 
 ## Changelog
+- 2025-08-21: Clarified Codex-only scope for `scripts/codex_setup.sh` and
+  restricted references to AGENTS files.
 - 2025-08-20: Restructured instructions, added dialectical reasoning and
   continuous improvement guidance, and cited AGENTS.md spec.
 - 2025-08-19: Added project snapshot, environment steps, Task commands,

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -6,6 +6,8 @@ These instructions apply to files in the `scripts/` directory.
 - **Purpose:** automation utilities and environment helpers.
 - **Primary languages:** Bash and Python.
 - **Key outputs:** CLI tools and setup scripts.
+- `codex_setup.sh` bootstraps only the Codex evaluation environment and must
+  not be referenced outside AGENTS.md files or the script itself.
 
 ## Conventions
 - Provide a clear CLI interface or usage comment at the top of each script.

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Usage: AR_INSTALL_UI=1 AR_INSTALL_NLP=1 ./scripts/codex_setup.sh
-# Codex environment bootstrap for this evaluation container; see AGENTS.md for
-# repository-wide guidelines. For any other environment, use
-# `./scripts/setup.sh`.
+# Codex-only environment bootstrap for this evaluation container; see AGENTS.md
+# for repository-wide guidelines. Do not use or document this script outside the
+# AGENTS.md system. For any other environment, use `./scripts/setup.sh`.
 set -euo pipefail
 
 LOG_FILE="codex_setup.log"


### PR DESCRIPTION
## Summary
- Clarify that `scripts/codex_setup.sh` is Codex-specific and should not be used generically or referenced outside AGENTS files
- Document Codex-only scope in `scripts/AGENTS.md`
- Annotate `codex_setup.sh` header with Codex exclusivity and AGENTS restrictions

## Testing
- `task check` *(fails: assert mismatches and storage errors)*

------
https://chatgpt.com/codex/tasks/task_e_68accde496808333b0e86ad4e710f820