### PR TITLE
Add targeted tests for optional extras

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,7 @@
 # Status
 
-As of **August 31, 2025**, `task check` and `task verify` are blocked by a missing
-`task` command. A direct `uv run pytest` attempt fails with
-`ModuleNotFoundError: pytest_bdd`, so no tests execute.
+As of **August 31, 2025**, `task` is available but `task verify` stalls while
+syncing large optional extras, so no tests execute.
 
 ## Lint, type checks, and spec tests
 Not run.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -159,16 +159,20 @@ tasks:
             --extra dev-minimal \
             --extra dev \
             --extra test \
-            --extra full \
-            --extra parsers \
+            --extra nlp \
+            --extra ui \
+            --extra vss \
             --extra git \
-            --extra llm
+            --extra distributed \
+            --extra analysis \
+            --extra llm \
+            --extra parsers
       - task check-env
       - uv run flake8 src tests
       - uv run mypy src
       - uv run python scripts/check_spec_tests.py
       - >
-          uv run pytest tests/targeted --noconftest
+          uv run pytest tests/targeted -m 'not slow' --noconftest
           --cov=autoresearch.search
           --cov=autoresearch.storage
           --cov=autoresearch.orchestration

--- a/tests/targeted/test_extras_install.py
+++ b/tests/targeted/test_extras_install.py
@@ -1,0 +1,81 @@
+import duckdb
+import pytest
+
+@pytest.mark.requires_nlp
+def test_nlp_extra_imports() -> None:
+    spacy = pytest.importorskip("spacy")
+    bertopic = pytest.importorskip("bertopic")
+
+    nlp = spacy.blank("en")
+    assert nlp.pipe_names == []
+    assert bertopic.__version__
+
+
+@pytest.mark.requires_ui
+def test_ui_extra_imports() -> None:
+    st = pytest.importorskip("streamlit")
+
+    assert hasattr(st, "__version__")
+
+
+@pytest.mark.requires_vss
+def test_vss_extra_imports() -> None:
+    vss = pytest.importorskip("duckdb_extension_vss")
+
+    con = duckdb.connect()
+    try:
+        assert con.execute("SELECT 1").fetchone()[0] == 1
+    finally:
+        con.close()
+    assert vss is not None
+
+
+@pytest.mark.requires_git
+def test_git_extra_imports(tmp_path) -> None:
+    git = pytest.importorskip("git")
+
+    repo = git.Repo.init(tmp_path)
+    assert repo.git_dir
+
+
+@pytest.mark.requires_distributed
+def test_distributed_extra_imports() -> None:
+    ray = pytest.importorskip("ray")
+    redis = pytest.importorskip("redis")
+
+    ray.init(num_cpus=1, local_mode=True, ignore_reinit_error=True)
+    try:
+        assert ray.is_initialized()
+    finally:
+        ray.shutdown()
+    assert redis.__version__
+
+
+@pytest.mark.requires_analysis
+def test_analysis_extra_imports() -> None:
+    pl = pytest.importorskip("polars")
+
+    df = pl.DataFrame({"a": [1, 2]})
+    assert df.shape == (2, 1)
+
+
+@pytest.mark.requires_llm
+def test_llm_extra_imports() -> None:
+    transformers = pytest.importorskip("transformers")
+    sentence_transformers = pytest.importorskip("sentence_transformers")
+
+    assert transformers.AutoTokenizer.__name__ == "AutoTokenizer"
+    assert (
+        sentence_transformers.SentenceTransformer.__name__
+        == "SentenceTransformer"
+    )
+
+
+@pytest.mark.requires_parsers
+def test_parsers_extra_imports(tmp_path) -> None:
+    docx = pytest.importorskip("docx")
+
+    path = tmp_path / "test.docx"
+    docx.Document().save(path)
+    doc = docx.Document(path)
+    assert len(doc.paragraphs) == 0


### PR DESCRIPTION
## Summary
- add targeted tests exercising optional extras via requires_* markers
- sync optional extras and run marked tests in `task verify`
- document current test status in `STATUS.md`

## Testing
- `task verify` *(fails: Downloading torch - terminated)*
- `uv run flake8 tests/targeted/test_extras_install.py Taskfile.yml STATUS.md` *(fails: flake8 missing)*
- `uv run pytest tests/targeted/test_extras_install.py -q` *(fails: pytest_bdd missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b57d75608333b858870e34978b6b