### PR TITLE
feat: support multiple extras in verify task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -141,7 +141,7 @@ tasks:
             --extra test \
             --extra nlp \
             --extra ui \
-            --extra vss{{if .EXTRAS}} --extra {{.EXTRAS}}{{end}}
+            --extra vss{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}
       - >
           uv run pytest tests/unit -m 'not slow' --cov=src --cov-report=term-missing --cov-append
       - >
@@ -174,12 +174,12 @@ tasks:
             --extra test \
             --extra nlp \
             --extra ui \
-            --extra vss{{if .EXTRAS}} --extra {{.EXTRAS}}{{end}}
+            --extra vss{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}
       - task check-env
       - uv run flake8 src tests
       - uv run mypy src
       - uv run python scripts/check_spec_tests.py
-      - task coverage{{if .EXTRAS}} EXTRAS={{.EXTRAS}}{{end}}
+      - task coverage{{if .EXTRAS}} EXTRAS="{{.EXTRAS}}"{{end}}
       - uv run coverage html
       - uv run coverage report --fail-under={{.COVERAGE_THRESHOLD}}
       - uv run python scripts/check_token_regression.py --threshold 5

--- a/tests/unit/test_download_duckdb_extensions.py
+++ b/tests/unit/test_download_duckdb_extensions.py
@@ -138,7 +138,7 @@ def test_setup_sh_skips_smoke_with_stub(monkeypatch, tmp_path):
 
     script = (
         'VSS_EXTENSION=$(find ./extensions -name "vss*.duckdb_extension" '
-        '-size +0c | head -n 1)\n'
+        "-size +0c | head -n 1)\n"
         'if [ -n "$VSS_EXTENSION" ]; then echo run; else echo skip; fi\n'
     )
     completed = subprocess.run(
@@ -149,4 +149,3 @@ def test_setup_sh_skips_smoke_with_stub(monkeypatch, tmp_path):
         check=True,
     )
     assert completed.stdout.strip() == "skip"
-


### PR DESCRIPTION
## Summary
- allow specifying multiple extras when running `task verify` and `task coverage`
- fix trailing blank line in `test_download_duckdb_extensions.py`

## Testing
- `uv run flake8 tests/unit/test_download_duckdb_extensions.py`
- `uv run task verify EXTRAS="git distributed analysis llm parsers"` *(fails: task coverage exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e5ac1a54833390a40f74ea29c5c3