### PR TITLE
Refactor setup scripts into platform hierarchy

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -27,21 +27,11 @@ LOG_FILE="codex_setup.log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 set -x
 
-source "$(dirname "$0")/setup_common.sh"
+SCRIPT_DIR="$(dirname "$0")"
+source "$SCRIPT_DIR/setup_common.sh"
 
-# Install system packages
-export DEBIAN_FRONTEND=noninteractive
-retry 3 apt-get update
-retry 3 apt-get install -y \
-    build-essential python3-dev python3-venv cmake pkg-config git \
-    libssl-dev libffi-dev libxml2-dev libargon2-dev libblas-dev \
-    liblapack-dev libopenblas-dev liblmdb-dev libz3-dev \
-    libcurl4-openssl-dev
-retry 3 apt-get clean
-rm -rf /var/lib/apt/lists/*
-
-# Delegate remaining setup to the universal script
-AR_EXTRAS="${AR_EXTRAS:-}" ./scripts/setup_universal.sh
+# Delegate platform setup to the Linux installer
+AR_EXTRAS="${AR_EXTRAS:-}" "$SCRIPT_DIR/setup_linux.sh"
 
 # Codex-specific offline model preparation
 if uv pip show sentence-transformers >/dev/null 2>&1; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 # Usage: AR_EXTRAS="nlp ui" ./scripts/setup.sh
-# Generic entry point that delegates to the universal setup script.
+# Detects the host platform and delegates to the appropriate setup script.
 set -euo pipefail
-"$(dirname "$0")/setup_universal.sh" "$@"
+
+SCRIPT_DIR="$(dirname "$0")"
+case "$(uname -s)" in
+    Linux*)
+        "$SCRIPT_DIR/setup_linux.sh" "$@"
+        ;;
+    Darwin*)
+        "$SCRIPT_DIR/setup_macos.sh" "$@"
+        ;;
+    *)
+        echo "Unsupported platform; running universal setup." >&2
+        "$SCRIPT_DIR/setup_universal.sh" "$@"
+        ;;
+esac
+

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Usage: AR_EXTRAS="nlp ui" ./scripts/setup_linux.sh
+# Linux-specific environment bootstrap; installs OS packages when possible and
+# delegates to the universal setup script.
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "This script is intended for Linux hosts." >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(dirname "$0")"
+source "$SCRIPT_DIR/setup_common.sh"
+
+if command -v apt-get >/dev/null 2>&1; then
+    if [[ "$(id -u)" -ne 0 ]]; then
+        echo "Skipping system package installation; run as root if required." >&2
+    else
+        export DEBIAN_FRONTEND=noninteractive
+        retry 3 apt-get update
+        retry 3 apt-get install -y \
+            build-essential python3-dev python3-venv cmake pkg-config git \
+            libssl-dev libffi-dev libxml2-dev libargon2-dev libblas-dev \
+            liblapack-dev libopenblas-dev liblmdb-dev libz3-dev \
+            libcurl4-openssl-dev
+        retry 3 apt-get clean
+        rm -rf /var/lib/apt/lists/*
+    fi
+else
+    echo "apt-get not found; please install required packages manually." >&2
+fi
+
+AR_EXTRAS="${AR_EXTRAS:-}" "$SCRIPT_DIR/setup_universal.sh" "$@"
+

--- a/scripts/setup_macos.sh
+++ b/scripts/setup_macos.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Usage: AR_EXTRAS="nlp ui" ./scripts/setup_macos.sh
+# macOS-specific environment bootstrap; installs dependencies via Homebrew and
+# delegates to the universal setup script.
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "This script is intended for macOS hosts." >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(dirname "$0")"
+source "$SCRIPT_DIR/setup_common.sh"
+
+if command -v brew >/dev/null 2>&1; then
+    brew update
+    brew install python cmake pkg-config git libffi libxml2 z3
+else
+    echo "Homebrew is required to install dependencies. Install from https://brew.sh/" >&2
+fi
+
+AR_EXTRAS="${AR_EXTRAS:-}" "$SCRIPT_DIR/setup_universal.sh" "$@"
+


### PR DESCRIPTION
## Summary
- Add platform dispatch to `setup.sh` and introduce Linux/macOS installers that delegate to the universal setup
- Deduplicate system package installation and call the Linux installer from the evaluation setup script

## Testing
- `task check`

------
https://chatgpt.com/codex/tasks/task_e_68b1dc297a6883339cb021ed8e06cae1