### PR TITLE
Document optional extras and streamline setup scripts

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,9 +20,8 @@ download fails. Manual installation instructions are below if needed.
 
 ## Setup scripts
 
-Use `scripts/setup.sh` for local development or any environment that is not the
-Codex evaluation container. The `scripts/codex_setup.sh` script configures that
-container and should not be used elsewhere.
+Use `scripts/setup.sh` for local development. Environment-specific helpers are
+documented in `AGENTS.md`.
 
 The Redis package installs with the `dev` extra. A running Redis server is
 required only for tests or features that use the `.[distributed]` extra. The
@@ -34,8 +33,9 @@ neither service is available. Run them explicitly with:
 uv run pytest -m requires_distributed -q
 ```
 
-Optional extras enable additional capabilities and are installed on
-demand with `uv sync --extra <name>`.
+Optional extras enable additional capabilities. Install them with
+`uv sync --extra <name>` or by setting `AR_EXTRAS` when running the setup
+script.
 
 For a lean setup, sync the minimal development and test extras:
 
@@ -64,6 +64,7 @@ Include extras only when required. Examples:
 EXTRAS="nlp" task install      # adds NLP packages
 uv sync --extra llm            # sentence-transformers and transformers
 VERIFY_PARSERS=1 task install  # adds PDF and DOCX parsers
+AR_EXTRAS="nlp ui" ./scripts/setup.sh  # extras via setup script
 ```
 
 Set `VERIFY_PARSERS=1` when running `task verify` to sync the `parsers`
@@ -291,18 +292,25 @@ extras explicitly with pip to enable additional features, e.g.
 
 Additional functionality is grouped into optional extras. These are not
 installed by `task install`; enable them with `uv sync --extra <name>` or
-`pip install "autoresearch[<name>]"`:
+`pip install "autoresearch[<name>]"`. `scripts/setup.sh` accepts extras via the
+`AR_EXTRAS` environment variable.
 
-- `nlp` – language processing via spaCy and BERTopic
-- `llm` – heavy dependencies like `sentence-transformers` and `transformers`
-- `parsers` – PDF and DOCX document ingestion
-- `ui` – the reference Streamlit interface
-- `vss` – DuckDB VSS extension for vector search
-- `distributed` – distributed processing with Ray and Redis
-- `analysis` – Polars-based data analysis utilities
-- `git` – local Git repository search support
-- `full` – installs most extras (nlp, ui, vss, distributed, analysis)
-  but omits `parsers` and `git`
+| Extra       | Setup command                     |
+|-------------|-----------------------------------|
+| minimal     | `uv sync --extra minimal`         |
+| nlp         | `uv sync --extra nlp`             |
+| ui          | `uv sync --extra ui`              |
+| vss         | `uv sync --extra vss`             |
+| parsers     | `uv sync --extra parsers`         |
+| git         | `uv sync --extra git`             |
+| distributed | `uv sync --extra distributed`     |
+| analysis    | `uv sync --extra analysis`        |
+| llm         | `uv sync --extra llm`             |
+| test        | `uv sync --extra test`            |
+| full        | `uv sync --extra full`            |
+| dev         | `uv sync --extra dev`             |
+| dev-minimal | `uv sync --extra dev-minimal`     |
+| build       | `uv sync --extra build`           |
 
 Examples:
 

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Usage: AR_INSTALL_UI=1 AR_INSTALL_NLP=1 ./scripts/codex_setup.sh
+# Usage: AR_EXTRAS="ui nlp" ./scripts/codex_setup.sh
 # Codex-only environment bootstrap for this evaluation container; see AGENTS.md
 # for repository-wide guidelines. Do not use or document this script outside the
 # AGENTS.md system. For any other environment, use `./scripts/setup.sh`.
@@ -98,7 +98,7 @@ if ! retry 3 apt-get clean; then
 fi
 rm -rf /var/lib/apt/lists/*
 
-# Install dev and test dependencies
+# Install dev and test dependencies plus AR_EXTRAS
 install_dev_test_extras
 ensure_venv_bin_on_path ".venv/bin"
 
@@ -113,14 +113,6 @@ command -v task >/dev/null 2>&1 || {
 }
 # Verify Task installation by printing its version
 task --version
-
-# Install optional extras on demand
-if [ "${AR_INSTALL_UI:-0}" -eq 1 ]; then
-    uv sync --extra ui
-fi
-if [ "${AR_INSTALL_NLP:-0}" -eq 1 ]; then
-    uv sync --extra nlp
-fi
 
 # Install pre-downloaded packages for offline use. Place wheel files in
 # $WHEELS_DIR and source archives in $ARCHIVES_DIR. See AGENTS.md for

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Usage: ./scripts/setup.sh
+# Usage: AR_EXTRAS="nlp ui" ./scripts/setup.sh
 # Full developer bootstrap; see docs/installation.md.
 # Create .venv, install or link Go Task to .venv/bin, and development/test
-# extras using uv. Ensure we are running with Python 3.12 or newer. Run
+# extras using uv. Optional extras are installed when AR_EXTRAS is set.
+# Ensure we are running with Python 3.12 or newer. Run
 # `uv run python scripts/check_env.py` at the end to validate tool versions.
 set -euo pipefail
 
@@ -58,7 +59,7 @@ if ! "$TASK_BIN" --version >/dev/null 2>&1; then
     exit 1
 fi
 
-# Install locked dependencies and development/test extras
+# Install locked dependencies, development/test extras, and AR_EXTRAS
 install_dev_test_extras
 
 # Verify dev and test extras are installed

--- a/scripts/setup_common.sh
+++ b/scripts/setup_common.sh
@@ -4,8 +4,12 @@
 set -euo pipefail
 
 install_dev_test_extras() {
-    echo "Installing dev and test extras via uv sync --extra dev --extra test"
-    uv sync --extra dev --extra test
+    local extras="dev test"
+    if [ -n "${AR_EXTRAS:-}" ]; then
+        extras="$extras ${AR_EXTRAS}"
+    fi
+    echo "Installing extras via uv sync --extra ${extras// / --extra }"
+    uv sync $(for e in $extras; do printf -- '--extra %s ' "$e"; done)
     uv pip install -e .
 }
 


### PR DESCRIPTION
## Summary
- allow setup helpers to install arbitrary extras via an `AR_EXTRAS` variable
- clarify optional extras and usage in the installation guide
- document all project extras in a consolidated table

## Testing
- `task check`
- `task verify` *(fails: check-coverage-docs)*
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68b0d0938390833382dfb02ce404a5f9