### PR TITLE
refactor: centralize shared interfaces

### DIFF
--- a/src/autoresearch/interfaces.py
+++ b/src/autoresearch/interfaces.py
@@ -1,0 +1,22 @@
+"""Common interfaces shared across the project."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Protocol, runtime_checkable
+
+from .models import QueryResponse
+
+CallbackMap = Dict[str, Callable[..., None]]
+
+
+@runtime_checkable
+class QueryStateLike(Protocol):
+    """Protocol for orchestration state objects."""
+
+    cycle: int
+
+    def update(self, result: Dict[str, Any]) -> None:
+        """Update state with agent result."""
+
+    def synthesize(self) -> QueryResponse:
+        """Produce a final response."""

--- a/src/autoresearch/orchestration/state.py
+++ b/src/autoresearch/orchestration/state.py
@@ -1,20 +1,24 @@
-"""
-State management for the dialectical reasoning process.
-"""
+"""State management for the dialectical reasoning process."""
 
-from typing import List, Dict, Any, Optional
+import time
+from threading import RLock
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, PrivateAttr
 
 from ..agents.feedback import FeedbackEvent
 from ..agents.messages import MessageProtocol
-import time
-from threading import RLock
-from pydantic import BaseModel, Field, PrivateAttr
-
 from ..models import QueryResponse
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..interfaces import QueryStateLike  # noqa: F401
 
 
 class QueryState(BaseModel):
-    """State object passed between agents during dialectical cycles."""
+    """State object passed between agents during dialectical cycles.
+
+    Implements :class:`~autoresearch.interfaces.QueryStateLike`.
+    """
 
     query: str
     claims: List[Dict[str, Any]] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- add `interfaces` module defining `CallbackMap` and `QueryStateLike`
- update distributed executors to rely on shared interfaces
- document `QueryState` implementation of the new protocol

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run pytest --collect-only tests/targeted`


------
https://chatgpt.com/codex/tasks/task_e_68af28ada0748333aad180589481ec8b