### PR TITLE
Add scheduler resource benchmark and test

### DIFF
--- a/docs/scheduler_benchmark.md
+++ b/docs/scheduler_benchmark.md
@@ -1,0 +1,28 @@
+# Scheduler Resource Benchmark
+
+This benchmark measures CPU and memory impact of the backup scheduler.
+
+## Methodology
+
+- Patch the backup creation routine to a no-op to isolate scheduler overhead.
+- Start the scheduler with a one-second interval and run for a short duration.
+- Measure CPU time and resident memory before and after using
+  `resource.getrusage`.
+
+CPU time is computed as:
+
+```
+cpu_time = end.ru_utime - start.ru_utime
+```
+
+Memory use is calculated with:
+
+```
+mem_kb = end.ru_maxrss - start.ru_maxrss
+```
+
+## Results and Tuning
+
+The test [test_scheduler_benchmark.py](../tests/unit/test_scheduler_benchmark.py)
+reports measured CPU and memory. Rising values suggest increasing the backup
+interval or optimizing the backup routine.

--- a/src/autoresearch/scheduler_benchmark.py
+++ b/src/autoresearch/scheduler_benchmark.py
@@ -1,0 +1,56 @@
+"""Micro-benchmark utilities for the backup scheduler."""
+
+import resource
+import time
+from datetime import datetime
+
+from autoresearch import storage_backup
+
+
+def benchmark_scheduler(duration: float = 0.1) -> tuple[float, int]:
+    """Run the backup scheduler and report CPU and memory usage.
+
+    Args:
+        duration: Seconds to run the scheduler.
+
+    Returns:
+        Tuple containing CPU time in seconds and memory usage in kilobytes.
+    """
+
+    def noop_backup(
+        backup_dir: str,
+        db_path: str,
+        rdf_path: str,
+        compress: bool = True,
+        config: storage_backup.BackupConfig | None = None,
+    ) -> storage_backup.BackupInfo:
+        del backup_dir, db_path, rdf_path, compress, config
+        return storage_backup.BackupInfo(
+            path="",
+            timestamp=datetime.now(),
+            compressed=False,
+            size=0,
+        )
+
+    scheduler = storage_backup.BackupScheduler()
+    original_backup = storage_backup._create_backup
+    storage_backup._create_backup = noop_backup
+    start = resource.getrusage(resource.RUSAGE_SELF)
+    try:
+        scheduler.schedule(
+            backup_dir=".",
+            db_path=":memory:",
+            rdf_path=":memory:",
+            interval_hours=1,
+            compress=False,
+            max_backups=1,
+            retention_days=1,
+        )
+        time.sleep(duration)
+    finally:
+        scheduler.stop()
+        storage_backup._create_backup = original_backup
+    end = resource.getrusage(resource.RUSAGE_SELF)
+    cpu_time = end.ru_utime - start.ru_utime
+    mem_kb = end.ru_maxrss - start.ru_maxrss
+    return cpu_time, mem_kb

--- a/tests/unit/test_scheduler_benchmark.py
+++ b/tests/unit/test_scheduler_benchmark.py
@@ -1,0 +1,10 @@
+"""Micro-benchmark tests for scheduler resource usage."""
+
+from autoresearch.scheduler_benchmark import benchmark_scheduler
+
+
+def test_benchmark_scheduler_resources():
+    """Scheduler consumes minimal CPU time and memory."""
+    cpu_time, mem_kb = benchmark_scheduler(0.05)
+    assert 0.0 <= cpu_time < 1.0
+    assert 0 <= mem_kb < 50000


### PR DESCRIPTION
## Summary
- add `benchmark_scheduler` utility to measure scheduler CPU and memory use
- document scheduler benchmarking methodology
- test scheduler resource overhead

## Testing
- `./bin/task check` *(passed)*
- `uv run flake8 src tests`
- `uv run mypy src`
- `uv run pytest tests/unit/test_scheduler_benchmark.py -q`
- `uv run mkdocs build` *(fails: mkdocstrings plugin missing)*
- `./bin/task verify` *(fails: missing extra value)*

------
https://chatgpt.com/codex/tasks/task_e_68b51c9f19a48333bef7b85a751972b7