### PR TITLE
test: disable hypothesis deadline

### DIFF
--- a/tests/unit/distributed/test_coordination_properties.py
+++ b/tests/unit/distributed/test_coordination_properties.py
@@ -4,7 +4,7 @@ import random
 import sys
 
 sys.modules.setdefault("numpy", None)
-from hypothesis import given, strategies as st  # noqa: E402
+from hypothesis import given, settings, strategies as st  # noqa: E402
 
 from scripts.distributed_coordination_sim import (  # noqa: E402
     elect_leader,
@@ -25,6 +25,7 @@ def test_election_converges_to_minimum(ids: list[int]) -> None:
         assert elect_leader(shuffled) == minimum
 
 
+@settings(deadline=None)
 @given(st.lists(st.text(min_size=0, max_size=5), max_size=20))
 def test_message_processing_is_idempotent(messages: list[str]) -> None:
     """Processing twice yields the same ordered sequence.


### PR DESCRIPTION
## Summary
- ensure message processing idempotency test ignores Hypothesis timeouts

## Testing
- `uv run --extra test pytest tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent -q`
- `uv run task verify` *(fails: task coverage exited with status 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e590bb008333ae606ee8d84d1764