### PR TITLE
Skip smoke test when only stub extension is present

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,7 +4,8 @@ As of **August 31, 2025**, the evaluation environment lacked the Go Task CLI.
 Dependencies were installed with `uv sync`, but `task check` could not run and
 `uv run pytest tests/unit` was interrupted after the first test, leaving overall
 test and coverage status unknown. When DuckDB extensions cannot be downloaded,
-setup logs a warning and skips the smoke test, falling back to a stub; see
+setup logs a warning, writes a zero-byte stub, and skips the smoke test. A real
+extension triggers the smoke test to confirm vector search; see
 `docs/duckdb_compatibility.md` for details. Dependency pins for `fastapi`
 (>=0.115.12) and `slowapi` (==0.1.9) remain in place.
 

--- a/docs/duckdb_compatibility.md
+++ b/docs/duckdb_compatibility.md
@@ -72,8 +72,10 @@ easier.
 This will download the appropriate VSS extension for the specified platform and
 store it in the specified directory. If the download fails, the script logs a
 warning and continues without the extension. The setup script then creates a
-placeholder file and skips the smoke test so installation finishes with vector
-search disabled. It prints the path to use in your configuration file.
+zero-byte placeholder and skips the smoke test so installation finishes with
+vector search disabled. When a real extension file is present, setup runs a
+short smoke test to confirm the environment. It prints the path to use in your
+configuration file.
 
 ### Configuration for Offline Use
 


### PR DESCRIPTION
## Summary
- ensure `scripts/setup.sh` ignores stub DuckDB extensions when deciding whether to run the smoke test
- add regression test for stub extension path selection
- document offline stub behavior in DuckDB docs and project status

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run pytest tests/unit/test_download_duckdb_extensions.py::test_setup_sh_skips_smoke_with_stub -q`
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68b4e5b408a48333a8c888f0dcea1750