### PR TITLE
Expand optional extra coverage and enable associated tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -135,12 +135,21 @@ tasks:
 
   coverage:
     cmds:
-      - uv run pytest tests/unit --cov=src --cov-report=term-missing --cov-append
-      - >
-          uv run pytest tests/integration -m 'not requires_ui and not requires_vss
-          and not requires_distributed' --cov=src --cov-report=term-missing
-          --cov-append
-      - uv run pytest --rootdir=. tests/behavior/steps/api_batch_query_steps.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/search_cli_steps.py tests/behavior/steps/monitor_cli_steps.py tests/behavior/steps/query_interface_steps.py --cov=src --cov-report=xml --cov-report=term-missing --cov-append
+      - |
+          uv sync \
+            --extra dev-minimal \
+            --extra test \
+            --extra nlp \
+            --extra ui \
+            --extra vss \
+            --extra git \
+            --extra distributed \
+            --extra analysis \
+            --extra llm \
+            --extra parsers
+      - uv run pytest tests/unit -m 'not slow' --cov=src --cov-report=term-missing --cov-append
+      - uv run pytest tests/integration -m 'not slow' --cov=src --cov-report=term-missing --cov-append
+      - uv run pytest --rootdir=. tests/behavior/steps/api_batch_query_steps.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/search_cli_steps.py tests/behavior/steps/monitor_cli_steps.py tests/behavior/steps/query_interface_steps.py -m 'not slow' --cov=src --cov-report=xml --cov-report=term-missing --cov-append
       - uv run coverage report --fail-under={{.COVERAGE_THRESHOLD}}
       - uv run python scripts/check_token_regression.py --threshold 5
       - task check-coverage-docs
@@ -167,6 +176,7 @@ tasks:
             --extra git \
             --extra distributed \
             --extra analysis \
+            --extra llm \
             --extra parsers{{if .EXTRAS}} --extra {{.EXTRAS}}{{end}}
       - task check-env
       - uv run flake8 src tests
@@ -178,7 +188,7 @@ tasks:
           --cov=autoresearch.storage
           --cov=autoresearch.orchestration
           --cov-report=term-missing --cov-report=xml
-      - uv run pytest --rootdir=. tests/behavior/steps/api_batch_query_steps.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/search_cli_steps.py tests/behavior/steps/monitor_cli_steps.py tests/behavior/steps/query_interface_steps.py --cov=src --cov-append --cov-report=term-missing
+      - uv run pytest --rootdir=. tests/behavior/steps/api_batch_query_steps.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/search_cli_steps.py tests/behavior/steps/monitor_cli_steps.py tests/behavior/steps/query_interface_steps.py -m 'not slow' --cov=src --cov-append --cov-report=term-missing
       - uv run coverage html
       - uv run coverage report --fail-under={{.COVERAGE_THRESHOLD}}
       - uv run python scripts/check_token_regression.py --threshold 5

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -44,6 +44,17 @@ These instructions apply to files in the `tests/` directory.
 - Prefer fixtures like `tmp_path` and `monkeypatch` to isolate side effects.
 - Run `task clean` if tests generate build artifacts.
 
+## Coverage Expectations
+- `[nlp]`: cover spaCy-powered NLP paths.
+- `[ui]`: exercise Streamlit-based interfaces.
+- `[vss]`: exercise DuckDB VSS extension hooks.
+- `[git]`: cover Git-backed search utilities.
+- `[distributed]`: exercise Redis or Ray orchestration helpers.
+- `[analysis]`: cover Polars-powered analytics modules.
+- `[llm]`: exercise transformer and DSPy integrations.
+- `[parsers]`: cover document parsing helpers such as PDF and DOCX.
+- When all extras are installed, `task coverage` must report ≥90% overall.
+
 ## Reasoning and Continuous Improvement
 - Challenge assumptions about coverage and edge cases when writing tests.
 - Capture notable testing strategies in commits and update this file as new

--- a/tests/fixtures/extras.py
+++ b/tests/fixtures/extras.py
@@ -31,6 +31,12 @@ def has_git() -> bool:
 
 
 @pytest.fixture
+def has_distributed() -> bool:
+    """Return True if distributed extras are installed."""
+    return _module_available("ray")
+
+
+@pytest.fixture
 def has_analysis() -> bool:
     """Return True if analysis extras are installed."""
     return _module_available("polars")

--- a/tests/unit/test_optional_extras.py
+++ b/tests/unit/test_optional_extras.py
@@ -30,6 +30,15 @@ def test_git_extra(has_git) -> None:
     assert hasattr(git, "__version__")
 
 
+@pytest.mark.requires_distributed
+def test_distributed_extra(has_distributed) -> None:
+    if not has_distributed:
+        pytest.skip("distributed extra not installed")
+    import ray
+
+    assert hasattr(ray, "__version__")
+
+
 @pytest.mark.requires_analysis
 def test_analysis_extra(has_analysis) -> None:
     if not has_analysis:


### PR DESCRIPTION
## Summary
- document coverage expectations for optional extras in `tests/AGENTS.md`
- add `has_distributed` fixture and corresponding unit test
- run extras during verify/coverage tasks and include llm extra

## Testing
- `task check`
- `task coverage` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ce8842dc83339ea59a14e86657bc