### PR TITLE
test: add redis service fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,14 @@ processing. Install them on demand with `uv sync --extra <name>` or
 `pip install "autoresearch[<name>]"`.
 
 A running Redis server is needed only for the `[distributed]` extra or tests
-tagged `requires_distributed`. When Redis is absent those scenarios are
-skipped.
+tagged `requires_distributed`. The test suite's `redis_client` fixture connects
+to a local server or starts a lightweight `fakeredis` instance. When neither
+service is available those scenarios are skipped. Run the distributed tests
+with:
+
+```bash
+uv run pytest -m requires_distributed -q
+```
 
 To bootstrap a Python 3.12+ environment with the lightweight development and test
 extras run:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,10 +12,15 @@ missing. Run `./scripts/setup.sh` for the full developer bootstrap or if the
 automatic download fails. Manual installation instructions are below if
 needed.
 
-The Redis package installs with the `dev` extra. A running Redis
-server is required only for tests or features that use the
-`.[distributed]` extra; when the service is absent those tests are skipped
-and distributed features stay disabled.
+The Redis package installs with the `dev` extra. A running Redis server is
+required only for tests or features that use the `.[distributed]` extra. The
+test suite includes a `redis_client` fixture that connects to a local server or
+spins up a lightweight `fakeredis` instance. Distributed tests are skipped when
+neither service is available. Run them explicitly with:
+
+```bash
+uv run pytest -m requires_distributed -q
+```
 
 Optional extras enable additional capabilities and are installed on
 demand with `uv sync --extra <name>`.

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -422,21 +422,18 @@ Install the extra and run the marked scenarios directly:
 
 ```bash
 uv pip install -e '.[distributed]'
-pytest -m requires_distributed
+uv run pytest -m requires_distributed -q
 ```
 
-For local development, a Redis service is defined in `docker-compose.yml`.
-Start it with:
+The `redis_client` fixture connects to a local Redis server when available and
+falls back to a lightweight `fakeredis` instance. Tests tagged
+`requires_distributed` are skipped when neither service is running.
+
+For local development you can start a Redis container with:
 
 ```bash
 docker-compose up -d redis
 ```
-
-If no Redis server is running, tests fall back to `fakeredis`.
-`pytest -m requires_distributed` exits quickly when neither Redis nor
-`fakeredis` is available.
-The `redis_client` fixture provides a lightweight `fakeredis` instance or an
-in-memory stub so most tests run without external services.
 
 ## Required services and data
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,10 +21,10 @@ uv run pytest tests/integration -m 'not slow and not requires_ui and not require
 - Fixtures such as `example_autoresearch_toml` and `example_env_file` provide
   temporary configuration and environment data. Use `tmp_path` and
   `monkeypatch` to isolate side effects in tests.
-- Redis-backed scenarios use the `requires_distributed` marker and skip when
-  no Redis server is available or the `.[distributed]` extra is missing.
-  A `redis_client` fixture backed by `fakeredis` or an in-memory stub allows
-  local testing without a running server.
+- Redis-backed scenarios use the `requires_distributed` marker. The
+  `redis_client` fixture connects to a local server or spins up a
+  lightweight `fakeredis` instance. Tests skip when neither service is
+  available or the `.[distributed]` extra is missing.
 - Tests tagged `requires_vss` depend on the DuckDB VSS extension but fall back
   to a stub implementation when the `vss` extra is not installed.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import importlib
 import importlib.util
 import os
 import sys
-import types
 from pathlib import Path
 from typing import Callable
 from unittest.mock import MagicMock, patch
@@ -120,29 +119,12 @@ NLP_AVAILABLE = _module_available("sentence_transformers")
 try:
     import redis
 
-    try:
-        redis.Redis.from_url("redis://localhost:6379/0", socket_connect_timeout=1).ping()
-        REDIS_AVAILABLE = True
-    except Exception:
-        import fakeredis
-
-        class _FakeRedis(fakeredis.FakeRedis):
-            @classmethod
-            def from_url(cls, url, **kwargs):
-                return cls(**kwargs)
-
-        redis.Redis = _FakeRedis  # type: ignore[assignment]
-        REDIS_AVAILABLE = True
+    redis.Redis.from_url("redis://localhost:6379/0", socket_connect_timeout=1).ping()
+    REDIS_AVAILABLE = True
 except Exception:
     try:
-        import fakeredis
+        import fakeredis  # noqa: F401
 
-        class _FakeRedis(fakeredis.FakeRedis):
-            @classmethod
-            def from_url(cls, url, **kwargs):
-                return cls(**kwargs)
-
-        sys.modules["redis"] = types.SimpleNamespace(Redis=_FakeRedis)
         REDIS_AVAILABLE = True
     except Exception:
         REDIS_AVAILABLE = False

--- a/tests/fixtures/redis.py
+++ b/tests/fixtures/redis.py
@@ -2,46 +2,33 @@ from __future__ import annotations
 
 import pytest
 
-try:
+try:  # pragma: no cover - optional dependency
+    import redis
+except Exception:  # pragma: no cover - redis optional
+    redis = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
     import fakeredis
 except Exception:  # pragma: no cover - fakeredis optional
-    fakeredis = None
-
-
-class _InMemoryRedis:
-    """Minimal Redis-like client for tests.
-
-    Provides `rpush`, `blpop`, and `close` methods so Redis-backed
-    components can be exercised without a running Redis server.
-    """
-
-    def __init__(self) -> None:
-        self._items: list[str] = []
-
-    def rpush(self, name: str, value: str) -> None:  # pragma: no cover - trivial
-        self._items.append(value)
-
-    def blpop(self, names):  # pragma: no cover - trivial
-        name = names[0]
-        return name, self._items.pop(0).encode()
-
-    def lrange(self, name: str, start: int, end: int):  # pragma: no cover - trivial
-        if end == -1:
-            end = len(self._items) - 1
-        return [v.encode() for v in self._items[start : end + 1]]
-
-    def close(self) -> None:  # pragma: no cover - no-op
-        pass
+    fakeredis = None  # type: ignore[assignment]
 
 
 @pytest.fixture()
 def redis_client():
-    """Return a lightweight Redis client for tests.
+    """Return a Redis client or skip when no service is available."""
 
-    Uses `fakeredis` when available; otherwise falls back to a simple
-    in-memory stub.
-    """
-
+    if redis is not None:
+        try:
+            client = redis.Redis.from_url("redis://localhost:6379/0", socket_connect_timeout=1)
+            client.ping()
+            yield client
+            client.close()
+            return
+        except Exception:  # pragma: no cover - fall back to fakeredis
+            pass
     if fakeredis is not None:
-        return fakeredis.FakeRedis()
-    return _InMemoryRedis()
+        client = fakeredis.FakeRedis()
+        yield client
+        client.close()
+        return
+    pytest.skip("Redis service not available")


### PR DESCRIPTION
## Summary
- provide redis_client fixture that uses local Redis or fallback fakeredis
- document distributed test setup and fixtures
- clarify installation docs for running Redis-backed tests

## Testing
- `task check` *(fails: command not found)*
- `uv run pytest -m requires_distributed -q`


------
https://chatgpt.com/codex/tasks/task_e_68afd51f5f7c833390c167dab8529f7a