### PR TITLE
Document Task CLI installation

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -8,6 +8,8 @@ strategies in `tests/unit/distributed/test_coordination_properties.py`.
 Coverage reports are generated. Dependency pins for `fastapi` (>=0.115.12) and
 `slowapi` (==0.1.9) remain in place.
 
+The evaluation setup makes Task CLI version 3.44.1 available (`task --version`).
+
 References to pre-built wheels for GPU-only packages live under `wheels/gpu`.
 `task verify` skips these dependencies by default; set `EXTRAS=gpu` when GPU
 features are required. Setup helpers and Taskfile commands consult this

--- a/issues/archive/install-task-cli-system-level.md
+++ b/issues/archive/install-task-cli-system-level.md
@@ -1,0 +1,15 @@
+# Install Task CLI system level
+
+## Context
+The evaluation environment requires the Task CLI available on the PATH so task commands can run.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- `task --version` reports the installed version
+- `task check` runs without missing-command errors
+- `task verify` runs without missing-command errors
+
+## Status
+Archived


### PR DESCRIPTION
## Summary
- note Task CLI availability in status documentation
- add archived issue recording the requirement for Task CLI on the PATH

## Testing
- `task --version`
- `task check`
- `task verify` *(fails: exit status 201)*

------
https://chatgpt.com/codex/tasks/task_e_68b76dbdceac83338d5c461e6b9cfe7a