### PR TITLE
feat: bootstrap storage schema

### DIFF
--- a/docs/algorithms/storage.md
+++ b/docs/algorithms/storage.md
@@ -1,0 +1,12 @@
+# Storage
+
+The storage layer maintains the project's hybrid persistence model.
+It uses a helper called `initialize_storage()` to bootstrap the DuckDB
+schema. The helper runs the normal setup routine and then creates the
+`nodes`, `edges`, `embeddings`, and `metadata` tables if they are
+missing.
+
+This bootstrapping step is required when using an empty or in-memory
+database. Tests call the helper from `tests/conftest.py` so each run starts
+with a valid schema. Applications may invoke it on startup as well. The
+creation statements use `IF NOT EXISTS`, making repeated calls safe.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,12 +273,13 @@ def initialize_storage(request, tmp_path, cleanup_storage):
         if not hasattr(StorageManager, "initialize"):
             StorageManager.initialize = staticmethod(storage.initialize_storage)  # type: ignore[attr-defined]
         if not hasattr(duckdb.DuckDBPyConnection, "fetchone"):
+
             def _fetchone(self):
                 rows = self.fetchall()
                 return rows[0] if rows else None
 
             duckdb.DuckDBPyConnection.fetchone = _fetchone  # type: ignore[attr-defined]
-        StorageManager.initialize(str(tmp_path / "kg.duckdb"))
+        storage.initialize_storage(str(tmp_path / "kg.duckdb"))
     yield
 
 


### PR DESCRIPTION
## Summary
- ensure DuckDB tables are created when missing
- prepare test schemas via `initialize_storage`
- document storage bootstrapping expectations

## Testing
- `task check` *(fails: No such command 'check')*
- `task verify` *(fails: No such command 'verify')*
- `uv run pytest tests/unit/test_storage_utils.py::test_initialize_storage_persistent tests/unit/test_eviction.py::test_initialize_storage_in_memory tests/unit/test_eviction.py::test_initialize_storage_persistent` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*
- `uv run mkdocs build` *(fails: PythonConfig.__init__() got an unexpected keyword argument 'selection')*


------
https://chatgpt.com/codex/tasks/task_e_68adfa095b6c833382827eb143ad4a26