### PR TITLE
docs: add error recovery spec

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -27,6 +27,7 @@ documented behaviour.
 | `src/autoresearch/config_utils.py` | [config-utils.md](config-utils.md) | `../../tests/unit/test_streamlit_app_edgecases.py<br>../../tests/unit/test_streamlit_utils.py` |
 | `src/autoresearch/config/` | [config.md](config.md) | `../../tests/unit/test_config_env_file.py<br>../../tests/unit/test_config_errors.py<br>../../tests/unit/test_config_loader_defaults.py` |
 | `src/autoresearch/distributed/` | [distributed.md](distributed.md) | `../../tests/unit/test_distributed.py<br>../../tests/unit/test_distributed_extra.py<br>../../tests/integration/test_distributed_agent_storage.py<br>../../tests/analysis/test_distributed_coordination.py` |
+| `src/autoresearch/error_recovery.py` | [error-recovery.md](error-recovery.md) | `../../tests/unit/test_error_recovery.py` |
 | `src/autoresearch/error_utils.py` | [error-utils.md](error-utils.md) | `../../tests/unit/test_error_utils_additional.py` |
 | `src/autoresearch/errors.py` | [errors.md](errors.md) | `../../tests/unit/test_config_errors.py<br>../../tests/unit/test_config_validation_errors.py<br>../../tests/unit/test_errors.py` |
 | `src/autoresearch/examples/` | [examples.md](examples.md) | `../../tests/unit/test_examples_package.py` |

--- a/docs/specs/error-recovery.md
+++ b/docs/specs/error-recovery.md
@@ -1,0 +1,20 @@
+# Error Recovery
+
+Utilities for retrying operations with exponential backoff. The backoff
+doubles the delay after each failure using `base_delay * 2^(attempt - 1)` and
+stops after a successful call or when retries are exhausted, at which point a
+`RuntimeError` is raised.
+
+The expected number of attempts for success with probability `p` is `1/p`, as
+shown in the [error recovery algorithm note][alg].
+
+## Traceability
+
+- Modules
+  - [src/autoresearch/error_recovery.py][m1]
+- Tests
+  - [tests/unit/test_error_recovery.py][t1]
+
+[m1]: ../../src/autoresearch/error_recovery.py
+[t1]: ../../tests/unit/test_error_recovery.py
+[alg]: ../algorithms/error_recovery.md


### PR DESCRIPTION
## Summary
- document retry strategy and failure modes in error recovery module
- link error recovery spec from module specs index

## Testing
- `task check` *(fails: exit status 2)*
- `uv run mkdocs build` *(fails: PythonConfig.__init__ unexpected keyword 'selection')*
- `task verify` *(fails: exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_68af816ab26c8333b647b298bb1f4886