### PR TITLE
test: add redis fixture

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -433,6 +433,8 @@ docker-compose up -d redis
 If no Redis server is running, tests fall back to `fakeredis`.
 `pytest -m requires_distributed` exits quickly when neither Redis nor
 `fakeredis` is available.
+The `redis_client` fixture provides a lightweight `fakeredis` instance or an
+in-memory stub so most tests run without external services.
 
 ## Required services and data
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,6 +23,8 @@ uv run pytest tests/integration -m 'not slow and not requires_ui and not require
   `monkeypatch` to isolate side effects in tests.
 - Redis-backed scenarios use the `requires_distributed` marker and skip when
   no Redis server is available or the `.[distributed]` extra is missing.
+  A `redis_client` fixture backed by `fakeredis` or an in-memory stub allows
+  local testing without a running server.
 - Tests tagged `requires_vss` depend on the DuckDB VSS extension but fall back
   to a stub implementation when the `vss` extra is not installed.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ except Exception:  # pragma: no cover - fastapi optional in some environments
 pytest_plugins = [
     "tests.fixtures.config",
     "tests.fixtures.storage",
+    "tests.fixtures.redis",
     "pytest_httpx",
 ]
 
@@ -120,9 +121,7 @@ try:
     import redis
 
     try:
-        redis.Redis.from_url(
-            "redis://localhost:6379/0", socket_connect_timeout=1
-        ).ping()
+        redis.Redis.from_url("redis://localhost:6379/0", socket_connect_timeout=1).ping()
         REDIS_AVAILABLE = True
     except Exception:
         import fakeredis

--- a/tests/fixtures/redis.py
+++ b/tests/fixtures/redis.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+try:
+    import fakeredis
+except Exception:  # pragma: no cover - fakeredis optional
+    fakeredis = None
+
+
+class _InMemoryRedis:
+    """Minimal Redis-like client for tests.
+
+    Provides `rpush`, `blpop`, and `close` methods so Redis-backed
+    components can be exercised without a running Redis server.
+    """
+
+    def __init__(self) -> None:
+        self._items: list[str] = []
+
+    def rpush(self, name: str, value: str) -> None:  # pragma: no cover - trivial
+        self._items.append(value)
+
+    def blpop(self, names):  # pragma: no cover - trivial
+        name = names[0]
+        return name, self._items.pop(0).encode()
+
+    def lrange(self, name: str, start: int, end: int):  # pragma: no cover - trivial
+        if end == -1:
+            end = len(self._items) - 1
+        return [v.encode() for v in self._items[start : end + 1]]
+
+    def close(self) -> None:  # pragma: no cover - no-op
+        pass
+
+
+@pytest.fixture()
+def redis_client():
+    """Return a lightweight Redis client for tests.
+
+    Uses `fakeredis` when available; otherwise falls back to a simple
+    in-memory stub.
+    """
+
+    if fakeredis is not None:
+        return fakeredis.FakeRedis()
+    return _InMemoryRedis()

--- a/tests/integration/test_distributed_redis_broker.py
+++ b/tests/integration/test_distributed_redis_broker.py
@@ -11,23 +11,8 @@ import redis
 pytestmark = [pytest.mark.slow, pytest.mark.requires_distributed]
 
 
-class FakeRedis:
-    def __init__(self) -> None:
-        self.items: list[str] = []
-
-    def rpush(self, name: str, value: str) -> None:  # pragma: no cover - simple
-        self.items.append(value)
-
-    def blpop(self, names: list[str]):
-        return names[0], self.items.pop(0).encode()
-
-    def close(self) -> None:  # pragma: no cover - no-op
-        pass
-
-
-def test_redis_broker_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
-    fake = FakeRedis()
-    monkeypatch.setattr(redis.Redis, "from_url", lambda url: fake)
+def test_redis_broker_roundtrip(monkeypatch: pytest.MonkeyPatch, redis_client) -> None:
+    monkeypatch.setattr(redis.Redis, "from_url", lambda url: redis_client)
     broker = RedisBroker("redis://localhost:6379/0", queue_name="test")
     broker.publish({"a": 1})
     msg = broker.queue.get()

--- a/tests/unit/test_distributed_broker.py
+++ b/tests/unit/test_distributed_broker.py
@@ -25,6 +25,7 @@ def test_get_message_broker_invalid() -> None:
         get_message_broker("unknown")
 
 
+@pytest.mark.requires_distributed
 def test_redis_broker_requires_dependency(monkeypatch) -> None:
     monkeypatch.setitem(__import__("sys").modules, "redis", None)
     with pytest.raises(ModuleNotFoundError):

--- a/tests/unit/test_distributed_extra.py
+++ b/tests/unit/test_distributed_extra.py
@@ -1,15 +1,13 @@
 import sys
 import types
 
+import pytest
+
 # Stub heavy modules before importing distributed
 sys.modules.setdefault("ray", types.SimpleNamespace(remote=lambda f: f))
+sys.modules.setdefault("autoresearch.orchestration.state", types.SimpleNamespace(QueryState=object))
 sys.modules.setdefault(
-    "autoresearch.orchestration.state",
-    types.SimpleNamespace(QueryState=object)
-)
-sys.modules.setdefault(
-    "autoresearch.orchestration.orchestrator",
-    types.SimpleNamespace(AgentFactory=object)
+    "autoresearch.orchestration.orchestrator", types.SimpleNamespace(AgentFactory=object)
 )
 sys.modules.setdefault("autoresearch.models", types.SimpleNamespace())
 
@@ -20,28 +18,14 @@ from autoresearch.distributed import (  # noqa: E402
 )
 
 
-class FakeRedis:
-    def __init__(self):
-        self.list = []
-
-    def rpush(self, name, value):
-        self.list.append(value)
-
-    def blpop(self, names):
-        return names[0], self.list.pop(0).encode()
-
-    def close(self):
-        pass
-
-
 def test_get_message_broker_default():
     broker = get_message_broker(None)
     assert isinstance(broker, InMemoryBroker)
     broker.shutdown()
 
 
-def test_redis_queue_roundtrip():
-    client = FakeRedis()
-    queue = RedisQueue(client, "q")
+@pytest.mark.requires_distributed
+def test_redis_queue_roundtrip(redis_client):
+    queue = RedisQueue(redis_client, "q")
     queue.put({"a": 1})
     assert queue.get() == {"a": 1}

--- a/tests/unit/test_failure_scenarios.py
+++ b/tests/unit/test_failure_scenarios.py
@@ -67,6 +67,7 @@ def test_get_message_broker_invalid():
         distributed.get_message_broker("unknown")
 
 
+@pytest.mark.requires_distributed
 def test_redis_broker_init_failure(monkeypatch):
     class DummyRedis:
         @staticmethod


### PR DESCRIPTION
## Summary
- add in-memory `redis_client` fixture for distributed tests
- mark Redis scenarios with `requires_distributed`
- document how to run/skip Redis tests

## Testing
- `task check` *(fails: command not found)*
- `uv run pytest -m requires_distributed -q`


------
https://chatgpt.com/codex/tasks/task_e_68af814acd008333bd1882c3717442de