### PR TITLE
Sync coverage statistics across project docs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -127,6 +127,10 @@ tasks:
           --cov-append
       - uv run coverage report --fail-under={{.COVERAGE_THRESHOLD}}
       - uv run python scripts/check_token_regression.py --threshold 5
+      - |
+          if [ -n "$CI" ]; then
+            uv run python scripts/update_coverage_docs.py
+          fi
     desc: "Run full test suite with coverage reporting"
 
   verify:

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -73,7 +73,8 @@ for **July 1, 2026** while packaging tasks are resolved.
   [validate-ranking-algorithms-and-agent-coordination.md](
   ../issues/archive/validate-ranking-algorithms-and-agent-coordination.md))
 - [ ] Confirm CHANGELOG.md, STATUS.md and this plan share the same coverage
-  details before tagging.
+  details before tagging. CI runs `scripts/update_coverage_docs.py` after
+  `task coverage` to sync the value.
 
 These tasks completed in order: environment bootstrap → packaging verification
 → integration tests → coverage gates → algorithm validation.

--- a/scripts/update_coverage_docs.py
+++ b/scripts/update_coverage_docs.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Update coverage numbers in project documentation.
+
+Usage:
+    uv run python scripts/update_coverage_docs.py [--file coverage.xml]
+    uv run python scripts/update_coverage_docs.py --value 75.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+FILES = [
+    ROOT / "STATUS.md",
+    ROOT / "ROADMAP.md",
+    ROOT / "docs" / "release_plan.md",
+    ROOT / "CHANGELOG.md",
+]
+
+PATTERNS = [
+    re.compile(r"(previous baseline was )\*\*\d+%\*\*"),
+    re.compile(r"(coverage from the unit subset is )\*\*\d+%\*\*"),
+    re.compile(r"(current coverage is )\*\*\d+%\*\*"),
+    re.compile(r"(Total coverage is )\*\*\d+%\*\*"),
+    re.compile(r"(currently reports )\*\*\d+%\*\*"),
+    re.compile(r"(coverage noted at )\*\*\d+%\*\*"),
+]
+
+COVERAGE_WORD = re.compile(r"\b\d+% coverage\b")
+
+
+def read_coverage(path: Path) -> int:
+    """Return rounded line coverage percentage from a coverage XML file."""
+    root = ET.parse(path).getroot()
+    return round(float(root.attrib["line-rate"]) * 100)
+
+
+def update_file(path: Path, coverage: int) -> None:
+    """Replace coverage references in *path* with *coverage*."""
+    text = path.read_text()
+    for pattern in PATTERNS:
+        text = pattern.sub(lambda m: f"{m.group(1)}**{coverage}%**", text)
+    text = COVERAGE_WORD.sub(f"{coverage}% coverage", text)
+    path.write_text(text)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Write coverage into docs")
+    parser.add_argument(
+        "--file", default="coverage.xml", type=Path, help="Coverage XML file to read"
+    )
+    parser.add_argument("--value", type=float, help="Override coverage percentage")
+    args = parser.parse_args(argv)
+
+    if args.value is not None:
+        coverage = round(args.value)
+    else:
+        coverage = read_coverage(args.file)
+
+    for file in FILES:
+        update_file(file, coverage)
+
+    print(f"Wrote coverage {coverage}% to {len(FILES)} files.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `scripts/update_coverage_docs.py` to write coverage percentages into STATUS.md, ROADMAP.md, docs/release_plan.md, and CHANGELOG.md
- invoke the sync script in `task coverage` when running under CI
- document the coverage sync step in the alpha release checklist

## Testing
- `task check` *(fails: No module named 'pytest_bdd')*
- `task verify` *(fails: No module named 'pytest_bdd')*


------
https://chatgpt.com/codex/tasks/task_e_68ae61a8eb848333b3141a08077408fa