### PR TITLE
Ensure install extras and document prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ setup is complete. See
 [docs/installation.md#after-cloning](docs/installation.md#after-cloning) for
 details.
 
+Optional extras provide features such as NLP, a UI, or distributed
+processing. Install them on demand with `uv sync --extra <name>` or
+`pip install "autoresearch[<name>]"`.
+
+A running Redis server is needed only for the `[distributed]` extra or tests
+tagged `requires_distributed`. When Redis is absent those scenarios are
+skipped.
+
 To bootstrap a Python 3.12+ environment with the lightweight development and test
 extras run:
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,6 +10,7 @@ tasks:
   install:
     cmds:
       - uv sync --extra dev-minimal --extra test
+      - uv run python -c "import pytest_httpx, tomli_w, redis"
       - uv run flake8 src tests
     desc: "Initialize dev env without heavy ML extras and verify lint"
   check-env:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,6 +10,13 @@ Autoresearch requires **Python 3.12 or newer**,
 installs Go Task to `~/.local/bin` and adds that directory to `PATH`.
 Manual installation instructions are below if needed.
 
+Redis is required only for tests or features that use the
+`.[distributed]` extra. When Redis is missing those tests are skipped and
+distributed features remain disabled.
+
+Optional extras enable additional capabilities and are installed on
+demand with `uv sync --extra <name>`.
+
 ## After cloning
 
 Run a bootstrap command immediately:

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,10 @@ uv run pytest tests/integration -m 'not slow and not requires_ui and not require
 - Fixtures such as `example_autoresearch_toml` and `example_env_file` provide
   temporary configuration and environment data. Use `tmp_path` and
   `monkeypatch` to isolate side effects in tests.
+- Redis-backed scenarios use the `requires_distributed` marker and skip when
+  no Redis server is available or the `.[distributed]` extra is missing.
+- Tests tagged `requires_vss` depend on the DuckDB VSS extension but fall back
+  to a stub implementation when the `vss` extra is not installed.
 
 No external databases or network services need to be running. Temporary
 artifacts are created under `tmp_path` and cleaned automatically.


### PR DESCRIPTION
## Summary
- Ensure `task install` verifies dev-minimal and test extras including pytest-httpx, tomli-w, and redis before running flake8
- Clarify prerequisites, extras, and optional Redis usage in installation docs and README
- Validate tools and extras resolve inside `.venv` during setup and note Redis/VSS test fallbacks

## Testing
- `task install`
- `task check` *(fails: assert 1 == 0, storage errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acd44409c08333bbe4de03797a7c15