### PR TITLE
docs: sync coverage baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ workflow is detailed in [docs/releasing.md](docs/releasing.md).
 
 ## Status
 
-See [STATUS.md](STATUS.md) for current test and coverage results. Task-level
-progress and test reconciliation live in
+See [STATUS.md](STATUS.md) for current test results and **91%** coverage.
+Task-level progress and test reconciliation live in
 [TASK_PROGRESS.md](TASK_PROGRESS.md).
 
 See [docs/release_plan.md](docs/release_plan.md#alpha-release-checklist) for the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ before running tests.
 - 0.1.0 (2026-07-01, status: released): Finalized packaging, docs and CI
   checks with all tests passing.
   - [improve-test-coverage-and-streamline-dependencies](
-    issues/improve-test-coverage-and-streamline-dependencies.md)
+    issues/archive/improve-test-coverage-and-streamline-dependencies.md)
   - [speed-up-task-check-and-reduce-dependency-footprint](
     issues/speed-up-task-check-and-reduce-dependency-footprint.md)
 - 0.1.1 (2026-09-15, status: planned): Bug fixes and documentation updates
@@ -71,8 +71,8 @@ reach **90%**, and a successful TestPyPI upload. The release is re-targeted for
   ([packaging-fallback](issues/archive/verify-packaging-workflow-and-duckdb-fallback.md)).
 - [ ] Integration tests stabilized
   ([stabilize-integration-tests](issues/archive/stabilize-integration-tests.md)).
-- [ ] Coverage gates target **90%** total coverage; current coverage is
-  **14%** ([coverage-gates](issues/archive/add-coverage-gates-and-regression-checks.md)).
+- [ ] Coverage gates target **90%** total coverage; current coverage is **91%**
+  ([coverage-gates](issues/archive/add-coverage-gates-and-regression-checks.md)).
 - [x] Algorithm validation for ranking and coordination
   ([ranking](issues/archive/validate-ranking-algorithms-and-agent-coordination.md)).
 

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -34,7 +34,7 @@ Current test and coverage results are tracked in
 - **0.1.0** (2026-07-01, status: released): Finalized packaging, docs and CI
   checks with all tests passing.
   - [improve-test-coverage-and-streamline-dependencies](
-    ../issues/improve-test-coverage-and-streamline-dependencies.md)
+    ../issues/archive/improve-test-coverage-and-streamline-dependencies.md)
   - [speed-up-task-check-and-reduce-dependency-footprint](
     ../issues/speed-up-task-check-and-reduce-dependency-footprint.md)
 - **0.1.1** (2026-09-15, status: planned): Bug fixes and documentation updates
@@ -69,8 +69,8 @@ while packaging tasks are resolved.
 - [ ] Integration test suite passes
   ([stabilize-integration-tests.md](
   ../issues/archive/stabilize-integration-tests.md))
-- [ ] Coverage gates target **90%** total coverage; current coverage is
-  **14%** (see
+- [ ] Coverage gates target **90%** total coverage; current coverage is **91%**
+  (see
   [add-coverage-gates-and-regression-checks.md](
   ../issues/archive/add-coverage-gates-and-regression-checks.md))
 - [x] Validate ranking algorithms and agent coordination
@@ -129,4 +129,6 @@ optional extras):
 - [ ] `uv run pytest -q`
 - [ ] `uv run pytest tests/behavior`
 - [ ] `task coverage` currently reports **91%** total coverage; target **90%**
+- [ ] [`scripts/update_coverage_docs.py`](../scripts/update_coverage_docs.py)
+  syncs docs with `baseline/coverage.xml`
 

--- a/issues/add-orchestration-proofs-and-tests.md
+++ b/issues/add-orchestration-proofs-and-tests.md
@@ -10,7 +10,7 @@ resource guarantees unspecified.
 - 0.1.0a1 (2026-04-15)
 
 ## Dependencies
-- [improve-test-coverage-and-streamline-dependencies](improve-test-coverage-and-streamline-dependencies.md)
+- [improve-test-coverage-and-streamline-dependencies](archive/improve-test-coverage-and-streamline-dependencies.md)
 
 ## Acceptance Criteria
 - Provide proofs or simulations demonstrating deterministic circuit breaker

--- a/issues/add-search-proofs-and-tests.md
+++ b/issues/add-search-proofs-and-tests.md
@@ -6,7 +6,7 @@ utilities operate without proofs or simulations, leaving correctness and failure
 recovery unspecified.
 
 ## Dependencies
-- [improve-test-coverage-and-streamline-dependencies](improve-test-coverage-and-streamline-dependencies.md)
+- [improve-test-coverage-and-streamline-dependencies](archive/improve-test-coverage-and-streamline-dependencies.md)
 
 ## Acceptance Criteria
 - Provide proofs or simulations for ranking logic and HTTP session handling.

--- a/issues/archive/add-token-budget-proofs-and-simulations.md
+++ b/issues/archive/add-token-budget-proofs-and-simulations.md
@@ -12,7 +12,7 @@ not match the specification.
 
 ## Dependencies
 
-- [improve-test-coverage-and-streamline-dependencies](../improve-test-coverage-and-streamline-dependencies.md)
+- [improve-test-coverage-and-streamline-dependencies](improve-test-coverage-and-streamline-dependencies.md)
 
 ## Acceptance Criteria
 - Provide mathematical proof or simulation demonstrating the algorithm's convergence and bounds.

--- a/issues/archive/improve-test-coverage-and-streamline-dependencies.md
+++ b/issues/archive/improve-test-coverage-and-streamline-dependencies.md
@@ -20,4 +20,4 @@ default.
 percent.
 
 ## Status
-Open
+Archived

--- a/issues/resolve-release-blockers-for-alpha.md
+++ b/issues/resolve-release-blockers-for-alpha.md
@@ -13,7 +13,7 @@ addressed in parallel while other feature issues progress.
 - [fix-duckdb-schema-initialization](fix-duckdb-schema-initialization.md)
 - [configure-redis-service-for-tests](configure-redis-service-for-tests.md)
 - [improve-test-coverage-and-streamline-dependencies](
-  improve-test-coverage-and-streamline-dependencies.md)
+  archive/improve-test-coverage-and-streamline-dependencies.md)
 - [plan-a2a-mcp-behavior-tests](plan-a2a-mcp-behavior-tests.md)
 - [speed-up-task-check-and-reduce-dependency-footprint](
   speed-up-task-check-and-reduce-dependency-footprint.md)

--- a/issues/speed-up-task-check-and-reduce-dependency-footprint.md
+++ b/issues/speed-up-task-check-and-reduce-dependency-footprint.md
@@ -8,7 +8,7 @@ requiring manual interruption.
 
 ## Dependencies
 - [improve-test-coverage-and-streamline-dependencies](
-  improve-test-coverage-and-streamline-dependencies.md)
+  archive/improve-test-coverage-and-streamline-dependencies.md)
 
 ## Acceptance Criteria
 - Minimal install path avoids GPU and ML dependencies for `task check`.


### PR DESCRIPTION
## Summary
- sync coverage references across README, roadmap, release plan, and status using baseline/coverage.xml
- add pre-release checklist item to ensure docs pull coverage from baseline
- archive outdated issue tracking 14% coverage

## Testing
- `task check` *(fails: task: Failed to run task "check": exit status 2)*
- `task coverage` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*
- `task verify` *(fails: ModuleNotFoundError: No module named 'pdfminer')*

------
https://chatgpt.com/codex/tasks/task_e_68afd595a4948333a7a429cd954751d5