### PR TITLE
Document LLM adapter selection and add simulation tool

### DIFF
--- a/docs/algorithms/llm_adapter.md
+++ b/docs/algorithms/llm_adapter.md
@@ -1,0 +1,35 @@
+# LLM Adapter Algorithm
+
+Adapter selection, token accounting, and fallback formulas guide LLM usage.
+Adapters are ordered by preference. The first adapter whose estimated token
+usage fits the budget is chosen. Estimated tokens follow:
+
+```
+expected = prompt_tokens + response_tokens
+```
+
+If `expected` exceeds `token_budget`, the next adapter in the list is tried.
+
+Token accounting tracks tokens for each call:
+
+```
+in_tokens = len(prompt.split())
+out_tokens = len(output.split())
+total = in_tokens + out_tokens
+```
+
+When `in_tokens` exceeds `token_budget`, prompt compression applies:
+
+```
+half = max(1, (token_budget - 1) // 2)
+compressed = tokens[:half] + ["..."] + tokens[-half:]
+```
+
+If a summarizer is available and produces `summary_tokens <= token_budget`,
+that summary replaces the compressed prompt.
+
+These heuristics balance fidelity and cost. Run the simulation script to
+explore different budgets and adapter orders.
+
+- [LLM specification](../specs/llm.md)
+- [Simulation script](../../scripts/simulate_llm_adapter.py)

--- a/docs/specs/llm.md
+++ b/docs/specs/llm.md
@@ -1,6 +1,8 @@
 # Llm
 
-Language Model (LLM) integration module for Autoresearch.
+Language Model (LLM) integration module for Autoresearch. See
+[adapter selection and token accounting][a1] for switching heuristics and
+fallback formulas.
 
 ## Traceability
 
@@ -11,6 +13,7 @@ Language Model (LLM) integration module for Autoresearch.
   - [tests/unit/test_llm_adapter.py][t2]
   - [tests/unit/test_llm_capabilities.py][t3]
 
+[a1]: ../algorithms/llm_adapter.md
 [m1]: ../../src/autoresearch/llm/
 [t1]: ../../tests/unit/test_agents_llm.py
 [t2]: ../../tests/unit/test_llm_adapter.py

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -53,6 +53,13 @@ After tests complete, verify coverage meets the threshold:
 uv run coverage report --fail-under=90
 ```
 
+The [scripts/simulate_llm_adapter.py](../scripts/simulate_llm_adapter.py)
+script models adapter switching and token budgets for exploratory testing:
+
+```bash
+uv run python scripts/simulate_llm_adapter.py "example prompt"
+```
+
 You can also invoke the slow suite directly with:
 
 ```bash

--- a/scripts/simulate_llm_adapter.py
+++ b/scripts/simulate_llm_adapter.py
@@ -1,0 +1,50 @@
+"""Simulate LLM adapter switching and token budgeting.
+
+Usage:
+    uv run python scripts/simulate_llm_adapter.py "prompt text" \
+        --adapters dummy openai --budget 50
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import List
+
+from autoresearch.llm import get_llm_adapter
+from autoresearch.llm.token_counting import compress_prompt
+
+
+def simulate(prompt: str, adapters: List[str], budget: int) -> None:
+    """Select the first adapter whose compressed prompt fits the budget."""
+    for name in adapters:
+        adapter = get_llm_adapter(name)
+        compressed = compress_prompt(prompt, budget)
+        tokens = len(compressed.split())
+        print(f"{name}: {tokens}/{budget} tokens")
+        if tokens <= budget:
+            print(f"selected {name}")
+            break
+    else:
+        print("no adapter met the token budget")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("prompt", help="prompt text to evaluate")
+    parser.add_argument(
+        "--adapters",
+        nargs="+",
+        default=["dummy"],
+        help="ordered adapter names to try",
+    )
+    parser.add_argument("--budget", type=int, default=100, help="token budget for prompt")
+    args = parser.parse_args()
+    if args.budget <= 0:
+        raise SystemExit("budget must be positive")
+    if not args.adapters:
+        raise SystemExit("provide at least one adapter")
+    simulate(args.prompt, args.adapters, args.budget)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_llm_adapter.py
+++ b/tests/unit/test_llm_adapter.py
@@ -1,5 +1,6 @@
 import responses
 from autoresearch.llm import get_llm_adapter, DummyAdapter
+from autoresearch.llm.token_counting import compress_prompt
 
 
 def test_dummy_adapter_generation():
@@ -39,3 +40,15 @@ def test_openai_adapter(monkeypatch):
     assert text == "ok"
     headers = responses.calls[0].request.headers
     assert headers.get("Authorization") == "Bearer test"
+
+
+def test_compress_prompt_falls_back_when_summary_exceeds_budget():
+    """Ellipsis fallback when summary exceeds token budget."""
+
+    def summarizer(_: str, __: int) -> str:
+        return "one two three four"
+
+    prompt = "alpha beta gamma delta epsilon zeta"
+    result = compress_prompt(prompt, 3, summarizer)
+    assert result == "alpha ... zeta"
+    assert len(result.split()) == 3


### PR DESCRIPTION
## Summary
- document adapter selection, token accounting, and fallback formulas
- add simulation script for adapter switching and token budgeting
- reference new docs in LLM spec and testing guidelines

## Testing
- `uv run pytest tests/unit/test_llm_adapter.py`
- `uv run black tests/unit/test_llm_adapter.py scripts/simulate_llm_adapter.py`
- `uv run flake8 tests/unit/test_llm_adapter.py scripts/simulate_llm_adapter.py` *(fail: command not found)*
- `uv run mkdocs build` *(fail: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ae1c77e3dc83339c15ed5cd77f62c1