### PR TITLE
Archive on_event issue

### DIFF
--- a/issues/archive/replace-fastapi-on-event-with-lifespan-events.md
+++ b/issues/archive/replace-fastapi-on-event-with-lifespan-events.md
@@ -14,4 +14,4 @@ None.
 - `task check` runs without FastAPI deprecation warnings.
 
 ## Status
-Open
+Archived


### PR DESCRIPTION
## Summary
- archive `replace-fastapi-on-event-with-lifespan-events` issue after verifying no remaining `on_event` references

## Testing
- `task check`
- `task verify` *(fails: tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a23703c88333ade4a74700db849d