### PR TITLE
feat(cli): improve backup error handling for missing tables

### DIFF
--- a/src/autoresearch/cli_helpers.py
+++ b/src/autoresearch/cli_helpers.py
@@ -7,6 +7,8 @@ from typing import Sequence, List
 import click
 import typer
 
+from rich.console import Console
+
 from .cli_utils import (
     print_error,
     print_info,
@@ -36,6 +38,24 @@ def parse_agent_groups(groups: Sequence[str]) -> List[List[str]]:
         if agents:
             parsed.append(agents)
     return parsed
+
+
+def report_missing_tables(tables: Sequence[str], console: Console | None = None) -> None:
+    """Report missing database tables in a user-friendly way."""
+    if not tables:
+        return
+    names = ", ".join(sorted(tables))
+    if console is None:
+        print_error(
+            f"Missing required tables: {names}",
+            suggestion="Ensure the storage schema has been initialized.",
+        )
+    else:
+        console.print(f"[bold red]Missing required tables: {names}[/bold red]")
+        console.print(
+            "[yellow]Suggestion:[/yellow] "
+            "Ensure the storage schema has been initialized."
+        )
 
 
 def handle_command_not_found(ctx: typer.Context, command: str) -> None:


### PR DESCRIPTION
## Summary
- handle `BackupError` context consistently through `_render_backup_error`
- expose `report_missing_tables` helper for CLI-friendly table errors
- expand backup CLI tests for success and missing table scenarios

## Testing
- `uv run pytest tests/unit/test_cli_backup_extra.py -q`
- `uv run pytest tests/unit/test_main_backup_commands.py -q`
- `./bin/task check` *(fails: tests/unit/test_main_cli.py::test_serve_command, tests/unit/test_main_monitor_commands.py::test_serve_a2a_command, tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt, tests/unit/test_metrics_token_budget_spec.py::test_token_budget_expands_then_shrinks, tests/unit/test_metrics_token_budget_spec.py::test_rounding_half_cases, tests/unit/test_search_backends_unit.py::test_local_git_backend_ast_search, tests/unit/test_storage_eviction.py::test_enforce_ram_budget_hybrid_policy, tests/unit/test_storage_eviction.py::test_enforce_ram_budget_adaptive_policy, tests/unit/test_token_budget_convergence.py::test_convergence_from_any_start, tests/unit/test_token_budget_convergence.py::test_margin_boundaries_converge, tests/unit/test_token_budget_convergence.py::test_agent_average_preserves_budget, tests/unit/test_token_budget_convergence.py::test_sparse_usage_retains_history, tests/unit/test_eviction.py::test_ram_eviction, tests/unit/test_eviction.py::test_score_eviction, tests/unit/test_eviction.py::test_lru_eviction_sequence, tests/unit/test_storage_persistence_eviction.py::test_persistence_and_eviction[lru], tests/unit/test_storage_persistence_eviction.py::test_persistence_and_eviction[score], tests/unit/test_storage_persistence_eviction.py::test_persistence_and_eviction[hybrid], tests/unit/test_storage_utils.py::test_clear_all)`}


------
https://chatgpt.com/codex/tasks/task_e_68ad201371548333a416f1cdf6597608