### PR TITLE
Use fakeredis fallback for redis tests

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -426,10 +426,15 @@ uv run pytest -m requires_distributed -q
 ```
 
 The `redis_client` fixture connects to a local Redis server when available and
-falls back to a lightweight `fakeredis` instance. Tests tagged
-`requires_distributed` are skipped when neither service is running.
+falls back to an in-memory `fakeredis` instance when the service is absent.
+Install `fakeredis` if you do not have a server running:
 
-For local development you can start a Redis container with:
+```bash
+uv pip install fakeredis
+```
+
+Tests tagged `requires_distributed` are skipped when neither backend is
+available. For local development you can start a Redis container with:
 
 ```bash
 docker-compose up -d redis

--- a/tests/behavior/features/message_broker_config.feature
+++ b/tests/behavior/features/message_broker_config.feature
@@ -15,7 +15,7 @@ Feature: Message broker selection
     When I obtain a message broker instance
     Then a message broker error should be raised
 
-  @requires_distributed
+  @requires_distributed @redis
   Scenario: Redis broker detection
     Given the message broker name "redis"
     When I obtain a message broker instance

--- a/tests/fixtures/redis.py
+++ b/tests/fixtures/redis.py
@@ -15,19 +15,23 @@ except Exception:  # pragma: no cover - fakeredis optional
 
 @pytest.fixture()
 def redis_client():
-    """Return a Redis client or skip when no service is available."""
+    """Return a Redis client, preferring a real server when available."""
 
     if redis is not None:
         try:
-            client = redis.Redis.from_url("redis://localhost:6379/0", socket_connect_timeout=1)
+            client = redis.Redis.from_url(
+                "redis://localhost:6379/0", socket_connect_timeout=1
+            )
             client.ping()
+            client.flushdb()
             yield client
             client.close()
             return
         except Exception:  # pragma: no cover - fall back to fakeredis
             pass
     if fakeredis is not None:
-        client = fakeredis.FakeRedis()
+        client = fakeredis.FakeStrictRedis()
+        client.flushdb()
         yield client
         client.close()
         return

--- a/tests/integration/test_distributed_redis_broker.py
+++ b/tests/integration/test_distributed_redis_broker.py
@@ -8,7 +8,11 @@ if importlib.util.find_spec("redis") is None:
     pytest.skip("redis not installed", allow_module_level=True)
 import redis
 
-pytestmark = [pytest.mark.slow, pytest.mark.requires_distributed]
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.requires_distributed,
+    pytest.mark.redis,
+]
 
 
 def test_redis_broker_roundtrip(monkeypatch: pytest.MonkeyPatch, redis_client) -> None:

--- a/tests/unit/test_distributed_extra.py
+++ b/tests/unit/test_distributed_extra.py
@@ -25,6 +25,7 @@ def test_get_message_broker_default():
 
 
 @pytest.mark.requires_distributed
+@pytest.mark.redis
 def test_redis_queue_roundtrip(redis_client):
     queue = RedisQueue(redis_client, "q")
     queue.put({"a": 1})

--- a/tests/unit/test_distributed_redis.py
+++ b/tests/unit/test_distributed_redis.py
@@ -5,7 +5,7 @@ import pytest
 
 from autoresearch.distributed import get_message_broker
 
-pytestmark = pytest.mark.requires_distributed
+pytestmark = [pytest.mark.requires_distributed, pytest.mark.redis]
 
 
 def test_get_message_broker_redis_roundtrip(monkeypatch, redis_client):

--- a/tests/unit/test_failure_scenarios.py
+++ b/tests/unit/test_failure_scenarios.py
@@ -68,6 +68,7 @@ def test_get_message_broker_invalid():
 
 
 @pytest.mark.requires_distributed
+@pytest.mark.redis
 def test_redis_broker_init_failure(monkeypatch):
     class DummyRedis:
         @staticmethod


### PR DESCRIPTION
## Summary
- enhance redis_client fixture to flush DB and fall back to fakeredis when no server is available
- tag redis scenarios with requires_distributed/redis markers
- document installing fakeredis and running distributed tests

## Testing
- `task check` *(fails: No module named 'pytest_bdd')*
- `task verify` *(fails: No coverage percentage found in STATUS.md)*
- `uv run flake8 src tests`
- `uv run mypy src --exclude src/autoresearch/distributed`
- `uv run pytest tests/unit/test_version.py tests/unit/test_cli_help.py -q`
- `uv run pytest tests/unit/test_distributed_redis.py -m requires_distributed -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0c44ee8108333979e9be455d3e49a