### PR TITLE
refactor setup scripts for hierarchical platform flow

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -27,11 +27,16 @@ LOG_FILE="codex_setup.log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 set -x
 
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "This script is intended for the Codex Linux environment." >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(dirname "$0")"
 source "$SCRIPT_DIR/setup_common.sh"
 
-# Delegate platform setup to the Linux installer
-AR_EXTRAS="${AR_EXTRAS:-}" "$SCRIPT_DIR/setup_linux.sh"
+# Run platform detection and universal setup
+AR_EXTRAS="${AR_EXTRAS:-}" "$SCRIPT_DIR/setup.sh" "$@"
 
 # Codex-specific offline model preparation
 if uv pip show sentence-transformers >/dev/null 2>&1; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Usage: AR_EXTRAS="nlp ui" ./scripts/setup.sh
-# Detects the host platform and delegates to the appropriate setup script.
+# Detects the host platform, runs platform-specific setup, then universal setup.
 set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
@@ -12,8 +12,9 @@ case "$(uname -s)" in
         "$SCRIPT_DIR/setup_macos.sh" "$@"
         ;;
     *)
-        echo "Unsupported platform; running universal setup." >&2
-        "$SCRIPT_DIR/setup_universal.sh" "$@"
+        echo "Unsupported platform; skipping platform-specific setup." >&2
         ;;
 esac
+
+AR_EXTRAS="${AR_EXTRAS:-}" "$SCRIPT_DIR/setup_universal.sh" "$@"
 

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Usage: AR_EXTRAS="nlp ui" ./scripts/setup_linux.sh
-# Linux-specific environment bootstrap; installs OS packages when possible and
-# delegates to the universal setup script.
+# Linux-specific environment setup; installs OS packages when possible.
+# The universal setup is invoked by setup.sh after this script completes.
 set -euo pipefail
 
 if [[ "$(uname -s)" != "Linux" ]]; then
@@ -29,6 +29,4 @@ if command -v apt-get >/dev/null 2>&1; then
 else
     echo "apt-get not found; please install required packages manually." >&2
 fi
-
-AR_EXTRAS="${AR_EXTRAS:-}" "$SCRIPT_DIR/setup_universal.sh" "$@"
 

--- a/scripts/setup_macos.sh
+++ b/scripts/setup_macos.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Usage: AR_EXTRAS="nlp ui" ./scripts/setup_macos.sh
-# macOS-specific environment bootstrap; installs dependencies via Homebrew and
-# delegates to the universal setup script.
+# macOS-specific environment setup; installs dependencies via Homebrew.
+# The universal setup is invoked by setup.sh after this script completes.
 set -euo pipefail
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
@@ -18,6 +18,4 @@ if command -v brew >/dev/null 2>&1; then
 else
     echo "Homebrew is required to install dependencies. Install from https://brew.sh/" >&2
 fi
-
-AR_EXTRAS="${AR_EXTRAS:-}" "$SCRIPT_DIR/setup_universal.sh" "$@"
 


### PR DESCRIPTION
## Summary
- centralize universal setup invocation so platform scripts only handle OS-specific tasks
- delegate Codex-only script to generic setup workflow before running offline model prep

## Testing
- `.venv/bin/task check`
- `.venv/bin/task verify` *(fails: No package metadata was found for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b1df135a8883338d20f9781cead95f