### PR TITLE
Document storage simulations and add concurrency tests

### DIFF
--- a/docs/algorithms/storage.md
+++ b/docs/algorithms/storage.md
@@ -38,8 +38,9 @@ second = ctx.db_backend._conn.execute("show tables").fetchall()
 assert first == second
 ```
 
-The [schema simulation][schema-sim] runs this routine multiple times and prints
-`schema stable` when every iteration yields the same table list.
+The [schema simulation][schema-sim] runs this routine against an in-memory
+database and reports `schema stable across 2 runs`, confirming the table list
+remains unchanged.
 
 ## Deterministic setup and teardown
 
@@ -52,9 +53,9 @@ whether or not a pool is in use, ensuring each run starts from a clean slate.
 ## Concurrent eviction
 
 Eviction maintains the RAM budget even when multiple writers persist claims
-simultaneously. The [simulation][evict-sim] spawns threads that insert claims
-while memory usage is forced above the budget. After all threads finish the
-in-memory graph is empty, proving the policy is thread safe.
+simultaneously. The [simulation][evict-sim] forces usage to 1000 MB and, after
+five insertions under an LRU policy, finishes with `nodes remaining after
+eviction: 0`, proving the policy is thread safe.
 
 The [RAM budget simulation][ram-sim] persists claims sequentially while
 memory usage is mocked above the limit, leaving the in-memory graph empty.

--- a/tests/unit/test_storage_manager_concurrency.py
+++ b/tests/unit/test_storage_manager_concurrency.py
@@ -1,0 +1,81 @@
+import threading
+import types
+
+import networkx as nx
+import autoresearch.storage as storage
+from autoresearch.storage import StorageManager
+
+
+def test_setup_thread_safe(monkeypatch):
+    calls: list[int] = []
+    original_setup = storage.setup
+
+    def counted_setup(*args, **kwargs):
+        calls.append(1)
+        return original_setup(*args, **kwargs)
+
+    monkeypatch.setattr(storage, "setup", counted_setup)
+    StorageManager.context.db_backend = None
+    StorageManager.context.graph = None
+    StorageManager.context.rdf_store = None
+
+    contexts: list = []
+
+    def worker() -> None:
+        ctx = StorageManager.setup(db_path=":memory:")
+        contexts.append(ctx)
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(calls) == 1
+    assert len({id(c) for c in contexts}) == 1
+    StorageManager.teardown(remove_db=True)
+
+
+def test_persist_claim_thread_safe(monkeypatch):
+    StorageManager.context.graph = nx.DiGraph()
+    StorageManager.context.rdf_store = object()
+
+    class DummyBackend:
+        def persist_claim(self, claim) -> None:  # pragma: no cover - stub
+            pass
+
+        def update_claim(self, claim, partial_update) -> None:  # pragma: no cover
+            pass
+
+    StorageManager.context.db_backend = DummyBackend()
+
+    monkeypatch.setattr(
+        storage,
+        "ConfigLoader",
+        lambda: types.SimpleNamespace(config=types.SimpleNamespace(ram_budget_mb=0)),
+    )
+    monkeypatch.setattr(StorageManager, "_persist_to_rdf", lambda c: None)
+    monkeypatch.setattr(StorageManager, "_update_rdf_claim", lambda c, p: None)
+    monkeypatch.setattr(StorageManager, "_persist_to_kuzu", lambda c: None)
+    monkeypatch.setattr(StorageManager, "_enforce_ram_budget", lambda b: None)
+    monkeypatch.setattr(StorageManager, "has_vss", lambda: False)
+
+    claims = [
+        {"id": f"c{i}", "type": "fact", "content": f"content {i}"}
+        for i in range(10)
+    ]
+
+    def worker(claim: dict) -> None:
+        StorageManager.persist_claim(claim)
+
+    threads = [threading.Thread(target=worker, args=(cl,)) for cl in claims]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    graph = StorageManager.get_graph()
+    assert graph.number_of_nodes() == len(claims)
+    StorageManager.context.graph.clear()
+    StorageManager.context.db_backend = None
+    StorageManager.context.rdf_store = None


### PR DESCRIPTION
## Summary
- document schema idempotency and eviction simulation results
- add unit tests exercising StorageManager setup and persistence under concurrency

## Testing
- `PATH=$PWD/.venv/bin:$PATH .venv/bin/task check`
- `PATH=$PWD/.venv/bin:$PATH .venv/bin/task verify`


------
https://chatgpt.com/codex/tasks/task_e_68b1256143288333ad55485e9132a39d