### PR TITLE
refactor: unify setup scripts

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,6 +16,8 @@ if ! command -v python3 >/dev/null 2>&1; then
     exit 1
 fi
 
+ensure_uv
+
 PYTHON_BIN=$(command -v python3)
 PYTHON_VERSION=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
 if ! python3 - <<'EOF' >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- centralize retry and uv bootstrap helpers in `setup_common.sh`
- ensure universal `setup.sh` installs uv before environment work
- streamline Codex bootstrap to rely on shared logic and avoid duplication

## Testing
- `./.venv/bin/task check`
- `./.venv/bin/task verify` *(fails: No package metadata was found for GitPython, bertopic, cibuildwheel, duckdb-extension-vss, fakeredis, freezegun, hypothesis, pdfminer-six, pytest-bdd, python-docx, sentence-transformers, spacy, transformers, types-networkx, types-protobuf, types-requests, types-tabulate)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cb2945188333aec1e2b704fe3a7e