### PR TITLE
feat: add deterministic orchestration simulations

### DIFF
--- a/docs/algorithms/orchestration.md
+++ b/docs/algorithms/orchestration.md
@@ -14,6 +14,13 @@ execution.
 4. After the cooldown passes, the breaker moves to half-open. The next
    success closes it and resets counters.
 
+Formally, the breaker is a deterministic finite state machine with
+states ``S = {closed, open, half-open}`` and transition function
+``\delta(s, e, t)``.  The function examines the current state ``s``, the
+incoming event ``e``, and the clock ``t``.  Because ``\delta`` is pure
+and the time steps are explicit, applying the same event sequence always
+produces the same state trajectory.
+
 Pseudo-code:
 
 ```
@@ -66,6 +73,13 @@ on_success():
 3. Completed group results update a shared query state in the order they
    finish.
 4. A synthesizer aggregates the state into a final response.
+
+Let ``C_i`` denote the claim set returned by group ``i``.  The update
+step computes ``U := U \cup C_i`` for each finished group.  Set union is
+associative and commutative, so the order in which groups finish does
+not affect the final ``U``.  Determinism therefore follows from the
+functional nature of ``collect_result`` and the absence of shared mutable
+state outside ``U``.
 
 Pseudo-code:
 
@@ -132,6 +146,8 @@ order.
   exercises the merging invariant under concurrent execution.
 - Unit test `tests/unit/orchestration/test_parallel_execute.py`
   covers mixed success, error, and timeout paths.
+- Script `scripts/orchestration_sim.py` replays both simulations to
+  demonstrate deterministic behavior.
 
 ### Assumptions
 

--- a/tests/unit/orchestration/test_orchestration_simulations.py
+++ b/tests/unit/orchestration/test_orchestration_simulations.py
@@ -1,0 +1,28 @@
+import sys
+from unittest.mock import patch
+
+from scripts.orchestration_sim import (
+    circuit_breaker_sim,
+    main,
+    parallel_execution_sim,
+)
+
+
+def test_circuit_breaker_sim_is_deterministic():
+    assert circuit_breaker_sim() == circuit_breaker_sim()
+
+
+def test_parallel_execution_sim_is_deterministic():
+    first = parallel_execution_sim()
+    second = parallel_execution_sim()
+    assert first == second
+    assert set(first.keys()) == {"A", "B", "C"}
+
+
+def test_cli_runs_modes(capsys):
+    with patch.object(sys, "argv", ["orchestration_sim.py", "circuit"]):
+        main()
+        assert "open" in capsys.readouterr().out
+    with patch.object(sys, "argv", ["orchestration_sim.py", "parallel"]):
+        main()
+        assert "claim-A" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- formalize circuit breaker as deterministic state machine and parallel merge via set union
- add `orchestration_sim.py` script to replay deterministic breaker and parallel simulations
- test simulations and CLI pathways for deterministic behavior

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run mkdocs build` *(fails: No such file or directory)*
- `uv run coverage run --rcfile=/dev/null --source=scripts -m pytest tests/unit/orchestration/test_orchestration_simulations.py`
- `uv run coverage report --rcfile=/dev/null -m scripts/orchestration_sim.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1b41befc08333863944b32b9542e9