### PR TITLE
docs: document package entry modules

### DIFF
--- a/docs/algorithms/__init__.md
+++ b/docs/algorithms/__init__.md
@@ -1,0 +1,14 @@
+# Package Initialization
+
+Central package entry that wires version metadata and optional distributed
+features.
+
+## Invariants
+
+- `__version__` reflects the installed package version.
+- `pydantic.root_model` is registered to avoid import errors in SDKs.
+- Distributed attributes load lazily through `__getattr__`.
+
+## References
+
+- [`__init__.py`](../../src/autoresearch/__init__.py)

--- a/docs/algorithms/__main__.md
+++ b/docs/algorithms/__main__.md
@@ -1,0 +1,13 @@
+# Command-Line Entrypoint
+
+Runs the CLI when the package is executed with `python -m autoresearch`.
+
+## Invariants
+
+- Delegates to `main.app` for a single point of CLI invocation.
+- Executes the application only when `__name__ == "__main__"`.
+
+## References
+
+- [`__main__.py`](../../src/autoresearch/__main__.py)
+- [../specs/main.md](../specs/main.md)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -142,8 +142,8 @@ Queries against these local indexes leverage DuckDB vector search. Matches retur
 
 Track algorithm notes for top-level modules.
 
-- [ ] `__init__`
-- [ ] `__main__`
+- [x] `__init__` (docs/algorithms/__init__.md)
+- [x] `__main__` (docs/algorithms/__main__.md)
 - [x] `a2a_interface` (docs/algorithms/a2a_interface.md)
 - [x] `cache` (docs/algorithms/cache.md)
 - [x] `cli_backup` (docs/algorithms/cli_backup.md)


### PR DESCRIPTION
## Summary
- add module notes for package initializer and CLI entry point
- record coverage for `__init__` and `__main__`

## Testing
- `uv run mkdocs build`
- `./.venv/bin/task check`
- `task verify` *(fails: coverage step exited 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b7392db2dc8333aad5dbc34a2cc295