### PR TITLE
Add tests for optional LLM paths

### DIFF
--- a/tests/unit/test_llm_adapters.py
+++ b/tests/unit/test_llm_adapters.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+import pytest
+
+from autoresearch.errors import LLMError
+from autoresearch.llm.adapters import DummyAdapter, LLMAdapter
+
+
+class EmptyAdapter(LLMAdapter):
+    """Adapter with no declared models for testing defaults."""
+
+    available_models: list[str] = []
+
+    def generate(self, prompt: str, model: str | None = None, **kwargs: Any) -> str:
+        return ""
+
+
+@pytest.mark.requires_llm
+def test_validate_model_defaults_to_available_first_model() -> None:
+    adapter = DummyAdapter()
+    assert adapter.validate_model(None) == "dummy-model"
+
+
+@pytest.mark.requires_llm
+def test_validate_model_uses_generic_default_when_no_models() -> None:
+    adapter = EmptyAdapter()
+    assert adapter.validate_model(None) == "default"
+
+
+@pytest.mark.requires_llm
+def test_validate_model_rejects_invalid_models() -> None:
+    adapter = DummyAdapter()
+    with pytest.raises(LLMError):
+        adapter.validate_model("unknown")

--- a/tests/unit/test_llm_pool.py
+++ b/tests/unit/test_llm_pool.py
@@ -1,0 +1,15 @@
+import pytest
+
+from autoresearch.config.models import ConfigModel
+from autoresearch.llm import pool as llm_pool
+
+
+@pytest.mark.requires_llm
+def test_get_session_reuses_existing_instance(monkeypatch) -> None:
+    cfg = ConfigModel()
+    monkeypatch.setattr("autoresearch.llm.pool.get_config", lambda: cfg)
+    llm_pool.close_session()
+    session1 = llm_pool.get_session()
+    session2 = llm_pool.get_session()
+    assert session1 is session2
+    llm_pool.close_session()


### PR DESCRIPTION
## Summary
- test `LLMAdapter.validate_model` default and invalid model handling
- test `pool.get_session` reuses existing sessions

## Testing
- ⚠️ `uv sync --extra llm` (terminated early due to large downloads)
- ⚠️ `uv run task verify` (terminated by interrupt signal)
- ✅ `uv run pytest tests/unit/test_llm_adapters.py tests/unit/test_llm_pool.py`

------
https://chatgpt.com/codex/tasks/task_e_68b76be7382c8333b63f17d52e891602