### PR TITLE
test: document behavior markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,10 @@ markers = [
     "requires_vss: tests that depend on the vss extra",
     "requires_git: tests that depend on the git extra",
     "requires_nlp: tests needing NLP resources",
-    "requires_distributed: tests that depend on the distributed extra"
+    "requires_distributed: tests that depend on the distributed extra",
+    "error_recovery: behavior tests verifying recovery paths",
+    "reasoning_modes: behavior tests for reasoning strategies",
+    "user_workflows: end-to-end user scenarios"
 ]
 
 [tool.mypy]

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,7 +17,7 @@ markers =
     requires_nlp: tests needing NLP resources
     requires_distributed: tests that depend on the distributed extra
     redis: tests that interact with Redis
-    error_recovery: behavior tests for error recovery workflows
-    reasoning_modes: behavior tests for reasoning mode coverage
-    user_workflows: behavior tests for user workflows
+    error_recovery: behavior tests verifying recovery paths
+    reasoning_modes: behavior tests for reasoning strategies
+    user_workflows: end-to-end user scenarios
     a2a_mcp: behavior tests for A2A MCP integration

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -23,8 +23,9 @@ These instructions apply to files in the `tests/` directory.
   `.[git]` extra.
 - Use `requires_distributed` for tests that depend on Redis or Ray; pair with
   the `.[distributed]` extra.
-- Use `error_recovery`, `reasoning_modes`, and `user_workflows` markers to
-  categorize behavior scenarios.
+- Use `error_recovery` for behavior tests verifying recovery paths.
+- Use `reasoning_modes` for behavior tests exploring reasoning strategies.
+- Use `user_workflows` for end-to-end user scenarios.
 - Register any new markers in `pytest.ini`.
 - Include extras corresponding to any other markers as needed.
 - Scenarios tagged `error_recovery` or `reasoning_modes` run with the base


### PR DESCRIPTION
## Summary
- register behavior markers in `pyproject.toml`
- clarify marker descriptions in `pytest.ini`
- document marker usage in tests guidelines

## Testing
- `task check`
- `uv run pytest --markers`
- `task verify`


------
https://chatgpt.com/codex/tasks/task_e_68b0eb864734833395a2e89296afef34