### PR TITLE
chore: improve setup scripts

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -296,5 +296,17 @@ fi
 # Validate required tool versions
 uv run python scripts/check_env.py
 
+# Append .venv/bin to PATH for the current shell session
+ensure_venv_bin_on_path "$PWD/.venv/bin"
+
+# Document how to activate the environment in future sessions
+cat <<'EOF'
+To activate the virtual environment, run:
+  source .venv/bin/activate
+EOF
+
+# Final verification step
+task --version
+
 # Python environment configured via uv sync and optional extras
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -207,3 +207,6 @@ echo "Running mypy..."
 uv run mypy src
 
 echo "Setup complete! VSS extension downloaded and configured."
+
+# Final verification step
+task --version


### PR DESCRIPTION
## Summary
- ensure Codex setup adds `.venv/bin` to PATH and prints activation instructions
- verify Task installation at the end of codex and standard setup scripts

## Testing
- `task check`
- `task verify` *(fails: check-coverage-docs: No coverage percentage found in STATUS.md)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cf8f670083338e66a2ce99586c25