### PR TITLE
Add tests for optional extras and sync full extras by default

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,18 +27,15 @@ tasks:
               export PATH="$(pwd)/.venv/bin:$PATH"
           fi
       - |
-          extras="dev-minimal test ui vss"
-          if [ "$VERIFY_PARSERS" = "1" ]; then
-              extras="$extras parsers"
-          fi
+          extras="dev-minimal test nlp ui vss git distributed analysis llm parsers"
           uv sync $(printf ' --extra %s' $extras){{if .EXTRAS}} --extra {{.EXTRAS}}{{end}}
       - uv run python -c "import pytest_httpx, tomli_w, redis"
       - uv run flake8 src tests
     desc: |
-      Initialize dev env with minimal tools.
-      Syncs dev-minimal, test, ui, and vss extras by default.
-      Set EXTRAS="nlp" to include optional features:
-      analysis, distributed, git, gpu, llm, minimal, nlp, parsers, ui, vss
+      Initialize dev env with all extras.
+      Syncs dev-minimal, test, nlp, ui, vss, git, distributed,
+      analysis, llm, and parsers extras by default.
+      Set EXTRAS="gpu" to include optional features such as gpu or minimal.
   check-env:
     cmds:
       - uv run python scripts/check_env.py

--- a/tests/behavior/features/optional_extras.feature
+++ b/tests/behavior/features/optional_extras.feature
@@ -1,0 +1,28 @@
+@behavior
+Feature: Optional extras availability
+  Verify optional extras can be imported.
+
+  @requires_nlp
+  Scenario: NLP extra modules are importable
+    Given the optional module "spacy" can be imported
+    Then the module exposes attribute "__version__"
+
+  @requires_git
+  Scenario: Git extra modules are importable
+    Given the optional module "git" can be imported
+    Then the module exposes attribute "Repo"
+
+  @requires_analysis
+  Scenario: Analysis extra modules are importable
+    Given the optional module "polars" can be imported
+    Then the module exposes attribute "__version__"
+
+  @requires_llm
+  Scenario: LLM extra modules are importable
+    Given the optional module "transformers" can be imported
+    Then the module exposes attribute "__version__"
+
+  @requires_parsers
+  Scenario: Parsers extra modules are importable
+    Given the optional module "docx" can be imported
+    Then the module exposes attribute "Document"

--- a/tests/behavior/steps/optional_extras_steps.py
+++ b/tests/behavior/steps/optional_extras_steps.py
@@ -1,0 +1,16 @@
+import pytest
+from pytest_bdd import given, scenarios, then, parsers
+
+pytest_plugins = ["tests.behavior.steps.common_steps"]
+
+scenarios("../features/optional_extras.feature")
+
+
+@given(parsers.parse('the optional module "{module}" can be imported'))
+def optional_module(module):
+    return pytest.importorskip(module)
+
+
+@then(parsers.parse('the module exposes attribute "{attr}"'))
+def module_has_attribute(optional_module, attr):
+    assert hasattr(optional_module, attr)

--- a/tests/integration/test_optional_extras.py
+++ b/tests/integration/test_optional_extras.py
@@ -1,0 +1,33 @@
+import pytest
+from docx import Document
+
+from autoresearch.config.loader import get_config, temporary_config
+from autoresearch.data_analysis import metrics_dataframe
+from autoresearch.search.context import _try_import_sentence_transformers
+from autoresearch.search.core import _local_file_backend
+
+
+@pytest.mark.requires_analysis
+def test_metrics_dataframe_polars() -> None:
+    metrics = {"agent_timings": {"agent": [1.0, 2.0, 3.0]}}
+    df = metrics_dataframe(metrics, polars_enabled=True)
+    assert df["avg_time"][0] == 2.0
+
+
+@pytest.mark.requires_llm
+def test_sentence_transformers_import() -> None:
+    assert _try_import_sentence_transformers() is True
+
+
+@pytest.mark.requires_parsers
+def test_local_file_backend_docx(tmp_path) -> None:
+    path = tmp_path / "sample.docx"
+    doc = Document()
+    doc.add_paragraph("hello world")
+    doc.save(path)
+    cfg = get_config()
+    cfg.search.local_file.path = str(tmp_path)
+    cfg.search.local_file.file_types = ["docx"]
+    with temporary_config(cfg):
+        results = _local_file_backend("hello", max_results=1)
+    assert results and "hello" in results[0]["snippet"].lower()


### PR DESCRIPTION
## Summary
- install all optional extras during `task install`
- add integration coverage for analysis, llm, and parser extras
- add behavior scenarios verifying optional extras availability

## Testing
- `./.venv/bin/task check`
- `uv run pytest tests/integration/test_optional_extras.py -q` (skipped)
- `uv run pytest tests/behavior/features/optional_extras.feature -q` (no tests run)
- `./.venv/bin/task verify` *(fails: large dependency downloads)*


------
https://chatgpt.com/codex/tasks/task_e_68b4724775f883338807513c95f7509f