### PR TITLE
docs: update status and clarify behavior test blockers

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,19 +1,21 @@
 # Status
 
-As of **August 31, 2025**, `task check` passes but `task verify` fails with
-19 behavior test failures and coverage is not reported.
+As of **August 31, 2025**, `task check` and `task verify` cannot run because the
+`task` CLI is missing. Invoking `uv run pytest -q` fails with
+`ModuleNotFoundError: No module named 'pytest_bdd'`, so behavior and integration
+tests remain unexecuted and coverage is not reported.
 
 ## Lint, type checks, and spec tests
-Passed.
+Not run.
 
 ## Targeted tests
-Passed.
+Not run.
 
 ## Integration tests
 Not executed.
 
 ## Behavior tests
-19 failures from missing step definitions and API query scenarios.
+Cannot run: `pytest_bdd` module missing.
 
 ## Coverage
-Unavailable while `task verify` fails.
+Unavailable while tests fail before collection.

--- a/issues/document-test-dependency-setup.md
+++ b/issues/document-test-dependency-setup.md
@@ -1,0 +1,17 @@
+# Document test dependency setup
+
+## Context
+Running `uv run pytest` fails with `ModuleNotFoundError: No module named 'pytest_bdd'` because
+the development `[test]` extra is not installed when the `task` CLI is unavailable. Contributors
+lack guidance for installing these dependencies manually.
+
+## Dependencies
+- [restore-task-cli-availability](restore-task-cli-availability.md)
+
+## Acceptance Criteria
+- Document manual installation steps for `[test]` extras in `README.md` or `STATUS.md`.
+- Ensure `scripts/setup.sh` installs `[test]` dependencies when the `task` CLI is missing.
+- After setup, `uv run pytest tests/unit -q` executes without missing plugin errors.
+
+## Status
+Open

--- a/issues/restore-behavior-driven-test-suite.md
+++ b/issues/restore-behavior-driven-test-suite.md
@@ -1,13 +1,14 @@
 # Restore behavior-driven test suite
 
 ## Context
-Recent runs of `task verify` report 19 failing scenarios across
-`api_batch_query_steps.py`, `api_async_query_steps.py`,
-`search_cli_steps.py`, `monitor_cli_steps.py`, and
-`query_interface_steps.py`. While `pytest-bdd` is installed, many step
-definitions are missing so the behavior suite aborts before coverage is
-recorded. Without passing BDD tests, critical user workflows, reasoning
-modes, and error recovery paths remain unverified.
+Running `uv run pytest` currently fails with
+`ModuleNotFoundError: No module named 'pytest_bdd'`. After installing this
+plugin, `task verify` reports 19 failing scenarios across
+`api_batch_query_steps.py`, `api_async_query_steps.py`, `search_cli_steps.py`,
+`monitor_cli_steps.py`, and `query_interface_steps.py`. Many step definitions
+are missing so the behavior suite aborts before coverage is recorded.
+Without passing BDD tests, critical user workflows, reasoning modes, and
+error recovery paths remain unverified.
 
 ## Dependencies
 - [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)


### PR DESCRIPTION
## Summary
- note missing `task` CLI and `pytest_bdd` plugin in status
- clarify behavior-driven test issue context to include missing plugin
- add planning ticket to document manual installation of test extras

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run pytest -q` *(fails: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_68b3c3b43a888333ae66898a3ffdfe35