### PR TITLE
test: cover UI reasoning modes and sync extras

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,7 +27,7 @@ tasks:
               export PATH="$(pwd)/.venv/bin:$PATH"
           fi
       - |
-          extras="dev-minimal test"
+          extras="dev-minimal test ui vss"
           if [ "$VERIFY_PARSERS" = "1" ]; then
               extras="$extras parsers"
           fi
@@ -36,8 +36,8 @@ tasks:
       - uv run flake8 src tests
     desc: |
       Initialize dev env with minimal tools.
-      Syncs dev-minimal and test extras by default.
-      Set EXTRAS="nlp ui" to include optional features:
+      Syncs dev-minimal, test, ui, and vss extras by default.
+      Set EXTRAS="nlp" to include optional features:
       analysis, distributed, git, llm, minimal, nlp, parsers, ui, vss
   check-env:
     cmds:

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -34,7 +34,7 @@ BASE_REQUIREMENTS = {
     "uv": "0.7.0",
 }
 
-EXTRAS_TO_CHECK = ["dev", "test"]
+EXTRAS_TO_CHECK = ["dev", "test", "ui", "vss"]
 
 
 def load_extra_requirements(extras_to_check: list[str]) -> dict[str, str]:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Usage: AR_EXTRAS="nlp ui" ./scripts/setup.sh
+# Usage: AR_EXTRAS="nlp" ./scripts/setup.sh
 # Detects the host platform, runs platform-specific setup, then universal setup.
 set -euo pipefail
 
@@ -16,5 +16,5 @@ case "$(uname -s)" in
         ;;
 esac
 
-AR_EXTRAS="${AR_EXTRAS:-}" "$SCRIPT_DIR/setup_universal.sh" "$@"
+AR_EXTRAS="${AR_EXTRAS:-ui vss}" "$SCRIPT_DIR/setup_universal.sh" "$@"
 

--- a/scripts/setup_universal.sh
+++ b/scripts/setup_universal.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Usage: AR_EXTRAS="nlp ui" ./scripts/setup_universal.sh
+# Usage: AR_EXTRAS="nlp" ./scripts/setup_universal.sh
 # Core environment bootstrap used by platform-specific setup scripts.
 # Creates .venv, installs or links Go Task to .venv/bin, and development/test
 # extras using uv. Optional extras are installed when AR_EXTRAS is set.

--- a/tests/behavior/features/reasoning_mode_ui.feature
+++ b/tests/behavior/features/reasoning_mode_ui.feature
@@ -1,0 +1,15 @@
+@behavior @reasoning_modes @requires_ui
+Feature: Reasoning mode selection in UI
+  As a user
+  I want to select a reasoning mode via the UI
+  So that the system adapts its execution style
+
+  Scenario Outline: choosing reasoning mode in the UI
+    Given the Streamlit application is running
+    When a reasoning mode "<mode>" is chosen
+    Then bdd_context records mode "<mode>"
+
+    Examples:
+      | mode        |
+      | direct      |
+      | dialectical |

--- a/tests/behavior/features/reasoning_mode_vss.feature
+++ b/tests/behavior/features/reasoning_mode_vss.feature
@@ -1,7 +1,12 @@
 @behavior @reasoning_modes @requires_vss
 Feature: Reasoning mode with VSS extension
-  Scenario: Dialectical reasoning uses VSS extension
+  Scenario Outline: reasoning mode uses VSS extension
     Given I have a valid configuration with VSS extension enabled
-    And reasoning mode is "dialectical"
+    And reasoning mode is "<mode>"
     When I run the orchestrator on query "mode test"
     Then the VSS extension should be loaded from the filesystem
+
+    Examples:
+      | mode        |
+      | dialectical |
+      | direct      |

--- a/tests/behavior/steps/reasoning_mode_ui_steps.py
+++ b/tests/behavior/steps/reasoning_mode_ui_steps.py
@@ -1,0 +1,8 @@
+from pytest_bdd import scenarios
+
+pytest_plugins = [
+    "tests.behavior.steps.streamlit_gui_steps",
+    "tests.behavior.steps.reasoning_modes_steps",
+]
+
+scenarios("../features/reasoning_mode_ui.feature")

--- a/tests/behavior/steps/reasoning_mode_vss_steps.py
+++ b/tests/behavior/steps/reasoning_mode_vss_steps.py
@@ -1,4 +1,4 @@
-from pytest_bdd import scenario
+from pytest_bdd import scenarios
 
 pytest_plugins = [
     "tests.behavior.steps.vector_extension_handling_steps",
@@ -6,10 +6,4 @@ pytest_plugins = [
     "tests.behavior.steps.agent_orchestration_steps",
 ]
 
-
-@scenario(
-    "../features/reasoning_mode_vss.feature",
-    "Dialectical reasoning uses VSS extension",
-)
-def test_reasoning_mode_vss() -> None:
-    """Ensure reasoning modes work with the VSS extension."""
+scenarios("../features/reasoning_mode_vss.feature")

--- a/tests/behavior/steps/reasoning_modes_steps.py
+++ b/tests/behavior/steps/reasoning_modes_steps.py
@@ -1,4 +1,3 @@
-import pytest
 from pytest_bdd import scenarios, when, then, parsers
 
 from autoresearch.orchestration import ReasoningMode


### PR DESCRIPTION
## Summary
- add UI reasoning-mode feature and steps
- broaden VSS reasoning-mode coverage
- install UI and VSS extras by default

## Testing
- `task check`
- `task coverage` *(fails: KeyboardInterrupt during run)*

------
https://chatgpt.com/codex/tasks/task_e_68b21bb1bb248333a0d7f8b1b5e0a32b