### PR TITLE
Ensure pytest-bdd available for check task

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,15 @@ uv pip install -e ".[test]"
 uv run scripts/download_duckdb_extensions.py --output-dir ./extensions
 ```
 
-This mirrors the DuckDB setup performed by `scripts/setup.sh` and lets
-`uv run pytest` succeed without `task`.
+The `[test]` extra installs dependencies like `pytest-bdd`, which `task check`
+expects for quick smoke tests. This mirrors the DuckDB setup performed by
+`scripts/setup.sh` and lets `uv run pytest` succeed without `task`.
 
-Run `task check` for linting, type checks, and quick smoke tests. It syncs only
-the `dev-minimal` extra and exercises a small unit subset (`test_version` and
-`test_cli_help`) for fast feedback. For the full suite, including integration
-and behavior tests, run `task verify` after syncing the `test` extra (the
-default behavior of `task install`).
+Run `task check` for linting, type checks, and quick smoke tests. It syncs the
+`dev-minimal` and `test` extras and exercises a small unit subset (`test_version`
+and `test_cli_help`) for fast feedback. For the full suite, including
+integration and behavior tests, run `task verify` after syncing the `test` extra
+(the default behavior of `task install`).
 
 For current capabilities and known limitations see
 [docs/release_notes.md](docs/release_notes.md).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -53,11 +53,11 @@ tasks:
           (echo "redis missing; run 'task install'." && exit 1)
     desc: "Validate required tool versions"
   check:
-    # Minimal validation for quick feedback. Syncs only dev-minimal extras and
-    # exercises version and CLI smoke tests. Skips slow tests and scenarios
+    # Minimal validation for quick feedback. Syncs dev-minimal and test extras
+    # and exercises version and CLI smoke tests. Skips slow tests and scenarios
     # requiring optional UI (`.[ui]`) or VSS (`.[vss]`) extras.
     cmds:
-      - uv sync --python-platform x86_64-manylinux_2_28 --extra dev-minimal
+      - uv sync --python-platform x86_64-manylinux_2_28 --extra dev-minimal --extra test
       - uv run flake8 src
       - uv run mypy src --exclude src/autoresearch/distributed
       - uv run python scripts/check_spec_tests.py

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -140,6 +140,18 @@ def check_package(pkg: str) -> CheckResult:
     return CheckResult(pkg, current, required)
 
 
+def check_pytest_bdd() -> CheckResult:
+    """Ensure pytest-bdd is installed and importable."""
+
+    try:
+        import pytest_bdd  # noqa: F401
+    except ModuleNotFoundError as exc:  # pragma: no cover - failure path
+        raise VersionError("pytest-bdd import failed; run 'task install'.") from exc
+    current = metadata.version("pytest-bdd")
+    required = REQUIREMENTS["pytest-bdd"]
+    return CheckResult("pytest-bdd", current, required)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Validate required tool versions")
     parser.parse_args()
@@ -150,6 +162,9 @@ def main() -> None:
     checks = [check_python, check_task, check_uv]
 
     for pkg in sorted(EXTRA_REQUIREMENTS):
+        if pkg == "pytest-bdd":
+            checks.append(check_pytest_bdd)
+            continue
         checks.append(lambda pkg=pkg: check_package(pkg))
 
     errors: list[str] = []


### PR DESCRIPTION
## Summary
- install test extras during `task check` so pytest-bdd is available
- verify pytest-bdd can be imported in `check_env`
- document pytest-bdd requirement when bootstrapping without Go Task

## Testing
- `uv run flake8 scripts/check_env.py`
- `task check`

------
https://chatgpt.com/codex/tasks/task_e_68b708aad8c883338cbbc141c4ef48d4