### PR TITLE
feat: expand setup bootstrap

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,8 +6,15 @@ environments.
 
 Autoresearch requires **Python 3.12 or newer**,
 [**uv**](https://github.com/astral-sh/uv), and
-[**Go Task**](https://taskfile.dev/) for Taskfile commands. Install Go Task
-manually when it is missing:
+[**Go Task**](https://taskfile.dev/) for Taskfile commands. Run the following
+one-step bootstrap to install them along with all extras needed for unit,
+integration, and behavior tests:
+
+```bash
+./scripts/setup.sh
+```
+
+The helper downloads Go Task when missing. If you prefer manual installation:
 
 ```bash
 curl -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
@@ -15,8 +22,7 @@ curl -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
 ```
 
 `task install` checks for Go Task and downloads it to `.venv/bin` when missing.
-Run `./scripts/setup.sh` for the full developer bootstrap or if the automatic
-download fails. Manual installation instructions are below if needed.
+Manual instructions are below if the setup script fails.
 
 ## Setup scripts
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Usage: AR_EXTRAS="nlp" ./scripts/setup.sh
-# Detects the host platform, runs platform-specific setup, then universal setup.
+# Usage: ./scripts/setup.sh
+# Detects the host platform, ensures uv and Go Task are installed, and installs
+# all extras required for unit, integration, and behavior tests.
 set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
@@ -16,5 +17,6 @@ case "$(uname -s)" in
         ;;
 esac
 
-AR_EXTRAS="${AR_EXTRAS:-ui vss}" "$SCRIPT_DIR/setup_universal.sh" "$@"
+AR_EXTRAS="${AR_EXTRAS:-nlp ui vss parsers git distributed analysis llm}" \
+    "$SCRIPT_DIR/setup_universal.sh" "$@"
 


### PR DESCRIPTION
## Summary
- install all test extras by default in `scripts/setup.sh`
- document one-step bootstrap with `./scripts/setup.sh`

## Testing
- `./scripts/setup.sh`
- `uv pip list | grep -E 'pydantic|fastapi|duckdb'`
- `uv run mkdocs build`
- `task check`
- `task verify`


------
https://chatgpt.com/codex/tasks/task_e_68b2321cf9588333804a24605c72b3e0