### PR TITLE
test: ensure storage schema initialized

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -408,6 +408,18 @@ pytest -m requires_distributed
 - Some search backends rely on `python-docx` for document parsing.
 - No external services are required; all components run in memory.
 
+### Storage fixtures
+
+- Use the `duckdb_path` fixture for storage tests. It invokes
+  `StorageManager.initialize_schema()` and yields a clean database path to
+  prevent cross-test contamination:
+
+  ```python
+  def test_example(duckdb_path):
+      storage.setup(duckdb_path)
+      ...
+  ```
+
 ## Updating Baselines
 
 Some integration tests compare runtime metrics against JSON files in

--- a/tests/unit/test_eviction.py
+++ b/tests/unit/test_eviction.py
@@ -49,15 +49,13 @@ def test_score_eviction(storage_manager, monkeypatch):
     assert "high" in graph.nodes
 
 
-def test_lru_eviction_order(monkeypatch, tmp_path):
-    storage.teardown(remove_db=True)
-    db_file = tmp_path / "kg.duckdb"
+def test_lru_eviction_order(monkeypatch, duckdb_path):
     config = ConfigModel(ram_budget_mb=1)
     config.search.context_aware.enabled = False
     config.storage.rdf_backend = "memory"
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: config)
     ConfigLoader()._config = None
-    storage.setup(str(db_file))
+    storage.setup(duckdb_path)
     StorageManager.clear_all()
     monkeypatch.setattr("autoresearch.storage.run_ontology_reasoner", lambda *_, **__: None)
     monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 0)

--- a/tests/unit/test_storage_utils.py
+++ b/tests/unit/test_storage_utils.py
@@ -18,7 +18,7 @@ def test_touch_node_updates_lru(monkeypatch):
     assert list(storage.StorageManager.state.lru.keys()) == ["b", "a"]
 
 
-def test_clear_all(storage_manager):
+def test_clear_all(storage_manager, duckdb_path):
     with patch("autoresearch.storage.run_ontology_reasoner") as mock_reasoner:
         mock_reasoner.return_value = None
 


### PR DESCRIPTION
## Summary
- add `duckdb_path` fixture to pre-create DuckDB schema and integrate with `storage_manager`
- use fixture in eviction and storage utility tests
- document `duckdb_path` fixture in testing guidelines

## Testing
- `uv run mkdocs build`
- `uv run flake8 tests/conftest.py tests/unit/test_eviction.py tests/unit/test_storage_utils.py`
- `uv run pytest tests/unit -q` *(fails: RecursionError in token budget tests, 14 failed, 108 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1c14c0ac83339bea71d5cec6e598