### PR TITLE
Add storage concurrency simulation and tests

### DIFF
--- a/docs/algorithms/storage.md
+++ b/docs/algorithms/storage.md
@@ -45,6 +45,11 @@ simultaneously. The [simulation][evict-sim] spawns threads that insert claims
 while memory usage is forced above the budget. After all threads finish the
 in-memory graph is empty, proving the policy is thread safe.
 
+The [concurrency simulation][concurrency-sim] accepts thread and item counts to
+demonstrate enforcement under heavier contention. Integration
+[tests][concurrency-test] show that writers retain all claims when usage stays
+within the budget and trigger eviction once mocked memory exceeds the limit.
+
 ## Formal proofs
 
 ### Schema idempotency
@@ -80,7 +85,9 @@ The benchmark in [duckdb-bench] shows that persistence triggers eviction when
 the RAM budget is exceeded, ensuring deterministic resource bounds.
 
 [evict-sim]: ../../scripts/storage_eviction_sim.py
+[concurrency-sim]: ../../scripts/storage_concurrency_sim.py
 [duckdb-bench]: ../../tests/integration/test_storage_duckdb_fallback.py
 [schema-test]: ../../tests/targeted/test_storage_eviction.py
 [evict-test]: ../../tests/targeted/test_storage_eviction.py
+[concurrency-test]: ../../tests/integration/test_storage_concurrency.py
 

--- a/scripts/storage_concurrency_sim.py
+++ b/scripts/storage_concurrency_sim.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Simulate concurrent writes enforcing the RAM budget.
+
+Usage:
+    uv run python scripts/storage_concurrency_sim.py --threads 5 --items 10
+"""
+
+from __future__ import annotations
+
+import argparse
+from threading import Thread
+
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel, StorageConfig
+from autoresearch.storage import StorageContext, StorageManager, StorageState
+
+
+def _run(threads: int, items: int) -> int:
+    """Persist claims concurrently and return remaining node count."""
+
+    cfg = ConfigModel(
+        storage=StorageConfig(duckdb_path=":memory:"),
+        ram_budget_mb=1,
+        graph_eviction_policy="lru",
+    )
+    loader = ConfigLoader.new_for_tests()
+    loader._config = cfg
+
+    st = StorageState()
+    ctx = StorageContext()
+    StorageManager.state = st
+    StorageManager.context = ctx
+
+    original = StorageManager._current_ram_mb
+    StorageManager._current_ram_mb = staticmethod(lambda: 1000)
+    try:
+        StorageManager.setup(db_path=":memory:", context=ctx, state=st)
+
+        def persist(idx: int) -> None:
+            for j in range(items):
+                StorageManager.persist_claim({"id": f"c{idx}-{j}", "type": "fact", "content": "c"})
+                StorageManager._enforce_ram_budget(cfg.ram_budget_mb)
+
+        ts = [Thread(target=persist, args=(i,)) for i in range(threads)]
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join()
+
+        remaining = StorageManager.get_graph().number_of_nodes()
+    finally:
+        StorageManager.teardown(remove_db=True, context=ctx, state=st)
+        StorageManager.state = StorageState()
+        StorageManager.context = StorageContext()
+        StorageManager._current_ram_mb = original  # type: ignore[assignment]
+        ConfigLoader.reset_instance()
+
+    return remaining
+
+
+def main(threads: int, items: int) -> None:
+    if threads <= 0 or items <= 0:
+        raise SystemExit("threads and items must be positive")
+    remaining = _run(threads, items)
+    print(f"nodes remaining after eviction: {remaining}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--threads", type=int, default=5, help="concurrent writers")
+    parser.add_argument("--items", type=int, default=10, help="items per thread")
+    args = parser.parse_args()
+    main(args.threads, args.items)

--- a/tests/integration/test_storage_concurrency.py
+++ b/tests/integration/test_storage_concurrency.py
@@ -1,0 +1,61 @@
+from threading import Thread
+
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel, StorageConfig
+from autoresearch.storage import StorageContext, StorageManager, StorageState
+
+
+def _setup(tmp_path, monkeypatch, ram_budget):
+    cfg = ConfigModel(
+        storage=StorageConfig(duckdb_path=str(tmp_path / "kg.duckdb")),
+        ram_budget_mb=ram_budget,
+        graph_eviction_policy="lru",
+    )
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+
+    st = StorageState()
+    ctx = StorageContext()
+    StorageManager.setup(db_path=cfg.storage.duckdb_path, context=ctx, state=st)
+    return cfg, st, ctx
+
+
+def _teardown(st, ctx):
+    StorageManager.teardown(remove_db=True, context=ctx, state=st)
+    StorageManager.state = StorageState()
+    StorageManager.context = StorageContext()
+    ConfigLoader()._config = None
+
+
+def test_concurrent_writes(tmp_path, monkeypatch):
+    cfg, st, ctx = _setup(tmp_path, monkeypatch, ram_budget=50)
+
+    def persist(idx: int) -> None:
+        StorageManager.persist_claim({"id": f"c{idx}", "type": "fact", "content": "c"})
+
+    threads = [Thread(target=persist, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert StorageManager.get_graph().number_of_nodes() == 5
+    _teardown(st, ctx)
+
+
+def test_concurrent_eviction(tmp_path, monkeypatch):
+    cfg, st, ctx = _setup(tmp_path, monkeypatch, ram_budget=1)
+    monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 1000)
+
+    def persist(idx: int) -> None:
+        StorageManager.persist_claim({"id": f"c{idx}", "type": "fact", "content": "c"})
+        StorageManager._enforce_ram_budget(cfg.ram_budget_mb)
+
+    threads = [Thread(target=persist, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert StorageManager.get_graph().number_of_nodes() == 0
+    _teardown(st, ctx)


### PR DESCRIPTION
## Summary
- add storage_concurrency_sim.py script for multithreaded RAM budget simulation
- document concurrency simulation in storage algorithm docs
- add integration tests for concurrent writes and eviction

## Testing
- `task check` *(fails: exit status 2)*
- `uv run pytest tests/integration/test_storage_concurrency.py --cov=autoresearch.storage -q` *(fails: ImportError pydantic RootModel)*
- `task verify` *(fails: TypeError in test_storage_eviction)*

------
https://chatgpt.com/codex/tasks/task_e_68afd56258848333bd181f739f4db0cf