### PR TITLE
chore: record test results and track circular import

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,44 +1,41 @@
 # Status
 
-As of **August 27, 2025**, the environment lacks the `task` CLI. After
-`uv sync --all-extras`, running `uv run pytest` exercises the suite with nine
-failing tests and 429 passing tests. Required packages, including
-`pdfminer.six`, are present.
+As of **August 27, 2025**, the environment includes the `task` CLI. Running
+`task check` executes linting, type checks, spec tests, and the unit subset.
+The command reports **9 failed, 336 passed, 1 skipped, 24 deselected, 1 xpassed**
+unit tests in about two minutes. Required packages, including `pdfminer.six`,
+are present.
 
 ## Lint, type checks, and spec tests
-`task check` could not run because the `task` command is unavailable.
+`task check` runs successfully until unit test failures occur. `flake8` and
+`mypy` pass without errors.
 
 ## Unit tests
-`uv run pytest` reported failures in the following tests:
+`task check` reports failures in the following tests:
 - `tests/unit/test_cli_backup_extra.py::test_backup_restore_error`
-- `tests/unit/test_download_duckdb_extensions.py::`
-  `test_download_extension_network_fallback`
-- `tests/unit/test_duckdb_storage_backend.py::`
-  `TestDuckDBStorageBackend::test_setup_with_default_path`
-- `tests/unit/test_duckdb_storage_backend.py::`
-  `TestDuckDBStorageBackend::test_initialize_schema_version`
-- `tests/unit/test_duckdb_storage_backend.py::`
-  `TestDuckDBStorageBackend::test_get_schema_version`
-- `tests/unit/test_duckdb_storage_backend.py::`
-  `TestDuckDBStorageBackend::test_get_schema_version_no_version`
-- `tests/unit/test_duckdb_storage_backend.py::`
-  `TestDuckDBStorageBackend::test_close`
+- `tests/unit/test_download_duckdb_extensions.py::test_download_extension_network_fallback`
+- `tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_setup_with_default_path`
+- `tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_initialize_schema_version`
+- `tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_get_schema_version`
+- `tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_get_schema_version_no_version`
+- `tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_close`
 - `tests/unit/test_main_backup_commands.py::test_backup_restore_command`
 - `tests/unit/test_main_backup_commands.py::test_backup_restore_error`
 
 ## Targeted tests
-`task verify` could not run because the `task` command is unavailable.
+`task verify` fails during collection with an `ImportError` from a circular
+import between `distributed.executors` and `orchestration.state`.
 
 ## Integration tests
 ```text
-Integration tests did not run; unit tests failing.
+Integration tests did not run; targeted tests failing.
 ```
 
 ## Behavior tests
 ```text
-Behavior tests did not run; unit tests failing.
+Behavior tests did not run; targeted tests failing.
 ```
 
 ## Coverage
-Coverage remains unavailable because tests failed. The previous baseline was
-**14%**, below the required 90% threshold.
+Coverage remains unavailable because targeted tests failed. The previous
+baseline was **14%**, below the required 90% threshold.

--- a/issues/resolve-distributed-circular-import.md
+++ b/issues/resolve-distributed-circular-import.md
@@ -1,0 +1,18 @@
+# Resolve distributed circular import
+
+## Context
+`task verify` fails during test collection with a circular import between
+`distributed.executors` and `orchestration.state`, preventing integration
+tests from running.
+
+## Dependencies
+
+- None
+
+## Acceptance Criteria
+- Refactor modules to break the circular dependency between distributed
+  executors and orchestration state.
+- `task verify` collects tests without ImportError.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- document latest `task check` and `task verify` results in `STATUS.md`
- add in-repo issue for distributed circular import blocking `task verify`

## Testing
- `task check`
- `task verify` *(fails: ImportError from circular import)*

------
https://chatgpt.com/codex/tasks/task_e_68af239fde388333ba3848ee35886fcb