### PR TITLE
Archive DuckDB extension error-handling issue

### DIFF
--- a/issues/archive/handle-duckdb-extension-download-errors.md
+++ b/issues/archive/handle-duckdb-extension-download-errors.md
@@ -17,4 +17,4 @@ None
 - `docs/algorithms/storage.md` notes the fallback behavior.
 
 ## Status
-Open
+Archived


### PR DESCRIPTION
## Summary
- confirm `download_duckdb_extensions.py` handles DuckDB errors with retries and offline fallback
- archive the resolved "handle-duckdb-extension-download-errors" issue

## Testing
- `task check`
- `task verify`


------
https://chatgpt.com/codex/tasks/task_e_68b0eb71f4a4833394fd9f4fc20cae8d