### PR TITLE
docs: track pre-alpha release blockers

### DIFF
--- a/.env.offline
+++ b/.env.offline
@@ -2,7 +2,7 @@
 # This file is used in test environments to ensure they can run without network access
 
 # Path to the VSS extension
-VECTOR_EXTENSION_PATH=extensions/vss_stub.duckdb_extension
+VECTOR_EXTENSION_PATH=./extensions/extensions/vss/vss.duckdb_extension
 
 # Database path
 DUCKDB_PATH=./test_kg.duckdb

--- a/issues/resolve-pre-alpha-release-blockers.md
+++ b/issues/resolve-pre-alpha-release-blockers.md
@@ -1,0 +1,16 @@
+# Resolve pre-alpha release blockers
+
+## Context
+The project targets its first public alpha (0.1.0a1) but currently lacks a passing full test suite and comprehensive release preparation. `task verify` fails due to missing package metadata, behavior-driven scenarios report failures, and coverage sits around 32%.
+
+## Dependencies
+- [fix-task-verify-package-metadata-errors](fix-task-verify-package-metadata-errors.md)
+
+## Acceptance Criteria
+- `task verify` completes without missing-package errors.
+- Behavior-driven tests run and pass in the default environment.
+- Line coverage reaches at least 90% with reports updated.
+- Release steps and known limitations documented for tagging 0.1.0a1.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- record blockers blocking the initial 0.1.0a1 alpha release
- update offline environment config with the downloaded DuckDB vector extension path

## Testing
- `task check`
- `task verify` *(fails: No package metadata was found for GitPython...)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f1c76f108333bdc7d8816d05f095