### PR TITLE
Reopen algorithm proof issues and update status

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,21 +1,20 @@
 # Status
 
-As of **August 27, 2025**, `scripts/setup.sh` installs dependencies and records
-the DuckDB VSS fallback. The current environment lacks the `task` command, so
-Taskfile recipes cannot run.
+As of **August 28, 2025**, `scripts/setup.sh` installs dependencies and records
+the DuckDB VSS fallback. The current environment lacks the `task` command and
+the `pytest_bdd` plugin, so Taskfile recipes and BDD tests cannot run.
 
 ## Lint, type checks, and spec tests
 ```text
 task check
 ```
-Result: command not found.
+Result: `task` command not found.
 
 ## Unit tests
 ```text
-uv sync --extra test && uv run pytest
+uv run pytest tests/unit -q
 ```
-Result: hangs in `redis.cluster` waiting for a Redis server. One test is
-skipped and four warnings appear before the run is interrupted.
+Result: fails during collection with `ImportError: No module named 'pytest_bdd'`.
 
 ## Integration tests
 ```text

--- a/issues/add-orchestration-proofs-and-tests.md
+++ b/issues/add-orchestration-proofs-and-tests.md
@@ -10,7 +10,7 @@ resource guarantees unspecified.
 - 0.1.0a1 (2026-04-15)
 
 ## Dependencies
-- [improve-test-coverage-and-streamline-dependencies](../improve-test-coverage-and-streamline-dependencies.md)
+- [improve-test-coverage-and-streamline-dependencies](improve-test-coverage-and-streamline-dependencies.md)
 
 ## Acceptance Criteria
 - Provide proofs or simulations demonstrating deterministic circuit breaker
@@ -20,4 +20,4 @@ resource guarantees unspecified.
 - Document reasoning and assumptions in `docs/algorithms/orchestration.md`.
 
 ## Status
-Archived
+Open

--- a/issues/add-storage-proofs-and-simulations.md
+++ b/issues/add-storage-proofs-and-simulations.md
@@ -9,7 +9,7 @@ simulations are needed to justify the storage design and prevent regressions.
 - 0.1.0a1 (2026-04-15)
 
 ## Dependencies
-- [resolve-storage-layer-test-failures](../resolve-storage-layer-test-failures.md)
+- [resolve-storage-layer-test-failures](resolve-storage-layer-test-failures.md)
 
 ## Acceptance Criteria
 - Provide a proof or simulation demonstrating idempotent schema initialization.
@@ -18,4 +18,4 @@ simulations are needed to justify the storage design and prevent regressions.
 - Document assumptions and results in `docs/algorithms/storage.md`.
 
 ## Status
-Archived
+Open


### PR DESCRIPTION
## Summary
- Reopen algorithm-proof planning tickets for orchestration and storage components
- Update status report with latest environment limitations and unit test failures

## Testing
- `task check` *(fails: command not found)*
- `uv run pytest tests/unit -q` *(fails: ImportError: No module named 'pytest_bdd')*


------
https://chatgpt.com/codex/tasks/task_e_68ae95ae596083338356fca979209e53