### PR TITLE
Document test run status and track search proofs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,27 +1,26 @@
 # Status
 
-As of **August 28, 2025**, the Go Task CLI is unavailable, so `task install`
-could not run. We invoked `uv run --extra test pytest`, which executed 84 unit
-tests before a manual interrupt with **956** remaining. Targeted, integration,
-and behavior suites were not exercised.
+As of **August 28, 2025**, `scripts/setup.sh` installed the Go Task CLI and
+development environment. Running `task check` executed linting, type checks, and
+spec tests. Unit tests completed (84 passed, 1 skipped, 29 deselected) before a
+manual interrupt prior to integration tests. Targeted and behavior suites were
+not exercised.
 
 ## Lint, type checks, and spec tests
-Not run; blocked by missing `task` CLI.
+Completed via `task check`.
 
 ## Unit tests
-`uv run --extra test pytest` reported 84 passed, 4 skipped, 122 deselected before
-interruption at `storage_backup.py`.
+84 passed, 1 skipped, 29 deselected before interruption.
 
 ## Targeted tests
-Still fail during collection because `pdfminer.six` and `python-docx` are
-missing.
+`task verify` fails during collection because `pdfminer.six` and `python-docx`
+are missing.
 
 ## Integration tests
-Not rerun; existing runs raise `AttributeError: 'DuckDBPyConnection' object has
-no attribute 'fetchone'` during schema initialization.
+Not run; `task check` interrupted before execution.
 
 ## Behavior tests
-Not rerun; expected to fail with the same DuckDB initialization error.
+Not run.
 
 ## Coverage
 Coverage was not recomputed; prior unit subset coverage remains at **91%**.

--- a/issues/add-search-proofs-and-tests.md
+++ b/issues/add-search-proofs-and-tests.md
@@ -1,0 +1,18 @@
+# Add search proofs and tests
+
+## Context
+Search components lack formal validation. Ranking algorithms and HTTP session
+utilities operate without proofs or simulations, leaving correctness and failure
+recovery unspecified.
+
+## Dependencies
+- [improve-test-coverage-and-streamline-dependencies](improve-test-coverage-and-streamline-dependencies.md)
+
+## Acceptance Criteria
+- Provide proofs or simulations for ranking logic and HTTP session handling.
+- Add unit and integration tests raising search module coverage above eighty
+  percent.
+- Document reasoning and assumptions in `docs/algorithms/search.md`.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- refresh STATUS.md to capture partial `task check` run and `task verify` failure
- add tracking issue for search proofs and tests

## Testing
- `task check` *(fails: KeyboardInterrupt)*
- `task verify` *(fails: ModuleNotFoundError: pdfminer)*

------
https://chatgpt.com/codex/tasks/task_e_68afc6092f7083338a9849571cdcd92d