### PR TITLE
feat: enforce codex setup runtime limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
   must not be referenced outside AGENTS.md files or the script itself. Use
   `scripts/setup.sh` for any other environment. It installs the project in
   editable mode and records the DuckDB vector extension path in `.env.offline`.
+  Ensure it finishes in under 15 minutes, with 10 minutes as a target.
 
 ## Testing
 - `task check` – run early for linting, type checks, and a fast test suite.
@@ -51,6 +52,7 @@
 - For extensive details, consult docs under `docs/` as required.
 
 ## Changelog
+- 2025-08-22: Added runtime goal for `scripts/codex_setup.sh`.
 - 2025-08-21: Clarified Codex-only scope for `scripts/codex_setup.sh` and
   restricted references to AGENTS files.
 - 2025-08-20: Restructured instructions, added dialectical reasoning and

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -9,7 +9,7 @@ These instructions apply to files in the `scripts/` directory.
 - `codex_setup.sh` bootstraps only the Codex evaluation environment and must
   not be referenced outside AGENTS.md files or the script itself. It installs
   the project in editable mode and updates `.env.offline` with the DuckDB
-  vector extension path.
+  vector extension path. Ensure it finishes in under 15 minutes, targeting 10.
 
 ## Conventions
 - Provide a clear CLI interface or usage comment at the top of each script.

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -5,6 +5,22 @@
 # AGENTS.md system. For any other environment, use `./scripts/setup.sh`.
 set -euo pipefail
 
+START_TIME=$(date +%s)
+finish() {
+    local exit_code=$?
+    local end_time=$(date +%s)
+    local elapsed=$((end_time - START_TIME))
+    echo "codex_setup.sh finished in ${elapsed}s"
+    if [ "$elapsed" -gt 900 ]; then
+        echo "ERROR: setup exceeded 15-minute limit" >&2
+        exit_code=1
+    elif [ "$elapsed" -gt 600 ]; then
+        echo "WARNING: setup exceeded 10-minute target" >&2
+    fi
+    exit "$exit_code"
+}
+trap finish EXIT
+
 LOG_FILE="codex_setup.log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 set -x


### PR DESCRIPTION
## Summary
- enforce a maximum runtime for `codex_setup.sh` and warn when it exceeds ten minutes
- document runtime goals for Codex environment setup in AGENTS guidelines

## Testing
- `scripts/codex_setup.sh` *(fails: Required tools or packages missing after install)*
- `task check` *(fails: some unit tests failed)*
- `task verify` *(fails: missing 'docx' and 'pdfminer' during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68af46ba92508333a77c7ee6f62b08ed