### PR TITLE
Add parser fixtures and tests for local file search

### DIFF
--- a/tests/fixtures/parsers.py
+++ b/tests/fixtures/parsers.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def sample_pdf_file(tmp_path: Path) -> Path:
+    """Create a minimal PDF containing known text."""
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_bytes = (
+        b"%PDF-1.2\n"
+        b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+        b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+        b"3 0 obj<</Type/Page/Parent 2 0 R/Resources<<>>/MediaBox[0 0 612 792]/"
+        b"Contents 4 0 R>>endobj\n"
+        b"4 0 obj<</Length 44>>stream\n"
+        b"BT /F1 24 Tf 100 700 Td (hello from pdf) Tj ET\n"
+        b"endstream\n"
+        b"endobj\n"
+        b"trailer<</Root 1 0 R>>\n"
+        b"%%EOF"
+    )
+    pdf_path.write_bytes(pdf_bytes)
+    return pdf_path
+
+
+@pytest.fixture
+def sample_docx_file(tmp_path: Path) -> Path:
+    """Create a DOCX file containing known text."""
+    docx = pytest.importorskip("docx")
+    path = tmp_path / "sample.docx"
+    doc = docx.Document()
+    doc.add_paragraph("hello from docx")
+    doc.save(path)
+    return path

--- a/tests/unit/test_local_git_backend.py
+++ b/tests/unit/test_local_git_backend.py
@@ -8,10 +8,13 @@ from autoresearch.config.models import ConfigModel
 from autoresearch.search.core import _local_git_backend
 from autoresearch.storage import StorageManager
 
+git = pytest.importorskip("git", reason="git extra not installed")
+if getattr(git, "Repo", object) is object:
+    pytest.skip("git extra not installed", allow_module_level=True)
+
 
 @pytest.mark.requires_git
 def test_local_git_backend_searches_repo(tmp_path, monkeypatch):
-    git = pytest.importorskip("git", reason="git extra not installed")
     repo_path = tmp_path / "repo"
     repo = git.Repo.init(repo_path)
     file_path = repo_path / "file.txt"

--- a/tests/unit/test_search_parsers.py
+++ b/tests/unit/test_search_parsers.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from autoresearch.config.loader import get_config, temporary_config
+from autoresearch.search import Search
+from autoresearch.search.core import _local_file_backend
+import tests.fixtures.parsers as _parsers  # noqa: F401
+
+
+@pytest.mark.requires_parsers
+def test_extract_pdf_text(sample_pdf_file, tmp_path):
+    """Verify PDF text extraction via the local_file backend."""
+    cfg = get_config()
+    cfg.search.local_file.path = str(tmp_path)
+    cfg.search.local_file.file_types = ["pdf"]
+    with temporary_config(cfg):
+        results = _local_file_backend("hello", max_results=1)
+    assert results and "hello from pdf" in results[0]["snippet"].lower()
+
+
+@pytest.mark.requires_parsers
+def test_extract_docx_text(sample_docx_file, tmp_path):
+    """Verify DOCX text extraction via the local_file backend."""
+    cfg = get_config()
+    cfg.search.local_file.path = str(tmp_path)
+    cfg.search.local_file.file_types = ["docx"]
+    with temporary_config(cfg):
+        results = _local_file_backend("hello", max_results=1)
+    assert results and "hello from docx" in results[0]["snippet"].lower()
+
+
+@pytest.mark.requires_parsers
+def test_search_local_file_backend(tmp_path, sample_pdf_file, sample_docx_file):
+    """Ensure Search.external_lookup finds content in PDF and DOCX files."""
+    cfg = get_config()
+    cfg.search.backends = ["local_file"]
+    cfg.search.local_file.path = str(tmp_path)
+    cfg.search.local_file.file_types = ["pdf", "docx"]
+    with temporary_config(cfg):
+        results = Search.external_lookup("hello", max_results=5)
+    snippets = " ".join(r["snippet"].lower() for r in results)
+    assert "hello from pdf" in snippets
+    assert "hello from docx" in snippets


### PR DESCRIPTION
## Summary
- add fixtures to generate sample PDF and DOCX files for parser tests
- verify local_file backend parses PDF/DOCX and integrates with Search
- skip git backend unit test when only stub implementations are available

## Testing
- `uv sync --extra parsers`
- `uv run task verify` *(fails: KeyboardInterrupt during test run)*

------
https://chatgpt.com/codex/tasks/task_e_68b76bee76bc8333ac1293b6ef21936b