### PR TITLE
Document coverage hang during task verify

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,12 +1,12 @@
 # Status
 
 As of **September 2, 2025**, `scripts/setup.sh` installs the Go Task CLI and
-syncs optional extras. `task check` passes, and `task verify` now completes
-after removing a trailing blank line in
-`tests/integration/test_storage_eviction_sim.py` and constraining Hypothesis
-strategies in `tests/unit/distributed/test_coordination_properties.py`.
-Coverage reports are generated. Dependency pins for `fastapi` (>=0.115.12) and
-`slowapi` (==0.1.9) remain in place.
+syncs optional extras. `task check` passes, but `task verify` still hangs
+during the coverage phase despite the earlier fixes to
+`tests/integration/test_storage_eviction_sim.py` and
+`tests/unit/distributed/test_coordination_properties.py`. The command requires
+manual interruption and produces no coverage report. Dependency pins for
+`fastapi` (>=0.115.12) and `slowapi` (==0.1.9) remain in place.
 
 The `[llm]` extra now installs CPU-friendly libraries (`fastembed`,
 `dspy-ai`) to avoid CUDA-heavy downloads. `task verify`
@@ -55,7 +55,8 @@ Not executed.
 Not executed.
 
 ## Coverage
-`task verify` succeeded, producing HTML coverage under `htmlcov/`.
+`task verify` currently hangs during the coverage phase, so no coverage report
+is generated.
 
 ## Open issues
 - [add-storage-eviction-proofs-and-simulations](

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -19,9 +19,10 @@ defined in `autoresearch.__version__`. Phase 3
 The dependency pins for `fastapi` (>=0.115.12) and `slowapi` (==0.1.9) are
 confirmed in `pyproject.toml` and [installation.md](installation.md).
 `flake8` and `mypy` pass. Coverage reports **100%** (57/57 lines) for
-targeted modules. Outstanding gaps are tracked in
-[resolve-pre-alpha-release-blockers][coverage-gap-issue]. Current test
-results are mirrored in [../STATUS.md](../STATUS.md).
+targeted modules, but recent runs of `task verify` hang during the coverage
+step, so current values remain unconfirmed. Outstanding gaps are tracked in
+[resolve-pre-alpha-release-blockers][coverage-gap-issue]. Current test results
+are mirrored in [../STATUS.md](../STATUS.md).
 
 ## Milestones
 

--- a/issues/fix-task-verify-coverage-hang.md
+++ b/issues/fix-task-verify-coverage-hang.md
@@ -9,6 +9,10 @@ still required manual interruption and exited with status 201 after
 triggered a `hypothesis.errors.DeadlineExceeded`. This prevents the project
 from assessing overall test health before the 0.1.0a1 release.
 
+On September 2, 2025, another run of `uv run task verify` hung during the
+coverage task. The process produced no further output for several minutes and
+was manually interrupted, leaving coverage reports incomplete.
+
 ## Dependencies
 - [fix-idempotent-message-processing-deadline](archive/fix-idempotent-message-processing-deadline.md)
 


### PR DESCRIPTION
## Summary
- note `task verify` coverage hang and missing reports in STATUS
- clarify coverage status in release plan
- expand issue on verify coverage hang with latest run details

## Testing
- `uv run task verify` *(fails: coverage phase hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b7750b1ae08333977bae0d5763f780