### PR TITLE
test: cover optional component paths

### DIFF
--- a/tests/integration/test_local_git_backend.py
+++ b/tests/integration/test_local_git_backend.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+
+from autoresearch.config.models import ConfigModel
+from autoresearch.search.core import _local_git_backend
+from autoresearch.storage import StorageManager
+
+
+@contextmanager
+def _dummy_connection():
+    class DummyConn:
+        def execute(self, *args, **kwargs):
+            class Cur:
+                def fetchall(self_inner):
+                    return []
+
+            return Cur()
+
+    yield DummyConn()
+
+
+@pytest.mark.requires_git
+def test_local_git_backend_finds_file_content(tmp_path, monkeypatch):
+    git = pytest.importorskip("git", reason="git extra not installed")
+    repo_path = tmp_path / "repo"
+    repo = git.Repo.init(repo_path)
+    file_path = repo_path / "data.txt"
+    file_path.write_text("searchable text")
+    repo.index.add([str(file_path)])
+    repo.index.commit("add data")
+
+    cfg = ConfigModel()
+    cfg.search.local_git.repo_path = str(repo_path)
+    cfg.search.local_git.branches = [repo.active_branch.name]
+    cfg.search.local_git.history_depth = 5
+    cfg.search.local_file.file_types = ["txt"]
+    monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
+    monkeypatch.setattr("autoresearch.search.core.Repo", git.Repo)
+    monkeypatch.setattr(StorageManager, "connection", staticmethod(_dummy_connection))
+
+    results = _local_git_backend("searchable", max_results=5)
+    assert any("searchable text" in r["snippet"] for r in results)
+
+
+@pytest.mark.requires_git
+def test_local_git_backend_finds_commit_message(tmp_path, monkeypatch):
+    git = pytest.importorskip("git", reason="git extra not installed")
+    repo_path = tmp_path / "repo"
+    repo = git.Repo.init(repo_path)
+    file_path = repo_path / "data.txt"
+    file_path.write_text("initial")
+    repo.index.add([str(file_path)])
+    repo.index.commit("initial commit")
+    file_path.write_text("updated")
+    repo.index.add([str(file_path)])
+    repo.index.commit("feature commitmarker")
+
+    cfg = ConfigModel()
+    cfg.search.local_git.repo_path = str(repo_path)
+    cfg.search.local_git.branches = [repo.active_branch.name]
+    cfg.search.local_git.history_depth = 5
+    cfg.search.local_file.file_types = ["txt"]
+    monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
+    monkeypatch.setattr("autoresearch.search.core.Repo", git.Repo)
+    monkeypatch.setattr(StorageManager, "connection", staticmethod(_dummy_connection))
+
+    results = _local_git_backend("commitmarker", max_results=5)
+    assert any(
+        r["title"] == "commit message" and "commitmarker" in r["snippet"] for r in results
+    )


### PR DESCRIPTION
## Summary
- add integration tests for local git backend file and commit message search

## Testing
- `uv sync --extra git`
- `uv run task verify` *(fails: exit status 201)*
- `uv run --extra git pytest tests/integration/test_local_git_backend.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76bd8db4c83338cf5bdd7d906e10b