### PR TITLE
docs: note coverage failure and log dry run

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -19,5 +19,5 @@ Not run.
 Not run.
 
 ## Coverage
-Total coverage is **100%**.
+Total coverage is **0%**.
 [speed-up-task-check]: issues/speed-up-task-check-and-reduce-dependency-footprint.md

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -42,6 +42,8 @@ Planned for **2026-06-15**. Dependency pins: `fastapi>=0.115.12` and
   [installation](installation.md).
 - VSS search and some tests require network access; see
   [DuckDB compatibility](duckdb_compatibility.md).
+- `task coverage` fails with an ImportError (`InMemorySpanExporter`), so
+  coverage is treated as 0%.
 
 For installation and usage instructions see the [README](../README.md).
 
@@ -75,7 +77,8 @@ Successfully built autoresearch-0.1.0a1.tar.gz and autoresearch-0.1.0a1-py3-none
 
 ### Test Publishing
 
-Dry-run upload using ``scripts/publish_dev.py --dry-run --repository testpypi``:
+Dry-run upload using ``scripts/publish_dev.py --dry-run --repository testpypi``
+on 2025-08-29 produced:
 
 ```text
 * Creating isolated environment: venv+pip...
@@ -92,3 +95,4 @@ Dry-run upload using ``scripts/publish_dev.py --dry-run --repository testpypi``:
 Successfully built autoresearch-0.1.0a1.tar.gz and autoresearch-0.1.0a1-py3-none-any.whl
 Dry run selected; skipping upload
 ```
+The build completed and, as expected for a dry run, the upload was skipped.

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -69,8 +69,8 @@ while packaging tasks are resolved.
 - [ ] Integration test suite passes
   ([stabilize-integration-tests.md](
   ../issues/archive/stabilize-integration-tests.md))
-- [ ] Coverage gates target **90%** total coverage; current coverage is **100%**
-  while `STATUS.md` lists **91%** (see
+- [ ] Coverage gates target **90%** total coverage; current coverage is **0%**
+  and `STATUS.md` lists **0%** (see
   [add-coverage-gates-and-regression-checks.md](
   ../issues/archive/add-coverage-gates-and-regression-checks.md))
 - [x] Validate ranking algorithms and agent coordination
@@ -87,7 +87,8 @@ These tasks completed in order: environment bootstrap → packaging verification
 ### Prerequisites for tagging 0.1.0a1
 
 - `flake8` and `mypy` pass, but several unit and integration tests still fail.
-- Current coverage is **100%**, but documentation still lists **91%**.
+- Current coverage is **0%** after an ImportError in `task coverage`; documentation
+  reflects this failure.
 - TestPyPI upload returns HTTP 403, so packaging needs a retry.
 
 The **0.1.0a1** date is re-targeted for **June 15, 2026** and the release

--- a/issues/fix-coverage-importerror-inmemoryspanexporter.md
+++ b/issues/fix-coverage-importerror-inmemoryspanexporter.md
@@ -1,0 +1,17 @@
+# Fix coverage task ImportError
+
+## Context
+`uv run task coverage` fails with `ImportError: cannot import name
+'InMemorySpanExporter'` from `opentelemetry.sdk.trace.export`. This blocks the
+full coverage run and forces documentation to record 0% coverage.
+
+## Dependencies
+- none
+
+## Acceptance Criteria
+- `uv run task coverage` completes without the ImportError.
+- `scripts/update_coverage_docs.py` records the actual coverage percentage.
+- Issue is archived after coverage succeeds.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- record coverage failure and sync STATUS.md and release plan at 0%
- note coverage ImportError in release notes and track in new issue
- document TestPyPI dry-run output

## Testing
- `uv run task check`
- `uv run task verify`
- `uv run task coverage` *(fails: ImportError: InMemorySpanExporter)*
- `uv run scripts/update_coverage_docs.py --value 0`
- `uv run scripts/publish_dev.py --dry-run --repository testpypi`
- `uv run mkdocs build` *(warnings about missing links)*

------
https://chatgpt.com/codex/tasks/task_e_68b12fc302408333b98004768c9fc005