### PR TITLE
Separate GPU extras and prefer manylinux wheels

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,7 +38,7 @@ tasks:
       Initialize dev env with minimal tools.
       Syncs dev-minimal, test, ui, and vss extras by default.
       Set EXTRAS="nlp" to include optional features:
-      analysis, distributed, git, llm, minimal, nlp, parsers, ui, vss
+      analysis, distributed, git, gpu, llm, minimal, nlp, parsers, ui, vss
   check-env:
     cmds:
       - uv run python scripts/check_env.py
@@ -157,6 +157,7 @@ tasks:
     cmds:
       - |
           uv sync \
+            --python-platform x86_64-manylinux_2_28 \
             --extra dev-minimal \
             --extra dev \
             --extra test \
@@ -184,7 +185,7 @@ tasks:
       - task check-coverage-docs
     desc: |
       Run linting, type checks, targeted tests, and coverage.
-      Set EXTRAS="llm" to include optional GPU packages.
+      Set EXTRAS="gpu" to include optional GPU packages.
 
   clean:
     cmds:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -67,9 +67,9 @@ uv sync --extra dev-minimal --extra test
 
 This installs `pytest_httpx`, `tomli_w`, and `redis` without heavy ML
 dependencies. `task check` syncs only these extras so it runs quickly.
-`task verify` automatically syncs the `dev-minimal`, `test`, `full`,
-`parsers`, `git`, and `llm` extras so packages such as GitPython, spaCy,
-and transformers are available for tests.
+`task verify` syncs the `dev-minimal`, `dev`, `test`, `nlp`, `ui`, `vss`,
+`git`, `distributed`, `analysis`, and `parsers` extras. Set
+`EXTRAS="gpu"` to install GPU-only packages.
 
 ## After cloning
 
@@ -85,7 +85,8 @@ Include extras only when required. Examples:
 
 ```bash
 EXTRAS="nlp" task install      # adds NLP packages
-uv sync --extra llm            # sentence-transformers and transformers
+uv sync --extra llm            # LLM libraries
+uv sync --extra gpu            # BERTopic and lmstudio
 VERIFY_PARSERS=1 task install  # adds PDF and DOCX parsers
 AR_EXTRAS="nlp ui" ./scripts/setup.sh  # extras via setup script
 ```
@@ -319,20 +320,21 @@ installed by `task install`; enable them with `uv sync --extra <name>` or
 `AR_EXTRAS` environment variable.
 
 `pyproject.toml` defines these groups: minimal, nlp, ui, vss, parsers, git,
-distributed, analysis, llm, test, full, dev, dev-minimal, and build. The table
-below summarizes their purpose and usage.
+distributed, analysis, gpu, llm, test, full, dev, dev-minimal, and build. The
+table below summarizes their purpose and usage.
 
 | Extra | Purpose | Setup command |
 |------|---------|---------------|
 | minimal | core embedding model support | `uv sync --extra minimal` |
-| nlp | topic modeling and transformers | `uv sync --extra nlp` |
+| nlp | spaCy processing | `uv sync --extra nlp` |
 | ui | Streamlit interface | `uv sync --extra ui` |
 | vss | DuckDB vector search extension | `uv sync --extra vss` |
 | parsers | PDF and DOCX ingestion | `uv sync --extra parsers` |
 | git | local Git repository search | `uv sync --extra git` |
 | distributed | Ray and Redis for scaling | `uv sync --extra distributed` |
 | analysis | data analysis via Polars | `uv sync --extra analysis` |
-| llm | heavy LLM dependencies | `uv sync --extra llm` |
+| gpu | GPU-only packages | `uv sync --extra gpu` |
+| llm | LLM libraries | `uv sync --extra llm` |
 | test | packages needed only for tests | `uv sync --extra test` |
 | full | all optional features | `uv sync --extra full` |
 | dev | developer tools | `uv sync --extra dev` |
@@ -346,6 +348,7 @@ uv sync --extra nlp          # language processing
 uv sync --extra ui           # Streamlit interface
 uv sync --extra distributed  # Ray and Redis
 uv sync --extra llm          # LLM libraries
+uv sync --extra gpu          # BERTopic and lmstudio
 ```
 
 Install multiple extras separated by commas:
@@ -381,7 +384,7 @@ version notes.
 If you installed Autoresearch before ``0.1.0`` simply upgrade the base
 package and reinstall any extras you require:
 ```bash
-pip install -U "autoresearch[full,llm]"
+pip install -U "autoresearch[full,gpu]"
 ```
 
 ## Troubleshooting optional package builds

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -124,8 +124,9 @@ Each milestone may include additional patch releases for critical fixes.
 
 ## CI Checklist
 
-Before tagging **0.1.0**, ensure the following checks pass (after installing
-optional extras):
+Before tagging **0.1.0**, ensure the following checks pass. `task verify`
+syncs with `--python-platform x86_64-manylinux_2_28` to prefer wheels and
+skips GPU-only packages unless `EXTRAS="gpu"` is set:
 
 - [ ] `uv run flake8 src tests`
 - [ ] `uv run mypy src`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ requires-python = ">=3.12,<4.0"
 packages = [{include = "autoresearch", from = "src"}]
 dependencies = [
     "a2a-sdk >=0.3.0",
-    "dspy-ai >=2.6.27",
     "duckdb >=1.3.0",
     "fastapi >=0.115.12", # 0.115.12+ needed for Pydantic v2 and Starlette 0.41
     "fastmcp >=2.11.2",
@@ -65,10 +64,14 @@ minimal = [
 ]
 # NLP features: topic modeling, vector search, and transformer models
 nlp = [
-    "spacy >=3.7.2",
+    "spacy >=3.7.2"
+]
+# GPU-only packages
+gpu = [
     "bertopic >=0.17.3",
     "pynndescent >=0.5.13",
-    "scipy >=1.16.0"
+    "scipy >=1.16.0",
+    "lmstudio >=1.4.1"
 ]
 # UI features: Streamlit-based user interface
 ui = [
@@ -98,6 +101,7 @@ analysis = [
 ]
 # Heavy LLM dependencies
 llm = [
+    "dspy-ai >=2.6.27",
     "sentence-transformers >=2.7.0",
     "transformers >=4.53.0"
 ]
@@ -124,18 +128,13 @@ test = [
 # Full install: all features for power users and development
 full = [
     "spacy >=3.7.2",
-    "bertopic >=0.17.3",
-    "pynndescent >=0.5.13",
-    "scipy >=1.16.0",
     "streamlit >=1.45.1",
     "duckdb-extension-vss >=1.3.0",
     "ray >=2.10.0",
     "redis >=6.2",
     "slowapi ==0.1.9", # Pinned to 0.1.9 for FastAPI/Starlette compatibility
-    "lmstudio >=1.4.1",
     "polars >=1.31.0",
     "matplotlib >=3.10.0",
-
 ]
 dev = [
     "pytest >=8.3.5",
@@ -160,7 +159,6 @@ dev = [
     "pdfminer-six >=20250506", # Date-based release with security fixes
     "python-docx >=1.2.0",
     "spacy >=3.7.2",
-    "bertopic >=0.17.3",
     "responses >=0.25.7",
     "uvicorn >=0.35.0",
     "psutil >=7.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -187,7 +187,6 @@ version = "0.1.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
-    { name = "dspy-ai" },
     { name = "duckdb" },
     { name = "fastapi" },
     { name = "fastmcp" },
@@ -233,7 +232,6 @@ build = [
 ]
 dev = [
     { name = "a2a-sdk" },
-    { name = "bertopic" },
     { name = "cibuildwheel" },
     { name = "duckdb" },
     { name = "duckdb-extension-vss" },
@@ -277,15 +275,11 @@ distributed = [
     { name = "redis" },
 ]
 full = [
-    { name = "bertopic" },
     { name = "duckdb-extension-vss" },
-    { name = "lmstudio" },
     { name = "matplotlib" },
     { name = "polars" },
-    { name = "pynndescent" },
     { name = "ray" },
     { name = "redis" },
-    { name = "scipy" },
     { name = "slowapi" },
     { name = "spacy" },
     { name = "streamlit" },
@@ -293,7 +287,14 @@ full = [
 git = [
     { name = "gitpython" },
 ]
+gpu = [
+    { name = "bertopic" },
+    { name = "lmstudio" },
+    { name = "pynndescent" },
+    { name = "scipy" },
+]
 llm = [
+    { name = "dspy-ai" },
     { name = "sentence-transformers" },
     { name = "transformers" },
 ]
@@ -301,9 +302,6 @@ minimal = [
     { name = "sentence-transformers" },
 ]
 nlp = [
-    { name = "bertopic" },
-    { name = "pynndescent" },
-    { name = "scipy" },
     { name = "spacy" },
 ]
 parsers = [
@@ -341,12 +339,10 @@ requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.3.0" },
     { name = "a2a-sdk", marker = "extra == 'dev'", specifier = ">=0.2.16" },
     { name = "a2a-sdk", marker = "extra == 'test'", specifier = ">=0.2.16" },
-    { name = "bertopic", marker = "extra == 'dev'", specifier = ">=0.17.3" },
-    { name = "bertopic", marker = "extra == 'full'", specifier = ">=0.17.3" },
-    { name = "bertopic", marker = "extra == 'nlp'", specifier = ">=0.17.3" },
+    { name = "bertopic", marker = "extra == 'gpu'", specifier = ">=0.17.3" },
     { name = "build", marker = "extra == 'build'", specifier = ">=1.2.2" },
     { name = "cibuildwheel", marker = "extra == 'dev'", specifier = ">=3.0.1" },
-    { name = "dspy-ai", specifier = ">=2.6.27" },
+    { name = "dspy-ai", marker = "extra == 'llm'", specifier = ">=2.6.27" },
     { name = "duckdb", specifier = ">=1.3.0" },
     { name = "duckdb", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "duckdb", marker = "extra == 'test'", specifier = ">=1.0.0" },
@@ -372,7 +368,7 @@ requires-dist = [
     { name = "langchain-community", specifier = ">=0.3.27" },
     { name = "langchain-openai", specifier = ">=0.3.29" },
     { name = "langgraph", specifier = ">=0.6.4" },
-    { name = "lmstudio", marker = "extra == 'full'", specifier = ">=1.4.1" },
+    { name = "lmstudio", marker = "extra == 'gpu'", specifier = ">=1.4.1" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "matplotlib", marker = "extra == 'full'", specifier = ">=3.10.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.12.4" },
@@ -397,8 +393,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic", marker = "extra == 'dev'", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
-    { name = "pynndescent", marker = "extra == 'full'", specifier = ">=0.5.13" },
-    { name = "pynndescent", marker = "extra == 'nlp'", specifier = ">=0.5.13" },
+    { name = "pynndescent", marker = "extra == 'gpu'", specifier = ">=0.5.13" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
     { name = "pytest", marker = "extra == 'dev-minimal'", specifier = ">=8.3.5" },
     { name = "pytest-bdd", marker = "extra == 'dev'", specifier = ">=8.1.0" },
@@ -427,8 +422,7 @@ requires-dist = [
     { name = "responses", marker = "extra == 'dev'", specifier = ">=0.25.7" },
     { name = "responses", marker = "extra == 'test'", specifier = ">=0.25.7" },
     { name = "rich", specifier = ">=14.1.0" },
-    { name = "scipy", marker = "extra == 'full'", specifier = ">=1.16.0" },
-    { name = "scipy", marker = "extra == 'nlp'", specifier = ">=1.16.0" },
+    { name = "scipy", marker = "extra == 'gpu'", specifier = ">=1.16.0" },
     { name = "sentence-transformers", marker = "extra == 'llm'", specifier = ">=2.7.0" },
     { name = "sentence-transformers", marker = "extra == 'minimal'", specifier = ">=2.7.0" },
     { name = "setuptools", specifier = ">=80.9.0" },
@@ -457,7 +451,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'test'", specifier = ">=0.35.0" },
     { name = "watchfiles", specifier = ">=1.1.0" },
 ]
-provides-extras = ["minimal", "nlp", "ui", "vss", "parsers", "git", "distributed", "analysis", "llm", "test", "full", "dev", "dev-minimal", "build"]
+provides-extras = ["minimal", "nlp", "gpu", "ui", "vss", "parsers", "git", "distributed", "analysis", "llm", "test", "full", "dev", "dev-minimal", "build"]
 
 [[package]]
 name = "backoff"


### PR DESCRIPTION
## Summary
- use x86_64-manylinux_2_28 in the verify task so uv selects pre-built wheels
- move heavy GPU libraries into a new `gpu` extra and drop them from default dev installs
- document the GPU workflow and manylinux verify step in installation and release plan docs

## Testing
- `task check`
- `uv run mkdocs build` *(fails: missing docs, but build completes)*
- `task verify` *(fails: StepDefinitionNotFound in behavior tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b3cb5f6f7c8333a4889ad4b0565c6a