### PR TITLE
Use prebuilt wheels and skip GPU extras by default

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,15 +27,16 @@ tasks:
               export PATH="$(pwd)/.venv/bin:$PATH"
           fi
       - |
-          extras="dev-minimal test nlp ui vss git distributed analysis llm parsers"
-          uv sync $(printf ' --extra %s' $extras){{if .EXTRAS}} --extra {{.EXTRAS}}{{end}}
+          extras="dev-minimal test nlp ui vss git distributed analysis parsers"
+          uv sync --python-platform x86_64-manylinux_2_28 \
+              $(printf ' --extra %s' $extras){{if .EXTRAS}} --extra {{.EXTRAS}}{{end}}
       - uv run python -c "import pytest_httpx, tomli_w, redis"
       - uv run flake8 src tests
     desc: |
       Initialize dev env with all extras.
       Syncs dev-minimal, test, nlp, ui, vss, git, distributed,
-      analysis, llm, and parsers extras by default.
-      Set EXTRAS="gpu" to include optional features such as gpu or minimal.
+      analysis and parsers extras by default.
+      Set EXTRAS="gpu" to include optional GPU packages.
   check-env:
     cmds:
       - uv run python scripts/check_env.py
@@ -54,7 +55,7 @@ tasks:
     # exercises version and CLI smoke tests. Skips slow tests and scenarios
     # requiring optional UI (`.[ui]`) or VSS (`.[vss]`) extras.
     cmds:
-      - uv sync --extra dev-minimal
+      - uv sync --python-platform x86_64-manylinux_2_28 --extra dev-minimal
       - uv run flake8 src
       - uv run mypy src --exclude src/autoresearch/distributed
       - uv run python scripts/check_spec_tests.py
@@ -142,11 +143,16 @@ tasks:
             --extra git \
             --extra distributed \
             --extra analysis \
-            --extra llm \
             --extra parsers
-      - uv run pytest tests/unit -m 'not slow' --cov=src --cov-report=term-missing --cov-append
-      - uv run pytest tests/integration -m 'not slow' --cov=src --cov-report=term-missing --cov-append
-      - uv run pytest tests/behavior -m 'not slow' --cov=src --cov-report=xml --cov-report=term-missing --cov-append
+      - >
+          uv run pytest tests/unit -m 'not slow' \
+          --cov=src --cov-report=term-missing --cov-append
+      - >
+          uv run pytest tests/integration -m 'not slow' \
+          --cov=src --cov-report=term-missing --cov-append
+      - >
+          uv run pytest tests/behavior -m 'not slow' \
+          --cov=src --cov-report=xml --cov-report=term-missing --cov-append
       - uv run coverage report --fail-under={{.COVERAGE_THRESHOLD}}
       - uv run python scripts/check_token_regression.py --threshold 5
       - task check-coverage-docs
@@ -173,7 +179,6 @@ tasks:
             --extra git \
             --extra distributed \
             --extra analysis \
-            --extra llm \
             --extra parsers{{if .EXTRAS}} --extra {{.EXTRAS}}{{end}}
       - task check-env
       - uv run flake8 src tests

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Usage: ./scripts/setup.sh
+# Set AR_SKIP_GPU=0 to include GPU-only dependencies.
 # Detects the host platform, ensures uv and Go Task are installed, and installs
 # all extras required for unit, integration, and behavior tests.
 set -euo pipefail
@@ -37,7 +38,7 @@ if ! command -v task >/dev/null 2>&1; then
     install_test_extras
 else
     AR_SKIP_SMOKE_TEST=1 \
-    AR_EXTRAS="${AR_EXTRAS:-nlp ui vss parsers git distributed analysis llm}" \
+    AR_EXTRAS="${AR_EXTRAS:-nlp ui vss parsers git distributed analysis}" \
         "$SCRIPT_DIR/setup_universal.sh" "$@" || {
             echo "setup_universal.sh failed; installing test extras without Go Task..."
             install_test_extras

--- a/scripts/setup_common.sh
+++ b/scripts/setup_common.sh
@@ -31,8 +31,13 @@ install_dev_test_extras() {
     if [ -n "${AR_EXTRAS:-}" ]; then
         extras="$extras ${AR_EXTRAS}"
     fi
-    echo "Installing extras via uv sync --extra ${extras// / --extra }"
-    uv sync $(for e in $extras; do printf -- '--extra %s ' "$e"; done)
+    if [ "${AR_SKIP_GPU:-1}" = "1" ]; then
+        extras=$(printf '%s\n' $extras | grep -v '^gpu$' | xargs)
+    fi
+    echo "Installing extras via uv sync --python-platform x86_64-manylinux_2_28 \"
+        "--extra ${extras// / --extra }"
+    uv sync --python-platform x86_64-manylinux_2_28 \
+        $(for e in $extras; do printf -- '--extra %s ' "$e"; done)
     uv pip install -e .
 }
 


### PR DESCRIPTION
## Summary
- Avoid GPU-only dependencies by default in setup and Taskfile, trimming the default extras and documenting `AR_SKIP_GPU`
- Sync dependencies using prebuilt manylinux wheels to reduce build times

## Testing
- `task check`
- `task verify` *(fails: KeyboardInterrupt during behavior tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b47eaa9d2083339dba8859c9b5b5c8