### PR TITLE
feat: add parsers extra and conditional sync

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,8 +26,12 @@ tasks:
               fi
               export PATH="$(pwd)/.venv/bin:$PATH"
           fi
-      - >
-          uv sync --extra dev-minimal --extra test{{if .EXTRAS}} --extra {{.EXTRAS}}{{end}}
+      - |
+          extras="dev-minimal test"
+          if [ "$VERIFY_PARSERS" = "1" ]; then
+              extras="$extras parsers"
+          fi
+          uv sync $(printf ' --extra %s' $extras){{if .EXTRAS}} --extra {{.EXTRAS}}{{end}}
       - uv run python -c "import pytest_httpx, tomli_w, redis"
       - uv run flake8 src tests
     desc: |
@@ -154,6 +158,10 @@ tasks:
     deps: [check-env]
     # Coverage-enabled check before committing.
     cmds:
+      - |
+          if [ "$VERIFY_PARSERS" = "1" ]; then
+              uv sync --extra dev-minimal --extra test --extra parsers
+          fi
       - uv run flake8 src tests
       - uv run mypy src
       - uv run python scripts/check_spec_tests.py

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -44,7 +44,11 @@ Include extras only when required. Examples:
 ```bash
 EXTRAS="nlp" task install      # adds NLP packages
 uv sync --extra llm            # sentence-transformers and transformers
+VERIFY_PARSERS=1 task install  # adds PDF and DOCX parsers
 ```
+
+Set `VERIFY_PARSERS=1` when running `task verify` to sync the `parsers`
+extra for tests that require PDF or DOCX ingestion.
 
 Use `./scripts/setup.sh` for the full developer bootstrap. It installs Go
 Task when missing, syncs the `dev` and `test` extras (including packages such

--- a/tests/stubs/docx.py
+++ b/tests/stubs/docx.py
@@ -3,7 +3,14 @@
 import sys
 import types
 
+import pytest
+
 if "docx" not in sys.modules:
     docx_stub = types.ModuleType("docx")
-    docx_stub.Document = object
+
+    class _MissingDoc:
+        def __init__(self, *args, **kwargs):
+            pytest.skip("python-docx not installed")
+
+    docx_stub.Document = _MissingDoc
     sys.modules["docx"] = docx_stub

--- a/tests/stubs/pdfminer.py
+++ b/tests/stubs/pdfminer.py
@@ -3,7 +3,13 @@
 import sys
 import types
 
+import pytest
+
 if "pdfminer.high_level" not in sys.modules:
     pm_stub = types.ModuleType("pdfminer.high_level")
-    pm_stub.extract_text = lambda *a, **k: ""
+
+    def _missing(*args, **kwargs):
+        pytest.skip("pdfminer.six not installed")
+
+    pm_stub.extract_text = _missing
     sys.modules["pdfminer.high_level"] = pm_stub


### PR DESCRIPTION
## Summary
- sync parsers extra when verifying
- allow task install to include parsers via VERIFY_PARSERS
- skip parser-dependent tests when parsers missing
- document optional parser installation

## Testing
- `VERIFY_PARSERS=1 task verify` *(fails: tests/targeted/test_http_session.py::test_set_and_close_http_session, tests/targeted/test_storage_eviction.py::test_ram_budget_eviction)*

------
https://chatgpt.com/codex/tasks/task_e_68af815a27288333a3106b23bf0eec2a