### PR TITLE
Add integration tests for extras and sync all extras before coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,20 @@ jobs:
             --extra llm
       - name: Run task verify
         run: uv run task verify
+      - name: Sync extras for coverage
+        run: |
+          uv sync \
+            --extra dev-minimal \
+            --extra dev \
+            --extra test \
+            --extra nlp \
+            --extra ui \
+            --extra vss \
+            --extra git \
+            --extra distributed \
+            --extra analysis \
+            --extra parsers \
+            --extra llm
       - name: Run task coverage
         run: uv run task coverage
       - name: Enforce coverage threshold

--- a/STATUS.md
+++ b/STATUS.md
@@ -44,7 +44,8 @@ The minimal unit subset used by `task check` passes (8 tests).
 Not executed in the current run.
 
 ## Coverage
-Coverage data was not generated because `task verify` failed.
+All optional extras were synchronized before invoking the coverage suite.
+The run exceeded resource limits and terminated before reporting metrics.
 
 ## Open issues
 - [add-ranking-algorithm-proofs-and-simulations](

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -143,7 +143,12 @@ tasks:
             --extra test \
             --extra nlp \
             --extra ui \
-            --extra vss{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}} \
+            --extra vss \
+            --extra git \
+            --extra distributed \
+            --extra analysis \
+            --extra parsers \
+            --extra llm{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}} \
             {{if and .EXTRAS (contains .EXTRAS "gpu")}}--find-links wheels/gpu{{end}}
       - uv run coverage erase
       - >

--- a/tests/integration/test_extra_usage.py
+++ b/tests/integration/test_extra_usage.py
@@ -1,0 +1,71 @@
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.requires_nlp
+def test_spacy_tokenization() -> None:
+    spacy = pytest.importorskip("spacy")
+    nlp = spacy.blank("en")
+    doc = nlp("hello world")
+    assert [t.text for t in doc] == ["hello", "world"]
+
+
+@pytest.mark.requires_ui
+def test_streamlit_markdown() -> None:
+    streamlit = pytest.importorskip("streamlit")
+    assert callable(streamlit.markdown)
+
+
+@pytest.mark.requires_vss
+def test_duckdb_query() -> None:
+    duckdb = pytest.importorskip("duckdb")
+    con = duckdb.connect()
+    assert con.execute("SELECT 42").fetchone()[0] == 42
+
+
+@pytest.mark.requires_git
+def test_gitpython_commit(tmp_path) -> None:
+    git = pytest.importorskip("git")
+    repo = git.Repo.init(tmp_path)
+    file_path = tmp_path / "README.md"
+    file_path.write_text("hello")
+    repo.index.add([str(file_path)])
+    repo.index.commit("init")
+    assert repo.head.commit.message == "init"
+
+
+@pytest.mark.requires_distributed
+def test_fakeredis_roundtrip() -> None:
+    fakeredis = pytest.importorskip("fakeredis")
+    r = fakeredis.FakeRedis()
+    r.set("k", "v")
+    assert r.get("k") == b"v"
+
+
+@pytest.mark.requires_analysis
+def test_polars_groupby() -> None:
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame({"x": [1, 2, 3], "y": [1, 1, 2]})
+    grouped = df.groupby("y").agg(pl.col("x").sum().alias("x_sum"))
+    assert grouped.filter(pl.col("y") == 1)["x_sum"][0] == 3
+
+
+@pytest.mark.requires_parsers
+def test_docx_roundtrip(tmp_path) -> None:
+    docx = pytest.importorskip("docx")
+    path = tmp_path / "hello.docx"
+    doc = docx.Document()
+    doc.add_paragraph("hi")
+    doc.save(path)
+    doc2 = docx.Document(path)
+    assert doc2.paragraphs[0].text == "hi"
+
+
+@pytest.mark.requires_llm
+def test_transformers_config() -> None:
+    pytest.importorskip("transformers")
+    from transformers import BertConfig
+
+    cfg = BertConfig()
+    assert cfg.hidden_size == 768


### PR DESCRIPTION
## Summary
- run `uv sync` with every optional extra before executing coverage in CI
- cover each optional extra with new integration tests tagged via `requires_*`
- document coverage attempt in STATUS

## Testing
- `uv run task check`
- `uv run task verify` *(fails: run interrupted after syncing large extras)*
- `uv run task coverage` *(fails: run interrupted before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68b708dd03308333b7a25d329f8f8707