### PR TITLE
test: add gated behavior scenarios

### DIFF
--- a/tests/behavior/features/error_recovery_redis.feature
+++ b/tests/behavior/features/error_recovery_redis.feature
@@ -1,0 +1,7 @@
+@behavior @error_recovery @requires_distributed @redis
+Feature: Redis error recovery
+  Scenario: Connection failure triggers recovery
+    Given a Redis client that fails to connect
+    When I attempt a Redis operation
+    Then the system should handle the Redis error
+

--- a/tests/behavior/features/reasoning_mode_vss.feature
+++ b/tests/behavior/features/reasoning_mode_vss.feature
@@ -1,0 +1,7 @@
+@behavior @reasoning_modes @requires_vss
+Feature: Reasoning mode with VSS extension
+  Scenario: Dialectical reasoning uses VSS extension
+    Given I have a valid configuration with VSS extension enabled
+    And reasoning mode is "dialectical"
+    When I run the orchestrator on query "mode test"
+    Then the VSS extension should be loaded from the filesystem

--- a/tests/behavior/features/user_workflows.feature
+++ b/tests/behavior/features/user_workflows.feature
@@ -13,3 +13,9 @@ Feature: User workflows
     Given the Autoresearch application is running
     When I run `autoresearch search --backend missing "workflow test"`
     Then the CLI should report an error
+
+  @requires_ui
+  Scenario: Streamlit interface displays results
+    Given the Streamlit application is running
+    When I run a query in the Streamlit interface
+    Then the results should be displayed in a tabbed interface

--- a/tests/behavior/steps/error_recovery_redis_steps.py
+++ b/tests/behavior/steps/error_recovery_redis_steps.py
@@ -1,0 +1,34 @@
+from pytest_bdd import given, scenario, then, when
+
+
+class FailingRedis:
+    """Simple Redis client that always fails."""
+
+    def ping(self) -> None:  # pragma: no cover - error path
+        raise ConnectionError("Redis unavailable")
+
+
+@given("a Redis client that fails to connect", target_fixture="redis_client")
+def redis_client() -> FailingRedis:
+    return FailingRedis()
+
+
+@when("I attempt a Redis operation")
+def attempt_redis_operation(redis_client, bdd_context) -> None:
+    try:
+        redis_client.ping()
+    except Exception as err:  # pragma: no cover - error path
+        bdd_context["redis_error"] = err
+
+
+@then("the system should handle the Redis error")
+def handle_redis_error(bdd_context) -> None:
+    assert bdd_context.get("redis_error") is not None
+
+
+@scenario(
+    "../features/error_recovery_redis.feature",
+    "Connection failure triggers recovery",
+)
+def test_redis_error_recovery() -> None:
+    """Ensure Redis connection failures are handled gracefully."""

--- a/tests/behavior/steps/reasoning_mode_vss_steps.py
+++ b/tests/behavior/steps/reasoning_mode_vss_steps.py
@@ -1,0 +1,15 @@
+from pytest_bdd import scenario
+
+pytest_plugins = [
+    "tests.behavior.steps.vector_extension_handling_steps",
+    "tests.behavior.steps.reasoning_mode_steps",
+    "tests.behavior.steps.agent_orchestration_steps",
+]
+
+
+@scenario(
+    "../features/reasoning_mode_vss.feature",
+    "Dialectical reasoning uses VSS extension",
+)
+def test_reasoning_mode_vss() -> None:
+    """Ensure reasoning modes work with the VSS extension."""

--- a/tests/behavior/steps/user_workflows_steps.py
+++ b/tests/behavior/steps/user_workflows_steps.py
@@ -1,6 +1,9 @@
 from pytest_bdd import scenario
 
-pytest_plugins = ["tests.behavior.steps.common_steps"]
+pytest_plugins = [
+    "tests.behavior.steps.common_steps",
+    "tests.behavior.steps.streamlit_gui_steps",
+]
 
 
 @scenario("../features/user_workflows.feature", "CLI search completes successfully")
@@ -14,3 +17,11 @@ def test_cli_workflow(bdd_context):
 )
 def test_cli_workflow_invalid_backend(bdd_context):
     assert bdd_context["result"].exit_code != 0
+
+
+@scenario(
+    "../features/user_workflows.feature",
+    "Streamlit interface displays results",
+)
+def test_streamlit_ui_workflow() -> None:
+    """Ensure the Streamlit UI renders search results."""


### PR DESCRIPTION
## Summary
- add Streamlit UI workflow scenario gated by `requires_ui`
- cover VSS usage in reasoning modes behind `requires_vss`
- exercise Redis error recovery with `requires_distributed` gating

## Testing
- `./bin/task check` *(fails: No module named 'pytest_bdd')*
- `./bin/task verify` *(fails: No module named 'pytest_bdd')*
- `uv run pytest tests/behavior/steps/user_workflows_steps.py::test_streamlit_ui_workflow -m requires_ui -q`
- `uv run pytest tests/behavior/steps/reasoning_mode_vss_steps.py::test_reasoning_mode_vss -m requires_vss -q`
- `uv run pytest tests/behavior/steps/error_recovery_redis_steps.py::test_redis_error_recovery -m 'requires_distributed and redis' -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0c47619688333a55952898fdd30f5