### PR TITLE
test: cover optional extras

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 minversion = 6.0
-addopts = -p pytest_bdd -m 'not slow and not requires_ui and not requires_vss and not requires_distributed and not pending'
+addopts = -p pytest_bdd -m 'not slow and not pending'
 testpaths = tests/unit tests/integration tests/behavior tests/behavior/features
 bdd_features_base_dir = tests/behavior/features
 norecursedirs = tests/behavior/archive

--- a/src/autoresearch/models.py
+++ b/src/autoresearch/models.py
@@ -1,5 +1,4 @@
-"""
-Data models for Autoresearch.
+"""This module provides data models for Autoresearch.
 
 See ``docs/algorithms/models.md`` for validation, hot reload, and schema
 guarantees.

--- a/tests/behavior/features/optional_extras.feature
+++ b/tests/behavior/features/optional_extras.feature
@@ -26,3 +26,18 @@ Feature: Optional extras availability
   Scenario: Parsers extra modules are importable
     Given the optional module "docx" can be imported
     Then the module exposes attribute "Document"
+
+  @requires_ui
+  Scenario: UI extra modules are importable
+    Given the optional module "streamlit" can be imported
+    Then the module exposes attribute "__version__"
+
+  @requires_vss
+  Scenario: VSS extra modules are importable
+    Given the optional module "duckdb" can be imported
+    Then the module exposes attribute "__version__"
+
+  @requires_distributed
+  Scenario: Distributed extra modules are importable
+    Given the optional module "redis" can be imported
+    Then the module exposes attribute "Redis"

--- a/tests/integration/test_optional_extras.py
+++ b/tests/integration/test_optional_extras.py
@@ -1,10 +1,41 @@
+"""Integration tests ensuring optional extras are importable."""
+
 import pytest
-from docx import Document
 
 from autoresearch.config.loader import get_config, temporary_config
 from autoresearch.data_analysis import metrics_dataframe
 from autoresearch.search.context import _try_import_sentence_transformers
 from autoresearch.search.core import _local_file_backend
+
+
+@pytest.mark.requires_nlp
+def test_spacy_import() -> None:
+    spacy = pytest.importorskip("spacy")
+    assert hasattr(spacy, "__version__")
+
+
+@pytest.mark.requires_ui
+def test_streamlit_import() -> None:
+    streamlit = pytest.importorskip("streamlit")
+    assert hasattr(streamlit, "__version__")
+
+
+@pytest.mark.requires_vss
+def test_duckdb_import() -> None:
+    duckdb = pytest.importorskip("duckdb")
+    assert hasattr(duckdb, "__version__")
+
+
+@pytest.mark.requires_git
+def test_git_import() -> None:
+    git = pytest.importorskip("git")
+    assert hasattr(git, "Repo")
+
+
+@pytest.mark.requires_distributed
+def test_redis_import() -> None:
+    redis = pytest.importorskip("redis")
+    assert hasattr(redis, "Redis")
 
 
 @pytest.mark.requires_analysis
@@ -21,8 +52,9 @@ def test_sentence_transformers_import() -> None:
 
 @pytest.mark.requires_parsers
 def test_local_file_backend_docx(tmp_path) -> None:
+    docx = pytest.importorskip("docx")
     path = tmp_path / "sample.docx"
-    doc = Document()
+    doc = docx.Document()
     doc.add_paragraph("hello world")
     doc.save(path)
     cfg = get_config()


### PR DESCRIPTION
## Summary
- expand optional extras behavior scenarios to include UI, VSS, and distributed modules
- add integration tests exercising all optional extras
- simplify pytest default markers to allow running optional extras
- clarify models module purpose and reference spec

## Testing
- `task check`
- `task verify EXTRAS="git distributed analysis llm parsers"` *(fails: task coverage exit status 2)*
- `uv run pytest tests/unit/test_models_docstrings.py::test_module_docstrings -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6397de0608333a67582b99e565036