### PR TITLE
chore: note behavior test failures

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,7 @@
 # Status
 
-As of **August 31, 2025**, `task verify` completes without GPU extras.
+As of **August 31, 2025**, `task check` passes but `task verify` fails with
+19 behavior test failures and coverage is not reported.
 
 ## Lint, type checks, and spec tests
 Passed.
@@ -9,10 +10,10 @@ Passed.
 Passed.
 
 ## Integration tests
-Passed.
+Not executed.
 
 ## Behavior tests
-Passed.
+19 failures from missing step definitions and API query scenarios.
 
 ## Coverage
-Total coverage is **100%**.
+Unavailable while `task verify` fails.

--- a/issues/restore-behavior-driven-test-suite.md
+++ b/issues/restore-behavior-driven-test-suite.md
@@ -1,23 +1,24 @@
 # Restore behavior-driven test suite
 
 ## Context
-Recent smoke runs report failing behavior-driven scenarios and `task verify`
-does not exercise the `tests/behavior` suite. The environment lacks the
-`pytest-bdd` dependency, causing collection errors. Without passing BDD tests,
-critical user workflows, reasoning modes, and error recovery paths remain
-unverified.
+Recent runs of `task verify` report 19 failing scenarios across
+`api_batch_query_steps.py`, `api_async_query_steps.py`,
+`search_cli_steps.py`, `monitor_cli_steps.py`, and
+`query_interface_steps.py`. While `pytest-bdd` is installed, many step
+definitions are missing so the behavior suite aborts before coverage is
+recorded. Without passing BDD tests, critical user workflows, reasoning
+modes, and error recovery paths remain unverified.
 
 ## Dependencies
 - [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)
 
 ## Acceptance Criteria
-- Feature files under `tests/behavior` run without failures using the base `[test]`
-  extras.
-- `uv run pytest tests/behavior -q` exercises `user_workflows`, `reasoning_modes`,
-  and `error_recovery` markers.
+- Implement missing step definitions so features in
+  `tests/behavior/steps/` run without failures using the base `[test]` extra.
+- `uv run pytest tests/behavior -q` exercises `user_workflows`,
+  `reasoning_modes`, and `error_recovery` markers.
 - `task verify` includes the behavior suite once it passes.
 - `tests/AGENTS.md` documents any new markers or extras used by behavior tests.
-- `pytest-bdd` dependency installed so behavior tests collect and run.
 
 ## Status
 Open


### PR DESCRIPTION
## Summary
- record that `task verify` currently fails due to missing behavior test step definitions
- clarify context for restoring the behavior-driven suite

## Testing
- `uv run task check`
- `uv run task verify` *(fails: 19 behavior tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c13668c08333a5b1421ef5d7e577