### PR TITLE
Break down API stabilization issue into sub-issues

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,6 +60,12 @@ before running tests.
   hot-reload and improved search backends.
   - [stabilize-api-and-improve-search](
     issues/stabilize-api-and-improve-search.md)
+    - [streaming-webhook-refinements](
+      issues/streaming-webhook-refinements.md)
+    - [configuration-hot-reload-tests](
+      issues/configuration-hot-reload-tests.md)
+    - [hybrid-search-ranking-benchmarks](
+      issues/hybrid-search-ranking-benchmarks.md)
   - [plan-a2a-mcp-behavior-tests](
     issues/plan-a2a-mcp-behavior-tests.md)
 - 0.3.0 (2027-03-01, status: planned): Distributed execution support and

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -49,6 +49,12 @@ test and coverage results are tracked in [../STATUS.md](../STATUS.md).
   hot-reload and improved search backends.
   - [stabilize-api-and-improve-search](
     ../issues/stabilize-api-and-improve-search.md)
+    - [streaming-webhook-refinements](
+      ../issues/streaming-webhook-refinements.md)
+    - [configuration-hot-reload-tests](
+      ../issues/configuration-hot-reload-tests.md)
+    - [hybrid-search-ranking-benchmarks](
+      ../issues/hybrid-search-ranking-benchmarks.md)
   - [plan-a2a-mcp-behavior-tests](
     ../issues/plan-a2a-mcp-behavior-tests.md)
 - **0.3.0** (2027-03-01, status: planned): Distributed execution support and

--- a/issues/configuration-hot-reload-tests.md
+++ b/issues/configuration-hot-reload-tests.md
@@ -1,0 +1,19 @@
+# Configuration hot-reload tests
+
+## Context
+To ensure runtime resilience after v0.1.0, configuration changes must apply
+without service restarts and failure scenarios should produce clear logs.
+
+## Dependencies
+- [deliver-bug-fixes-and-docs-update](deliver-bug-fixes-and-docs-update.md)
+
+## Acceptance Criteria
+- Automated tests demonstrate config changes take effect without service
+  restarts.
+- Failure scenarios (invalid configs, missing files) are surfaced with clear
+  logs.
+- Documentation updated with reload sequence diagrams.
+
+## Status
+Open
+

--- a/issues/hybrid-search-ranking-benchmarks.md
+++ b/issues/hybrid-search-ranking-benchmarks.md
@@ -1,0 +1,18 @@
+# Hybrid search ranking benchmarks
+
+## Context
+Post v0.1.0, benchmarking search ranking across supported backends with shared
+datasets will guard against regressions and surface performance gaps.
+
+## Dependencies
+- [deliver-bug-fixes-and-docs-update](deliver-bug-fixes-and-docs-update.md)
+
+## Acceptance Criteria
+- Benchmark suite compares ranking across supported backends using shared
+  datasets.
+- Metrics (precision, recall, latency) are published in docs.
+- Regression threshold alerts trigger if metrics degrade.
+
+## Status
+Open
+

--- a/issues/stabilize-api-and-improve-search.md
+++ b/issues/stabilize-api-and-improve-search.md
@@ -2,7 +2,8 @@
 
 ## Context
 The 0.2.0 milestone targets API stabilization, configuration hot reload and
-enhanced search capabilities.
+enhanced search capabilities. After tagging v0.1.0, work continues through
+discrete sub-issues that refine streaming, configuration and search behavior.
 
 ## Milestone
 
@@ -13,9 +14,9 @@ enhanced search capabilities.
 - [deliver-bug-fixes-and-docs-update](deliver-bug-fixes-and-docs-update.md)
 
 ## Acceptance Criteria
-- Provide stable API endpoints with streaming and webhook support.
-- Implement hybrid search with ranking across backends.
-- Document configuration hot reload behavior.
+- [streaming-webhook-refinements](streaming-webhook-refinements.md) completed.
+- [configuration-hot-reload-tests](configuration-hot-reload-tests.md) completed.
+- [hybrid-search-ranking-benchmarks](hybrid-search-ranking-benchmarks.md) completed.
 
 ## Status
 Open

--- a/issues/streaming-webhook-refinements.md
+++ b/issues/streaming-webhook-refinements.md
@@ -1,0 +1,17 @@
+# Streaming webhook refinements
+
+## Context
+After tagging v0.1.0, streaming endpoints and webhook callbacks need refinement
+so long-running tasks maintain connections and deliver results reliably.
+
+## Dependencies
+- [deliver-bug-fixes-and-docs-update](deliver-bug-fixes-and-docs-update.md)
+
+## Acceptance Criteria
+- Streaming endpoints maintain connections for long-running tasks.
+- Webhooks deliver final results with verified retry logic and documentation.
+- End-to-end tests cover streaming errors and webhook callbacks.
+
+## Status
+Open
+


### PR DESCRIPTION
## Summary
- split API stabilization epic into streaming/webhook, config reload, and search benchmark issues
- link new issues across roadmap and release plan
- update parent issue to depend on sub-issues

## Testing
- `task check`
- `task verify` *(fails: KeyboardInterrupt during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a257325c83338c8f9e87b8a1a1b6