### PR TITLE
Document current test baseline and track behavior suite restoration

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,11 +1,10 @@
 # Status
 
-As of **August 31, 2025**, `.venv/bin/task check` succeeds. Running
-`.venv/bin/task verify` attempts to download large CUDA packages and was
-terminated, so the full test suite did not run. Integration and behavior suites
-remain untested. See
+As of **August 30, 2025**, `task check` and `task verify` complete. `task verify`
+installs CUDA wheels and runs only the targeted suite, so integration and
+behavior tests remain unexecuted. See
 [address-task-verify-dependency-builds](issues/address-task-verify-dependency-builds.md)
-for dependency build concerns and
+for dependency optimizations and
 [add-test-coverage-for-optional-components](issues/add-test-coverage-for-optional-components.md)
 for coverage gaps.
 
@@ -13,14 +12,14 @@ for coverage gaps.
 Ran via `task verify`.
 
 ## Targeted tests
-Ran via `task verify`.
+Ran via `task verify` (21 passed).
 
 ## Integration tests
 Not run.
 
 ## Behavior tests
-Not run.
+Not run; a smoke run reported failing scenarios.
 
 ## Coverage
-Total coverage is **100%** for the targeted tests that run.
+Total coverage is **100%** across 57 statements in targeted modules.
 

--- a/issues/address-task-verify-dependency-builds.md
+++ b/issues/address-task-verify-dependency-builds.md
@@ -1,9 +1,10 @@
 # Address task verify dependency builds
 
 ## Context
-`task verify` stalls when building heavy dependencies such as hdbscan and CUDA
-packages during `scripts/setup.sh`. This prevents the full test suite from
-running and delays the 0.1.0a1 release.
+`task verify` previously stalled while compiling heavy dependencies such as
+hdbscan and CUDA packages. Recent runs finish by pulling pre-built wheels, but
+GPU libraries are still installed, inflating setup time and size. Further work is
+needed to keep the default workflow lightweight for the 0.1.0a1 release.
 
 ## Dependencies
 

--- a/issues/resolve-pre-alpha-release-blockers.md
+++ b/issues/resolve-pre-alpha-release-blockers.md
@@ -1,15 +1,16 @@
 # Resolve pre-alpha release blockers
 
 ## Context
-The project targets its first public alpha (0.1.0a1) but currently lacks a
-passing full test suite and comprehensive release preparation. After running
-`scripts/setup.sh`, `task verify` stalls while compiling heavy dependencies and
-still reports missing package metadata. Behavior-driven scenarios remain
-unexecuted, and coverage sits around 32%.
+The project targets its first public alpha (0.1.0a1) but still lacks a
+comprehensive release-ready test suite. `task verify` now completes using
+pre-built CUDA wheels yet exercises only a small targeted set of tests.
+Behavior-driven scenarios continue to fail and coverage reflects just the
+57 statements in those targeted modules.
 
 ## Dependencies
 - [fix-task-verify-package-metadata-errors](fix-task-verify-package-metadata-errors.md)
 - [address-task-verify-dependency-builds](address-task-verify-dependency-builds.md)
+- [restore-behavior-driven-test-suite](restore-behavior-driven-test-suite.md)
 
 ## Acceptance Criteria
 - `task verify` completes without missing-package errors.

--- a/issues/restore-behavior-driven-test-suite.md
+++ b/issues/restore-behavior-driven-test-suite.md
@@ -1,0 +1,21 @@
+# Restore behavior-driven test suite
+
+## Context
+Recent smoke runs report failing behavior-driven scenarios and `task verify`
+does not exercise the `tests/behavior` suite. Without passing BDD tests,
+critical user workflows, reasoning modes, and error recovery paths remain
+unverified.
+
+## Dependencies
+- [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)
+
+## Acceptance Criteria
+- Feature files under `tests/behavior` run without failures using the base `[test]`
+  extras.
+- `uv run pytest tests/behavior -q` exercises `user_workflows`, `reasoning_modes`,
+  and `error_recovery` markers.
+- `task verify` includes the behavior suite once it passes.
+- `tests/AGENTS.md` documents any new markers or extras used by behavior tests.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- record current test and coverage status
- update release blocker context and dependency build notes
- add ticket to restore behavior-driven test suite

## Testing
- `task check`
- `task verify`


------
https://chatgpt.com/codex/tasks/task_e_68b316e1a8408333a895ba7650c414e4