### PR TITLE
docs: record failing tests and add pdfminer issue

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,21 +1,40 @@
 # Status
 
-As of **August 27, 2025**, `scripts/codex_setup.sh` followed by
-`uv sync --extra dev --extra test` installs dependencies and exposes the
-`task` command. `task check` launches but the unit suite runs slowly and was
-interrupted after exceeding the allotted runtime.
+As of **August 27, 2025**, running `scripts/codex_setup.sh` then
+`.venv/bin/task install` provisions dependencies and exposes the `task`
+command. `task check` executes linting and type checks, but nine unit tests
+fail and the run ends early. `task verify` aborts during collection because the
+`pdfminer` package is missing.
 
 ## Lint, type checks, and spec tests
 ```text
 task check
 ```
-Result: lint and type checks passed; unit tests were interrupted after an
-extended run.
+Result: lint and type checks passed; unit tests failed before completion.
 
 ## Unit tests
-Sample failing tests when run individually:
+`task check` reported failures in the following tests:
 - `tests/unit/test_cli_backup_extra.py::test_backup_restore_error`
-- `tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_setup_with_default_path`
+- `tests/unit/test_download_duckdb_extensions.py::`
+  `test_download_extension_network_fallback`
+- `tests/unit/test_duckdb_storage_backend.py::`
+  `TestDuckDBStorageBackend::test_setup_with_default_path`
+- `tests/unit/test_duckdb_storage_backend.py::`
+  `TestDuckDBStorageBackend::test_initialize_schema_version`
+- `tests/unit/test_duckdb_storage_backend.py::`
+  `TestDuckDBStorageBackend::test_get_schema_version`
+- `tests/unit/test_duckdb_storage_backend.py::`
+  `TestDuckDBStorageBackend::test_get_schema_version_no_version`
+- `tests/unit/test_duckdb_storage_backend.py::`
+  `TestDuckDBStorageBackend::test_close`
+- `tests/unit/test_main_backup_commands.py::test_backup_restore_command`
+- `tests/unit/test_main_backup_commands.py::test_backup_restore_error`
+
+## Targeted tests
+```text
+task verify
+```
+Result: collection errors (`ModuleNotFoundError: No module named 'pdfminer'`).
 
 ## Integration tests
 ```text
@@ -28,5 +47,5 @@ Behavior tests did not run; unit tests failing.
 ```
 
 ## Coverage
-Coverage remains unavailable because `task check` did not complete. The previous
-baseline was **14%**, below the required 90% threshold.
+Coverage remains unavailable because tests failed. The previous baseline was
+**14%**, below the required 90% threshold.

--- a/issues/add-pdfminer-dependency-and-fix-targeted-tests.md
+++ b/issues/add-pdfminer-dependency-and-fix-targeted-tests.md
@@ -1,0 +1,19 @@
+# Add pdfminer dependency and fix targeted tests
+
+## Context
+`task verify` fails during test collection with
+`ModuleNotFoundError: No module named 'pdfminer'`. The search module relies on
+`pdfminer.six` for PDF text extraction, so targeted tests cannot run and
+coverage reports remain incomplete.
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- `pdfminer.six` included in development and test dependencies.
+- `task verify` runs without missing dependency errors.
+- Targeted tests for PDF search scenarios pass.
+- Documentation mentions optional PDF support requirements.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- document current failing unit tests and missing `pdfminer` dependency in `STATUS.md`
- open in-repo issue to add `pdfminer.six` and restore targeted tests

## Testing
- `task check` *(fails: backup and duckdb storage tests)*
- `task verify` *(fails: ModuleNotFoundError: No module named 'pdfminer')*


------
https://chatgpt.com/codex/tasks/task_e_68af17731c148333a3da4a0171fa8a4e