### PR TITLE
docs: detail token budget convergence

### DIFF
--- a/docs/algorithms/token_budgeting.md
+++ b/docs/algorithms/token_budgeting.md
@@ -49,21 +49,29 @@ Let usage settle at a constant value `u` and define
 `b* = ceil(u * (1 + m))`. Averaging the last ten non-zero samples blocks
 isolated spikes from influencing the limit.
 
-### Proof
+### Assumptions
 
-Assume there exists `T` such that for all `t >= T`, every agent consumes
-`u` tokens. Because `\bar{u}_t` and each `\bar{a}_{i,t}` average the last
-ten non-zero values, for `t >= T + 10` these statistics equal `u`. At that
-point the update becomes
+- `m >= 0`.
+- There exists `T` such that for all `t >= T` each agent consumes exactly
+  `u` tokens per cycle.
+- `\bar{u}_t` averages the last ten **non-zero** totals, while every
+  `\bar{a}_{i,t}` averages the last ten per-agent totals **including**
+  zeros.
+
+### Derivation
+
+For `t >= T + 10` the candidates satisfy
+`u_t = \bar{u}_t = a_t = \bar{a}_t = u`. Substituting into the update
+rule yields
 
 \[
-b_{t+1} = \left\lceil \max(u, u, u, u) (1 + m) \right\rceil = b*.
+b_{t+1} = \left\lceil u (1 + m) \right\rceil = b*.
 \]
 
-Since `b*` is a fixed point of the update rule, the sequence `{b_t}` is
-constant for `t > T + 10`. Thus `{b_t}` converges to `b*`. Ten consecutive
-zero-usage cycles after activity similarly force all candidates to zero,
-yielding the fixed point `b_t = 1`.
+Thus `b*` is a fixed point and the sequence `{b_t}` remains constant for
+`t > T + 10`. Ten consecutive zero-usage cycles after activity force all
+usage candidates to zero. The implementation floors the suggestion at
+one token, giving the fixed point `b_t = 1` in that case.
 
 ## Simulation
 


### PR DESCRIPTION
## Summary
- clarify token budget convergence assumptions and derivation
- test convergence and rounding of suggest_token_budget

## Testing
- `uv run flake8 src tests/unit/test_metrics_token_budget_spec.py`
- `uv run mypy src`
- `uv run pytest tests/unit/test_metrics_token_budget_spec.py -q`
- `uv run pytest tests/targeted --noconftest --cov=autoresearch.search --cov=autoresearch.storage --cov=autoresearch.orchestration --cov-report=term-missing --cov-report=xml`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68ad2020a1648333a03aed4108a1f87e