### PR TITLE
Document task verify dependency build issues

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,9 @@
 # Status
 
-As of **August 29, 2025**, `task check` succeeds but `task verify` fails with
-missing package metadata. Integration and behavior suites remain untested.
-See [speed-up-task-check] for dependency footprint concerns and
+As of **August 30, 2025**, `task check` succeeds. After running
+`scripts/setup.sh`, `task verify` stalls compiling heavy dependencies and still
+reports missing package metadata. Integration and behavior suites remain
+untested. See [speed-up-task-check] for dependency footprint concerns and
 [add-behavior-driven-test-coverage](issues/add-behavior-driven-test-coverage.md)
 for behavior tests.
 
@@ -19,5 +20,5 @@ Not run.
 Not run.
 
 ## Coverage
-Total coverage is **100%**.
+Total coverage is **100%** for the targeted tests that run.
 [speed-up-task-check]: issues/speed-up-task-check-and-reduce-dependency-footprint.md

--- a/issues/address-task-verify-dependency-builds.md
+++ b/issues/address-task-verify-dependency-builds.md
@@ -1,0 +1,19 @@
+# Address task verify dependency builds
+
+## Context
+`task verify` stalls when building heavy dependencies such as hdbscan and CUDA
+packages during `scripts/setup.sh`. This prevents the full test suite from
+running and delays the 0.1.0a1 release.
+
+## Dependencies
+
+None.
+
+## Acceptance Criteria
+- Replace or provide pre-built wheels for heavy packages to avoid lengthy
+  builds.
+- Update setup and verify tasks to skip GPU-only dependencies by default.
+- `task verify` completes in under 15 minutes on a clean environment.
+
+## Status
+Open

--- a/issues/resolve-pre-alpha-release-blockers.md
+++ b/issues/resolve-pre-alpha-release-blockers.md
@@ -1,10 +1,15 @@
 # Resolve pre-alpha release blockers
 
 ## Context
-The project targets its first public alpha (0.1.0a1) but currently lacks a passing full test suite and comprehensive release preparation. `task verify` fails due to missing package metadata, behavior-driven scenarios report failures, and coverage sits around 32%.
+The project targets its first public alpha (0.1.0a1) but currently lacks a
+passing full test suite and comprehensive release preparation. After running
+`scripts/setup.sh`, `task verify` stalls while compiling heavy dependencies and
+still reports missing package metadata. Behavior-driven scenarios remain
+unexecuted, and coverage sits around 32%.
 
 ## Dependencies
 - [fix-task-verify-package-metadata-errors](fix-task-verify-package-metadata-errors.md)
+- [address-task-verify-dependency-builds](address-task-verify-dependency-builds.md)
 
 ## Acceptance Criteria
 - `task verify` completes without missing-package errors.


### PR DESCRIPTION
## Summary
- record that `task verify` stalls on heavy dependency builds and misses package metadata
- track dependency build problem as its own issue
- note current test status after running `scripts/setup.sh`

## Testing
- `uv run task check`
- `uv run task verify` *(fails: interrupt while building dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b296e0180c8333840cf5b9e61a3585