### PR TITLE
Add token budgeting proof and orchestration unit tests

### DIFF
--- a/docs/algorithms/orchestration.md
+++ b/docs/algorithms/orchestration.md
@@ -89,6 +89,35 @@ return state.synthesize()
 - The final state therefore contains the set ``{c_1, ..., c_n}`` regardless of
   ``p``. Each claim appears once because no group is processed twice.
 
+## Token budgeting simulation
+
+1. Start with a budget ``b`` and a query of ``q`` tokens.
+2. If the orchestration loops ``l`` times, divide ``b`` by ``l`` to
+   distribute tokens across loops.
+3. Clamp the budget to ``[q + buffer, q * f]`` where ``f`` is the adaptive
+   maximum factor and ``buffer`` a safety margin.
+4. The adjusted budget bounds token usage while scaling with query size and
+   loop count.
+
+Pseudo-code:
+
+```
+budget //= max(1, loops)
+budget = min(budget, q * factor)
+budget = max(budget, q + buffer)
+```
+
+### Proof of bounds
+
+- Division by ``max(1, l)`` ensures each loop receives at most ``b / l``
+  tokens.
+- The ``min`` operation caps usage at ``q * f``, so the budget never exceeds
+  the scaled query length.
+- The ``max`` operation enforces a floor of ``q + buffer`` when the initial
+  budget is too small.
+- Therefore the final budget lies in ``[q + buffer, q * f]`` and the sum of
+  per-loop allocations does not exceed ``b``.
+
 These simulations confirm that three critical failures trip the breaker and
 that parallel merging preserves one claim per group regardless of scheduling
 order.

--- a/tests/unit/orchestration/test_budgeting_algorithm.py
+++ b/tests/unit/orchestration/test_budgeting_algorithm.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+
+from autoresearch.orchestration.budgeting import _apply_adaptive_token_budget
+
+
+def test_budget_scaled_by_loops_and_limits() -> None:
+    config = SimpleNamespace(token_budget=300, loops=3, adaptive_max_factor=20)
+    _apply_adaptive_token_budget(config, "one two three four")
+    assert config.token_budget == 80
+
+
+def test_budget_minimum_buffer_applied() -> None:
+    config = SimpleNamespace(token_budget=1, loops=1, adaptive_min_buffer=10)
+    _apply_adaptive_token_budget(config, "a b c d e")
+    assert config.token_budget == 15
+
+
+def test_budget_unchanged_within_bounds() -> None:
+    config = SimpleNamespace(token_budget=50, loops=1)
+    _apply_adaptive_token_budget(config, "a b c d e")
+    assert config.token_budget == 50

--- a/tests/unit/orchestration/test_utils_confidence.py
+++ b/tests/unit/orchestration/test_utils_confidence.py
@@ -1,0 +1,27 @@
+import autoresearch.orchestration.utils as utils
+from autoresearch.models import QueryResponse
+
+
+def test_calculate_confidence_rewards_signal() -> None:
+    resp = QueryResponse(
+        answer="",
+        citations=[{"id": i} for i in range(3)],
+        reasoning=["r"] * 10,
+        metrics={"token_usage": {"total": 30, "max_tokens": 50}},
+    )
+    score = utils.calculate_result_confidence(resp)
+    assert score == 0.85
+
+
+def test_calculate_confidence_penalties() -> None:
+    resp = QueryResponse(
+        answer="",
+        citations=[],
+        reasoning=[],
+        metrics={
+            "token_usage": {"total": 100, "max_tokens": 50},
+            "errors": [1, 2],
+        },
+    )
+    score = utils.calculate_result_confidence(resp)
+    assert score == 0.2


### PR DESCRIPTION
## Summary
- expand orchestration algorithm docs with a token budgeting proof
- add unit tests for adaptive token budgeting and result confidence helpers

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run coverage run --source=src/autoresearch/orchestration -m pytest tests/unit/orchestration/test_budgeting_algorithm.py tests/unit/orchestration/test_utils_confidence.py --confcutdir=tests/unit/orchestration`
- `uv run coverage report`
- `uv run mkdocs build`
- `uv run python scripts/orchestration_sim.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1255bcb1c8333906a6887fbf6099a