### PR TITLE
Document coverage hang and track follow-up

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,13 +1,12 @@
 # Status
 
-As of **August 31, 2025**, the environment now installs the Go Task CLI and
-optional extras. Dependency pins for `fastapi` (>=0.115.12) and `slowapi`
-(==0.1.9) remain in place. `task check` passes, but `task verify` fails:
-`tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent`
-hits a Hypothesis deadline, and 19 behavior-driven tests still lack step
-definitions. Coverage stops before recording results. When DuckDB extensions
-cannot be downloaded, setup now logs a warning and skips the smoke test,
-falling back to a stub; see `docs/duckdb_compatibility.md` for details.
+As of **September 15, 2025**, the environment installs the Go Task CLI and
+optional extras. `task check` passes, but `task verify` stalled during the
+coverage step after syncing all extras. The run exited after a manual
+interrupt, leaving coverage data unreported. When DuckDB extensions cannot be
+downloaded, setup logs a warning and skips the smoke test, falling back to a
+stub; see `docs/duckdb_compatibility.md` for details. Dependency pins for
+`fastapi` (>=0.115.12) and `slowapi` (==0.1.9) remain in place.
 
 References to pre-built wheels for GPU-only packages live under `wheels/gpu`.
 `task verify` skips these dependencies by default; set `EXTRAS=gpu` when GPU
@@ -41,5 +40,5 @@ Not executed.
 Fail: missing step definitions in 19 scenarios; suite not executed in latest run.
 
 ## Coverage
-Not reported: run halted after unit-test failure; previous targeted modules were
-**100%** (57/57 lines).
+Not reported: coverage run stalled and was interrupted; previous targeted
+modules were **100%** (57/57 lines).

--- a/issues/add-test-coverage-for-optional-components.md
+++ b/issues/add-test-coverage-for-optional-components.md
@@ -10,6 +10,9 @@ the 90% project goal.
 The **August 31, 2025** coverage run failed during unit tests, so suites using
 optional extras never executed.
 
+On **September 15, 2025**, `task verify` stalled during the coverage step after
+syncing all extras, preventing optional-component tests from running.
+
 ## Dependencies
 - [address-task-verify-dependency-builds](address-task-verify-dependency-builds.md)
 

--- a/issues/fix-task-verify-coverage-hang.md
+++ b/issues/fix-task-verify-coverage-hang.md
@@ -1,0 +1,19 @@
+# Fix task verify coverage hang
+
+## Context
+Recent attempts to run `task verify` stall during the coverage phase after
+syncing all extras, requiring manual interruption and leaving coverage reports
+incomplete. This prevents the project from assessing overall test health before
+the 0.1.0a1 release.
+
+## Dependencies
+None.
+
+## Acceptance Criteria
+- Identify the cause of the coverage hang during `task verify`.
+- Ensure the coverage phase completes and produces reports without manual
+  intervention.
+- Document any new requirements or limitations in `STATUS.md`.
+
+## Status
+Open

--- a/issues/resolve-pre-alpha-release-blockers.md
+++ b/issues/resolve-pre-alpha-release-blockers.md
@@ -11,6 +11,11 @@ The **August 31, 2025** `task verify` attempt failed early with
 `test_message_processing_is_idempotent` raising a Hypothesis deadline error, so
 coverage data was not generated.
 
+On **September 15, 2025**, another `task verify` run required manually adding
+`.venv/bin` to `PATH` so nested tasks could execute. The coverage step stalled
+and the task exited after a manual interrupt, leaving coverage results
+unreported.
+
 ## Dependencies
 - [fix-task-verify-package-metadata-errors](fix-task-verify-package-metadata-errors.md)
 - [address-task-verify-dependency-builds](address-task-verify-dependency-builds.md)


### PR DESCRIPTION
## Summary
- note latest `task verify` interruption in STATUS and open issues
- track coverage hang with dedicated planning ticket

## Testing
- `task check`
- `task verify` *(fails: coverage run interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b4cafb928c833383ee1c288f6192d8