### PR TITLE
Add optional extras markers and tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,9 @@ markers =
     requires_git: tests that depend on the git extra
     requires_nlp: tests needing NLP resources
     requires_distributed: tests that depend on the distributed extra
+    requires_analysis: tests that depend on the analysis extra
+    requires_llm: tests that depend on the llm extra
+    requires_parsers: tests that depend on the parsers extra
     redis: tests that interact with Redis
     error_recovery: behavior tests verifying recovery paths
     reasoning_modes: behavior tests exploring reasoning strategies

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -23,6 +23,12 @@ These instructions apply to files in the `tests/` directory.
   `.[git]` extra.
 - Use `requires_distributed` for tests that depend on Redis or Ray; pair with
   the `.[distributed]` extra.
+- Use `requires_analysis` for tests needing data analysis libraries; pair with
+  the `.[analysis]` extra.
+- Use `requires_llm` for tests requiring heavy LLM dependencies; pair with the
+  `.[llm]` extra.
+- Use `requires_parsers` for tests needing document parsing utilities; pair
+  with the `.[parsers]` extra.
 - Use `error_recovery` for behavior tests verifying recovery paths.
 - Use `reasoning_modes` for behavior tests exploring reasoning strategies.
 - Use `user_workflows` for end-to-end user scenarios.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ pytest_plugins = [
     "tests.fixtures.config",
     "tests.fixtures.storage",
     "tests.fixtures.redis",
+    "tests.fixtures.extras",
     "pytest_httpx",
 ]
 

--- a/tests/fixtures/extras.py
+++ b/tests/fixtures/extras.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+
+def _module_available(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except Exception:
+        return False
+
+
+@pytest.fixture
+def has_ui() -> bool:
+    """Return True if the UI extra is installed."""
+    return _module_available("streamlit")
+
+
+@pytest.fixture
+def has_vss() -> bool:
+    """Return True if the DuckDB VSS extension is available."""
+    return _module_available("duckdb_extension_vss")
+
+
+@pytest.fixture
+def has_git() -> bool:
+    """Return True if GitPython is installed."""
+    return _module_available("git")
+
+
+@pytest.fixture
+def has_analysis() -> bool:
+    """Return True if analysis extras are installed."""
+    return _module_available("polars")
+
+
+@pytest.fixture
+def has_nlp() -> bool:
+    """Return True if NLP extras are installed."""
+    return _module_available("spacy")
+
+
+@pytest.fixture
+def has_llm() -> bool:
+    """Return True if LLM extras are installed."""
+    return _module_available("transformers")
+
+
+@pytest.fixture
+def has_parsers() -> bool:
+    """Return True if parser extras are installed."""
+    return _module_available("pdfminer")

--- a/tests/unit/test_optional_extras.py
+++ b/tests/unit/test_optional_extras.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.requires_ui
+def test_ui_extra(has_ui) -> None:
+    if not has_ui:
+        pytest.skip("ui extra not installed")
+    import streamlit
+
+    assert hasattr(streamlit, "__version__")
+
+
+@pytest.mark.requires_vss
+def test_vss_extra(has_vss) -> None:
+    if not has_vss:
+        pytest.skip("vss extra not installed")
+    import duckdb_extension_vss as vss
+
+    assert hasattr(vss, "__version__")
+
+
+@pytest.mark.requires_git
+def test_git_extra(has_git) -> None:
+    if not has_git:
+        pytest.skip("git extra not installed")
+    import git
+
+    assert hasattr(git, "__version__")
+
+
+@pytest.mark.requires_analysis
+def test_analysis_extra(has_analysis) -> None:
+    if not has_analysis:
+        pytest.skip("analysis extra not installed")
+    import polars
+
+    assert hasattr(polars, "__version__")
+
+
+@pytest.mark.requires_nlp
+def test_nlp_extra(has_nlp) -> None:
+    if not has_nlp:
+        pytest.skip("nlp extra not installed")
+    import spacy
+
+    assert hasattr(spacy, "__version__")
+
+
+@pytest.mark.requires_llm
+def test_llm_extra(has_llm) -> None:
+    if not has_llm:
+        pytest.skip("llm extra not installed")
+    import transformers
+
+    assert hasattr(transformers, "__version__")
+
+
+@pytest.mark.requires_parsers
+def test_parsers_extra(has_parsers) -> None:
+    if not has_parsers:
+        pytest.skip("parsers extra not installed")
+    import pdfminer
+
+    assert hasattr(pdfminer, "__version__")


### PR DESCRIPTION
## Summary
- document analysis, llm, and parsers markers
- add fixtures and tests for optional extras
- register extras fixtures with pytest

## Testing
- `uv run flake8 tests/fixtures/extras.py tests/unit/test_optional_extras.py tests/conftest.py`
- `uv run pytest tests/unit/test_optional_extras.py -q`
- `task check`

------
https://chatgpt.com/codex/tasks/task_e_68b1c5ef97948333be08f3f57aad6d1d