### PR TITLE
chore: align extras validation across setup

### DIFF
--- a/issues/audit-setup-script-dependencies.md
+++ b/issues/audit-setup-script-dependencies.md
@@ -6,6 +6,12 @@ missing packages. A comprehensive inventory is needed to ensure `scripts/setup.s
 and the Codex bootstrap script install consistent dependency sets and record
 DuckDB extension paths.
 
+**Extras inventory:** minimal, nlp, ui, vss, parsers, git, distributed, analysis,
+llm, test, full, dev, dev-minimal, build. Both setup scripts install the `dev`
+and `test` extras by default and accept additional extras via `AR_EXTRAS`. The
+environment check now validates all packages from these development and test
+extras.
+
 ## Dependencies
 - [synchronize-codex-and-generic-setup-scripts](synchronize-codex-and-generic-setup-scripts.md)
 - [fix-task-check-dependency-removal-and-extension-bootstrap](archive/fix-task-check-dependency-removal-and-extension-bootstrap.md)

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -3,6 +3,8 @@
 # Codex-only environment bootstrap for this evaluation container; see AGENTS.md
 # for repository-wide guidelines. Do not use or document this script outside the
 # AGENTS.md system. For any other environment, use `./scripts/setup.sh`.
+# Installs the project in editable mode with development and test extras. Use
+# `AR_EXTRAS` to specify additional optional extras.
 set -euo pipefail
 
 START_TIME=$(date +%s)


### PR DESCRIPTION
## Summary
- load dev and test extras from `pyproject.toml` dynamically and verify their packages in `scripts/check_env.py`
- clarify `scripts/codex_setup.sh` installs dev/test extras plus optional `AR_EXTRAS`
- document full extras inventory and validation in `issues/audit-setup-script-dependencies.md`

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run black scripts/check_env.py`
- `uv run flake8 scripts/check_env.py` *(fails: No such file or directory)*
- `uv run python scripts/check_env.py` *(fails: missing packages and Go Task)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c5de77488333850659ea58f746e2