### PR TITLE
Use dev-minimal for `task check` and clarify testing modes

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,8 +56,7 @@ tasks:
     # Minimal validation for quick feedback. Skips slow tests and scenarios
     # requiring optional UI (`.[ui]`) or VSS (`.[vss]`) extras.
     cmds:
-      - uv sync --extra dev-minimal --extra test
-      - task check-env
+      - uv sync --extra dev-minimal
       - uv run flake8 src tests
       - uv run mypy src --exclude src/autoresearch/distributed
       - uv run python scripts/check_spec_tests.py

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -20,14 +20,16 @@ Tests are organized into four categories:
 
 Two installation strategies support different workflows:
 
-- **Minimal:** `task check` syncs only the `dev-minimal` and `test` extras for
-  linting and core tests. Add optional features with
+- **Minimal:** `task check` runs linting, type checks, and a fast targeted
+  subset. It syncs only the `dev-minimal` extra. Add optional features with
   `task install EXTRAS="nlp ui"` choosing from `analysis`, `distributed`,
   `git`, `llm`, `minimal`, `nlp`, `parsers`, `ui`, and `vss`.
-- **Full:** `task verify` expects the `dev` and `test` extras plus any
-  targeted-test requirements such as `parsers` or `git`. Install them with
-  `uv sync --extra dev --extra test` and append extras as needed for
-  integration scenarios.
+- **Full:** `task verify` requires the `dev` and `test` extras and executes the
+  targeted suite with coverage. Install them with `uv sync --extra dev --extra
+  test` and append extras as needed for integration scenarios.
+
+`task check` offers fast feedback, while `task verify` enforces coverage and is
+expected before committing.
 
 Redis is an optional dependency but required for distributed tests. The
 integration suite skips those tests automatically when Redis is missing.


### PR DESCRIPTION
## Summary
- Run `task check` with only the `dev-minimal` extra and a trimmed unit test subset for faster feedback.
- Document differences between `task check` and `task verify`, noting coverage expectations and environment requirements.

## Testing
- `task check`


------
https://chatgpt.com/codex/tasks/task_e_68b125c56c608333a17ae37aaa9aadcc