### PR TITLE
Add search ranking and retry simulations with docs

### DIFF
--- a/docs/algorithms/search.md
+++ b/docs/algorithms/search.md
@@ -12,11 +12,28 @@ proven monotonic: increasing any component increases the final
 relevance. Weight normalization ensures convergence as detailed in
 [relevance_ranking.md](relevance_ranking.md).
 
+## Ranking convergence
+
+The
+[ranking_convergence.py](../../src/autoresearch/search/ranking_convergence.py)
+simulation ranks sample documents multiple times. The ordering stabilizes
+after the first pass, demonstrating convergence of the weighted relevance
+formula.
+
 ## Query expansion convergence
 
 A simple simulation iteratively expands queries using stored entities.
 After an initial enrichment step, further expansions return the same
 string, indicating the process converges.
+
+## Retry algorithm
+
+`get_http_session` configures a pooled session with a
+[Retry](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.retry.Retry)
+strategy using three attempts and exponential backoff. The
+[simulate_rate_limit.py](../../src/autoresearch/search/simulate_rate_limit.py)
+tool models backoff delays of 0.2, 0.4, and 0.8 seconds for successive
+retries, illustrating graceful handling of transient server errors.
 
 ## HTTP session behavior
 

--- a/src/autoresearch/search/ranking_convergence.py
+++ b/src/autoresearch/search/ranking_convergence.py
@@ -1,0 +1,73 @@
+"""Simulation for convergence of search ranking."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+
+@dataclass(frozen=True)
+class DocScores:
+    """Component scores used during ranking.
+
+    Args:
+        bm25: Lexical match score.
+        semantic: Embedding similarity score.
+        credibility: Domain credibility score.
+    """
+
+    bm25: float
+    semantic: float
+    credibility: float
+
+
+def _validate_weights(weights: Sequence[float]) -> None:
+    """Ensure ranking weights sum to 1.0."""
+    if not math.isclose(sum(weights), 1.0, abs_tol=1e-9):
+        raise ValueError("weights must sum to 1.0")
+
+
+def relevance_scores(docs: Iterable[DocScores], weights: Sequence[float]) -> List[float]:
+    """Compute relevance scores from component scores.
+
+    Args:
+        docs: Iterable of :class:`DocScores`.
+        weights: Tuple of BM25, semantic, and credibility weights.
+
+    Returns:
+        List[float]: Weighted relevance scores.
+    """
+    _validate_weights(weights)
+    w_bm25, w_sem, w_cred = weights
+    return [
+        d.bm25 * w_bm25 + d.semantic * w_sem + d.credibility * w_cred
+        for d in docs
+    ]
+
+
+def simulate_ranking_convergence(
+    docs: Sequence[DocScores],
+    weights: Sequence[float],
+    iterations: int = 3,
+) -> List[List[int]]:
+    """Rank documents repeatedly to illustrate convergence.
+
+    Args:
+        docs: Sequence of documents with component scores.
+        weights: Ranking weights that must sum to 1.0.
+        iterations: Number of ranking rounds to perform.
+
+    Returns:
+        List[List[int]]: Index orderings for each iteration.
+    """
+    orderings: List[List[int]] = []
+    current_docs = list(docs)
+    indices = list(range(len(docs)))
+    for _ in range(iterations):
+        scores = relevance_scores(current_docs, weights)
+        ordering = sorted(range(len(current_docs)), key=lambda i: scores[i], reverse=True)
+        orderings.append([indices[i] for i in ordering])
+        current_docs = [current_docs[i] for i in ordering]
+        indices = [indices[i] for i in ordering]
+    return orderings

--- a/src/autoresearch/search/simulate_rate_limit.py
+++ b/src/autoresearch/search/simulate_rate_limit.py
@@ -1,0 +1,18 @@
+"""Model exponential backoff delays for HTTP retries."""
+
+from __future__ import annotations
+
+from typing import List
+
+
+def simulate_rate_limit(backoff_factor: float = 0.2, max_retries: int = 3) -> List[float]:
+    """Return delays for successive retries using exponential backoff.
+
+    Args:
+        backoff_factor: Base delay in seconds.
+        max_retries: Number of retry attempts to model.
+
+    Returns:
+        List[float]: Delay before each retry attempt.
+    """
+    return [backoff_factor * (2**i) for i in range(max_retries)]

--- a/tests/unit/search/test_ranking_convergence_simulation.py
+++ b/tests/unit/search/test_ranking_convergence_simulation.py
@@ -1,0 +1,41 @@
+import sys
+import pytest
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from pathlib import Path
+
+
+def _load_module():
+    root = Path(__file__).resolve().parents[3]
+    path = root / "src/autoresearch/search/ranking_convergence.py"
+    name = "src.autoresearch.search.ranking_convergence"
+    loader = SourceFileLoader(name, str(path))
+    spec = spec_from_loader(name, loader)
+    module = module_from_spec(spec)
+    module.__package__ = "src.autoresearch.search"
+    sys.modules[name] = module
+    loader.exec_module(module)
+    return module
+
+
+@pytest.mark.unit
+def test_ranking_converges():
+    module = _load_module()
+    Doc = module.DocScores
+    docs = [
+        Doc(0.2, 0.5, 0.3),
+        Doc(0.1, 0.7, 0.2),
+        Doc(0.9, 0.1, 0.0),
+    ]
+    weights = (0.4, 0.4, 0.2)
+    orderings = module.simulate_ranking_convergence(docs, weights, iterations=3)
+    assert orderings[0] == orderings[1] == orderings[2]
+
+
+@pytest.mark.unit
+def test_invalid_weights_raise():
+    module = _load_module()
+    Doc = module.DocScores
+    docs = [Doc(0.1, 0.2, 0.7)]
+    with pytest.raises(ValueError):
+        module.simulate_ranking_convergence(docs, (0.5, 0.5, 0.5))

--- a/tests/unit/search/test_simulate_rate_limit.py
+++ b/tests/unit/search/test_simulate_rate_limit.py
@@ -1,0 +1,30 @@
+import sys
+import pytest
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from pathlib import Path
+
+
+def _load_module():
+    root = Path(__file__).resolve().parents[3]
+    path = root / "src/autoresearch/search/simulate_rate_limit.py"
+    name = "src.autoresearch.search.simulate_rate_limit"
+    loader = SourceFileLoader(name, str(path))
+    spec = spec_from_loader(name, loader)
+    module = module_from_spec(spec)
+    module.__package__ = "src.autoresearch.search"
+    sys.modules[name] = module
+    loader.exec_module(module)
+    return module
+
+
+@pytest.mark.unit
+def test_default_backoff():
+    mod = _load_module()
+    assert mod.simulate_rate_limit() == [0.2, 0.4, 0.8]
+
+
+@pytest.mark.unit
+def test_custom_backoff():
+    mod = _load_module()
+    assert mod.simulate_rate_limit(backoff_factor=1.0, max_retries=4) == [1.0, 2.0, 4.0, 8.0]


### PR DESCRIPTION
## Summary
- document ranking convergence and retry strategy in search algorithm guide
- add ranking and rate-limit simulations for search package
- test convergence and retry delay calculations

## Testing
- `task check`
- `task verify` *(fails: scripts/check_coverage_docs.py exit status 1)*
- `uv run pytest tests/unit/search/test_ranking_convergence_simulation.py tests/unit/search/test_simulate_rate_limit.py`
- `uv run mkdocs build` *(fails: Config value 'plugins': The "mkdocstrings" plugin is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b125a3352c8333a438e15edc039337