### PR TITLE
Ensure Go Task in venv PATH and document requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ Autoresearch requires **Python 3.12+**,
 [Go Task](https://taskfile.dev/). Both `task install` and
 `./scripts/setup.sh` automatically place `task` in `.venv/bin` when it's
 missing. See [docs/installation.md#after-cloning](docs/installation.md#after-cloning)
-for details.
+for details. Ensure `.venv/bin` is on your `PATH` so the bundled `task`
+binary resolves:
+
+```bash
+export PATH="$(pwd)/.venv/bin:$PATH"
+task --version
+```
 
 Install Go Task manually if needed:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,6 +14,19 @@ integration, and behavior tests:
 ./scripts/setup.sh
 ```
 
+After bootstrapping, `.venv/bin` is added to `PATH` and `task --version`
+should report the installed CLI:
+
+```bash
+task --version
+```
+
+Activate the virtual environment in new shells to restore the path:
+
+```bash
+source .venv/bin/activate
+```
+
 The helper downloads Go Task into `.venv/bin` when missing. If you prefer
 manual installation:
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
+source "$SCRIPT_DIR/setup_common.sh"
 case "$(uname -s)" in
     Linux*)
         "$SCRIPT_DIR/setup_linux.sh" "$@"
@@ -20,7 +21,6 @@ esac
 
 install_test_extras() {
     # Install test dependencies when Go Task is unavailable so pytest can run.
-    source "$SCRIPT_DIR/setup_common.sh"
     ensure_uv
     uv venv
     ensure_venv_bin_on_path "$(pwd)/.venv/bin"
@@ -64,6 +64,7 @@ fi
 # invocations use the expected binary. Link an existing installation when
 # possible; otherwise download it.
 VENV_BIN="$(pwd)/.venv/bin"
+ensure_venv_bin_on_path "$VENV_BIN"
 TASK_BIN="$VENV_BIN/task"
 if [ ! -x "$TASK_BIN" ]; then
     echo "Installing Go Task into $VENV_BIN..."
@@ -75,6 +76,5 @@ if [ ! -x "$TASK_BIN" ]; then
             || echo "Warning: failed to download Go Task; continuing without it" >&2
     fi
 fi
-"$TASK_BIN" --version >/dev/null 2>&1 \
-    || echo "task --version failed; continuing without Go Task" >&2
+task --version || echo "task --version failed; continuing without Go Task" >&2
 

--- a/scripts/setup_common.sh
+++ b/scripts/setup_common.sh
@@ -34,7 +34,7 @@ install_dev_test_extras() {
     if [ "${AR_SKIP_GPU:-1}" = "1" ]; then
         extras=$(printf '%s\n' $extras | grep -v '^gpu$' | xargs)
     fi
-    echo "Installing extras via uv sync --python-platform x86_64-manylinux_2_28 \"
+    echo "Installing extras via uv sync --python-platform x86_64-manylinux_2_28 " \\
         "--extra ${extras// / --extra }"
     uv sync --python-platform x86_64-manylinux_2_28 \
         $(for e in $extras; do printf -- '--extra %s ' "$e"; done)

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -30,3 +30,6 @@ else
     echo "apt-get not found; please install required packages manually." >&2
 fi
 
+# Ensure the virtual environment's bin directory is available to later steps.
+ensure_venv_bin_on_path "$(pwd)/.venv/bin"
+

--- a/scripts/setup_macos.sh
+++ b/scripts/setup_macos.sh
@@ -19,3 +19,6 @@ else
     echo "Homebrew is required to install dependencies. Install from https://brew.sh/" >&2
 fi
 
+# Ensure the virtual environment's bin directory is available to later steps.
+ensure_venv_bin_on_path "$(pwd)/.venv/bin"
+


### PR DESCRIPTION
## Summary
- load shared helpers and ensure `.venv/bin` is on PATH in setup scripts so `task --version` succeeds after bootstrapping
- document PATH requirement in README and installation guide
- fix quoting in `setup_common.sh`

## Testing
- `task --version`
- `uv run task check`

------
https://chatgpt.com/codex/tasks/task_e_68b4e58ad83c833386b3761ccfd3418e