### PR TITLE
Ensure check task syncs test extras

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,7 +56,7 @@ tasks:
     # Minimal validation for quick feedback. Skips slow tests and scenarios
     # requiring optional UI (`.[ui]`) or VSS (`.[vss]`) extras.
     cmds:
-      - uv sync --extra dev-minimal
+      - uv sync --extra dev-minimal --extra test
       - task check-env
       - uv run flake8 src tests
       - uv run mypy src --exclude src/autoresearch/distributed

--- a/tests/targeted/test_uv_sync_retains_test_deps.py
+++ b/tests/targeted/test_uv_sync_retains_test_deps.py
@@ -1,0 +1,9 @@
+"""Regression test ensuring essential test dependencies survive `uv sync`."""
+
+from importlib import import_module
+
+
+def test_uv_sync_retains_test_dependencies() -> None:
+    """Verify `uv sync` keeps packages required for the test suite."""
+    for module in ("pytest_bdd", "freezegun", "hypothesis"):
+        import_module(module)


### PR DESCRIPTION
## Summary
- keep `pytest-bdd`, `freezegun`, and `hypothesis` by syncing `test` extras during `task check`
- add regression test verifying these test dependencies remain installed after a sync

## Testing
- `task check`
- `task verify` *(fails: No coverage percentage found in STATUS.md, No coverage percentage found in ROADMAP.md)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c427f2c4833394bc9440743f474a