### PR TITLE
Ensure setup installs Go Task automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ For orchestrator state transitions and API contracts see
 
 Autoresearch requires **Python 3.12+**,
 [uv](https://github.com/astral-sh/uv), and
-[Go Task](https://taskfile.dev/). Running `task install` automatically downloads
-`task` to `.venv/bin` when it's missing; the same check occurs in
-`./scripts/setup.sh` during a full developer bootstrap. See
-[docs/installation.md#after-cloning](docs/installation.md#after-cloning) for
-details.
+[Go Task](https://taskfile.dev/). Both `task install` and
+`./scripts/setup.sh` automatically place `task` in `.venv/bin` when it's
+missing. See [docs/installation.md#after-cloning](docs/installation.md#after-cloning)
+for details.
 
 Install Go Task manually if needed:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,8 @@ integration, and behavior tests:
 ./scripts/setup.sh
 ```
 
-The helper downloads Go Task when missing. If you prefer manual installation:
+The helper downloads Go Task into `.venv/bin` when missing. If you prefer
+manual installation:
 
 ```bash
 curl -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
@@ -92,10 +93,10 @@ AR_EXTRAS="nlp ui" ./scripts/setup.sh  # extras via setup script
 `task verify` always includes the `parsers` extra, so no additional flags are
 required for PDF or DOCX tests.
 
-Use `./scripts/setup.sh` for the full developer bootstrap. It installs Go
-Task when missing, syncs the `dev` and `test` extras (including packages such
-as `pytest_httpx`, `tomli_w`, and `redis`), and exits if `task --version`
-fails.
+Use `./scripts/setup.sh` for the full developer bootstrap. It installs Go Task
+into `.venv/bin` when missing, syncs the `dev` and `test` extras (including
+packages such as `pytest_httpx`, `tomli_w`, and `redis`), and exits if
+`task --version` fails.
 
 The setup script verifies Go Task with `task --version`. You can manually
 confirm the CLI and development packages are available:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -20,3 +20,22 @@ esac
 AR_EXTRAS="${AR_EXTRAS:-nlp ui vss parsers git distributed analysis llm}" \
     "$SCRIPT_DIR/setup_universal.sh" "$@"
 
+# Ensure Go Task resides in the virtual environment so subsequent Taskfile
+# invocations use the expected binary. Link an existing installation when
+# possible; otherwise download it.
+VENV_BIN="$(pwd)/.venv/bin"
+TASK_BIN="$VENV_BIN/task"
+if [ ! -x "$TASK_BIN" ]; then
+    echo "Installing Go Task into $VENV_BIN..."
+    mkdir -p "$VENV_BIN"
+    if command -v task >/dev/null 2>&1; then
+        ln -sf "$(command -v task)" "$TASK_BIN"
+    else
+        curl -sSL https://taskfile.dev/install.sh | sh -s -- -b "$VENV_BIN"
+    fi
+fi
+"$TASK_BIN" --version >/dev/null 2>&1 || {
+    echo "task --version failed; Go Task is required" >&2
+    exit 1
+}
+


### PR DESCRIPTION
## Summary
- install Go Task into `.venv/bin` from `scripts/setup.sh` when missing
- document automatic Go Task installation in README and installation guide

## Testing
- `uv run mkdocs build`
- `task --version`
- `task check`
- `task verify` *(fails: exit status 130, dependency downloads exceeded environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b54ade2083339917421c3e3e75dc