### PR TITLE
feat: bootstrap task installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,9 @@ For orchestrator state transitions and API contracts see
 
 Autoresearch requires **Python 3.12+**,
 [uv](https://github.com/astral-sh/uv), and
-[Go Task](https://taskfile.dev/). Run `./scripts/setup.sh` before invoking any
-`task` commands; it installs Go Task to `.venv/bin` and updates activation
-scripts so the binary resolves. After cloning, run `./scripts/setup.sh` for the
-full developer bootstrap or `task install` for a minimal environment once
-setup is complete. See
+[Go Task](https://taskfile.dev/). `task install` checks for Go Task and
+downloads it to `.venv/bin` when missing. Run `./scripts/setup.sh` for a full
+developer bootstrap or if the automatic download fails. See
 [docs/installation.md#after-cloning](docs/installation.md#after-cloning) for
 details.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,17 @@ tasks:
     vars:
       EXTRAS: "{{.EXTRAS | default \"\"}}"
     cmds:
+      - |
+          if ! command -v task >/dev/null 2>&1; then
+              echo "Go Task missing; installing into .venv/bin..."
+              mkdir -p .venv/bin
+              if ! curl -sSL https://taskfile.dev/install.sh \
+                  | sh -s -- -b .venv/bin; then
+                  echo "Failed to install Go Task. Run scripts/setup.sh." >&2
+                  exit 1
+              fi
+              export PATH="$(pwd)/.venv/bin:$PATH"
+          fi
       - >
           uv sync --extra dev-minimal{{if .EXTRAS}} --extra {{.EXTRAS}}{{end}}
       - uv run python -c "import pytest_httpx, tomli_w, redis"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,10 +6,11 @@ environments.
 
 Autoresearch requires **Python 3.12 or newer**,
 [**uv**](https://github.com/astral-sh/uv), and
-[**Go Task**](https://taskfile.dev/) for Taskfile commands. Run
-`./scripts/setup.sh` before invoking any `task` commands; it installs Go
-Task to `.venv/bin` and updates activation scripts so the binary resolves.
-Manual installation instructions are below if needed.
+[**Go Task**](https://taskfile.dev/) for Taskfile commands.
+`task install` checks for Go Task and downloads it to `.venv/bin` when
+missing. Run `./scripts/setup.sh` for the full developer bootstrap or if the
+automatic download fails. Manual installation instructions are below if
+needed.
 
 The Redis package installs with the `dev` extra. A running Redis
 server is required only for tests or features that use the
@@ -30,14 +31,8 @@ dependencies.
 
 ## After cloning
 
-Run the setup script immediately after cloning:
-
-```bash
-./scripts/setup.sh  # full developer bootstrap
-```
-
-After the script completes you can use `task install` to provision the
-minimal development tools:
+Run `task install` after cloning to bootstrap Go Task and the minimal
+development tools:
 
 ```bash
 task install
@@ -50,9 +45,10 @@ EXTRAS="test nlp" task install  # adds test and NLP packages
 uv sync --extra llm             # sentence-transformers and transformers
 ```
 
-`./scripts/setup.sh` installs Go Task when missing, syncs the `dev` and
-`test` extras (including packages such as `pytest_httpx`, `tomli_w`, and
-`redis`), and exits if `task --version` fails.
+Use `./scripts/setup.sh` for the full developer bootstrap. It installs Go
+Task when missing, syncs the `dev` and `test` extras (including packages such
+as `pytest_httpx`, `tomli_w`, and `redis`), and exits if `task --version`
+fails.
 
 After the script completes, confirm Go Task and the development packages are
 available:


### PR DESCRIPTION
## Summary
- bootstrap Go Task in `task install` when missing and suggest `scripts/setup.sh` on failure
- document automatic Task bootstrap in README and installation guide

## Testing
- `task check` *(fails: AttributeError in DuckDB schema version check)*
- `task verify` *(fails: exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_68ae619115e08333903f3d131617d66c