### PR TITLE
Document setup gaps and add issue for script parity

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,26 +1,22 @@
 # Status
 
-As of **August 28, 2025**, the environment was provisioned with Go Task and
-required tooling via `scripts/codex_setup.sh`. `task check` fails because
-`uv sync --extra dev-minimal` removes test packages, causing
-`scripts/check_env.py` to report missing modules. Manual `uv run flake8 src
-tests`, `uv run mypy src`, and the quick unit tests pass.
+As of **August 28, 2025**, Go Task is installed locally, but `task check` fails because
+`uv sync --extra dev-minimal` removes `pytest_bdd`, `freezegun`, and `hypothesis`. Attempts
+to reinstall them are undone by `uv sync`, so `scripts/check_env.py` reports missing modules
+and `task verify` stops before running tests.
 
 ## Lint, type checks, and spec tests
 `uv run flake8 src tests` and `uv run mypy src` ran without errors.
-`uv run python scripts/check_spec_tests.py` produced no output, indicating
-success.
+`uv run python scripts/check_spec_tests.py` produced no output, indicating success.
 
 ## Targeted tests
-`task verify` runs targeted tests and reported `20 passed, 3 skipped`.
+Not run. `task verify` exits during environment checks.
 
 ## Integration tests
-Not run separately.
+Not run.
 
 ## Behavior tests
 Not run.
 
 ## Coverage
-`task verify` reported **100%** coverage for targeted modules. The current
-coverage is **100%**, and the run initially failed because `STATUS.md` listed
-**91%**, but the file now matches the report.
+Not generated because `task verify` fails before executing tests.

--- a/issues/synchronize-codex-and-generic-setup-scripts.md
+++ b/issues/synchronize-codex-and-generic-setup-scripts.md
@@ -1,0 +1,23 @@
+# Synchronize Codex and generic setup scripts
+
+## Context
+`scripts/codex_setup.sh` installs development dependencies for Codex, while
+`scripts/setup.sh` targets generic environments. Missing parity between these
+scripts leaves out testing tools such as `pytest-bdd`, `freezegun`, and
+`hypothesis`, leading `task check` and `task verify` to fail on fresh clones.
+
+## Dependencies
+- [document-task-cli-requirement](document-task-cli-requirement.md)
+- [resolve-release-blockers-for-alpha](resolve-release-blockers-for-alpha.md)
+
+## Acceptance Criteria
+- `scripts/codex_setup.sh` and `scripts/setup.sh` both install `pytest`,
+  `pytest-bdd`, `freezegun`, and `hypothesis`.
+- `task check` runs without reinstalling removed test packages after either
+  setup script.
+- Documentation clarifies which script to use for Codex versus general
+  contributors.
+- Setup scripts finish within ten minutes.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- record failing environment setup and unavailable test runs in STATUS.md
- add planning ticket to synchronize `codex_setup.sh` and generic setup scripts

## Testing
- `uv run flake8 src tests`
- `uv run mypy src`
- `task check` *(fails: No module named 'pytest_bdd')*
- `task verify` *(fails: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_68b09827e96883339188d4d37f59bab5