### PR TITLE
feat: handle offline setup gracefully

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,7 @@ optional extras. Dependency pins for `fastapi` (>=0.115.12) and `slowapi`
 (==0.1.9) remain in place. `task check` passes, but `task verify` fails:
 19 behavior-driven tests lack step definitions, so coverage only reflects the
 57 statements in targeted modules. When DuckDB extensions cannot be downloaded,
-setup falls back to a stub yet still runs the environment smoke test; see
+setup now logs a warning and skips the smoke test, falling back to a stub; see
 `docs/duckdb_compatibility.md` for details.
 
 References to pre-built wheels for GPU-only packages live under `wheels/gpu`.

--- a/docs/duckdb_compatibility.md
+++ b/docs/duckdb_compatibility.md
@@ -71,10 +71,9 @@ easier.
 
 This will download the appropriate VSS extension for the specified platform and
 store it in the specified directory. If the download fails, the script logs a
-warning and exits so the application can continue without the extension. The
-setup script then creates a placeholder file and skips the smoke test so
-installation finishes with vector search disabled. The script will output the
-exact path to use in your configuration file.
+warning and continues without the extension. The setup script then creates a
+placeholder file and skips the smoke test so installation finishes with vector
+search disabled. It prints the path to use in your configuration file.
 
 ### Configuration for Offline Use
 


### PR DESCRIPTION
## Summary
- skip smoke test when DuckDB extension stub is detected
- warn instead of exiting on DuckDB or Go Task download failures
- document offline setup behavior

## Testing
- `task check`
- `uv run mkdocs build`
- `task verify` *(fails: exit status 201)*
- `http_proxy=http://0.0.0.0 https_proxy=http://0.0.0.0 ./scripts/setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b4a226c3648333912dcf902d40dfca