### PR TITLE
Archive closed issues and add search regression test

### DIFF
--- a/docs/api_reference/index.md
+++ b/docs/api_reference/index.md
@@ -12,12 +12,16 @@ The Autoresearch API is organized into several modules:
 - **LLM**: Language model integration and adapters
 - **Search**: Search functionality and backends
 - **Config**: Configuration management
-The HTTP API also exposes REST endpoints. Use `DELETE /query/{query_id}` to cancel an asynchronous query.
 
+## HTTP Endpoints
+
+The HTTP API exposes versioned REST endpoints under `/v1`.
+Use `DELETE /v1/query/{query_id}` to cancel an asynchronous query.
 
 ## Using the API
 
-The API documentation provides detailed information about classes, methods, and functions, including:
+The API documentation provides detailed information about classes, methods, and
+functions, including:
 
 - Method signatures with parameter types and return types
 - Docstrings with descriptions of functionality

--- a/issues/archive/configuration-hot-reload-tests.md
+++ b/issues/archive/configuration-hot-reload-tests.md
@@ -15,5 +15,5 @@ without service restarts and failure scenarios should produce clear logs.
 - Documentation updated with reload sequence diagrams.
 
 ## Status
-Open
+Archived
 

--- a/issues/archive/hybrid-search-ranking-benchmarks.md
+++ b/issues/archive/hybrid-search-ranking-benchmarks.md
@@ -14,5 +14,5 @@ datasets will guard against regressions and surface performance gaps.
 - Regression threshold alerts trigger if metrics degrade.
 
 ## Status
-Open
+Archived
 

--- a/issues/archive/streaming-webhook-refinements.md
+++ b/issues/archive/streaming-webhook-refinements.md
@@ -13,5 +13,5 @@ so long-running tasks maintain connections and deliver results reliably.
 - End-to-end tests cover streaming errors and webhook callbacks.
 
 ## Status
-Open
+Archived
 

--- a/tests/data/search_baselines.json
+++ b/tests/data/search_baselines.json
@@ -1,0 +1,8 @@
+{
+  "tests/integration/test_search_regression.py::test_search_results_stable": [
+    {
+      "title": "example",
+      "url": "https://example.com"
+    }
+  ]
+}

--- a/tests/integration/test_search_regression.py
+++ b/tests/integration/test_search_regression.py
@@ -1,0 +1,20 @@
+"""Regression test for search results stability."""
+
+from autoresearch.search import Search
+from autoresearch.config.models import ConfigModel
+
+
+def test_search_results_stable(monkeypatch, search_baseline):
+    """Search results remain stable across releases."""
+
+    def backend(query, max_results=5):
+        return [{"title": "example", "url": "https://example.com"}]
+
+    monkeypatch.setitem(Search.backends, "dummy", backend)
+    cfg = ConfigModel(loops=1)
+    cfg.search.backends = ["dummy"]
+    cfg.search.context_aware.enabled = False
+    monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
+
+    results = Search.external_lookup("example")
+    search_baseline(results)


### PR DESCRIPTION
## Summary
- archive streaming-webhook, configuration hot-reload, and hybrid search issues
- document `/v1` versioning in API reference
- add regression test ensuring search results remain stable across releases

## Testing
- `uv run --extra test pytest tests/integration/test_search_regression.py`
- `uv run --extra test pytest` *(failed: interrupted after full run)*
- `task check` *(command not found)*
- `task verify` *(command not found)*
- `uv run mkdocs build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b708f0ffb4833397c2697f394fd549