### PR TITLE
Document Go Task installation and status

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status
 
-As of **September 1, 2025**, the environment lacks the Go Task CLI and
-`uv run pytest` fails with
-`ModuleNotFoundError: No module named 'pytest_bdd'`. The earlier
+As of **September 1, 2025**, the Go Task CLI is available and `task check`
+passes in a clean environment. `task verify` still fails during the coverage
+step, consistent with the open coverage-hang issue. The earlier
 `test_backup_manager` stall remains resolved: the unit test completes
 immediately using an event-based backup trigger. DuckDB extension downloads
 still fall back to a stub if the network is unavailable; a real extension
@@ -13,36 +13,20 @@ References to pre-built wheels for GPU-only packages live under `wheels/gpu`.
 `task verify` skips these dependencies by default; set `EXTRAS=gpu` when GPU
 features are required.
 
-## Bootstrapping without Go Task
-
-If the Go Task CLI cannot be installed, set up the environment with:
-
-```bash
-uv venv
-source .venv/bin/activate
-uv pip install -e ".[test]"
-uv run scripts/download_duckdb_extensions.py --output-dir ./extensions
-```
-
-This installs the `[test]` extras and uses
-`scripts/download_duckdb_extensions.py` to record the DuckDB VSS extension path
-so `uv run pytest` works without `task`.
-
 ## Lint, type checks, and spec tests
-Not run: missing Task CLI prevents `task check`.
+Passed: `task check`.
 
 ## Targeted tests
-Failed: `uv run pytest` aborts before running tests due to missing
-`pytest_bdd`.
+Failed: `task verify` aborts during coverage.
 
 ## Integration tests
-Not executed.
+Not executed: `task verify` aborts during coverage.
 
 ## Behavior tests
-Not executed.
+Not executed: `task verify` aborts during coverage.
 
 ## Coverage
-Coverage reports 100% (57/57 lines) for targeted modules.
+Unavailable: `task verify` aborts during coverage.
 
 ## Open issues
 - [restore-task-cli-availability](

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,7 +2,9 @@
 # Usage: ./scripts/setup.sh
 # Set AR_SKIP_GPU=0 to include GPU-only dependencies.
 # Detects the host platform, ensures uv and Go Task are installed, and installs
-# all extras required for unit, integration, and behavior tests.
+# all extras required for unit, integration, and behavior tests. If automatic
+# Go Task installation fails, install it manually from:
+# https://taskfile.dev/installation/
 set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
@@ -74,9 +76,12 @@ if [ ! -x "$TASK_BIN" ]; then
     if command -v task >/dev/null 2>&1; then
         ln -sf "$(command -v task)" "$TASK_BIN"
     else
-        curl -sSL https://taskfile.dev/install.sh | sh -s -- -b "$VENV_BIN" \
-            || echo "Warning: failed to download Go Task; continuing without it" >&2
+        if ! curl -sSL https://taskfile.dev/install.sh | sh -s -- -b "$VENV_BIN"; then
+            echo "Warning: failed to download Go Task; install manually:" \
+                "https://taskfile.dev/installation/" >&2
+        fi
     fi
 fi
-task --version || echo "task --version failed; continuing without Go Task" >&2
+task --version || echo "task --version failed; install from" \
+    "https://taskfile.dev/installation/" >&2
 


### PR DESCRIPTION
## Summary
- clarify `scripts/setup.sh` with manual Go Task installation guidance
- refresh `STATUS.md` to reflect available Task CLI and current test outcomes

## Testing
- `task --version`
- `task check`
- `task verify` *(fails: test_models_docstrings; coverage step aborts)*

------
https://chatgpt.com/codex/tasks/task_e_68b51c1eaf4c8333970fbef9f258b335