### PR TITLE
Document current test status and track DuckDB schema issue

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,13 +3,15 @@
 This roadmap summarizes planned features for upcoming releases.
 Dates and milestones align with the [release plan](docs/release_plan.md).
 Installation and environment details are covered in the [README](README.md).
-Last updated **August 27, 2025**.
+Last updated **August 28, 2025**.
 
 ## Status
 
-See [STATUS.md](STATUS.md) for current test and coverage results. Current
-coverage from the unit subset is **91%**. Dependency pins:
-`fastapi>=0.115.12` and `slowapi==0.1.9`. Use Python 3.12+ with:
+See [STATUS.md](STATUS.md) for current results. Unit tests pass with coverage
+**91%**, but targeted tests are missing `python-docx` and `pdfminer.six`, and
+integration and behavior suites fail due to DuckDB schema initialization
+errors. Dependency pins: `fastapi>=0.115.12` and `slowapi==0.1.9`. Use Python
+3.12+ with:
 
 ```
 uv venv && uv sync --all-extras &&

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,33 +1,26 @@
 # Status
 
-As of **August 4, 2025**, the environment includes the `task` CLI. Running
-`task check` executes linting, type checks, spec tests, and the unit subset.
-The command reports **84 passed, 1 skipped, and 29 deselected** unit tests.
-
-After constraining `task check` to sync only the `dev-minimal` and `test`
-extras, the run now finishes in about a minute and a half while avoiding NLP
-and LLM dependencies.
+As of **August 28, 2025**, the environment lacks the `task` CLI. Manual
+`uv` commands validate linting and type checks, but storage backend errors
+block full test execution.
 
 ## Lint, type checks, and spec tests
-`task check` completes without failures. `flake8` and `mypy` pass without
-errors.
+`flake8`, `mypy`, and `scripts/check_spec_tests.py` pass with no issues.
 
 ## Unit tests
-All unit tests in `tests/unit` now pass.
+`pytest tests/unit` reports **84 passed, 1 skipped, and 29 deselected**.
 
 ## Targeted tests
-`task verify` fails during collection: targeted tests require missing
-dependencies `python-docx` and `pdfminer.six`.
+`pytest tests/targeted` fails during collection: modules `docx` and
+`pdfminer` are missing.
 
 ## Integration tests
-```text
-Integration tests did not run; targeted tests failing.
-```
+Storage initialization raises `AttributeError: 'DuckDBPyConnection' object has
+no attribute 'fetchone'`, yielding **15 failed, 157 passed, 4 skipped, 93
+deselected, 39 errors**.
 
 ## Behavior tests
-```text
-Behavior tests did not run; targeted tests failing.
-```
+Behavior scenarios trigger the same DuckDB initialization error and all fail.
 
 ## Coverage
-coverage noted at **91%**, meeting the 90% threshold.
+Coverage was not recomputed; unit subset coverage remains at **91%**.

--- a/issues/fix-duckdb-schema-initialization.md
+++ b/issues/fix-duckdb-schema-initialization.md
@@ -1,0 +1,19 @@
+# Fix DuckDB schema initialization
+
+## Context
+Integration and behavior tests fail because `DuckDBStorageBackend._initialize_schema_version`
+uses `fetchone` on a `DuckDBPyConnection`, raising `AttributeError` and preventing
+table creation.
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- Use a `DuckDBPyCursor` or `fetchall` to check for the schema version without
+  triggering `AttributeError`.
+- Integration tests complete without `StorageError`.
+- Behavior tests involving storage pass.
+- Document the fix in `docs/algorithms/storage.md`.
+
+## Status
+Open

--- a/issues/resolve-release-blockers-for-alpha.md
+++ b/issues/resolve-release-blockers-for-alpha.md
@@ -10,6 +10,7 @@ addressed in parallel while other feature issues progress.
 ## Dependencies
 - [add-orchestration-proofs-and-tests](add-orchestration-proofs-and-tests.md)
 - [add-storage-proofs-and-simulations](add-storage-proofs-and-simulations.md)
+- [fix-duckdb-schema-initialization](fix-duckdb-schema-initialization.md)
 - [configure-redis-service-for-tests](configure-redis-service-for-tests.md)
 - [improve-test-coverage-and-streamline-dependencies](
   improve-test-coverage-and-streamline-dependencies.md)


### PR DESCRIPTION
## Summary
- update status and roadmap with latest test results
- record DuckDB schema init bug and add it as release dependency

## Testing
- `uv run flake8 src tests`
- `uv run mypy src --exclude src/autoresearch/distributed`
- `uv run python scripts/check_spec_tests.py`
- `uv run pytest tests/unit -q`
- `uv run pytest tests/targeted --noconftest --cov=autoresearch.search --cov=autoresearch.storage --cov=autoresearch.orchestration --cov-report=term-missing --cov-report=xml` *(fails: ModuleNotFoundError: No module named 'docx')*
- `uv run pytest tests/integration -m "not slow and not requires_ui and not requires_vss and not requires_distributed" -q` *(fails: StorageError: Failed to create tables)*
- `uv run pytest --rootdir=. tests/behavior -q` *(fails: StorageError: Failed to create tables)*

------
https://chatgpt.com/codex/tasks/task_e_68afae5e3dc88333a0fb0b87572ce238