### PR TITLE
doc: update status and issue tickets

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,25 +1,20 @@
 # Status
 
-As of **August 30, 2025**, `task check` and `task verify` complete. `task verify`
-installs CUDA wheels and runs only the targeted suite, so integration and
-behavior tests remain unexecuted. See
-[address-task-verify-dependency-builds](issues/address-task-verify-dependency-builds.md)
-for dependency optimizations and
-[add-test-coverage-for-optional-components](issues/add-test-coverage-for-optional-components.md)
-for coverage gaps.
+As of **August 31, 2025**, `task check` and `task verify` are blocked by a missing
+`task` command. A direct `uv run pytest` attempt fails with
+`ModuleNotFoundError: pytest_bdd`, so no tests execute.
 
 ## Lint, type checks, and spec tests
-Ran via `task verify`.
+Not run.
 
 ## Targeted tests
-Ran via `task verify` (21 passed).
+Not run.
 
 ## Integration tests
 Not run.
 
 ## Behavior tests
-Not run; a smoke run reported failing scenarios.
+Not run.
 
 ## Coverage
-Total coverage is **100%** across 57 statements in targeted modules.
-
+Not measured.

--- a/issues/restore-behavior-driven-test-suite.md
+++ b/issues/restore-behavior-driven-test-suite.md
@@ -2,7 +2,8 @@
 
 ## Context
 Recent smoke runs report failing behavior-driven scenarios and `task verify`
-does not exercise the `tests/behavior` suite. Without passing BDD tests,
+does not exercise the `tests/behavior` suite. The environment lacks the
+`pytest-bdd` dependency, causing collection errors. Without passing BDD tests,
 critical user workflows, reasoning modes, and error recovery paths remain
 unverified.
 
@@ -16,6 +17,7 @@ unverified.
   and `error_recovery` markers.
 - `task verify` includes the behavior suite once it passes.
 - `tests/AGENTS.md` documents any new markers or extras used by behavior tests.
+- `pytest-bdd` dependency installed so behavior tests collect and run.
 
 ## Status
 Open

--- a/issues/restore-task-cli-availability.md
+++ b/issues/restore-task-cli-availability.md
@@ -1,0 +1,17 @@
+# Restore task cli availability
+
+## Context
+The current environment lacks the `task` command, preventing `task check` and
+`task verify` from running. This regression blocks linting and tests,
+contradicting previous setup expectations.
+
+## Dependencies
+None.
+
+## Acceptance Criteria
+- `task --version` reports a valid version after environment setup.
+- Setup scripts ensure Go Task is installed or document manual steps.
+- `task check` and `task verify` run successfully in a clean environment.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- note current test blockage and missing `pytest_bdd` in STATUS
- clarify BDD suite issue and add requirement for `pytest-bdd`
- add issue to restore Task CLI availability

## Testing
- `task check` *(fails: command not found)*
- `uv run pytest` *(fails: No module named 'pytest_bdd')*
- `task verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a47a06a88333b08974ca100f6ed7