### PR TITLE
test: cover optional component paths

### DIFF
--- a/tests/integration/test_semantic_similarity.py
+++ b/tests/integration/test_semantic_similarity.py
@@ -1,0 +1,34 @@
+import importlib
+import sys
+import types
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.requires_nlp
+
+
+def test_semantic_similarity_uses_sentence_transformer(monkeypatch):
+    """Verify semantic similarity uses sentence-transformers when available."""
+    sys.modules.pop("sentence_transformers", None)
+    core = importlib.reload(importlib.import_module("autoresearch.search.core"))
+
+    class DummySentenceTransformer:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+        def encode(self, texts):
+            if isinstance(texts, str):
+                return np.array([1.0, 0.0])
+            return np.array([[1.0, 0.0], [0.0, 1.0]])
+
+    dummy_module = types.ModuleType("sentence_transformers")
+    dummy_module.SentenceTransformer = DummySentenceTransformer
+    monkeypatch.setitem(sys.modules, "sentence_transformers", dummy_module)
+
+    search = core.Search()
+    docs = [{"title": "a"}, {"title": "b"}]
+    scores = search.calculate_semantic_similarity("query", docs)
+    assert scores == [1.0, 0.5]
+    assert core.SENTENCE_TRANSFORMERS_AVAILABLE
+    assert isinstance(search.get_sentence_transformer(), DummySentenceTransformer)

--- a/tests/unit/test_search_context_spacy.py
+++ b/tests/unit/test_search_context_spacy.py
@@ -1,0 +1,67 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+pytestmark = pytest.mark.requires_nlp
+
+
+def _install_dummy_spacy(monkeypatch, load_behavior):
+    """Install a minimal spaCy stub with controllable load behavior."""
+    dummy_cli = types.ModuleType("cli")
+    download_calls = []
+
+    def download(model: str) -> None:
+        download_calls.append(model)
+
+    dummy_cli.download = download
+
+    class DummySpacy(types.ModuleType):
+        def __init__(self) -> None:
+            super().__init__("spacy")
+            self.cli = dummy_cli
+            self.load_calls = 0
+
+        def load(self, model: str):
+            self.load_calls += 1
+            return load_behavior(self, model)
+
+    dummy_spacy = DummySpacy()
+    monkeypatch.setitem(sys.modules, "spacy", dummy_spacy)
+    monkeypatch.setitem(sys.modules, "spacy.cli", dummy_cli)
+    return dummy_spacy, download_calls
+
+
+def test_initialize_nlp_no_auto_download(monkeypatch):
+    """spaCy load failure without auto-download leaves NLP unset."""
+    for name in ("spacy", "spacy.cli"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.delenv("AUTORESEARCH_AUTO_DOWNLOAD_SPACY_MODEL", raising=False)
+    module = importlib.reload(importlib.import_module("autoresearch.search.context"))
+
+    def load_behavior(_self, _model):
+        raise OSError("missing model")
+
+    _install_dummy_spacy(monkeypatch, load_behavior)
+    ctx = module.SearchContext.new_for_tests()
+    assert ctx.nlp is None
+
+
+def test_initialize_nlp_downloads_when_env(monkeypatch):
+    """Auto-download path loads model after download."""
+    for name in ("spacy", "spacy.cli"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setenv("AUTORESEARCH_AUTO_DOWNLOAD_SPACY_MODEL", "true")
+    module = importlib.reload(importlib.import_module("autoresearch.search.context"))
+
+    def load_behavior(self, _model):
+        if self.load_calls == 1:
+            raise OSError("missing model")
+        return "nlp"
+
+    dummy_spacy, downloads = _install_dummy_spacy(monkeypatch, load_behavior)
+    ctx = module.SearchContext.new_for_tests()
+    assert ctx.nlp == "nlp"
+    assert downloads == ["en_core_web_sm"]
+    assert dummy_spacy.load_calls == 2


### PR DESCRIPTION
## Summary
- add tests for spaCy model initialization including auto-download fallback
- add integration test ensuring semantic similarity leverages sentence transformers

## Testing
- `uv sync --extra nlp`
- `uv run task check` *(fails: `task` not installed)*
- `uv run task verify` *(fails: `task` not installed)*
- `uv run pytest tests/unit/test_search_context_spacy.py tests/integration/test_semantic_similarity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b76bcd3b808333a5bc712854d874ec