### PR TITLE
Update roadmap and task progress after test review

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ For current capabilities and known limitations see
 
 ## Roadmap
 
-As of **August 18, 2025**, Autoresearch is in the **Development** phase
+As of **August 26, 2025**, Autoresearch is in the **Development** phase
 preparing for the upcoming **0.1.0** release. The version is defined in
 `autoresearch.__version__` and mirrored in `pyproject.toml`, but it has
 **not** been published yet. The first official release was originally
 planned for **July 20, 2025**, but the schedule slipped. An
-**0.1.0-alpha.1** preview is scheduled for **2026-03-01**, with
+**0.1.0-alpha.1** preview is re-targeted for **2026-06-15**, with
 the final **0.1.0** milestone targeted for **July 1, 2026**. See
 
 [ROADMAP.md](ROADMAP.md) for feature milestones and
@@ -62,7 +62,9 @@ workflow is detailed in [docs/releasing.md](docs/releasing.md).
 
 ## Status
 
-See [STATUS.md](STATUS.md) for current test and coverage results.
+See [STATUS.md](STATUS.md) for current test and coverage results. Task-level
+progress and test reconciliation live in
+[TASK_PROGRESS.md](TASK_PROGRESS.md).
 
 See [docs/release_plan.md](docs/release_plan.md#alpha-release-checklist) for the
 alpha release checklist.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ Last updated **August 26, 2025**.
 ## Status
 
 See [STATUS.md](STATUS.md) for current test and coverage results. Current
-coverage from the unit subset is **67%**. Use Python 3.12+ with:
+coverage from the unit subset is **14%**. Use Python 3.12+ with:
 
 ```
 uv venv && uv sync --all-extras &&
@@ -19,7 +19,7 @@ before running tests.
 
 ## Milestones
 
-- 0.1.0a1 (2026-04-15, status: in progress): Alpha preview to collect
+- 0.1.0a1 (2026-06-15, status: in progress): Alpha preview to collect
   feedback while aligning environment requirements
   ([prepare-first-alpha-release](issues/prepare-first-alpha-release.md)).
 - 0.1.0 (2026-07-01, status: planned): Finalize packaging, docs and CI checks
@@ -52,17 +52,17 @@ are verified. Related issue
 ([prepare-first-alpha-release](issues/prepare-first-alpha-release.md)) tracks
 the work. Tagging **0.1.0a1** requires `task verify` to complete, coverage to
 reach **90%**, and a successful TestPyPI upload. The release is re-targeted for
-**April 15, 2026**. Key activities include:
+**June 15, 2026**. Key activities include:
 
 - [x] Environment bootstrap documented and installation instructions
   consolidated
   ([environment-bootstrap](issues/archive/document-environment-bootstrap.md)).
 - [x] Packaging verification with DuckDB fallback
   ([packaging-fallback](issues/archive/verify-packaging-workflow-and-duckdb-fallback.md)).
-- [x] Integration tests stabilized
+- [ ] Integration tests stabilized
   ([stabilize-integration-tests](issues/archive/stabilize-integration-tests.md)).
 - [ ] Coverage gates target **90%** total coverage; current coverage is
-  **67%** ([coverage-gates](issues/archive/add-coverage-gates-and-regression-checks.md)).
+  **14%** ([coverage-gates](issues/archive/add-coverage-gates-and-regression-checks.md)).
 - [x] Algorithm validation for ranking and coordination
   ([ranking](issues/archive/validate-ranking-algorithms-and-agent-coordination.md)).
 

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -3,7 +3,7 @@
 This document tracks the progress of tasks for the Autoresearch project,
 organized by phases from the code complete plan. As of **August 26, 2025**, see
 [docs/release_plan.md](docs/release_plan.md) for current test and coverage
-status. An **0.1.0-alpha.1** preview is scheduled for **2026-04-15**, with the
+status. An **0.1.0-alpha.1** preview is re-targeted for **2026-06-15**, with the
 final **0.1.0** release targeted for **July 1, 2026**.
 
 ## Phase 1: Core System Completion (Weeks 1-2)
@@ -32,10 +32,10 @@ final **0.1.0** release targeted for **July 1, 2026**.
 
 ### 1.3 Storage System
 
-- [x] Complete the DuckDB integration
-  - [x] Optimize vector search capabilities
-  - [x] Implement efficient eviction policies (see `StorageManager._enforce_ram_budget`)
-  - [x] Add support for incremental updates (see `StorageManager.persist_claim`)
+- [ ] Complete the DuckDB integration
+  - [ ] Optimize vector search capabilities
+  - [ ] Implement efficient eviction policies (see `StorageManager._enforce_ram_budget`)
+  - [ ] Add support for incremental updates (see `StorageManager.persist_claim`)
 - [x] Enhance the RDF knowledge graph
   - [x] Implement more sophisticated reasoning capabilities
   - [x] Add support for ontology-based reasoning
@@ -44,9 +44,9 @@ final **0.1.0** release targeted for **July 1, 2026**.
 
 ### 1.4 Search System
 
-- [x] Complete all search backends
+- [ ] Complete all search backends
   - [x] Finalize the local file search implementation
-  - [x] Enhance the local git search with better code understanding
+  - [ ] Enhance the local git search with better code understanding
   - [x] Implement cross-backend result ranking
 - [x] Add semantic search capabilities
   - [x] Implement embedding-based search across all backends
@@ -60,7 +60,7 @@ final **0.1.0** release targeted for **July 1, 2026**.
 
 - [ ] Complete test coverage for all modules
   - [x] Verified spec documents reference existing tests
-- [x] Ensure at least 90% code coverage
+- [ ] Ensure at least 90% code coverage
   - [ ] Add tests for edge cases and error conditions
   - [ ] Implement property-based testing for complex components
 - [ ] Enhance test fixtures
@@ -175,11 +175,11 @@ These behavior test issues remain open until the test suite passes.
 
 ### 5.1 Performance Optimization
 
-- [x] Complete token usage optimization
-  - [x] Implement prompt compression techniques
-  - [x] Add context pruning for long conversations
-  - [x] Create adaptive token budget management
-  - [x] Use per-agent historical averages for budget adjustment
+- [ ] Complete token usage optimization
+  - [ ] Implement prompt compression techniques
+  - [ ] Add context pruning for long conversations
+  - [ ] Create adaptive token budget management
+  - [ ] Use per-agent historical averages for budget adjustment
 - [x] Enhance memory management
   - [x] Implement efficient caching strategies
   - [x] Add support for memory-constrained environments
@@ -226,7 +226,7 @@ These behavior test issues remain open until the test suite passes.
 
 ### Coverage Report
 
-Running a focused subset of tests with coverage produced **44%** line coverage
+Running a focused subset of tests with coverage produced **14%** line coverage
 across targeted modules. Full `task coverage` was attempted but could not
 complete in this environment.
 
@@ -238,7 +238,7 @@ Full suite attempts:
 ./.venv/bin/task check
 ```
 
-Result: 39 failed, 629 passed, 26 skipped, 24 deselected, 2 xfailed, 32 warnings, 7 errors
+Result: 39 failed, 624 passed, 26 skipped, 24 deselected, 1 xfailed, 1 xpassed, 32 warnings, 7 errors
 
 ```
 ./.venv/bin/task verify
@@ -258,4 +258,6 @@ Current benchmark metrics for a single dummy query:
 
 ### Phase 1 Review
 
-All orchestrator, specialized agent, search, and storage features match the CODE_COMPLETE_PLAN Phase 1 goals. No discrepancies were found during review.
+Storage and search features remain under active development as tests reveal
+failing scenarios. Further work is required to meet the CODE_COMPLETE_PLAN Phase
+1 goals.

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -9,7 +9,7 @@ The publishing workflow follows the steps in
 [ROADMAP.md](../ROADMAP.md) for high-level milestones.
 
 The project kicked off in **May 2025** (see the initial commit dated
-`2025-05-18`). This schedule was last updated on **August 24, 2025** and
+`2025-05-18`). This schedule was last updated on **August 26, 2025** and
 reflects that the codebase currently sits at the **unreleased 0.1.0a1** version
 defined in `autoresearch.__version__`. Phase 3
 (stabilization/testing/documentation) and Phase 4 activities remain planned.
@@ -23,7 +23,7 @@ Current test and coverage results are tracked in
 
 ## Milestones
 
-- **0.1.0a1** (2026-04-15, status: in progress): Alpha preview to collect
+- **0.1.0a1** (2026-06-15, status: in progress): Alpha preview to collect
   feedback
   ([prepare-first-alpha-release](
   ../issues/prepare-first-alpha-release.md)).
@@ -49,7 +49,7 @@ Current test and coverage results are tracked in
 
 The project originally targeted **0.1.0** for **July 20, 2025**, but the
 schedule slipped. To gather early feedback, an alpha **0.1.0a1** release is
-now re-targeted for **April 15, 2026**. The final **0.1.0** milestone is set
+now re-targeted for **June 15, 2026**. The final **0.1.0** milestone is set
 for **July 1, 2026** while packaging tasks are resolved.
 
 ### Alpha release checklist
@@ -61,11 +61,11 @@ for **July 1, 2026** while packaging tasks are resolved.
 - [x] Packaging verification with DuckDB fallback
   ([verify-packaging-workflow-and-duckdb-fallback.md](
   ../issues/archive/verify-packaging-workflow-and-duckdb-fallback.md))
-- [x] Integration test suite passes
+- [ ] Integration test suite passes
   ([stabilize-integration-tests.md](
   ../issues/archive/stabilize-integration-tests.md))
 - [ ] Coverage gates target **90%** total coverage; current coverage is
-  **67%** (see
+  **14%** (see
   [add-coverage-gates-and-regression-checks.md](
   ../issues/archive/add-coverage-gates-and-regression-checks.md))
 - [x] Validate ranking algorithms and agent coordination
@@ -79,10 +79,10 @@ These tasks completed in order: environment bootstrap → packaging verification
 ### Prerequisites for tagging 0.1.0a1
 
 - `flake8` and `mypy` pass, but several unit and integration tests still fail.
-- Total coverage is **67%**, short of the **90%** gate.
+- Total coverage is **14%**, short of the **90%** gate.
 - TestPyPI upload returns HTTP 403, so packaging needs a retry.
 
-The **0.1.0a1** date is re-targeted for **April 15, 2026** and the release
+The **0.1.0a1** date is re-targeted for **June 15, 2026** and the release
 remains in progress until these prerequisites are satisfied.
 
 Completion of these items confirms the alpha baseline for **0.1.0**.
@@ -120,5 +120,5 @@ optional extras):
 - [ ] `uv run mypy src`
 - [ ] `uv run pytest -q`
 - [ ] `uv run pytest tests/behavior`
-- [ ] `task coverage` currently reports **67%** total coverage; target **90%**
+- [ ] `task coverage` currently reports **14%** total coverage; target **90%**
 


### PR DESCRIPTION
## Summary
- Mark storage, search, and token-budget tasks as incomplete in `TASK_PROGRESS.md`
- Retarget 0.1.0a1 milestone to 2026-06-15 and note 14% coverage in roadmap and release plan
- Link README status to `TASK_PROGRESS.md` for current progress tracking

## Testing
- `./.venv/bin/task check` *(fails: 39 failed, 624 passed)*
- `./.venv/bin/task verify` *(fails: total coverage 14% < 90%)*

------
https://chatgpt.com/codex/tasks/task_e_68ad183057108333b6a2f4d7b9181f01