### PR TITLE
Ensure setup installs Go Task automatically

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status
 
-As of **September 2, 2025**, `task` must be installed manually. After adding
-`.venv/bin` to the `PATH`, `task --version` reports `3.44.1` and `task check`
-completes successfully. A prior stall in
+As of **September 2, 2025**, `scripts/setup.sh` installs `task` automatically
+and adds `.venv/bin` to the `PATH`. After running the script, `task --version`
+reports `3.44.1` and `task check` completes successfully. A prior stall in
 `tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent`
 was resolved by reducing the Hypothesis workload and disabling the deadline.
 `task verify` previously stalled when downloading heavy `llm` dependencies.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,17 +13,24 @@ TASK_BIN="$VENV_BIN/task"
 ensure_venv_bin_on_path "$VENV_BIN"
 export PATH="$VENV_BIN:$PATH"
 
-if [ ! -x "$TASK_BIN" ]; then
+install_go_task() {
     echo "Installing Go Task into $VENV_BIN..."
-    mkdir -p "$VENV_BIN"
+    ensure_uv
+    uv venv
+    ensure_venv_bin_on_path "$VENV_BIN"
     if command -v task >/dev/null 2>&1; then
         ln -sf "$(command -v task)" "$TASK_BIN"
     else
         curl -sSL https://taskfile.dev/install.sh | sh -s -- -b "$VENV_BIN" || {
             echo "Warning: failed to download Go Task; install manually from" \
                 " https://taskfile.dev/installation/ and re-run setup" >&2
+            return
         }
     fi
+}
+
+if [ ! -x "$TASK_BIN" ]; then
+    install_go_task
 fi
 
 case "$(uname -s)" in


### PR DESCRIPTION
## Summary
- add `install_go_task` to create a virtualenv, fetch Go Task, and expose it on PATH
- note automatic Task installation in `STATUS.md`

## Testing
- `./scripts/setup.sh`
- `task --version`
- `task check`


------
https://chatgpt.com/codex/tasks/task_e_68b7364473948333b688b737fd0901af