### PR TITLE
Fix tmp_path handling in coordination tests

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,11 +1,12 @@
 # Status
 
 As of **September 3, 2025**, `scripts/setup.sh` installs the Go Task CLI and
-syncs optional extras. `task check` passes, but `task verify` continues to fail
-during the coverage phase. The latest run triggered a `KeyError` from the
-`tmp_path` fixture after several minutes, and coverage reports were not
-generated. Dependency pins for `fastapi` (>=0.115.12) and `slowapi` (==0.1.9)
-remain in place.
+syncs optional extras. `task check` passes. A full
+`uv run --all-extras task verify` attempt began downloading large GPU
+dependencies and was aborted. With test extras only, the fixed
+`tests/unit/distributed/test_coordination_properties.py` now runs without the
+previous `tmp_path` `KeyError`. Dependency pins for `fastapi` (>=0.115.12) and
+`slowapi` (==0.1.9) remain in place.
 
 The `[llm]` extra now installs CPU-friendly libraries (`fastembed`, `dspy-ai`)
 to avoid CUDA-heavy downloads. `task verify EXTRAS="llm"` succeeds with these
@@ -54,8 +55,10 @@ Not executed.
 Not executed.
 
 ## Coverage
-`task verify` currently hangs during the coverage phase, so no coverage report
-is generated.
+Targeted coverage for `tests/unit/distributed/test_coordination_properties.py`
+completed, reporting **32%** combined coverage for
+`src/autoresearch/orchestration/budgeting.py` and
+`src/autoresearch/search/http.py`.
 
 ## Open issues
 - [add-storage-eviction-proofs-and-simulations](

--- a/tests/unit/distributed/test_coordination_properties.py
+++ b/tests/unit/distributed/test_coordination_properties.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import random
 import sys
+from pathlib import Path
+
+import pytest
 
 sys.modules.setdefault("numpy", None)
-from hypothesis import given, settings, strategies as st  # noqa: E402
+from hypothesis import HealthCheck, given, settings, strategies as st  # noqa: E402
 
 from scripts.distributed_coordination_sim import (  # noqa: E402
     elect_leader,
@@ -12,7 +15,18 @@ from scripts.distributed_coordination_sim import (  # noqa: E402
 )
 
 
-@settings(max_examples=10, deadline=None)
+@pytest.fixture
+def tmp_path_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Ensure multiprocessing uses the per-test temp directory."""
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    return tmp_path
+
+
+@settings(
+    max_examples=10,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
 @given(
     st.lists(
         st.integers(min_value=0, max_value=100),
@@ -21,7 +35,7 @@ from scripts.distributed_coordination_sim import (  # noqa: E402
         unique=True,
     )
 )
-def test_election_converges_to_minimum(ids: list[int]) -> None:
+def test_election_converges_to_minimum(tmp_path_env: Path, ids: list[int]) -> None:
     """Election converges to the global minimum identifier.
 
     See docs/algorithms/distributed_coordination.md for proof.
@@ -34,11 +48,15 @@ def test_election_converges_to_minimum(ids: list[int]) -> None:
 
 
 # The processing pipeline can run longer on constrained runners. Limit the
-# workload and disable Hypothesis deadlines to avoid spurious timeouts during
+# workload and relax Hypothesis deadlines to avoid spurious timeouts during
 # coverage runs.
-@settings(max_examples=3, deadline=None)
+@settings(
+    max_examples=3,
+    deadline=1000,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
 @given(st.lists(st.text(min_size=0, max_size=5), max_size=5))
-def test_message_processing_is_idempotent(messages: list[str]) -> None:
+def test_message_processing_is_idempotent(tmp_path_env: Path, messages: list[str]) -> None:
     """Processing twice yields the same ordered sequence.
 
     See docs/algorithms/distributed_coordination.md for proof.


### PR DESCRIPTION
## Summary
- ensure multiprocessing respects pytest tmp_path in coordination property tests
- relax idempotency deadline and suppress fixture health checks
- document targeted coverage results in STATUS.md

## Testing
- `uv run --all-extras task verify` *(fails: large GPU downloads triggered)*
- `uv run --extra test --with pytest-cov pytest tests/unit/distributed/test_coordination_properties.py --cov=src --cov-report=term`


------
https://chatgpt.com/codex/tasks/task_e_68b79a1a68d88333b7220e3cd4eb7975