### PR TITLE
test: add fakeredis service for distributed tests

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -425,18 +425,16 @@ uv pip install -e '.[distributed]'
 uv run pytest -m requires_distributed -q
 ```
 
-The `redis_client` fixture connects to a local Redis server when available and
-falls back to an in-memory `fakeredis` instance when the service is absent.
-Install `fakeredis` if you do not have a server running:
+`tests/conftest.py` starts a lightweight Redis service using `fakeredis` when a
+real server is not reachable. The `redis_client` fixture connects to this
+service so distributed tests run without external infrastructure. Install
+`fakeredis` if you do not have a server running. Tests marked
+`requires_distributed` are skipped when neither a real Redis server nor
+`fakeredis` is available. For local development you can start a Redis container
+with:
 
 ```bash
 uv pip install fakeredis
-```
-
-Tests tagged `requires_distributed` are skipped when neither backend is
-available. For local development you can start a Redis container with:
-
-```bash
 docker-compose up -d redis
 ```
 

--- a/tests/fixtures/redis.py
+++ b/tests/fixtures/redis.py
@@ -2,37 +2,9 @@ from __future__ import annotations
 
 import pytest
 
-try:  # pragma: no cover - optional dependency
-    import redis
-except Exception:  # pragma: no cover - redis optional
-    redis = None  # type: ignore[assignment]
-
-try:  # pragma: no cover - optional dependency
-    import fakeredis
-except Exception:  # pragma: no cover - fakeredis optional
-    fakeredis = None  # type: ignore[assignment]
-
 
 @pytest.fixture()
-def redis_client():
-    """Return a Redis client, preferring a real server when available."""
-
-    if redis is not None:
-        try:
-            client = redis.Redis.from_url(
-                "redis://localhost:6379/0", socket_connect_timeout=1
-            )
-            client.ping()
-            client.flushdb()
-            yield client
-            client.close()
-            return
-        except Exception:  # pragma: no cover - fall back to fakeredis
-            pass
-    if fakeredis is not None:
-        client = fakeredis.FakeStrictRedis()
-        client.flushdb()
-        yield client
-        client.close()
-        return
-    pytest.skip("Redis service not available")
+def redis_client(redis_service):
+    """Return a Redis client backed by the session-level service."""
+    redis_service.flushdb()
+    yield redis_service


### PR DESCRIPTION
## Summary
- spin up a lightweight Redis service via `fakeredis` in the test suite
- tag Redis-dependent tests with `requires_distributed` and skip when Redis is missing
- document Redis setup and skipping behavior in testing guidelines

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run pytest tests/unit/test_distributed_redis.py::test_get_message_broker_redis_roundtrip -m requires_distributed -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1253d3d348333a48d174172dcaff1