### PR TITLE
docs: update issues and track FastAPI deprecation

### DIFF
--- a/issues/document-test-dependency-setup.md
+++ b/issues/document-test-dependency-setup.md
@@ -6,7 +6,7 @@ the development `[test]` extra is not installed when the `task` CLI is unavailab
 lack guidance for installing these dependencies manually.
 
 ## Dependencies
-- [restore-task-cli-availability](restore-task-cli-availability.md)
+- [restore-task-cli-availability](archive/restore-task-cli-availability.md)
 
 ## Acceptance Criteria
 - Document manual installation steps for `[test]` extras in `README.md` or `STATUS.md`.

--- a/issues/replace-fastapi-on-event-with-lifespan-events.md
+++ b/issues/replace-fastapi-on-event-with-lifespan-events.md
@@ -1,0 +1,17 @@
+# Replace FastAPI on event with lifespan events
+
+## Context
+Recent test runs emit `DeprecationWarning` from FastAPI that `on_event` is deprecated in favor of
+lifespan handlers in `src/autoresearch/api/routing.py`. Using `on_event` may break with FastAPI
+0.115+.
+
+## Dependencies
+None.
+
+## Acceptance Criteria
+- Refactor startup and shutdown hooks to FastAPI lifespan handlers.
+- Update tests to cover application lifespan behavior.
+- `task check` runs without FastAPI deprecation warnings.
+
+## Status
+Open

--- a/issues/restore-behavior-driven-test-suite.md
+++ b/issues/restore-behavior-driven-test-suite.md
@@ -3,12 +3,14 @@
 ## Context
 Running `uv run pytest` currently fails with
 `ModuleNotFoundError: No module named 'pytest_bdd'`. After installing this
-plugin, `task verify` reports 19 failing scenarios across
-`api_batch_query_steps.py`, `api_async_query_steps.py`, `search_cli_steps.py`,
-`monitor_cli_steps.py`, and `query_interface_steps.py`. Many step definitions
-are missing so the behavior suite aborts before coverage is recorded.
-Without passing BDD tests, critical user workflows, reasoning modes, and
-error recovery paths remain unverified.
+plugin, `task verify` reports 42 failing scenarios across
+`error_recovery_workflow_steps.py`, `first_run_steps.py`, `gui_cli_steps.py`,
+`hybrid_search_steps.py`, `interactive_monitor_steps.py`,
+`interface_test_cli_steps.py`, `mcp_interface_steps.py`,
+`orchestration_system_steps.py`, and others. Many step definitions are
+missing so the behavior suite aborts before coverage is recorded. Without
+passing BDD tests, critical user workflows, reasoning modes, and error
+recovery paths remain unverified.
 
 ## Dependencies
 - [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)


### PR DESCRIPTION
## Summary
- fix broken dependency link in test dependency setup issue
- update behavior test issue with current failing scenarios
- add issue to replace deprecated FastAPI `on_event` hooks with lifespan events

## Testing
- `task check`
- `task verify` *(fails: 42 behavior tests and KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b4556ed0f083338ed2b1825976a152