### PR TITLE
docs: archive task cli issue and refresh status

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,11 +1,11 @@
 # Status
 
-As of **August 28, 2025**, Go Task is installed locally, but `task check` fails because
-`uv sync --extra dev-minimal` removes `pytest_bdd`, `freezegun`, and `hypothesis`. Attempts
-to reinstall them are undone by `uv sync`, so `scripts/check_env.py` reports missing modules
-and `task verify` stops before running tests.
-The extension bootstrap script also fails to catch `duckdb.Error`, leaving the
-vector search extension absent.
+As of **August 28, 2025**, the local environment installs Go Task, but `task check`
+fails because `uv sync --extra dev-minimal` removes `pytest_bdd`, `freezegun`, and
+`hypothesis`. The subsequent `scripts/check_env.py` call reports these modules
+missing, causing `task check` and `task verify` to exit early without running
+tests. The extension bootstrap script still fails to catch `duckdb.Error`, leaving
+the vector search extension absent.
 
 ## Lint, type checks, and spec tests
 `uv run flake8 src tests` and `uv run mypy src` ran without errors.

--- a/issues/archive/document-task-cli-requirement.md
+++ b/issues/archive/document-task-cli-requirement.md
@@ -17,4 +17,4 @@ contributors cannot run `task check` or `task verify`.
 - `task install` completes on a clean clone without manual intervention.
 
 ## Status
-Open
+Archived


### PR DESCRIPTION
## Summary
- archive issue for documenting Go Task requirement
- update project status to reflect missing test dependencies

## Testing
- `task check` *(fails: No module named 'pytest_bdd')*
- `task verify` *(fails: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_68b09dca9bfc8333a2a52af562e1a623