### PR TITLE
feat: simulate storage eviction under concurrency

### DIFF
--- a/docs/algorithms/storage.md
+++ b/docs/algorithms/storage.md
@@ -27,6 +27,16 @@ second = ctx.db_backend._conn.execute("show tables").fetchall()
 assert first == second
 ```
 
+### Proof
+
+- `CREATE TABLE IF NOT EXISTS` guarantees that an existing table remains
+  untouched. DuckDB documents this behaviour in its [SQL
+  reference](https://duckdb.org/docs/sql/statements/create_table.html).
+- The `setup` helper issues that statement for each table, so repeated
+  invocations cannot modify the schema.
+- The above code sample runs the setup twice and compares table listings,
+  providing a constructive witness that the schema is unchanged.
+
 ## Concurrent eviction
 
 Eviction maintains the RAM budget even when multiple writers persist claims
@@ -34,10 +44,21 @@ simultaneously. The [simulation][evict-sim] spawns threads that insert claims
 while memory usage is forced above the budget. After all threads finish the
 in-memory graph is empty, proving the policy is thread safe.
 
+### Proof
+
+- Every `persist_claim` call ends with `_enforce_ram_budget`, which checks
+  current memory use against `ram_budget_mb`.
+- The simulation patches the memory check so each write appears to exceed the
+  budget and runs several threads that insert claims.
+- After the threads join the NetworkX graph reports zero nodes, which the
+  [targeted test][evict-test] asserts, confirming evicted state under
+  concurrency.
+
 ## DuckDB fallback benchmark
 
 The benchmark in [duckdb-bench] shows that persistence triggers eviction when
  the RAM budget is exceeded, ensuring deterministic resource bounds.
 
-[evict-sim]: ../../tests/integration/test_storage_eviction.py
+[evict-sim]: ../../scripts/storage_eviction_sim.py
+[evict-test]: ../../tests/targeted/test_storage_eviction.py
 [duckdb-bench]: ../../tests/integration/test_storage_duckdb_fallback.py

--- a/scripts/storage_eviction_sim.py
+++ b/scripts/storage_eviction_sim.py
@@ -1,0 +1,62 @@
+"""Simulate concurrent writes that trigger RAM-budget eviction.
+
+Usage:
+    uv run scripts/storage_eviction_sim.py --workers 4 --claims 10 --budget 1
+"""
+
+from __future__ import annotations
+
+import argparse
+import threading
+from typing import Callable
+
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.storage import StorageContext, StorageManager, StorageState
+
+
+def _insert(start: int, count: int) -> None:
+    """Persist a sequence of synthetic claims."""
+    for i in range(start, start + count):
+        StorageManager.persist_claim({"id": f"c{i}", "type": "t", "content": "x"})
+
+
+def run_simulation(budget: int = 1, workers: int = 4, claims: int = 10) -> int:
+    """Run the eviction simulation and return remaining graph nodes.
+
+    Args:
+        budget: RAM budget in megabytes.
+        workers: Number of concurrent writer threads.
+        claims: Number of claims per worker.
+    """
+    loader = ConfigLoader()
+    loader.config.ram_budget_mb = budget
+    ConfigLoader._instance = loader
+    original: Callable[[], float] = StorageManager._current_ram_mb
+    StorageManager._current_ram_mb = staticmethod(lambda: float(budget * 1000))
+    ctx, st = StorageContext(), StorageState()
+    StorageManager.setup(db_path=":memory:", context=ctx, state=st)
+    threads = [threading.Thread(target=_insert, args=(n * claims, claims)) for n in range(workers)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    graph_nodes = (
+        StorageManager.context.graph.number_of_nodes() if StorageManager.context.graph else 0
+    )
+    StorageManager.teardown(remove_db=True, context=ctx, state=st)
+    StorageManager._current_ram_mb = original
+    return graph_nodes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workers", type=int, default=4, help="number of writer threads")
+    parser.add_argument("--claims", type=int, default=10, help="claims per worker")
+    parser.add_argument("--budget", type=int, default=1, help="RAM budget in MB")
+    args = parser.parse_args()
+    remaining = run_simulation(args.budget, args.workers, args.claims)
+    print(f"final nodes={remaining}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/targeted/test_storage_eviction.py
+++ b/tests/targeted/test_storage_eviction.py
@@ -1,0 +1,10 @@
+"""Targeted tests for RAM-budget eviction with concurrent writes."""
+
+from scripts.storage_eviction_sim import run_simulation
+
+
+def test_concurrent_eviction(config) -> None:
+    """All claims are evicted when memory is above the budget."""
+    config.ram_budget_mb = 1
+    remaining = run_simulation(budget=1, workers=4, claims=5)
+    assert remaining == 0


### PR DESCRIPTION
## Summary
- prove idempotent storage setup and eviction in docs
- add script that simulates eviction under concurrent writers
- test RAM-budget eviction behavior

## Testing
- `uv run black --check scripts/storage_eviction_sim.py tests/targeted/test_storage_eviction.py`
- `uv run flake8 scripts/storage_eviction_sim.py tests/targeted/test_storage_eviction.py`
- `uv run pytest tests/targeted/test_storage_eviction.py`
- `uv run mkdocs build`
- `task check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af28ce35f08333a035e09b415aba98