### PR TITLE
docs: update roadmap test status

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,12 +31,26 @@ before running tests.
     issues/add-storage-proofs-and-simulations.md)
   - [configure-redis-service-for-tests](
     issues/configure-redis-service-for-tests.md)
+  - [fix-duckdb-schema-initialization](
+    issues/fix-duckdb-schema-initialization.md)
+  - [fix-task-check-dependency-removal-and-extension-bootstrap](
+    issues/fix-task-check-dependency-removal-and-extension-bootstrap.md)
+  - [handle-duckdb-extension-download-errors](
+    issues/handle-duckdb-extension-download-errors.md)
+  - [ensure-task-cli-available-after-setup](
+    issues/ensure-task-cli-available-after-setup.md)
+  - [audit-setup-script-dependencies](
+    issues/audit-setup-script-dependencies.md)
+  - [add-behavior-driven-test-coverage](
+    issues/add-behavior-driven-test-coverage.md)
+  - [speed-up-task-check-and-reduce-dependency-footprint](
+    issues/speed-up-task-check-and-reduce-dependency-footprint.md)
+  - [resolve-release-blockers-for-alpha](
+    issues/resolve-release-blockers-for-alpha.md)
 - 0.1.0 (2026-07-01, status: released): Finalized packaging, docs and CI
   checks with all tests passing.
   - [improve-test-coverage-and-streamline-dependencies](
     issues/archive/improve-test-coverage-and-streamline-dependencies.md)
-  - [speed-up-task-check-and-reduce-dependency-footprint](
-    issues/speed-up-task-check-and-reduce-dependency-footprint.md)
 - 0.1.1 (2026-09-15, status: planned): Bug fixes and documentation updates
   ([deliver-bug-fixes-and-docs-update](
   issues/deliver-bug-fixes-and-docs-update.md)).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,11 +7,12 @@ Last updated **August 28, 2025**.
 
 ## Status
 
-See [STATUS.md](STATUS.md) for current results. Coverage is not generated
-because `task verify` fails during environment checks that remove required
-test packages (see [fix-task-check-deps]). Integration and behavior suites are
-not executed. Dependency pins:
-`fastapi>=0.115.12` and `slowapi==0.1.9`. Use Python 3.12+ with:
+See [STATUS.md](STATUS.md) for current results. `task verify` completes after
+running `scripts/setup.sh`, but `uv sync --extra dev-minimal` prunes optional
+packages, so only targeted tests run. Integration and behavior suites remain
+skipped and coverage reports 100% for exercised modules (see
+[fix-task-check-deps]). Dependency pins: `fastapi>=0.115.12` and
+`slowapi==0.1.9`. Use Python 3.12+ with:
 
 ```
 uv venv && uv sync --all-extras &&

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,13 +1,13 @@
 # Status
 
-As of **August 28, 2025**, activating `.venv/bin/activate` exposes the `task` CLI and
-both `task check` and `task verify` complete. `uv sync --extra dev-minimal` still
-prunes optional packages, so only targeted unit tests run. Coverage reports
-**100%** for exercised modules. Integration and behavior suites remain skipped.
-See [fix-task-check-deps] for tracking.
+As of **August 28, 2025**, activating `.venv/bin/activate` exposes the `task` CLI.
+`task check` and `task verify` complete, but `uv sync --extra dev-minimal` still
+prunes optional packages so only targeted unit tests run. Integration and behavior
+suites remain skipped, and coverage reports **100%** for exercised modules. See
+[fix-task-check-deps] for tracking.
 
 ## Lint, type checks, and spec tests
-`task check` runs linting, mypy, and spec tests successfully.
+`task check` runs linting, mypy, and a fast subset of unit tests (8 passed).
 
 ## Targeted tests
 `task verify` runs 21 targeted tests with 3 skips.
@@ -19,5 +19,5 @@ Not run.
 Not run.
 
 ## Coverage
-Total coverage is **100%**, limited to targeted modules.
+Total coverage is **100%**, limited to two targeted modules.
 [fix-task-check-deps]: issues/fix-task-check-dependency-removal-and-extension-bootstrap.md


### PR DESCRIPTION
## Summary
- note that `task verify` now runs after setup but only targeted tests execute and coverage is limited

## Testing
- `task check`
- `task verify`


------
https://chatgpt.com/codex/tasks/task_e_68b0de4975e083338d7b971b6ca2e29c