### PR TITLE
Document distributed workflows and tag distributed tests

### DIFF
--- a/docs/algorithms/distributed_workflows.md
+++ b/docs/algorithms/distributed_workflows.md
@@ -1,27 +1,41 @@
 # Distributed Workflows
 
-Redis-backed workflows coordinate agents across processes using a simple
-list queue (see [broker.py](../../src/autoresearch/distributed/broker.py)).
-Each call to `publish` serializes the message to JSON and appends it to the
-queue with `RPUSH`, preserving order. Workers block with `BLPOP`, ensuring
-at-most-one consumer retrieves each entry and maintaining FIFO semantics.
+## Coordination
+
+Redis-backed workflows coordinate agents across processes using a list
+queue (see [broker.py](../../src/autoresearch/distributed/broker.py)). Each
+call to `publish` serializes the message to JSON and appends it with
+`RPUSH`, preserving order. Workers block with `BLPOP` so at most one
+consumer retrieves each entry and FIFO semantics hold.
 
 ## Latency and Throughput
 
 Queue operations run in `O(1)` time, so latency is dominated by network
-hops. Given average network round trip `t_n` and payload size `s`, expected
-enqueue delay is `t_n`, while dequeue waits `t_n` plus any blocking time
-until data arrives.
+hops. Given average network round trip `t_n` and payload size `s`, enqueue
+delay is `t_n`, while dequeue waits `t_n` plus any blocking time until data
+arrives.
 
 ## Failure Recovery
 
-Connection failures raise a `redis.exceptions.RedisError`. The error
-recovery workflow retries the operation and surfaces a warning when the
-client remains unavailable.
+Connection failures raise `redis.exceptions.RedisError`. The error recovery
+workflow retries the operation and surfaces a warning when the client
+remains unavailable.
+
+## Checklist
+
+Trace these behaviors against the [distributed specification][spec].
+
+- [ ] Message queues perform `O(1)` operations and scale linearly with
+  workers.
+- [ ] `ProcessExecutor` schedules `A` agents over `L` loops in `O(L * A)`
+  time.
+- [ ] On worker failure, shutdown drains `M` messages across `P` workers in
+  `O(M / P + P)` time without losing data.
 
 ## Related Issue
 
 See [add-redis-distributed-workflows-specification][issue] for the
 discussion that introduced this specification.
 
+[spec]: ../specs/distributed.md#acceptance-criteria
 [issue]: ../../issues/add-redis-distributed-workflows-specification.md

--- a/tests/behavior/features/distributed_execution.feature
+++ b/tests/behavior/features/distributed_execution.feature
@@ -1,3 +1,4 @@
+@behavior @requires_distributed
 Feature: Distributed Execution
   As a developer
   I want to run queries across multiple processes
@@ -5,6 +6,8 @@ Feature: Distributed Execution
 
   Background:
     Given mock agents that persist claims
+
+  # Spec: docs/algorithms/distributed_workflows.md - distributed coordination
 
   Scenario: Run distributed query with Ray executor
     Given a distributed configuration using Ray

--- a/tests/behavior/steps/distributed_execution_steps.py
+++ b/tests/behavior/steps/distributed_execution_steps.py
@@ -16,6 +16,7 @@ from autoresearch.models import QueryResponse
 
 # Scenarios
 @pytest.mark.slow
+@pytest.mark.requires_distributed
 @scenario("../features/distributed_execution.feature", "Run distributed query with Ray executor")
 def test_ray_executor(bdd_context):
     """Run distributed query with Ray executor."""
@@ -23,6 +24,7 @@ def test_ray_executor(bdd_context):
 
 
 @pytest.mark.slow
+@pytest.mark.requires_distributed
 @scenario("../features/distributed_execution.feature", "Run distributed query with multiprocessing")
 def test_process_executor(bdd_context):
     """Run distributed query with multiprocessing."""

--- a/tests/behavior/steps/error_recovery_redis_steps.py
+++ b/tests/behavior/steps/error_recovery_redis_steps.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest_bdd import given, scenario, then, when
 
 
@@ -26,6 +27,7 @@ def handle_redis_error(bdd_context) -> None:
     assert bdd_context.get("redis_error") is not None
 
 
+@pytest.mark.requires_distributed
 @scenario(
     "../features/error_recovery_redis.feature",
     "Connection failure triggers recovery",


### PR DESCRIPTION
## Summary
- detail coordination, latency, and fault recovery for distributed workflows and add a checklist linked to the distributed spec
- tag distributed execution behavior tests with `@requires_distributed`
- mark redis error recovery behavior test as requiring distributed resources

## Testing
- `uv run mkdocs build`
- `bin/task check`
- `PATH=$PWD/bin:$PATH bin/task verify` *(fails: Coverage mismatch in STATUS.md and docs/release_plan.md)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b439d29c833388bfe08b747cc8c4