### PR TITLE
Add deterministic breaker simulation and parallel utility tests

### DIFF
--- a/tests/unit/orchestration/test_circuit_breaker_determinism.py
+++ b/tests/unit/orchestration/test_circuit_breaker_determinism.py
@@ -1,0 +1,25 @@
+"""Deterministic simulation of circuit breaker states."""
+
+from __future__ import annotations
+
+from autoresearch.orchestration.circuit_breaker import simulate_circuit_breaker
+
+
+def test_circuit_breaker_determinism_and_recovery() -> None:
+    """Same event sequence always yields identical states and recovers."""
+
+    events = [
+        "critical",
+        "critical",
+        "critical",
+        "tick",
+        "tick",
+        "recoverable",
+        "success",
+    ]
+
+    states_first = simulate_circuit_breaker(events, threshold=3, cooldown=1)
+    states_second = simulate_circuit_breaker(events, threshold=3, cooldown=1)
+
+    assert states_first == states_second
+    assert states_first[-1] == "closed"

--- a/tests/unit/orchestration/test_circuit_breaker_thresholds.py
+++ b/tests/unit/orchestration/test_circuit_breaker_thresholds.py
@@ -8,17 +8,15 @@ from __future__ import annotations
 from autoresearch.orchestration.circuit_breaker import CircuitBreakerManager
 
 
-def test_circuit_breaker_threshold_and_recovery(monkeypatch) -> None:
+def test_circuit_breaker_threshold_and_recovery() -> None:
     """Three critical failures open the breaker and recovery closes it."""
-
-    mgr = CircuitBreakerManager(threshold=3, cooldown=1)
 
     times = [0.0]
 
     def fake_time() -> float:
         return times[0]
 
-    monkeypatch.setattr("time.time", fake_time)
+    mgr = CircuitBreakerManager(threshold=3, cooldown=1, time_func=fake_time)
 
     for _ in range(3):
         mgr.update_circuit_breaker("agent", "critical")

--- a/tests/unit/orchestration/test_parallel_execute.py
+++ b/tests/unit/orchestration/test_parallel_execute.py
@@ -1,0 +1,109 @@
+"""Tests for parallel execution utilities."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+
+from autoresearch.config.models import ConfigModel
+from autoresearch.errors import OrchestrationError
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.parallel import execute_parallel_query
+
+
+class DummyTracer:
+    def start_as_current_span(self, name: str):
+        class Span:
+            def __enter__(self) -> Span:  # type: ignore[name-defined]
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - no cleanup
+                return None
+
+            def set_attribute(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - logging only
+                return None
+
+            def add_event(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - logging only
+                return None
+
+        return Span()
+
+
+class DummySynthesizer:
+    def execute(self, state, config):  # pragma: no cover - simple passthrough
+        return {"answer": "combined"}
+
+
+@pytest.fixture(autouse=True)
+def patch_parallel(monkeypatch):
+    monkeypatch.setattr(
+        "autoresearch.orchestration.parallel.setup_tracing", lambda *_: None
+    )
+    monkeypatch.setattr(
+        "autoresearch.orchestration.parallel.get_tracer", lambda *_: DummyTracer()
+    )
+    monkeypatch.setattr(
+        "autoresearch.orchestration.parallel._get_memory_usage", lambda: 0.0
+    )
+    monkeypatch.setattr(
+        "autoresearch.orchestration.parallel._calculate_result_confidence",
+        lambda _r: 0.5,
+    )
+    monkeypatch.setattr(
+        "autoresearch.orchestration.parallel.AgentFactory.get",
+        lambda _name: DummySynthesizer(),
+    )
+
+
+class SelectorOrchestrator:
+    def run_query(self, query: str, config: ConfigModel) -> QueryResponse:
+        agent = config.agents[0]
+        if agent == "good":
+            return QueryResponse(
+                answer="good",
+                citations=[],
+                reasoning=["ok"],
+                metrics={"token_usage": {"total": 1, "max_tokens": 10}},
+            )
+        if agent == "bad":  # pragma: no cover - error branch
+            raise OrchestrationError("fail")
+        if agent == "slow":  # pragma: no cover - timeout branch
+            time.sleep(0.5)
+            return QueryResponse(answer="slow", citations=[], reasoning=[], metrics={})
+        raise OrchestrationError("unknown")
+
+
+def test_execute_parallel_query_error_and_timeout(monkeypatch):
+    monkeypatch.setattr(
+        "autoresearch.orchestration.orchestrator.Orchestrator",
+        SelectorOrchestrator,
+    )
+
+    config = ConfigModel()
+    resp_err = execute_parallel_query("q", config, [["good"], ["bad"]], timeout=1.0)
+    meta_err = resp_err.metrics["parallel_execution"]
+    assert meta_err["successful_groups"] == 1
+    assert meta_err["error_groups"] == 1
+    assert meta_err["timeout_groups"] == 0
+
+    config2 = ConfigModel()
+    resp_timeout = execute_parallel_query("q", config2, [["good"], ["slow"]], timeout=0.1)
+    meta_timeout = resp_timeout.metrics["parallel_execution"]
+    assert meta_timeout["successful_groups"] == 1
+    assert meta_timeout["error_groups"] == 0
+    assert meta_timeout["timeout_groups"] == 1
+
+
+def test_execute_parallel_query_all_fail(monkeypatch):
+    monkeypatch.setattr(
+        "autoresearch.orchestration.orchestrator.Orchestrator",
+        SelectorOrchestrator,
+    )
+
+    config = ConfigModel()
+    groups = [["bad"], ["bad"]]
+
+    with pytest.raises(OrchestrationError):
+        execute_parallel_query("q", config, groups, timeout=0.3)


### PR DESCRIPTION
## Summary
- expose circuit breaker timing hook and provide `simulate_circuit_breaker` helper
- exercise parallel execution with error and timeout paths
- document deterministic breaker recovery in orchestration algorithms

## Testing
- `uv run coverage report --include='src/autoresearch/orchestration/*'`
- `uv run coverage run --source=autoresearch.orchestration -m pytest tests/unit/orchestration`
- `PATH=$PWD/.venv/bin:$PATH task verify` *(fails: task check-coverage-docs exited with status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c46c68788333983c5b3a2cb75343