### PR TITLE
Add config hot reload invariants and simulation

### DIFF
--- a/docs/algorithms/config_hot_reload.md
+++ b/docs/algorithms/config_hot_reload.md
@@ -21,6 +21,20 @@ If validation fails, the previous configuration remains active. The atomic
 rename prevents partial writes from replacing the live file, so a failed
 swap leaves the system operating with the last valid snapshot.
 
+## Invariants
+
+- The active configuration always matches the last successfully validated
+  snapshot.
+- Failed validations keep the previous configuration active.
+- Each active configuration satisfies the validator predicates.
+
+## Convergence
+
+Assume updates stop at time ``T``. The watcher observes the last write within
+``t_p``. Validation completes in ``t_v`` and the atomic swap finishes in
+``t_io``. By ``T + t_p + t_v + t_io`` the active state equals the final valid
+snapshot and remains fixed, establishing convergence after reload.
+
 ## Empirical Results
 
 Running ``uv run``

--- a/scripts/config_hot_reload_sim.py
+++ b/scripts/config_hot_reload_sim.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Simulate config hot reload and verify invariants.
+
+Usage:
+    uv run scripts/config_hot_reload_sim.py --updates 1 2 3 4
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, Callable
+
+
+def is_valid(value: int) -> bool:
+    """Check whether a configuration value is valid."""
+    return value % 2 == 0
+
+
+def simulate_reload(
+    updates: Iterable[int],
+    *,
+    validator: Callable[[int], bool] = is_valid,
+) -> int:
+    """Process a sequence of config updates.
+
+    Args:
+        updates: Iterable of candidate config values.
+        validator: Function validating each candidate.
+
+    Returns:
+        Final active configuration.
+
+    Raises:
+        AssertionError: If invariants are violated.
+    """
+    active = 0
+    for candidate in updates:
+        previous = active
+        if validator(candidate):
+            active = candidate
+        # Invariant 1: active config is always valid.
+        assert validator(active)
+        # Invariant 2: invalid updates do not change the active config.
+        if not validator(candidate):
+            assert active == previous
+    return active
+
+
+def main() -> None:
+    """Run the simulation from the command line."""
+    parser = argparse.ArgumentParser(description="Simulate config hot reload")
+    parser.add_argument(
+        "--updates",
+        nargs="*",
+        type=int,
+        default=[1, 2, 3, 4],
+        help="Sequence of config values",
+    )
+    args = parser.parse_args()
+    final = simulate_reload(args.updates)
+    print(f"final config: {final}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_config_hot_reload_sim.py
+++ b/tests/unit/test_config_hot_reload_sim.py
@@ -1,0 +1,9 @@
+"""Run config hot reload simulation."""
+
+from scripts.config_hot_reload_sim import simulate_reload
+
+
+def test_config_hot_reload_sim() -> None:
+    """Simulation converges to last valid configuration."""
+    final = simulate_reload([1, 2, 3, 4])
+    assert final == 4


### PR DESCRIPTION
## Summary
- Document invariants and convergence proof for config hot reload
- Add simulation script verifying hot reload invariants
- Test simulation to ensure convergence to last valid config

## Testing
- `uv run scripts/config_hot_reload_sim.py --updates 1 2 3 4`
- `uv run --extra test pytest tests/unit/test_config_hot_reload_sim.py -q`
- `uv run mkdocs build` *(fails: No such file or directory)*
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e5c006c88333b3a0e37fad8d60cb