### PR TITLE
Add ranking formula proof and simulation utility

### DIFF
--- a/docs/algorithms/ranking_formula.md
+++ b/docs/algorithms/ranking_formula.md
@@ -12,6 +12,15 @@ the final score is a convex combination and also resides in :math:`[0, 1]`.
 Increasing any component score strictly increases the final relevance score.
 This property ensures consistent ranking across repeated evaluations.
 
+## Proof sketch from information retrieval theory
+
+The probability ranking principle (PRP) states that ordering documents by
+their probability of relevance yields optimal retrieval. BM25, semantic
+similarity, and source credibility each approximate this probability from
+distinct evidence sources. Their non-negative weights form a convex mixture, so
+the combined score preserves the ordering mandated by the PRP and remains a
+consistent relevance estimator.
+
 ## Simulation across datasets
 
 Synthetic datasets with differing noise levels confirm that noisier data
@@ -26,3 +35,5 @@ cumulative gain (NDCG) for datasets with noise parameters `0.0` and `0.3`.
   https://www.mir2ed.org
 - D. Knuth. *The Art of Computer Programming, Volume 3: Sorting and
   Searching*. https://www-cs-faculty.stanford.edu/~knuth/taocp.html
+- S. E. Robertson. "The Probability Ranking Principle in IR." *Journal of
+  Documentation*, 1977. https://doi.org/10.1108/eb026648

--- a/scripts/ranking_sim.py
+++ b/scripts/ranking_sim.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+"""Compare ranking variants on synthetic corpora.
+
+Usage:
+    uv run scripts/ranking_sim.py --docs 50 --queries 10 --noise 0.2
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import random
+from typing import Dict, List
+
+
+def synthetic_corpus(queries: int, docs: int, noise: float) -> Dict[str, List[Dict[str, float]]]:
+    """Generate synthetic relevance data."""
+    data: Dict[str, List[Dict[str, float]]] = {}
+    for q in range(queries):
+        entries: List[Dict[str, float]] = []
+        for _ in range(docs):
+            rel = random.random()
+            bm25 = max(0.0, min(1.0, rel + random.gauss(0.0, noise)))
+            semantic = max(0.0, min(1.0, rel + random.gauss(0.0, noise)))
+            cred = max(0.0, min(1.0, rel + random.gauss(0.0, noise)))
+            entries.append(
+                {"bm25": bm25, "semantic": semantic, "credibility": cred, "relevance": rel}
+            )
+        data[f"q{q}"] = entries
+    return data
+
+
+def _ndcg(relevances: List[float]) -> float:
+    """Compute normalized discounted cumulative gain."""
+    dcg = sum((2 ** r - 1) / math.log2(i + 2) for i, r in enumerate(relevances))
+    ideal = sorted(relevances, reverse=True)
+    idcg = sum((2 ** r - 1) / math.log2(i + 2) for i, r in enumerate(ideal))
+    return dcg / idcg if idcg else 0.0
+
+
+def _evaluate(
+    weights: tuple[float, float, float],
+    data: Dict[str, List[Dict[str, float]]],
+) -> float:
+    w_s, w_b, w_c = weights
+    total = 0.0
+    for docs in data.values():
+        scores = [
+            w_s * d["semantic"] + w_b * d["bm25"] + w_c * d["credibility"]
+            for d in docs
+        ]
+        ranked = [
+            docs[i]["relevance"]
+            for i in sorted(
+                range(len(docs)), key=lambda i: scores[i], reverse=True
+            )
+        ]
+        total += _ndcg(ranked)
+    return total / len(data)
+
+
+def compare(data: Dict[str, List[Dict[str, float]]]) -> Dict[str, float]:
+    """Evaluate standard ranking variants on data."""
+    variants = {
+        "bm25_only": (0.0, 1.0, 0.0),
+        "semantic_only": (1.0, 0.0, 0.0),
+        "credibility_only": (0.0, 0.0, 1.0),
+        "combined": (0.3, 0.5, 0.2),
+    }
+    return {name: _evaluate(weights, data) for name, weights in variants.items()}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compare ranking variants on synthetic corpora",
+    )
+    parser.add_argument("--docs", type=int, default=50, help="documents per query")
+    parser.add_argument("--queries", type=int, default=10, help="number of queries")
+    parser.add_argument("--noise", type=float, default=0.1, help="noise standard deviation")
+    args = parser.parse_args()
+    if args.docs <= 0 or args.queries <= 0:
+        parser.error("docs and queries must be positive")
+    if args.noise < 0:
+        parser.error("noise must be non-negative")
+    data = synthetic_corpus(args.queries, args.docs, args.noise)
+    scores = compare(data)
+    for name, score in scores.items():
+        print(f"{name}: {score:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_ranking_formula_consistency.py
+++ b/tests/integration/test_ranking_formula_consistency.py
@@ -1,0 +1,49 @@
+from unittest.mock import patch
+
+import pytest
+
+from autoresearch.config.models import ConfigModel, SearchConfig
+from autoresearch.search import Search
+
+
+def test_convex_combination_matches_docs(monkeypatch):
+    search_cfg = SearchConfig.model_construct(
+        semantic_similarity_weight=0.2,
+        bm25_weight=0.6,
+        source_credibility_weight=0.2,
+    )
+    cfg = ConfigModel.model_construct(search=search_cfg)
+    cfg.api.role_permissions["anonymous"] = ["query"]
+    monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
+
+    bm25 = [0.7, 0.2]
+    semantic = [0.4, 0.9]
+    cred = [0.5, 0.1]
+    docs = [
+        {"id": 0, "similarity": semantic[0]},
+        {"id": 1, "similarity": semantic[1]},
+    ]
+
+    with (
+        patch.object(
+            Search, "calculate_bm25_scores", staticmethod(lambda q, results: bm25)
+        ),
+        patch.object(
+            Search, "calculate_semantic_similarity", return_value=semantic
+        ),
+        patch.object(Search, "assess_source_credibility", return_value=cred),
+    ):
+        ranked = Search.rank_results("q", docs)
+
+    w_s = search_cfg.semantic_similarity_weight
+    w_b = search_cfg.bm25_weight
+    w_c = search_cfg.source_credibility_weight
+    expected = [w_b * bm25[i] + w_s * semantic[i] + w_c * cred[i] for i in range(2)]
+
+    ranked_ids = [r["id"] for r in ranked]
+    expected_ids = [i for i, _ in sorted(enumerate(expected), key=lambda p: p[1], reverse=True)]
+    assert ranked_ids == expected_ids
+
+    for r in ranked:
+        idx = r["id"]
+        assert r["relevance_score"] == pytest.approx(expected[idx])


### PR DESCRIPTION
## Summary
- Extend ranking formula docs with a probability ranking principle proof sketch
- Add `ranking_sim.py` to benchmark ranking variants on synthetic corpora
- Add integration test asserting runtime scores follow documented convex combination

## Testing
- `task check` *(fails: command not found)*
- `uv run pre-commit run --files docs/algorithms/ranking_formula.md scripts/ranking_sim.py tests/integration/test_ranking_formula_consistency.py` *(fails: `.pre-commit-config.yaml` is not a file)*
- `uv run --extra test pytest tests/integration/test_ranking_formula_consistency.py`
- `uv run mkdocs build`
- `task verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b708cff15c8333ba03a9ee6f73aea3