### PR TITLE
test: cover cache git backend and token budgeting

### DIFF
--- a/tests/unit/test_cache_deepcopy.py
+++ b/tests/unit/test_cache_deepcopy.py
@@ -1,0 +1,19 @@
+import autoresearch.cache as cache
+
+
+def test_cache_results_are_deepcopied(tmp_path):
+    db_path = tmp_path / "c.json"
+    c = cache.SearchCache(str(db_path))
+    original = [{"title": "t", "url": "u"}]
+    cache.cache_results("q", "b", original)
+    cached = cache.get_cached_results("q", "b")
+    assert cached == original
+    cached[0]["title"] = "changed"
+    assert cache.get_cached_results("q", "b")[0]["title"] == "t"
+    c.teardown(remove_file=True)
+
+
+def test_get_cache_returns_singleton():
+    c1 = cache.get_cache()
+    c2 = cache.get_cache()
+    assert c1 is c2

--- a/tests/unit/test_local_git_backend.py
+++ b/tests/unit/test_local_git_backend.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import git
+import pytest
+
+from autoresearch.config.models import ConfigModel
+from autoresearch.search.core import _local_git_backend
+from autoresearch.storage import StorageManager
+
+
+@pytest.mark.requires_git
+def test_local_git_backend_searches_repo(tmp_path, monkeypatch):
+    repo_path = tmp_path / "repo"
+    repo = git.Repo.init(repo_path)
+    file_path = repo_path / "file.txt"
+    file_path.write_text("hello world")
+    repo.index.add([str(file_path)])
+    repo.index.commit("initial commit")
+
+    cfg = ConfigModel()
+    cfg.search.local_git.repo_path = str(repo_path)
+    cfg.search.local_git.branches = [repo.active_branch.name]
+    cfg.search.local_git.history_depth = 5
+    cfg.search.local_file.file_types = ["txt"]
+    monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
+    monkeypatch.setattr("autoresearch.search.core.shutil.which", lambda name: None)
+
+    @contextmanager
+    def dummy_connection():
+        class DummyConn:
+            def execute(self, *args, **kwargs):
+                class Cur:
+                    def fetchall(self_inner):
+                        return []
+                return Cur()
+        yield DummyConn()
+
+    monkeypatch.setattr(StorageManager, "connection", staticmethod(dummy_connection))
+
+    results = _local_git_backend("hello", max_results=5)
+    assert any("hello" in r["snippet"] for r in results)

--- a/tests/unit/test_storage_delegate_extra.py
+++ b/tests/unit/test_storage_delegate_extra.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from autoresearch.storage import StorageManager, get_delegate, set_delegate
+
+
+class DummyStorage(StorageManager):
+    touched: list[str] = []
+
+    @staticmethod
+    def touch_node(node_id: str) -> None:  # pragma: no cover - simple delegation
+        DummyStorage.touched.append(node_id)
+
+
+@pytest.fixture(autouse=True)
+def _reset_delegate():
+    set_delegate(None)
+    yield
+    set_delegate(None)
+
+
+def test_touch_node_uses_delegate():
+    set_delegate(DummyStorage)
+    StorageManager.touch_node("n1")
+    assert DummyStorage.touched == ["n1"]
+    assert get_delegate() is DummyStorage

--- a/tests/unit/test_token_budget_property.py
+++ b/tests/unit/test_token_budget_property.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from hypothesis import given, strategies as st
+
+from autoresearch.llm.token_counting import compress_prompt, prune_context
+
+
+@given(st.text(min_size=1), st.integers(min_value=3, max_value=50))
+def test_compress_prompt_respects_budget(prompt: str, budget: int) -> None:
+    result = compress_prompt(prompt, budget)
+    assert len(result.split()) <= budget
+
+
+@given(st.lists(st.text(min_size=1), max_size=10), st.integers(min_value=0, max_value=50))
+def test_prune_context_keeps_latest_items(context: list[str], budget: int) -> None:
+    pruned = prune_context(context, budget)
+    assert sum(len(c.split()) for c in pruned) <= budget
+    assert pruned == context[len(context) - len(pruned) :]


### PR DESCRIPTION
## Summary
- add deep-copy and singleton tests for cache API
- ensure StorageManager delegates touch_node via set_delegate
- verify local Git search backend and token budgeting with Hypothesis

## Testing
- `uv run pytest tests/unit/test_cache_deepcopy.py tests/unit/test_local_git_backend.py tests/unit/test_storage_delegate_extra.py tests/unit/test_token_budget_property.py -q`
- `task check` *(fails: many unit tests failing; see logs)*
- `task coverage` *(fails: 14 tests failing, no coverage report)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7ac8c10c83339ffc074c2e149f23