### PR TITLE
chore: record missing test deps

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Status
 
-As of **August 27, 2025**, the environment includes the `task` CLI. Running
+As of **August 4, 2025**, the environment includes the `task` CLI. Running
 `task check` executes linting, type checks, spec tests, and the unit subset.
 The command reports **84 passed, 1 skipped, and 24 deselected** unit tests in
 roughly two and a half minutes.
@@ -13,9 +13,8 @@ errors.
 All unit tests in `tests/unit` now pass.
 
 ## Targeted tests
-`task verify` fails: `tests/targeted/test_http_session.py::test_set_and_close_http_session`
-raises an assertion error, and earlier runs reported `ModuleNotFoundError: No
-module named 'pdfminer'`.
+`task verify` fails during collection: targeted tests require missing
+dependencies `python-docx` and `pdfminer.six`.
 
 ## Integration tests
 ```text

--- a/issues/improve-test-coverage-and-streamline-dependencies.md
+++ b/issues/improve-test-coverage-and-streamline-dependencies.md
@@ -1,10 +1,10 @@
 # Improve test coverage and streamline dependencies
 
 ## Context
-`task check` now completes successfully using the minimal extras, but `task
-verify` fails during collection because the `pdfminer.six` dependency is
-absent. This prevents targeted tests from running and keeps coverage at the
-previous **14%** baseline.
+`task check` now completes successfully using the minimal extras, but
+`task verify` fails during collection because the `pdfminer.six` and
+`python-docx` dependencies are absent. This prevents targeted tests from
+running and keeps coverage at the previous **14%** baseline.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
- note missing `python-docx` and `pdfminer.six` in project status and coverage issue

## Testing
- `task check`
- `task verify` *(fails: ModuleNotFoundError: No module named 'docx'; ModuleNotFoundError: No module named 'pdfminer')*


------
https://chatgpt.com/codex/tasks/task_e_68af77895cb4833393b3d5f4624c545a