### PR TITLE
Document task verify dependency gap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,6 +45,8 @@ before running tests.
     issues/add-behavior-driven-test-coverage.md)
   - [speed-up-task-check-and-reduce-dependency-footprint](
     issues/speed-up-task-check-and-reduce-dependency-footprint.md)
+  - [fix-task-verify-package-metadata-errors](
+    issues/fix-task-verify-package-metadata-errors.md)
   - [resolve-release-blockers-for-alpha](
     issues/resolve-release-blockers-for-alpha.md)
 - 0.1.0 (2026-07-01, status: released): Finalized packaging, docs and CI

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status
 
-As of **August 29, 2025**, `task check` and `task verify` complete in the
-current environment. Integration and behavior suites remain untested. See
-[speed-up-task-check] for dependency footprint concerns and
+As of **August 29, 2025**, `task check` succeeds but `task verify` fails with
+missing package metadata. Integration and behavior suites remain untested.
+See [speed-up-task-check] for dependency footprint concerns and
 [add-behavior-driven-test-coverage](issues/add-behavior-driven-test-coverage.md)
 for behavior tests.
 

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -31,6 +31,8 @@ Current test and coverage results are tracked in
     ../issues/add-storage-proofs-and-simulations.md)
   - [configure-redis-service-for-tests](
     ../issues/configure-redis-service-for-tests.md)
+  - [fix-task-verify-package-metadata-errors](
+    ../issues/fix-task-verify-package-metadata-errors.md)
 - **0.1.0** (2026-07-01, status: released): Finalized packaging, docs and CI
   checks with all tests passing.
   - [improve-test-coverage-and-streamline-dependencies](

--- a/issues/fix-task-verify-package-metadata-errors.md
+++ b/issues/fix-task-verify-package-metadata-errors.md
@@ -1,0 +1,19 @@
+# Fix task verify package metadata errors
+
+## Context
+`task verify` fails in the current environment due to missing package metadata for
+several optional dependencies (e.g. GitPython, spacy, transformers). The full
+test suite cannot run until these packages are available or the task gracefully
+handles absent metadata.
+
+## Dependencies
+
+None.
+
+## Acceptance Criteria
+- `task verify` installs or resolves all required extras without metadata errors.
+- Full test suite runs after `task verify` completes.
+- Document the required extras in `docs/installation.md` if steps change.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- note that `task verify` currently fails due to missing package metadata
- track the gap with a new planning issue
- link the issue into roadmap and release plan

## Testing
- `task check`
- `task verify` *(fails: No package metadata for GitPython, bertopic, cibuildwheel, duckdb-extension-vss, fakeredis, freezegun, hypothesis, pdfminer-six, pytest-bdd, python-docx, sentence-transformers, spacy, transformers, types-networkx, types-protobuf, types-requests, types-tabulate)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ec38b81883338bcfb4fa663eb394