### PR TITLE
Handle offline VSS extension in setup and document behavior

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -27,6 +27,13 @@ This installs the `[test]` extras and uses
 `scripts/download_duckdb_extensions.py` to record the DuckDB VSS extension path
 so `uv run pytest` works without `task`.
 
+## Offline DuckDB extension
+
+`scripts/setup.sh` now continues when the VSS extension download fails. It
+records a zero-byte stub at `extensions/vss/vss.duckdb_extension` and proceeds
+with smoke tests, allowing offline environments to initialize without vector
+search.
+
 ## Lint, type checks, and spec tests
 `task check` was not executed because the Go Task CLI is unavailable.
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -78,16 +78,12 @@ else
     }
 fi
 
-# Run the smoke test even when the VSS extension is missing. Ignore failures
-# when only the zero-byte stub exists so offline setups do not halt.
-VSS_EXTENSION=$(find ./extensions -name "vss*.duckdb_extension" -size +0c | head -n 1)
-if [ -n "$VSS_EXTENSION" ]; then
-    echo "Running smoke test to verify environment..."
-    uv run python scripts/smoke_test.py || \
-        echo "Smoke test failed; environment may be incomplete" >&2
-else
-    echo "VSS extension not found; running smoke test with stub..."
-    uv run python scripts/smoke_test.py >/dev/null || true
+# Run the smoke test even if the VSS extension is missing; the script
+# handles the zero-byte stub and prints warnings when vector search is
+# unavailable.
+echo "Running smoke test to verify environment..."
+if ! uv run python scripts/smoke_test.py; then
+    echo "Smoke test failed; environment may be incomplete" >&2
 fi
 
 task --version || echo "task --version failed; continuing without Go Task" >&2


### PR DESCRIPTION
## Summary
- Ensure setup always runs smoke tests and continues with a stubbed VSS extension when download fails
- Document offline DuckDB extension fallback in STATUS.md

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run python scripts/smoke_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7415a12808333813b0ab9cacdb581