### PR TITLE
Document data analysis and test metrics dataframe

### DIFF
--- a/docs/algorithms/data_analysis.md
+++ b/docs/algorithms/data_analysis.md
@@ -1,0 +1,9 @@
+# Data analysis
+
+Metrics aggregation converts nested timing measurements into a tabular view.
+`metrics_dataframe` builds a table from agent timings, computing mean
+runtime and count per agent. The function relies on the optional
+[Polars](https://pola.rs) library. When enabled, it returns a
+`polars.DataFrame` with `agent`, `avg_time`, and `count`. If Polars is
+disabled or missing, a `RuntimeError` is raised. See the
+[specification](../specs/data-analysis.md) for full details.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -150,7 +150,7 @@ Track algorithm notes for top-level modules.
 - [x] `cli_helpers` (docs/algorithms/cli_helpers.md)
 - [x] `cli_utils` (docs/algorithms/cli_utils.md)
 - [x] `config_utils` (docs/algorithms/config_utils.md)
-- [ ] `data_analysis`
+- [x] `data_analysis` (docs/algorithms/data_analysis.md)
 - [x] `distributed_coordination` (docs/algorithms/distributed_coordination.md)
 - [x] `error_recovery` (docs/algorithms/error_recovery.md)
 - [x] `error_utils` (docs/algorithms/error_utils.md)

--- a/scripts/avg_timing_simulation.py
+++ b/scripts/avg_timing_simulation.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Simulate agent timings and verify average duration per agent.
+
+Usage:
+    uv run python scripts/avg_timing_simulation.py
+"""
+from __future__ import annotations
+
+from autoresearch.data_analysis import metrics_dataframe
+
+
+def main() -> None:
+    metrics = {"agent_timings": {"A": [1.0, 2.0], "B": [3.0, 3.0]}}
+    try:
+        df = metrics_dataframe(metrics, polars_enabled=True)
+    except RuntimeError as exc:  # pragma: no cover - dependency check
+        print(f"Polars required: {exc}")
+        return
+    assert df["avg_time"].to_list() == [1.5, 3.0]
+    print(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_data_analysis.py
+++ b/tests/unit/test_data_analysis.py
@@ -4,7 +4,8 @@ from autoresearch.data_analysis import metrics_dataframe
 
 
 # Spec: docs/specs/data-analysis.md#polars-enabled
-def test_metrics_dataframe_enabled():
+@pytest.mark.requires_analysis
+def test_metrics_dataframe_enabled() -> None:
     pytest.importorskip("polars")
     metrics = {"agent_timings": {"A": [1.0, 2.0], "B": [3.0]}}
     df = metrics_dataframe(metrics, polars_enabled=True)
@@ -13,7 +14,14 @@ def test_metrics_dataframe_enabled():
 
 
 # Spec: docs/specs/data-analysis.md#polars-disabled
-def test_metrics_dataframe_disabled():
+def test_metrics_dataframe_disabled() -> None:
     metrics = {"agent_timings": {"A": [1.0]}}
     with pytest.raises(RuntimeError):
         metrics_dataframe(metrics, polars_enabled=False)
+
+
+def test_metrics_dataframe_polars_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    metrics = {"agent_timings": {"A": [1.0]}}
+    monkeypatch.setattr("autoresearch.data_analysis.pl", None)
+    with pytest.raises(RuntimeError):
+        metrics_dataframe(metrics, polars_enabled=True)


### PR DESCRIPTION
## Summary
- describe metrics aggregation and optional Polars usage in new `docs/algorithms/data_analysis.md`
- link data_analysis coverage in specification and add deterministic timing simulation script
- expand metrics_dataframe tests to handle optional Polars dependency

## Testing
- `uv run mkdocs build` *(fails: No such file or directory)*
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run --extra test pytest tests/unit/test_data_analysis.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4a24566d48333a9e396fcbef6cb9e