### PR TITLE
feat: bootstrap all test extras

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,6 +4,13 @@ This guide is the canonical bootstrap reference for Autoresearch. It covers
 the minimal developer workflow and links to helper scripts for specific
 environments.
 
+For a one-step bootstrap that installs uv, Go Task, and all extras needed for
+unit, integration, and behavior tests, run:
+
+```bash
+./scripts/setup.sh
+```
+
 Autoresearch requires **Python 3.12 or newer**,
 [**uv**](https://github.com/astral-sh/uv), and
 [**Go Task**](https://taskfile.dev/) for Taskfile commands. Install Go Task

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
-# Usage: AR_EXTRAS="nlp ui" ./scripts/setup.sh
-# Detects the host platform, runs platform-specific setup, then universal setup.
+# Usage: ./scripts/setup.sh
+# Bootstraps Autoresearch by installing uv, Go Task, and extras for unit,
+# integration, and behavior tests. Override extras via AR_EXTRAS.
 set -euo pipefail
+
+DEFAULT_EXTRAS="nlp ui vss parsers git distributed analysis llm"
+AR_EXTRAS="${AR_EXTRAS:-$DEFAULT_EXTRAS}"
 
 SCRIPT_DIR="$(dirname "$0")"
 case "$(uname -s)" in
@@ -16,5 +20,5 @@ case "$(uname -s)" in
         ;;
 esac
 
-AR_EXTRAS="${AR_EXTRAS:-}" "$SCRIPT_DIR/setup_universal.sh" "$@"
+AR_EXTRAS="$AR_EXTRAS" "$SCRIPT_DIR/setup_universal.sh" "$@"
 


### PR DESCRIPTION
## Summary
- install uv, Go Task, and all optional extras by default in setup script
- document one-step bootstrap command

## Testing
- `.venv/bin/task check`
- `uv pip list | grep -E 'pydantic|fastapi|duckdb'`


------
https://chatgpt.com/codex/tasks/task_e_68b21bcad58483339bcffabf3e1155be