### PR TITLE
Tune hypothesis settings for distributed coordination tests

### DIFF
--- a/tests/unit/distributed/test_coordination_properties.py
+++ b/tests/unit/distributed/test_coordination_properties.py
@@ -12,6 +12,7 @@ from scripts.distributed_coordination_sim import (  # noqa: E402
 )
 
 
+@settings(max_examples=20, deadline=None)
 @given(st.lists(st.integers(min_value=0, max_value=100), min_size=1, unique=True))
 def test_election_converges_to_minimum(ids: list[int]) -> None:
     """Election converges to the global minimum identifier.
@@ -25,7 +26,7 @@ def test_election_converges_to_minimum(ids: list[int]) -> None:
         assert elect_leader(shuffled) == minimum
 
 
-@settings(deadline=None)
+@settings(max_examples=20, deadline=None)
 @given(st.lists(st.text(min_size=0, max_size=5), max_size=20))
 def test_message_processing_is_idempotent(messages: list[str]) -> None:
     """Processing twice yields the same ordered sequence.


### PR DESCRIPTION
## Summary
- prevent Hypothesis deadline failures in distributed coordination tests by disabling deadlines and reducing examples

## Testing
- `uv run pytest tests/unit/distributed/test_coordination_properties.py -q`
- `task verify EXTRAS="analysis"` *(fails: coverage subtask exits 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b51c49c2c883338968d0b5fb478ffa