### PR TITLE
Add streaming webhook reliability simulation and proof

### DIFF
--- a/docs/algorithms/api_streaming.md
+++ b/docs/algorithms/api_streaming.md
@@ -21,9 +21,21 @@ state to the client, then posts the final response to any configured webhooks.
   result is queued, a `None` sentinel signals completion and the response
   closes promptly.
 
+## Proof sketch
+
+Assume each webhook attempt succeeds independently with probability `p` within
+the configured timeout. With at most `r` retries, the probability of at least
+one success is `1 - (1 - p)^{r+1}`. This lower bounds connection reliability
+and shows diminishing returns as `r` grows. Expected delivery attempts are
+bounded by the geometric series `<= (1 - (1 - p)^{r+1}) / p`.
+
+The [simulation script](../../scripts/streaming_webhook_sim.py) models these
+retries and validates the bound empirically.
+
 ## Simulation
 
 Automated tests confirm api streaming behavior.
 
 - [Spec](../specs/api.md)
 - [Tests](../../tests/behavior/steps/api_streaming_steps.py)
+- [Simulation script](../../scripts/streaming_webhook_sim.py)

--- a/scripts/streaming_webhook_sim.py
+++ b/scripts/streaming_webhook_sim.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Simulate webhook retries and timeouts.
+
+Usage:
+    uv run scripts/streaming_webhook_sim.py --success-prob 0.8 --retries 3
+
+This utility models independent webhook delivery attempts with a fixed timeout
+per attempt. It reports the empirical success rate and average number of
+attempts over the given trials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+from dataclasses import dataclass
+
+
+@dataclass
+class SimulationResult:
+    """Store results from ``simulate_webhook``."""
+
+    success_rate: float
+    avg_attempts: float
+
+
+def simulate_webhook(
+    success_prob: float,
+    retries: int,
+    timeout: float,
+    trials: int = 1000,
+    seed: int | None = None,
+) -> SimulationResult:
+    """Run a Monte Carlo simulation of webhook retry behavior."""
+
+    if not 0 <= success_prob <= 1:
+        raise ValueError("success_prob must be between 0 and 1")
+    if retries < 0:
+        raise ValueError("retries must be non-negative")
+    rng = random.Random(seed)
+    successes = 0
+    total_attempts = 0
+    for _ in range(trials):
+        for attempt in range(retries + 1):
+            total_attempts += 1
+            if rng.random() < success_prob:
+                successes += 1
+                break
+    success_rate = successes / trials
+    avg_attempts = total_attempts / trials
+    return SimulationResult(success_rate, avg_attempts)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simulate webhook retry behavior and timeouts.")
+    parser.add_argument(
+        "--success-prob",
+        type=float,
+        default=0.7,
+        help="Probability a single attempt succeeds within timeout.",
+    )
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=3,
+        help="Maximum number of retries after the initial attempt.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=1.0,
+        help="Timeout per attempt in seconds.",
+    )
+    parser.add_argument("--trials", type=int, default=1000, help="Number of simulated requests.")
+    args = parser.parse_args()
+    result = simulate_webhook(args.success_prob, args.retries, args.timeout, args.trials)
+    total_time = result.avg_attempts * args.timeout
+    print(f"success rate: {result.success_rate:.3f}")
+    print(f"avg attempts: {result.avg_attempts:.2f}")
+    print(f"expected time: {total_time:.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_streaming_webhook_sim.py
+++ b/tests/unit/test_streaming_webhook_sim.py
@@ -1,0 +1,18 @@
+"""Validate streaming webhook simulation against reliability bound.
+
+See :mod:`docs.algorithms.api_streaming` for proof sketch.
+"""
+
+from scripts.streaming_webhook_sim import simulate_webhook
+
+
+def test_simulated_success_matches_bound() -> None:
+    """Simulation approximates reliability bound from the proof sketch."""
+
+    success_prob = 0.3
+    retries = 4
+    trials = 2000
+    result = simulate_webhook(success_prob, retries, timeout=1.0, trials=trials, seed=42)
+    bound = 1 - (1 - success_prob) ** (retries + 1)
+    assert abs(result.success_rate - bound) < 0.05
+    assert result.avg_attempts <= retries + 1


### PR DESCRIPTION
## Summary
- outline reliability and retry bounds for API streaming webhooks
- simulate webhook retries and timeouts via new `streaming_webhook_sim.py`
- test simulation against theoretical reliability bound

## Testing
- `task check`
- `uv run mkdocs build`
- `task verify` *(fails: exit status 201)*
- `uv run --extra test pytest tests/unit/test_streaming_webhook_sim.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4e5bccf8c8333b750002c5bc9c726