### PR TITLE
Install Task earlier and default to dev-minimal extras

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,12 +12,13 @@ tasks:
       EXTRAS: "{{.EXTRAS | default \"\"}}"
     cmds:
       - >
-          uv sync --extra dev-minimal --extra test{{if .EXTRAS}} --extra {{.EXTRAS}}{{end}}
+          uv sync --extra dev-minimal{{if .EXTRAS}} --extra {{.EXTRAS}}{{end}}
       - uv run python -c "import pytest_httpx, tomli_w, redis"
       - uv run flake8 src tests
     desc: |
-      Initialize dev env with minimal tools. Provide EXTRAS="nlp ui" to include
-      optional features
+      Initialize dev env with minimal tools.
+      Set EXTRAS="test nlp ui" to include optional features:
+      analysis, distributed, git, llm, minimal, nlp, parsers, ui, vss, test
   check-env:
     cmds:
       - uv run python scripts/check_env.py

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,10 +19,10 @@ and distributed features stay disabled.
 Optional extras enable additional capabilities and are installed on
 demand with `uv sync --extra <name>`.
 
-For a lean setup, sync only the minimal development and test extras:
+For a lean setup, sync only the minimal development extras:
 
 ```bash
-uv sync --extra dev-minimal --extra test
+uv sync --extra dev-minimal
 ```
 
 This installs `pytest_httpx`, `tomli_w`, and `redis` without heavy ML
@@ -36,18 +36,18 @@ Run the setup script immediately after cloning:
 ./scripts/setup.sh  # full developer bootstrap
 ```
 
-After the script completes you can use `task install` to provision all
-development tools via the `dev` and `test` extras:
+After the script completes you can use `task install` to provision the
+minimal development tools:
 
 ```bash
 task install
 ```
 
-Install additional groups only when required:
+Include extras only when required. Example:
 
 ```bash
-uv sync --extra nlp  # spaCy and BERTopic
-uv sync --extra llm  # sentence-transformers and transformers
+EXTRAS="test nlp" task install  # adds test and NLP packages
+uv sync --extra llm             # sentence-transformers and transformers
 ```
 
 `./scripts/setup.sh` installs Go Task when missing, syncs the `dev` and

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -39,6 +39,17 @@ EOF
 VENV_BIN="$(pwd)/.venv/bin"
 export PATH="$VENV_BIN:$PATH"
 
+# Ensure Go Task is available for later Taskfile commands
+if ! command -v task >/dev/null 2>&1; then
+    echo "Go Task missing; installing into $VENV_BIN..."
+    curl -sSL https://taskfile.dev/install.sh | sh -s -- -b "$VENV_BIN"
+    export PATH="$VENV_BIN:$PATH"
+fi
+task --version >/dev/null 2>&1 || {
+    echo "task --version failed; Go Task is required but was not installed" >&2
+    exit 1
+}
+
 # Install locked dependencies and development/test extras
 echo "Installing development and test extras via uv sync --extra dev --extra test"
 uv sync --extra dev --extra test
@@ -53,16 +64,6 @@ for pkg in pytest_httpx tomli_w freezegun hypothesis redis; do
         exit 1
     fi
 done
-
-# Ensure Go Task is installed inside the virtual environment
-if ! command -v task >/dev/null 2>&1; then
-    echo "Go Task missing; installing into $VENV_BIN..."
-    curl -sL https://taskfile.dev/install.sh | sh -s -- -b "$VENV_BIN"
-fi
-if ! command -v task >/dev/null 2>&1; then
-    echo "task --version failed; Go Task is required but was not installed" >&2
-    exit 1
-fi
 
 # Append Go Task path to activation scripts if absent
 for script in "$VENV_BIN/activate" \


### PR DESCRIPTION
## Summary
- install Go Task in setup.sh via official script and ensure PATH
- default `task install` to dev-minimal extras and document optional extras
- document lighter default install and how to add extras

## Testing
- `task install`
- `uv pip show transformers`
- `uv pip show sentence-transformers`
- `task check` *(fails: tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1c2686fc8333bb09448161afd5b2