### PR TITLE
docs: update status with environment results

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,18 +1,19 @@
 # Status
 
-As of **August 29, 2025**, activating `.venv/bin/activate` exposes the `task` CLI.
-`task check` and `task verify` pass on a clean environment with dependencies
-retained. Integration and behavior suites remain skipped pending broader
-coverage work, and coverage reports **100%** for exercised modules. See
+As of **August 29, 2025**, the evaluation environment does not expose the
+`task` CLI, and direct test invocation fails due to missing plugins. Attempts
+to run `task check` or `task verify` fail with `command not found: task`, and
+`uv run pytest -q` raises `ImportError: No module named 'pytest_bdd'`.
+Integration and behavior suites therefore remain untested. See
 [speed-up-task-check] for dependency footprint concerns and
 [add-behavior-driven-test-coverage](issues/add-behavior-driven-test-coverage.md)
 for behavior tests.
 
 ## Lint, type checks, and spec tests
-`task check` runs linting, mypy, and a fast subset of unit tests (8 passed).
+Did not run; the `task` command is unavailable.
 
 ## Targeted tests
-`task verify` runs 21 targeted tests with 3 skips.
+Did not run; the `task` command is unavailable and `pytest_bdd` is missing.
 
 ## Integration tests
 Not run.
@@ -21,5 +22,5 @@ Not run.
 Not run.
 
 ## Coverage
-Total coverage is **100%**, limited to two targeted modules.
+Not computed due to failing test invocation.
 [speed-up-task-check]: issues/speed-up-task-check-and-reduce-dependency-footprint.md


### PR DESCRIPTION
## Summary
- document that `task` CLI and `pytest_bdd` are missing in the evaluation environment
- note that linting, targeted tests, and coverage could not run

## Testing
- `task check` *(fails: command not found)*
- `uv run pytest -q` *(fails: ImportError: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_68b11cd4cee48333ba2733e7bd57bb45