### PR TITLE
Document verify failures and update release tickets

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -3,10 +3,11 @@
 As of **August 31, 2025**, the environment now installs the Go Task CLI and
 optional extras. Dependency pins for `fastapi` (>=0.115.12) and `slowapi`
 (==0.1.9) remain in place. `task check` passes, but `task verify` fails:
-19 behavior-driven tests lack step definitions, so coverage only reflects the
-57 statements in targeted modules. When DuckDB extensions cannot be downloaded,
-setup now logs a warning and skips the smoke test, falling back to a stub; see
-`docs/duckdb_compatibility.md` for details.
+`tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent`
+hits a Hypothesis deadline, and 19 behavior-driven tests still lack step
+definitions. Coverage stops before recording results. When DuckDB extensions
+cannot be downloaded, setup now logs a warning and skips the smoke test,
+falling back to a stub; see `docs/duckdb_compatibility.md` for details.
 
 References to pre-built wheels for GPU-only packages live under `wheels/gpu`.
 `task verify` skips these dependencies by default; set `EXTRAS=gpu` when GPU
@@ -30,13 +31,14 @@ This installs the `[test]` extras and records the DuckDB VSS extension path so
 Passed via `task check`.
 
 ## Targeted tests
-Passed during `task verify`.
+Fail: `test_message_processing_is_idempotent` exceeded its Hypothesis deadline.
 
 ## Integration tests
 Not executed.
 
 ## Behavior tests
-Fail: missing step definitions in 19 scenarios.
+Fail: missing step definitions in 19 scenarios; suite not executed in latest run.
 
 ## Coverage
-**100%** (57/57 lines) for targeted modules; behavior tests remain missing.
+Not reported: run halted after unit-test failure; previous targeted modules were
+**100%** (57/57 lines).

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -18,11 +18,14 @@ defined in `autoresearch.__version__`. Phase 3
 
 The dependency pins for `fastapi` (>=0.115.12) and `slowapi` (==0.1.9) are
 confirmed in `pyproject.toml` and [installation.md](installation.md).
-`flake8` and `mypy` pass, targeted tests succeed, and integration tests are
-skipped. Behavior-driven scenarios fail: 19 steps lack definitions. Coverage
-is **100%** (57/57 lines) for targeted modules. Outstanding coverage gaps are
-tracked in [resolve-pre-alpha-release-blockers][coverage-gap-issue]. Current
-test and coverage results are tracked in [../STATUS.md](../STATUS.md).
+`flake8` and `mypy` pass, but `task verify` fails:
+`tests/unit/distributed/test_coordination_properties.py::`
+`test_message_processing_is_idempotent` exceeds its Hypothesis deadline and 19
+behavior scenarios lack definitions.
+Coverage was not generated; targeted modules remain at **100%** (57/57 lines).
+Outstanding gaps are tracked in
+[resolve-pre-alpha-release-blockers][coverage-gap-issue]. Current test results
+are mirrored in [../STATUS.md](../STATUS.md).
 
 ## Milestones
 

--- a/issues/add-test-coverage-for-optional-components.md
+++ b/issues/add-test-coverage-for-optional-components.md
@@ -7,6 +7,9 @@ behavior, and feature-specific suites that rely on optional extras such as
 regressions may slip into optional modules and overall coverage stays far below
 the 90% project goal.
 
+The **August 31, 2025** coverage run failed during unit tests, so suites using
+optional extras never executed.
+
 ## Dependencies
 - [address-task-verify-dependency-builds](address-task-verify-dependency-builds.md)
 

--- a/issues/address-task-verify-dependency-builds.md
+++ b/issues/address-task-verify-dependency-builds.md
@@ -6,6 +6,10 @@ hdbscan and CUDA packages. Recent runs finish by pulling pre-built wheels, but
 GPU libraries are still installed, inflating setup time and size. Further work is
 needed to keep the default workflow lightweight for the 0.1.0a1 release.
 
+The **August 31, 2025** `task verify` run pulled pre-built GPU wheels but still
+installed them, and the task failed later due to a unit-test deadline rather than
+build steps.
+
 ## Dependencies
 
 None.

--- a/issues/fix-idempotent-message-processing-deadline.md
+++ b/issues/fix-idempotent-message-processing-deadline.md
@@ -1,0 +1,17 @@
+# Fix idempotent message processing deadline
+
+## Context
+`tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent`
+fails with `hypothesis.errors.DeadlineExceeded` during `task verify` and `task coverage`,
+preventing coverage collection and blocking the release workflow.
+
+## Dependencies
+
+None.
+
+## Acceptance Criteria
+- Adjust the test or default Hypothesis settings so the scenario completes under the deadline.
+- `task verify` and `task coverage` run without this failure.
+
+## Status
+Open

--- a/issues/fix-task-verify-package-metadata-errors.md
+++ b/issues/fix-task-verify-package-metadata-errors.md
@@ -1,0 +1,19 @@
+# Fix task verify package metadata errors
+
+## Context
+Earlier attempts to run `task verify` surfaced package metadata problems
+when building the distribution. The latest run on **August 31, 2025** built the
+sdist and wheel without errors, but the issue remains open pending further
+validation.
+
+## Dependencies
+
+None.
+
+## Acceptance Criteria
+- Confirm `task verify` and `scripts/publish_dev.py --dry-run` build distributions
+  without metadata warnings.
+- Remove this ticket once multiple runs show no metadata errors.
+
+## Status
+Open

--- a/issues/resolve-pre-alpha-release-blockers.md
+++ b/issues/resolve-pre-alpha-release-blockers.md
@@ -7,6 +7,10 @@ pre-built CUDA wheels yet exercises only a small targeted set of tests.
 Behavior-driven scenarios continue to fail and coverage reflects just the
 57 statements in those targeted modules.
 
+The **August 31, 2025** `task verify` attempt failed early with
+`test_message_processing_is_idempotent` raising a Hypothesis deadline error, so
+coverage data was not generated.
+
 ## Dependencies
 - [fix-task-verify-package-metadata-errors](fix-task-verify-package-metadata-errors.md)
 - [address-task-verify-dependency-builds](address-task-verify-dependency-builds.md)

--- a/issues/restore-behavior-driven-test-suite.md
+++ b/issues/restore-behavior-driven-test-suite.md
@@ -12,6 +12,9 @@ missing so the behavior suite aborts before coverage is recorded. Without
 passing BDD tests, critical user workflows, reasoning modes, and error
 recovery paths remain unverified.
 
+On **August 31, 2025**, `task coverage` stopped during unit tests and never
+reached the behavior suite, so the step-definition gaps persist.
+
 ## Dependencies
 - [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)
 


### PR DESCRIPTION
## Summary
- note verify failure and missing coverage in project status
- refresh release plan status and add tickets for failing tests and metadata checks
- expand issues tracking dependency builds, BDD steps, and optional extras

## Testing
- `task verify` *(fails: DeadlineExceeded in test_message_processing_is_idempotent)*
- `task coverage` *(fails: DeadlineExceeded in test_message_processing_is_idempotent)*
- `uv run scripts/publish_dev.py --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68b4c6c8e66c8333a263af7c82bb1e55