### PR TITLE
Document task CLI availability and test hang

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,23 +1,22 @@
 # Status
 
-As of **August 28, 2025**, the environment lacks the `task` CLI. Manual
-`uv` commands validate linting and type checks, but storage backend errors
-block full test execution.
+As of **August 28, 2025**, the `task` CLI is installed and `task install` completes. `task check`
+ran linting and type checks, but `pytest tests/unit -q` hung and required manual interruption.
+Targeted, integration, and behavior suites were not rerun.
 
 ## Lint, type checks, and spec tests
-`flake8`, `mypy`, and `scripts/check_spec_tests.py` pass with no issues.
+`flake8`, `mypy`, and `scripts/check_spec_tests.py` pass.
 
 ## Unit tests
-`pytest tests/unit` reports **84 passed, 1 skipped, and 29 deselected**.
+`task check` hangs while running `pytest tests/unit -q`; the run was terminated after prolonged
+inactivity.
 
 ## Targeted tests
-`pytest tests/targeted` fails during collection: modules `docx` and
-`pdfminer` are missing.
+`pytest tests/targeted` still fails during collection: modules `docx` and `pdfminer` are missing.
 
 ## Integration tests
-Storage initialization raises `AttributeError: 'DuckDBPyConnection' object has
-no attribute 'fetchone'`, yielding **15 failed, 157 passed, 4 skipped, 93
-deselected, 39 errors**.
+Storage initialization raises `AttributeError: 'DuckDBPyConnection' object has no attribute
+'fetchone'`, yielding **15 failed, 157 passed, 4 skipped, 93 deselected, 39 errors**.
 
 ## Behavior tests
 Behavior scenarios trigger the same DuckDB initialization error and all fail.

--- a/issues/speed-up-task-check-and-reduce-dependency-footprint.md
+++ b/issues/speed-up-task-check-and-reduce-dependency-footprint.md
@@ -3,10 +3,12 @@
 ## Context
 `task check` installs heavy ML packages via `uv sync --extra dev --extra test` and
 runs the entire unit suite, which leads to long startup times and timeouts in
-constrained environments.
+constrained environments. Recent runs hang during `pytest tests/unit -q`,
+requiring manual interruption.
 
 ## Dependencies
-- [improve-test-coverage-and-streamline-dependencies](improve-test-coverage-and-streamline-dependencies.md)
+- [improve-test-coverage-and-streamline-dependencies](
+  improve-test-coverage-and-streamline-dependencies.md)
 
 ## Acceptance Criteria
 - Minimal install path avoids GPU and ML dependencies for `task check`.


### PR DESCRIPTION
## Summary
- update STATUS.md to note task CLI availability and unit test hang
- log task check hang in speed-up-task-check issue

## Testing
- `uv run flake8 src tests`
- `uv run mypy src --exclude src/autoresearch/distributed`
- `task check` *(fails: requires manual interrupt during pytest tests/unit -q)*

------
https://chatgpt.com/codex/tasks/task_e_68afb3d8bffc8333b4f4a6faebe8f386