### PR TITLE
Add storage simulations and DuckDB backend tests

### DIFF
--- a/docs/algorithms/storage.md
+++ b/docs/algorithms/storage.md
@@ -31,6 +31,9 @@ second = ctx.db_backend._conn.execute("show tables").fetchall()
 assert first == second
 ```
 
+The [schema simulation][schema-sim] runs this routine multiple times and prints
+`schema stable` when every iteration yields the same table list.
+
 ## Deterministic setup and teardown
 
 `DuckDBStorageBackend.setup` now retains the database path, even for
@@ -46,10 +49,22 @@ simultaneously. The [simulation][evict-sim] spawns threads that insert claims
 while memory usage is forced above the budget. After all threads finish the
 in-memory graph is empty, proving the policy is thread safe.
 
+The [RAM budget simulation][ram-sim] persists claims sequentially while
+memory usage is mocked above the limit, leaving the in-memory graph empty.
+
 The [concurrency simulation][concurrency-sim] accepts thread and item counts to
 demonstrate enforcement under heavier contention. Integration
 [tests][concurrency-test] show that writers retain all claims when usage stays
 within the budget and trigger eviction once mocked memory exceeds the limit.
+
+## Concurrency and failure modes
+
+`DuckDBStorageBackend.setup` uses a lock so concurrent callers
+initialise the schema once. The unit test [backend-test] spawns
+threads that call `setup` simultaneously and confirms that
+`_create_tables` executes only once. The same module injects a fault
+into `_initialize_schema_version` and verifies that a
+`StorageError` surfaces to the caller.
 
 ## Formal proofs
 
@@ -92,3 +107,6 @@ the RAM budget is exceeded, ensuring deterministic resource bounds.
 [evict-test]: ../../tests/targeted/test_storage_eviction.py
 [concurrency-test]: ../../tests/integration/test_storage_concurrency.py
 
+[schema-sim]: ../../scripts/schema_idempotency_sim.py
+[ram-sim]: ../../scripts/ram_budget_enforcement_sim.py
+[backend-test]: ../../tests/unit/test_duckdb_storage_backend_concurrency.py

--- a/scripts/ram_budget_enforcement_sim.py
+++ b/scripts/ram_budget_enforcement_sim.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Simulate sequential writes enforcing the RAM budget.
+
+Usage:
+    uv run python scripts/ram_budget_enforcement_sim.py --items 5
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel, StorageConfig
+from autoresearch.storage import StorageContext, StorageManager, StorageState
+
+
+def _run(items: int) -> int:
+    """Persist claims and return remaining node count after eviction."""
+
+    cfg = ConfigModel(
+        storage=StorageConfig(duckdb_path=":memory:"),
+        ram_budget_mb=1,
+        graph_eviction_policy="lru",
+    )
+    loader = ConfigLoader.new_for_tests()
+    loader._config = cfg
+
+    st = StorageState()
+    ctx = StorageContext()
+    StorageManager.state = st
+    StorageManager.context = ctx
+
+    original = StorageManager._current_ram_mb
+    StorageManager._current_ram_mb = staticmethod(lambda: 1000)
+    try:
+        StorageManager.setup(db_path=":memory:", context=ctx, state=st)
+        for i in range(items):
+            StorageManager.persist_claim({"id": f"c{i}", "type": "fact", "content": "c"})
+            StorageManager._enforce_ram_budget(cfg.ram_budget_mb)
+        remaining = StorageManager.get_graph().number_of_nodes()
+    finally:
+        StorageManager.teardown(remove_db=True, context=ctx, state=st)
+        StorageManager.state = StorageState()
+        StorageManager.context = StorageContext()
+        StorageManager._current_ram_mb = original  # type: ignore[assignment]
+        ConfigLoader.reset_instance()
+
+    return remaining
+
+
+def main(items: int) -> None:
+    if items <= 0:
+        raise SystemExit("items must be positive")
+    remaining = _run(items)
+    print(f"nodes remaining after eviction: {remaining}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--items", type=int, default=5, help="items to persist")
+    args = parser.parse_args()
+    main(args.items)

--- a/scripts/schema_idempotency_sim.py
+++ b/scripts/schema_idempotency_sim.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Simulate idempotent DuckDB schema creation.
+
+Usage:
+    uv run python scripts/schema_idempotency_sim.py --runs 3
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import List, Sequence, Tuple
+
+from autoresearch.storage_backends import DuckDBStorageBackend
+
+
+def _run(runs: int) -> List[Sequence[Tuple[str, ...]]]:
+    """Execute repeated setup calls and record table listings."""
+
+    backend = DuckDBStorageBackend()
+    tables: List[Sequence[Tuple[str, ...]]] = []
+    try:
+        for _ in range(runs):
+            backend.setup(db_path=":memory:")
+            assert backend._conn is not None  # for type checkers
+            rows = backend._conn.execute("SHOW TABLES").fetchall()
+            tables.append(rows)
+        return tables
+    finally:
+        backend.close()
+
+
+def main(runs: int) -> None:
+    if runs <= 0:
+        raise SystemExit("runs must be positive")
+    tables = _run(runs)
+    first = tables[0]
+    stable = all(t == first for t in tables[1:])
+    status = "stable" if stable else "changed"
+    print(f"schema {status} across {runs} runs")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runs", type=int, default=2, help="number of setup iterations")
+    args = parser.parse_args()
+    main(args.runs)

--- a/tests/unit/test_duckdb_storage_backend_concurrency.py
+++ b/tests/unit/test_duckdb_storage_backend_concurrency.py
@@ -1,0 +1,56 @@
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.errors import StorageError
+from autoresearch.storage_backends import DuckDBStorageBackend
+
+
+@pytest.fixture(autouse=True)
+def reset_config_loader() -> None:
+    """Reset ``ConfigLoader`` before and after each test."""
+
+    ConfigLoader.reset_instance()
+    with patch("autoresearch.storage_backends.ConfigLoader") as mock_loader:
+        mock_cfg = MagicMock()
+        mock_cfg.config.storage.duckdb.path = "kg.duckdb"
+        mock_loader.return_value.config = mock_cfg
+        yield
+    ConfigLoader.reset_instance()
+
+
+def test_concurrent_setup_is_idempotent(tmp_path) -> None:
+    """Concurrent setup calls create the schema only once."""
+
+    backend = DuckDBStorageBackend()
+    db_file = tmp_path / "test.duckdb"
+
+    with patch("autoresearch.storage_backends.duckdb.connect", return_value=MagicMock()):
+        with patch.object(DuckDBStorageBackend, "_create_tables") as create_tables:
+            threads = [
+                threading.Thread(target=backend.setup, kwargs={"db_path": str(db_file)})
+                for _ in range(5)
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            assert create_tables.call_count == 1
+
+    backend.close()
+
+
+def test_initialize_schema_version_failure(tmp_path) -> None:
+    """Errors during schema version init raise ``StorageError``."""
+
+    backend = DuckDBStorageBackend()
+
+    with patch("autoresearch.storage_backends.duckdb.connect", return_value=MagicMock()):
+        with patch.object(
+            DuckDBStorageBackend, "_initialize_schema_version", side_effect=Exception("boom")
+        ):
+            with pytest.raises(StorageError):
+                backend.setup(db_path=str(tmp_path / "db.duckdb"))


### PR DESCRIPTION
## Summary
- add schema_idempotency_sim to demonstrate repeated setup stability
- add ram_budget_enforcement_sim for sequential eviction proof
- cover DuckDBStorageBackend concurrency and initialization failures with tests
- document simulations and tests in storage algorithms overview

## Testing
- `uv run flake8 scripts/schema_idempotency_sim.py scripts/ram_budget_enforcement_sim.py tests/unit/test_duckdb_storage_backend_concurrency.py`
- `uv run mkdocs build`
- `uv run pytest tests/unit/test_duckdb_storage_backend_concurrency.py`
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c46712dc833392cce7d8221b1f1e