### PR TITLE
Track DuckDB extension download errors in planning

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,8 @@ As of **August 28, 2025**, Go Task is installed locally, but `task check` fails 
 `uv sync --extra dev-minimal` removes `pytest_bdd`, `freezegun`, and `hypothesis`. Attempts
 to reinstall them are undone by `uv sync`, so `scripts/check_env.py` reports missing modules
 and `task verify` stops before running tests.
+The extension bootstrap script also fails to catch `duckdb.Error`, leaving the
+vector search extension absent.
 
 ## Lint, type checks, and spec tests
 `uv run flake8 src tests` and `uv run mypy src` ran without errors.

--- a/issues/handle-duckdb-extension-download-errors.md
+++ b/issues/handle-duckdb-extension-download-errors.md
@@ -1,0 +1,18 @@
+# Handle DuckDB extension download errors
+
+## Context
+`scripts/download_duckdb_extensions.py` assumes `duckdb.DuckDBError` exists when
+network failures occur. Current DuckDB releases raise `duckdb.Error`, causing
+tracebacks and repeated retries that still leave the VSS extension absent.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Script catches `duckdb.Error` instead of `duckdb.DuckDBError`.
+- Failing downloads fall back to the stub extension without stack traces.
+- Unit test covers the error path.
+- `docs/algorithms/storage.md` notes the fallback behavior.
+
+## Status
+Open

--- a/issues/resolve-release-blockers-for-alpha.md
+++ b/issues/resolve-release-blockers-for-alpha.md
@@ -20,6 +20,7 @@ issues progress.
 - [speed-up-task-check-and-reduce-dependency-footprint](
   speed-up-task-check-and-reduce-dependency-footprint.md)
 - [document-task-cli-requirement](document-task-cli-requirement.md)
+- [handle-duckdb-extension-download-errors](handle-duckdb-extension-download-errors.md)
 
 ## Acceptance Criteria
 - `scripts/codex_setup.sh` installs and verifies `pytest`, `pytest-bdd`,


### PR DESCRIPTION
## Summary
- note duckdb extension bootstrap failures in status report
- add dependency and ticket to address download errors before alpha

## Testing
- `task check` *(fails: No module named 'pytest_bdd')*
- `task verify` *(fails: No module named 'pytest_bdd')*


------
https://chatgpt.com/codex/tasks/task_e_68b099fff7888333ad1dcc5591aa217f