### PR TITLE
Add reasoning modes feature and refine behavior test markers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,6 @@ markers =
     requires_distributed: tests that depend on the distributed extra
     redis: tests that interact with Redis
     error_recovery: behavior tests verifying recovery paths
-    reasoning_modes: behavior tests for reasoning strategies
-    user_workflows: end-to-end user scenarios
+    reasoning_modes: behavior tests exploring reasoning strategies
+    user_workflows: behavior tests for end-to-end user workflows
     a2a_mcp: behavior tests for A2A MCP integration

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -26,6 +26,9 @@ These instructions apply to files in the `tests/` directory.
 - Use `error_recovery` for behavior tests verifying recovery paths.
 - Use `reasoning_modes` for behavior tests exploring reasoning strategies.
 - Use `user_workflows` for end-to-end user scenarios.
+- Combine these markers with `requires_*` markers when scenarios need optional
+  extras, e.g. tag Streamlit flows with `requires_ui`.
+- Implement steps with existing fixtures such as `bdd_context` or `cli_runner`.
 - Register any new markers in `pytest.ini`.
 - Include extras corresponding to any other markers as needed.
 - Scenarios tagged `error_recovery` or `reasoning_modes` run with the base

--- a/tests/behavior/features/reasoning_modes.feature
+++ b/tests/behavior/features/reasoning_modes.feature
@@ -1,0 +1,15 @@
+@behavior @reasoning_modes @requires_nlp
+Feature: Basic reasoning modes
+  As a developer
+  I want to capture selected reasoning modes
+  So the orchestrator can adjust execution
+
+  Scenario Outline: selecting a reasoning mode
+    When a reasoning mode "<mode>" is chosen
+    Then bdd_context records mode "<mode>"
+
+    Examples:
+      | mode        |
+      | direct      |
+      | dialectical |
+

--- a/tests/behavior/steps/error_recovery_steps.py
+++ b/tests/behavior/steps/error_recovery_steps.py
@@ -15,6 +15,7 @@ from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.storage import StorageManager
 
 pytest_plugins = ["tests.behavior.steps.common_steps"]
+pytestmark = pytest.mark.requires_git
 
 
 def _assert_error_schema(errors: list[dict]) -> None:

--- a/tests/behavior/steps/reasoning_modes_steps.py
+++ b/tests/behavior/steps/reasoning_modes_steps.py
@@ -1,0 +1,19 @@
+import pytest
+from pytest_bdd import scenarios, when, then, parsers
+
+from autoresearch.orchestration import ReasoningMode
+
+pytest_plugins = ["tests.behavior.steps.common_steps"]
+pytestmark = pytest.mark.requires_nlp
+
+scenarios("../features/reasoning_modes.feature")
+
+
+@when(parsers.parse('a reasoning mode "{mode}" is chosen'))
+def choose_mode(bdd_context, mode):
+    bdd_context["mode"] = ReasoningMode(mode)
+
+
+@then(parsers.parse('bdd_context records mode "{mode}"'))
+def record_mode(bdd_context, mode):
+    assert bdd_context.get("mode") == ReasoningMode(mode)

--- a/tests/behavior/steps/user_workflows_steps.py
+++ b/tests/behavior/steps/user_workflows_steps.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest_bdd import scenario
 
 pytest_plugins = [
@@ -6,11 +7,13 @@ pytest_plugins = [
 ]
 
 
+@pytest.mark.requires_git
 @scenario("../features/user_workflows.feature", "CLI search completes successfully")
 def test_cli_workflow(bdd_context):
     assert bdd_context["result"].exit_code == 0
 
 
+@pytest.mark.requires_git
 @scenario(
     "../features/user_workflows.feature",
     "CLI search with invalid backend reports error",
@@ -19,6 +22,7 @@ def test_cli_workflow_invalid_backend(bdd_context):
     assert bdd_context["result"].exit_code != 0
 
 
+@pytest.mark.requires_ui
 @scenario(
     "../features/user_workflows.feature",
     "Streamlit interface displays results",


### PR DESCRIPTION
## Summary
- add dedicated reasoning modes feature with required steps
- tag behavior step modules with appropriate `requires_*` markers
- document new markers in `pytest.ini` and testing AGENTS guidelines

## Testing
- `task check`
- `task verify` *(fails: task check-coverage-docs exit status 1)*


------
https://chatgpt.com/codex/tasks/task_e_68b12551d59c8333b86e4fa8da15c709