### PR TITLE
test: setup duckdb schema fixture

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -148,6 +148,9 @@ Use fixtures for common setup and teardown to reduce code duplication:
 Common project fixtures live in `tests/conftest.py`. Use
 `example_autoresearch_toml` for a realistic `autoresearch.toml` and
 `example_env_file` for a sample `.env` with required variables.
+`ensure_duckdb_schema` invokes `StorageManager.setup` so tests that touch
+storage start with a fresh DuckDB database. The setup routine automatically
+creates any missing tables.
 
 Example:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -217,6 +217,20 @@ def duckdb_path(tmp_path):
 
 
 @pytest.fixture
+def ensure_duckdb_schema(tmp_path, monkeypatch):
+    """Ensure StorageManager setup creates required DuckDB tables."""
+    db_file = tmp_path / "kg.duckdb"
+    StorageManager.teardown(remove_db=True)
+    monkeypatch.setattr(
+        storage.DuckDBStorageBackend, "_initialize_schema_version", lambda self: None
+    )
+    monkeypatch.setattr(storage.DuckDBStorageBackend, "_run_migrations", lambda self: None)
+    StorageManager.setup(str(db_file))
+    yield str(db_file)
+    StorageManager.teardown(remove_db=True)
+
+
+@pytest.fixture
 def storage_manager(duckdb_path):
     """Initialize storage using a prepared DuckDB path and clean up."""
     storage.initialize_storage(duckdb_path)

--- a/tests/unit/test_eviction.py
+++ b/tests/unit/test_eviction.py
@@ -9,7 +9,7 @@ from autoresearch.orchestration import metrics
 from autoresearch.storage import StorageManager
 
 
-def test_ram_eviction(storage_manager, monkeypatch):
+def test_ram_eviction(ensure_duckdb_schema, monkeypatch):
     StorageManager.clear_all()
     monkeypatch.setattr("autoresearch.storage.run_ontology_reasoner", lambda *_, **__: None)
     config = ConfigModel(ram_budget_mb=1)
@@ -26,7 +26,7 @@ def test_ram_eviction(storage_manager, monkeypatch):
     assert "c1" not in StorageManager.get_graph().nodes
 
 
-def test_score_eviction(storage_manager, monkeypatch):
+def test_score_eviction(ensure_duckdb_schema, monkeypatch):
     StorageManager.clear_all()
     monkeypatch.setattr("autoresearch.storage.run_ontology_reasoner", lambda *_, **__: None)
     config = ConfigModel(ram_budget_mb=1, graph_eviction_policy="score")
@@ -49,13 +49,12 @@ def test_score_eviction(storage_manager, monkeypatch):
     assert "high" in graph.nodes
 
 
-def test_lru_eviction_order(monkeypatch, duckdb_path):
+def test_lru_eviction_order(monkeypatch, ensure_duckdb_schema):
     config = ConfigModel(ram_budget_mb=1)
     config.search.context_aware.enabled = False
     config.storage.rdf_backend = "memory"
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: config)
     ConfigLoader()._config = None
-    storage.setup(duckdb_path)
     StorageManager.clear_all()
     monkeypatch.setattr("autoresearch.storage.run_ontology_reasoner", lambda *_, **__: None)
     monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 0)
@@ -76,7 +75,7 @@ def test_lru_eviction_order(monkeypatch, duckdb_path):
     assert "c2" in graph.nodes
 
 
-def test_lru_eviction_sequence(storage_manager, monkeypatch):
+def test_lru_eviction_sequence(ensure_duckdb_schema, monkeypatch):
     """Verify older nodes are evicted before newer ones with LRU policy."""
     StorageManager.clear_all()
     monkeypatch.setattr("autoresearch.storage.run_ontology_reasoner", lambda *_, **__: None)

--- a/tests/unit/test_storage_utils.py
+++ b/tests/unit/test_storage_utils.py
@@ -18,7 +18,7 @@ def test_touch_node_updates_lru(monkeypatch):
     assert list(storage.StorageManager.state.lru.keys()) == ["b", "a"]
 
 
-def test_clear_all(storage_manager, duckdb_path):
+def test_clear_all(ensure_duckdb_schema):
     with patch("autoresearch.storage.run_ontology_reasoner") as mock_reasoner:
         mock_reasoner.return_value = None
 


### PR DESCRIPTION
## Summary
- add `ensure_duckdb_schema` fixture invoking `StorageManager.setup`
- refactor storage tests to leverage new fixture
- document DuckDB schema setup in test guidelines

## Testing
- `uv run pytest tests/unit/test_eviction.py::test_ram_eviction -q`
- `uv run pytest tests/unit/test_eviction.py::test_score_eviction -q`
- `uv run pytest tests/unit/test_eviction.py::test_lru_eviction_order -q`
- `uv run pytest tests/unit/test_eviction.py::test_lru_eviction_sequence -q`
- `uv run pytest tests/unit/test_storage_utils.py::test_clear_all -q`
- `uv run mkdocs build` *(fails: No such file or directory)*
- `task check` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6187acc08333825bd2e64bf6fe6d