### PR TITLE
Enable optional extras test coverage

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -141,7 +141,12 @@ tasks:
             --extra test \
             --extra nlp \
             --extra ui \
-            --extra vss{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}
+            --extra vss \
+            --extra git \
+            --extra distributed \
+            --extra analysis \
+            --extra parsers \
+            --extra llm{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}}
       - >
           uv run pytest tests/unit -m 'not slow' --cov=src --cov-report=term-missing --cov-append
       - >
@@ -174,7 +179,12 @@ tasks:
             --extra test \
             --extra nlp \
             --extra ui \
-            --extra vss{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}
+            --extra vss \
+            --extra git \
+            --extra distributed \
+            --extra analysis \
+            --extra parsers \
+            --extra llm{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}}
       - task check-env
       - uv run flake8 src tests
       - uv run mypy src

--- a/tests/behavior/features/optional_extras.feature
+++ b/tests/behavior/features/optional_extras.feature
@@ -7,10 +7,25 @@ Feature: Optional extras availability
     Given the optional module "spacy" can be imported
     Then the module exposes attribute "__version__"
 
+  @requires_ui
+  Scenario: UI extra modules are importable
+    Given the optional module "streamlit" can be imported
+    Then the module exposes attribute "__version__"
+
+  @requires_vss
+  Scenario: VSS extra modules are importable
+    Given the optional module "duckdb_extension_vss" can be imported
+    Then the module exposes attribute "__file__"
+
   @requires_git
   Scenario: Git extra modules are importable
     Given the optional module "git" can be imported
     Then the module exposes attribute "Repo"
+
+  @requires_distributed
+  Scenario: Distributed extra modules are importable
+    Given the optional module "ray" can be imported
+    Then the module exposes attribute "__version__"
 
   @requires_analysis
   Scenario: Analysis extra modules are importable

--- a/tests/integration/test_optional_extras.py
+++ b/tests/integration/test_optional_extras.py
@@ -1,3 +1,4 @@
+import duckdb
 import pytest
 from docx import Document
 
@@ -5,6 +6,51 @@ from autoresearch.config.loader import get_config, temporary_config
 from autoresearch.data_analysis import metrics_dataframe
 from autoresearch.search.context import _try_import_sentence_transformers
 from autoresearch.search.core import _local_file_backend
+
+
+@pytest.mark.requires_nlp
+def test_spacy_blank_model() -> None:
+    spacy = pytest.importorskip("spacy")
+    nlp = spacy.blank("en")
+    assert nlp.pipe_names == []
+
+
+@pytest.mark.requires_ui
+def test_streamlit_import() -> None:
+    st = pytest.importorskip("streamlit")
+    assert hasattr(st, "__version__")
+
+
+@pytest.mark.requires_vss
+def test_duckdb_vss_extension() -> None:
+    pytest.importorskip("duckdb_extension_vss")
+    con = duckdb.connect()
+    try:
+        assert con.execute("SELECT 1").fetchone()[0] == 1
+    finally:
+        con.close()
+
+
+@pytest.mark.requires_git
+def test_git_repo(tmp_path) -> None:
+    git = pytest.importorskip("git")
+    repo = git.Repo.init(tmp_path)
+    assert repo.git_dir
+
+
+@pytest.mark.requires_distributed
+def test_ray_and_redis_import() -> None:
+    ray = pytest.importorskip("ray")
+    redis = pytest.importorskip("redis")
+    try:
+        ray.init(num_cpus=1, local_mode=True, ignore_reinit_error=True)
+    except Exception:
+        pytest.skip("ray init failed")
+    try:
+        assert ray.is_initialized()
+    finally:
+        ray.shutdown()
+    assert redis.__version__
 
 
 @pytest.mark.requires_analysis


### PR DESCRIPTION
## Summary
- install all optional extras during `verify`/`coverage`
- exercise optional extras in integration and behavior suites

## Testing
- `task check`
- `task verify` *(fails: terminated after timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b51c2e289c833392a1faf94ec3430c