### PR TITLE
chore: archive duckdb extension fallback issue

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,8 +64,8 @@ release is re-targeted for **June 15, 2026**. Key activities include:
 - [x] Task CLI availability restored
   ([restore-task-cli-availability](issues/archive/restore-task-cli-availability.md)).
 - [x] Packaging verification with DuckDB fallback.
-- [ ] Improve DuckDB extension fallback
-  ([improve-duckdb-extension-fallback](issues/improve-duckdb-extension-fallback.md)).
+- [x] Improve DuckDB extension fallback
+  ([improve-duckdb-extension-fallback](issues/archive/improve-duckdb-extension-fallback.md)).
 - [ ] Integration tests stabilized.
 - [ ] Coverage gates target **90%** total coverage once tests run
   ([add-test-coverage-for-optional-components](

--- a/STATUS.md
+++ b/STATUS.md
@@ -57,8 +57,6 @@ Coverage was not generated; `task verify` exited during linting.
   issues/add-test-coverage-for-optional-components.md)
 - [fix-task-verify-coverage-hang](
   issues/fix-task-verify-coverage-hang.md)
-- [improve-duckdb-extension-fallback](
-  issues/improve-duckdb-extension-fallback.md)
 - [prepare-v0-1-0a1-release](
   issues/prepare-v0-1-0a1-release.md)
 - [reach-stable-performance-and-interfaces](

--- a/issues/archive/improve-duckdb-extension-fallback.md
+++ b/issues/archive/improve-duckdb-extension-fallback.md
@@ -15,4 +15,4 @@ None.
 - Document offline extension fallback behavior in `STATUS.md` or docs.
 
 ## Status
-Open
+Archived

--- a/issues/prepare-v0-1-0a1-release.md
+++ b/issues/prepare-v0-1-0a1-release.md
@@ -8,7 +8,6 @@ initial proofs. Completing these steps clears the way to tag v0.1.0a1.
 ## Dependencies
 - [fix-task-verify-coverage-hang](fix-task-verify-coverage-hang.md)
 - [resolve-llm-extra-installation-failure](resolve-llm-extra-installation-failure.md)
-- [improve-duckdb-extension-fallback](improve-duckdb-extension-fallback.md)
 - [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)
 - [add-storage-eviction-proofs-and-simulations](add-storage-eviction-proofs-and-simulations.md)
 


### PR DESCRIPTION
## Summary
- archive the DuckDB extension fallback issue
- remove archived issue dependency from release planning
- mark fallback improvements complete in roadmap and status docs

## Testing
- `task check`
- `task verify` *(fails: tests/integration/test_storage_eviction_sim.py:47:1: W391 blank line at end of file)*

------
https://chatgpt.com/codex/tasks/task_e_68b766b3d3248333b82e9f2e9a260ed1