### PR TITLE
docs: update status and outline alpha release blockers

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,8 +2,7 @@
 
 As of **August 4, 2025**, the environment includes the `task` CLI. Running
 `task check` executes linting, type checks, spec tests, and the unit subset.
-The command reports **84 passed, 1 skipped, and 24 deselected** unit tests in
-roughly two and a half minutes.
+The command reports **84 passed, 1 skipped, and 29 deselected** unit tests.
 
 After constraining `task check` to sync only the `dev-minimal` and `test`
 extras, the run now finishes in about a minute and a half while avoiding NLP

--- a/issues/resolve-release-blockers-for-alpha.md
+++ b/issues/resolve-release-blockers-for-alpha.md
@@ -1,0 +1,29 @@
+# Resolve release blockers for alpha
+
+## Context
+`task check` passes after installing missing test dependencies, but the Codex
+setup script fails to provision `pytest`, `pytest-bdd`, `freezegun`, and
+`hypothesis` by default. `task verify` also halts because `pdfminer.six` and
+`python-docx` are absent. These gaps block tagging **0.1.0a1** and can be
+addressed in parallel while other feature issues progress.
+
+## Dependencies
+- [add-orchestration-proofs-and-tests](add-orchestration-proofs-and-tests.md)
+- [add-storage-proofs-and-simulations](add-storage-proofs-and-simulations.md)
+- [configure-redis-service-for-tests](configure-redis-service-for-tests.md)
+- [improve-test-coverage-and-streamline-dependencies](
+  improve-test-coverage-and-streamline-dependencies.md)
+- [plan-a2a-mcp-behavior-tests](plan-a2a-mcp-behavior-tests.md)
+- [speed-up-task-check-and-reduce-dependency-footprint](
+  speed-up-task-check-and-reduce-dependency-footprint.md)
+
+## Acceptance Criteria
+- `scripts/codex_setup.sh` installs and verifies `pytest`, `pytest-bdd`,
+  `freezegun`, and `hypothesis` without manual intervention.
+- `task verify` succeeds on a fresh clone by including `pdfminer.six` and
+  `python-docx` in the appropriate extras.
+- `STATUS.md` reflects the passing `task check` output and targeted tests.
+- Release notes describe remaining known limitations before tagging **0.1.0a1**.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- record latest task check results in status page
- add issue enumerating environment and testing blockers for the alpha release

## Testing
- `task check` *(fails: KeyboardInterrupt after tests complete)*
- `uv run pytest tests/unit -vv`

------
https://chatgpt.com/codex/tasks/task_e_68af9659d59c8333b717c8b6998e5167