### PR TITLE
fix: add missing step definitions

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -9,7 +9,7 @@ These instructions apply to files in the `tests/` directory.
 
 ## Setup
 - Install base development dependencies with `task install` (uses `uv`).
-- When invoking `pytest` directly, prefix commands with `uv run`.
+- When invoking `pytest` directly, prefix commands with `uv run --extra test` to include test extras.
 - The behavior suite runs as part of `task verify` and `task coverage`.
 
 ## Conventions

--- a/tests/behavior/steps/api_orchestrator_integration_steps.py
+++ b/tests/behavior/steps/api_orchestrator_integration_steps.py
@@ -67,9 +67,7 @@ def test_api_handles_errors():
     pass
 
 
-@scenario(
-    "../features/api_orchestrator_integration.feature", "API respects query parameters"
-)
+@scenario("../features/api_orchestrator_integration.feature", "API respects query parameters")
 def test_api_respects_parameters():
     """Test that the API respects query parameters."""
     pass
@@ -116,7 +114,7 @@ def test_api_config_crud():
 def api_server_running(test_context, api_client, monkeypatch):
     """Set up a running API server for testing with permissive permissions."""
     cfg = ConfigModel(api=APIConfig())
-    cfg.api.role_permissions["anonymous"].append("capabilities")
+    cfg.api.role_permissions["anonymous"].extend(["capabilities", "config"])
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     test_context["client"] = api_client
 
@@ -143,18 +141,16 @@ def orchestrator_receives_query(test_context):
     mock_orchestrator = test_context["mock_orchestrator"]
     mock_orchestrator.run_query.assert_called_once()
     args, kwargs = mock_orchestrator.run_query.call_args
-    assert args[0] == test_context["query"], (
-        f"Expected query '{test_context['query']}', got '{args[0]}'"
-    )
+    assert (
+        args[0] == test_context["query"]
+    ), f"Expected query '{test_context['query']}', got '{args[0]}'"
 
 
 @then("the API should return the orchestrator's response")
 def api_returns_orchestrator_response(test_context):
     """Verify that the API returns the orchestrator's response."""
     response = test_context["response"]
-    assert response.status_code == 200, (
-        f"Expected status code 200, got {response.status_code}"
-    )
+    assert response.status_code == 200, f"Expected status code 200, got {response.status_code}"
 
     # The response should match what the orchestrator returned
     query = test_context["query"]
@@ -219,9 +215,7 @@ def api_returns_error_response(test_context):
         # Error information in the response body
         data = response.json()
         assert "answer" in data, "Response does not contain an answer field"
-        assert "Error:" in data["answer"], (
-            f"Answer does not indicate an error: {data['answer']}"
-        )
+        assert "Error:" in data["answer"], f"Answer does not indicate an error: {data['answer']}"
 
 
 @then("the error response should include a helpful message")
@@ -236,12 +230,8 @@ def error_response_includes_message(test_context):
         assert data["detail"], "Error detail is empty"
     else:
         assert "answer" in data, "Response does not contain an answer field"
-        assert "Error:" in data["answer"], (
-            f"Answer does not indicate an error: {data['answer']}"
-        )
-        assert len(data["answer"]) > 7, (
-            "Error message is too short"
-        )  # "Error: " is 7 characters
+        assert "Error:" in data["answer"], f"Answer does not indicate an error: {data['answer']}"
+        assert len(data["answer"]) > 7, "Error message is too short"  # "Error: " is 7 characters
 
 
 @then("the error should be logged")
@@ -259,9 +249,7 @@ def error_is_logged(test_context, monkeypatch, caplog):
         assert True, "API returned an error status code"
     else:
         assert "answer" in data, "Response does not contain an answer field"
-        assert "Error:" in data["answer"], (
-            f"Answer does not indicate an error: {data['answer']}"
-        )
+        assert "Error:" in data["answer"], f"Answer does not indicate an error: {data['answer']}"
 
 
 # Scenario: API respects query parameters
@@ -321,9 +309,7 @@ def send_concurrent_queries(test_context):
     # Use ThreadPoolExecutor to send concurrent requests
     with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
         futures = [
-            executor.submit(
-                test_context["client"].post, "/query", json={"query": query}
-            )
+            executor.submit(test_context["client"].post, "/query", json={"query": query})
             for query in queries
         ]
         responses = [future.result() for future in futures]
@@ -336,12 +322,8 @@ def send_concurrent_queries(test_context):
 def all_queries_processed(test_context):
     """Verify that all queries were processed."""
     responses = test_context["concurrent_responses"]
-    assert len(responses) == len(test_context["queries"]), (
-        "Not all queries were processed"
-    )
-    assert all(response.status_code == 200 for response in responses), (
-        "Some queries failed"
-    )
+    assert len(responses) == len(test_context["queries"]), "Not all queries were processed"
+    assert all(response.status_code == 200 for response in responses), "Some queries failed"
 
 
 @then("each response should be correct for its query")
@@ -351,9 +333,7 @@ def responses_match_queries(test_context):
     for query, response in zip(test_context["queries"], responses):
         data = response.json()
         assert data.get("answer") == query
-        assert data.get("citations") == [
-            {"text": "Test citation", "url": "https://example.com"}
-        ]
+        assert data.get("citations") == [{"text": "Test citation", "url": "https://example.com"}]
         assert data.get("reasoning") == [
             "Test reasoning step 1",
             "Test reasoning step 2",

--- a/tests/behavior/steps/backup_cli_steps.py
+++ b/tests/behavior/steps/backup_cli_steps.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from datetime import datetime
-from pytest_bdd import scenario, given, when, then, parsers
+
+import pytest
+from pytest_bdd import given, parsers, scenario, then, when
 
 from autoresearch.main import app as cli_app
 from autoresearch.config.loader import ConfigLoader
@@ -8,11 +10,16 @@ from autoresearch.storage_backup import BackupManager, BackupInfo
 from .common_steps import assert_cli_success
 
 
-@given("a temporary work directory", target_fixture="work_dir")
+@pytest.fixture
 def work_dir(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     ConfigLoader.reset_instance()
     return tmp_path
+
+
+@given("a temporary work directory", target_fixture="work_dir")
+def given_work_dir(work_dir):
+    return work_dir
 
 
 @given(parsers.parse('a dummy backup file "{path}"'))
@@ -23,7 +30,7 @@ def dummy_backup_file(work_dir, path):
     return file_path
 
 
-@when(parsers.parse('I run `autoresearch config backup create --dir {dir}`'))
+@when(parsers.parse("I run `autoresearch config backup create --dir {dir}`"))
 def run_backup_create(
     dir,
     cli_runner,
@@ -59,7 +66,7 @@ def run_backup_create(
     bdd_context["backup_dir"] = Path(dir)
 
 
-@when(parsers.parse('I run `autoresearch config backup list --dir {dir}`'))
+@when(parsers.parse("I run `autoresearch config backup list --dir {dir}`"))
 def run_backup_list(
     dir,
     cli_runner,
@@ -86,7 +93,7 @@ def run_backup_list(
     bdd_context["result"] = result
 
 
-@when(parsers.parse('I run `autoresearch config backup restore {path} --dir {dir} --force`'))
+@when(parsers.parse("I run `autoresearch config backup restore {path} --dir {dir} --force`"))
 def run_backup_restore(
     path,
     dir,


### PR DESCRIPTION
## Summary
- provide default work directory fixture for backup CLI steps
- allow API config updates in integration tests
- document using test extras for pytest runs

## Testing
- `uv run --extra test flake8 tests/behavior/steps/api_orchestrator_integration_steps.py tests/behavior/steps/backup_cli_steps.py`
- `uv run --extra test pytest tests/behavior -q` *(fails: 78 failed, 120 passed, 4 skipped, 65 deselected)*

------
https://chatgpt.com/codex/tasks/task_e_68b46635704c8333af287fb4d3962353