### PR TITLE
Add ranking proofs and session recovery tests

### DIFF
--- a/docs/algorithms/search.md
+++ b/docs/algorithms/search.md
@@ -12,13 +12,23 @@ proven monotonic: increasing any component increases the final
 relevance. Weight normalization ensures convergence as detailed in
 [relevance_ranking.md](relevance_ranking.md).
 
+### Proof of monotonic relevance
+
+Let the score for document *d* be
+$S_d = w_b B_d + w_s S_d + w_c C_d$ where each weight $w_*$ is
+non\-negative and $w_b + w_s + w_c = 1$.
+For any component, e.g. $B_d$, the partial derivative
+$\partial S_d/\partial B_d = w_b \ge 0$.
+Thus increasing $B_d$ strictly increases $S_d$ when $w_b > 0$.
+The same argument applies to $S_d$ and $C_d$, establishing monotonicity.
+
 ## Ranking convergence
 
 The
-[ranking_convergence.py](../../src/autoresearch/search/ranking_convergence.py)
-simulation ranks sample documents multiple times. The ordering stabilizes
-after the first pass, demonstrating convergence of the weighted relevance
-formula.
+[ranking_convergence.py](../../scripts/ranking_convergence.py)
+simulation ranks sample documents repeatedly. The ordering stabilizes
+after the first pass, demonstrating convergence of the weighted
+relevance formula.
 
 ## Query expansion convergence
 
@@ -41,3 +51,11 @@ All network requests share a pooled `requests.Session`. The session
 mounts an `HTTPAdapter` configured for connection reuse and up to three
 retries on common server errors. `close_http_session` releases resources
 when search work completes.
+
+### Proof of session recovery
+
+The global session is stored in `_http_session`. When
+`close_http_session` runs, it sets this variable to `None`. A subsequent
+call to `get_http_session` detects the `None` value, constructs a fresh
+session, and registers a cleanup hook. Therefore the system recovers
+from session closure or transient failures without leaking resources.

--- a/tests/integration/test_search_ranking_convergence.py
+++ b/tests/integration/test_search_ranking_convergence.py
@@ -1,0 +1,18 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.integration
+def test_ranking_convergence_script() -> None:
+    """The ranking convergence simulation reports completion."""
+    script = Path(__file__).resolve().parents[2] / "scripts" / "ranking_convergence.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--items", "3"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "converged in" in result.stdout

--- a/tests/integration/test_search_session_recovery.py
+++ b/tests/integration/test_search_session_recovery.py
@@ -1,0 +1,15 @@
+import pytest
+
+from autoresearch.search import Search
+
+
+@pytest.mark.integration
+def test_session_recovery_integration() -> None:
+    """Search recreates HTTP session after closure."""
+    session1 = Search.get_http_session()
+    Search.close_http_session()
+    session2 = Search.get_http_session()
+    try:
+        assert session1 is not session2
+    finally:
+        Search.close_http_session()

--- a/tests/unit/search/test_ranking_formula.py
+++ b/tests/unit/search/test_ranking_formula.py
@@ -2,6 +2,7 @@ import pytest
 
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel, SearchConfig
+from autoresearch.errors import ConfigError
 from autoresearch.search import Search
 
 
@@ -40,6 +41,32 @@ def test_rank_results_weighted_combination(monkeypatch: pytest.MonkeyPatch) -> N
         merged = bm25[i] * 0.3 + semantic[i] * 0.4
         scores.append(merged + credibility[i] * 0.3)
     assert [r["title"] for r in ranked] == ["B", "A"]
-    assert [r["relevance_score"] for r in ranked] == pytest.approx(
-        sorted(scores, reverse=True)
+    assert [r["relevance_score"] for r in ranked] == pytest.approx(sorted(scores, reverse=True))
+
+
+def test_rank_results_invalid_weights(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid weight sums raise ConfigError."""
+    cfg = ConfigModel(
+        search=SearchConfig(
+            bm25_weight=0.3,
+            semantic_similarity_weight=0.4,
+            source_credibility_weight=0.3,
+            use_bm25=True,
+            use_semantic_similarity=True,
+            use_source_credibility=True,
+        )
     )
+    cfg.search.bm25_weight = 0.6
+    cfg.search.semantic_similarity_weight = 0.3
+    cfg.search.source_credibility_weight = 0.2
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    ConfigLoader()._config = None
+    monkeypatch.setattr(Search, "calculate_bm25_scores", staticmethod(lambda q, r: [1.0]))
+    monkeypatch.setattr(
+        Search,
+        "calculate_semantic_similarity",
+        lambda self, q, r, query_embedding=None: [1.0],
+    )
+    monkeypatch.setattr(Search, "assess_source_credibility", lambda self, r: [1.0])
+    with pytest.raises(ConfigError):
+        Search.rank_results("q", [{"url": "https://a"}])

--- a/tests/unit/search/test_session_retry.py
+++ b/tests/unit/search/test_session_retry.py
@@ -1,4 +1,8 @@
+import pytest
+
 from autoresearch.search import Search
+
+pytestmark = [pytest.mark.unit]
 
 
 def test_http_session_retries_and_reuse() -> None:
@@ -9,3 +13,14 @@ def test_http_session_retries_and_reuse() -> None:
     adapter = session1.get_adapter("https://")
     assert adapter.max_retries.total >= 3
     Search.close_http_session()
+
+
+def test_http_session_recovery() -> None:
+    """A new session is created after the previous one is closed."""
+    session1 = Search.get_http_session()
+    Search.close_http_session()
+    session2 = Search.get_http_session()
+    try:
+        assert session1 is not session2
+    finally:
+        Search.close_http_session()


### PR DESCRIPTION
## Summary
- Document proofs for ranking monotonicity and HTTP session recovery
- Add unit and integration tests covering session recovery and ranking convergence

## Testing
- `uv run flake8 docs/algorithms/search.md tests/unit/search/test_ranking_formula.py tests/unit/search/test_session_retry.py tests/integration/test_search_ranking_convergence.py tests/integration/test_search_session_recovery.py`
- `uv run mkdocs build`
- `uv run pytest tests/unit/search/test_session_retry.py tests/unit/search/test_ranking_formula.py tests/integration/test_search_session_recovery.py tests/integration/test_search_ranking_convergence.py --cov=src/autoresearch/search --cov-report=term`
- `uv run task check` *(fails: Failed to spawn: `task`)*
- `uv run task verify` *(fails: Failed to spawn: `task`)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b4304c408333af014059f62a51cd