### PR TITLE
Retry DuckDB extension downloads before offline fallback

### DIFF
--- a/docs/algorithms/storage.md
+++ b/docs/algorithms/storage.md
@@ -7,6 +7,13 @@ Autoresearch supports DuckDB versions 1.2.2 up to, but not including, 2.0.0.
 See [DuckDB and VSS Extension Compatibility](../duckdb_compatibility.md) for
 details.
 
+## Offline extension downloads
+
+`download_duckdb_extensions.py` retries network failures before copying a
+previously cached file referenced by `VECTOR_EXTENSION_PATH` in `.env.offline`.
+If no copy exists, a stub is created so tests can proceed without vector
+search.
+
 ## Schema bootstrapping
 
 `initialize_storage` runs setup and verifies that the core DuckDB tables


### PR DESCRIPTION
## Summary
- retry DuckDB extension downloads up to three times before using the offline fallback, catching `duckdb.Error`
- assert retry behavior in DuckDB extension download tests
- document DuckDB extension offline fallback behavior

## Testing
- `uv run pre-commit run --files scripts/download_duckdb_extensions.py tests/unit/test_download_duckdb_extensions.py docs/algorithms/storage.md` *(fails: .pre-commit-config.yaml is not a file)*
- `uv run python scripts/run_task.py check` *(fails: Go Task is not installed)*
- `uv run python scripts/run_task.py verify` *(fails: Go Task is not installed)*
- `uv run pytest tests/unit/test_download_duckdb_extensions.py`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68b0c43e20288333aad140e476b57a26