### PR TITLE
Plan A2A MCP behavior tests

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -92,6 +92,7 @@ These integration test issues are archived after stabilization.
   - [ ] Add more detailed assertions [add-more-detailed-assertions](issues/archive/add-more-detailed-assertions.md)
   - [ ] Implement better test isolation [implement-better-test-isolation](issues/archive/implement-better-test-isolation.md)
   - [ ] Create more comprehensive test contexts [create-more-comprehensive-test-contexts](issues/archive/create-more-comprehensive-test-contexts.md)
+- [ ] Plan A2A MCP behavior tests [plan-a2a-mcp-behavior-tests](issues/plan-a2a-mcp-behavior-tests.md)
 
 These behavior test issues remain open until the test suite passes.
 

--- a/issues/plan-a2a-mcp-behavior-tests.md
+++ b/issues/plan-a2a-mcp-behavior-tests.md
@@ -1,0 +1,20 @@
+# Plan A2A MCP behavior tests
+
+## Context
+The A2A MCP integration needs behavior-driven tests to verify handshake
+success, timeout handling, and recovery from errors. Breaking the effort into
+smaller tasks will ease review and coordination.
+
+## Acceptance Criteria
+- Add a handshake success scenario in
+  `tests/behavior/features/a2a_mcp_integration.feature`.
+- Add a handshake timeout scenario in the same feature file.
+- Add an error recovery scenario in the feature file.
+- Implement step definitions for each scenario in
+  `tests/behavior/steps/a2a_mcp_steps.py` and tag them with the
+  `requires_distributed` marker for multi-agent coordination.
+- Register `a2a_mcp` and `requires_distributed` markers in `pytest.ini`.
+- Validate with `uv run pytest tests/behavior -m a2a_mcp -q`.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- record work items for A2A MCP behavior test coverage
- update task progress to track new behavior test planning

## Testing
- `uv run pytest tests/behavior -m a2a_mcp -q` *(fails: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_68ae1c7f17c083339474a00606eb2e5e