### PR TITLE
Add storage eviction simulation and documentation

### DIFF
--- a/scripts/storage_eviction_sim.py
+++ b/scripts/storage_eviction_sim.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Simulate concurrent storage writes that trigger RAM-budget eviction.
+
+Usage:
+    uv run python scripts/storage_eviction_sim.py --threads 5
+"""
+
+from __future__ import annotations
+
+import argparse
+from threading import Thread
+
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel, StorageConfig
+from autoresearch.storage import StorageContext, StorageManager, StorageState
+
+
+def _run(threads: int) -> int:
+    """Persist claims concurrently and return remaining node count."""
+
+    cfg = ConfigModel(
+        storage=StorageConfig(duckdb_path=":memory:"),
+        ram_budget_mb=1,
+        graph_eviction_policy="lru",
+    )
+    loader = ConfigLoader.new_for_tests()
+    loader._config = cfg
+
+    st = StorageState()
+    ctx = StorageContext()
+    StorageManager.state = st
+    StorageManager.context = ctx
+
+    original = StorageManager._current_ram_mb
+    StorageManager._current_ram_mb = staticmethod(lambda: 1000)
+    try:
+        StorageManager.setup(db_path=":memory:", context=ctx, state=st)
+
+        def persist(idx: int) -> None:
+            StorageManager.persist_claim({"id": f"c{idx}", "type": "fact", "content": "c"})
+
+        threads_list = [Thread(target=persist, args=(i,)) for i in range(threads)]
+        for t in threads_list:
+            t.start()
+        for t in threads_list:
+            t.join()
+
+        remaining = StorageManager.get_graph().number_of_nodes()
+    finally:
+        StorageManager.teardown(remove_db=True, context=ctx, state=st)
+        StorageManager.state = StorageState()
+        StorageManager.context = StorageContext()
+        StorageManager._current_ram_mb = original  # type: ignore[assignment]
+        ConfigLoader.reset_instance()
+
+    return remaining
+
+
+def main(threads: int) -> None:
+    if threads <= 0:
+        raise SystemExit("threads must be positive")
+    remaining = _run(threads)
+    print(f"nodes remaining after eviction: {remaining}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--threads", type=int, default=5, help="concurrent writers")
+    args = parser.parse_args()
+    main(args.threads)

--- a/tests/targeted/test_storage_eviction.py
+++ b/tests/targeted/test_storage_eviction.py
@@ -1,0 +1,57 @@
+"""Targeted tests for storage eviction and schema initialization."""
+
+from threading import Thread
+
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel, StorageConfig
+from autoresearch.storage import (
+    StorageContext,
+    StorageManager,
+    StorageState,
+    initialize_storage,
+)
+
+
+def test_initialize_storage_idempotent() -> None:
+    """`initialize_storage` can run repeatedly without side effects."""
+    ctx = StorageContext()
+    st = StorageState()
+    initialize_storage(db_path=":memory:", context=ctx, state=st)
+    first = ctx.db_backend._conn.execute("show tables").fetchall()
+    initialize_storage(db_path=":memory:", context=ctx, state=st)
+    second = ctx.db_backend._conn.execute("show tables").fetchall()
+    assert first == second
+    StorageManager.teardown(remove_db=True, context=ctx, state=st)
+    StorageManager.state = StorageState()
+    StorageManager.context = StorageContext()
+
+
+def test_ram_budget_eviction(tmp_path, monkeypatch) -> None:
+    """Concurrent writers respect the configured RAM budget."""
+    cfg = ConfigModel(
+        storage=StorageConfig(duckdb_path=str(tmp_path / "kg.duckdb")),
+        ram_budget_mb=1,
+        graph_eviction_policy="lru",
+    )
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+
+    st = StorageState()
+    ctx = StorageContext()
+    monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 1000)
+    StorageManager.setup(db_path=cfg.storage.duckdb_path, context=ctx, state=st)
+
+    def persist(idx: int) -> None:
+        StorageManager.persist_claim({"id": f"c{idx}", "type": "fact", "content": "c"})
+
+    threads = [Thread(target=persist, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert StorageManager.get_graph().number_of_nodes() == 0
+    StorageManager.teardown(remove_db=True, context=ctx, state=st)
+    StorageManager.state = StorageState()
+    StorageManager.context = StorageContext()
+    ConfigLoader()._config = None


### PR DESCRIPTION
## Summary
- document proof sketches for idempotent schema initialization and RAM-budget eviction
- add `storage_eviction_sim.py` to simulate concurrent eviction
- add targeted tests for storage initialization idempotency and RAM budget enforcement

## Testing
- `task check` *(fails: command not found)*
- `uv run pytest tests/targeted/test_storage_eviction.py -q`
- `uv run mkdocs build`
- `task verify` *(fails: command not found)*
- `uv run black --check scripts/storage_eviction_sim.py tests/targeted/test_storage_eviction.py`
- `uv run flake8 scripts/storage_eviction_sim.py tests/targeted/test_storage_eviction.py`


------
https://chatgpt.com/codex/tasks/task_e_68af3886e3308333a9718b9465e012c4