### PR TITLE
Ensure optional extras run during verification

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,11 +1,9 @@
 # Status
 
-As of **September 3, 2025**, `scripts/setup.sh` installs the Go Task CLI and
-syncs optional extras. `task check` passes, but `task verify` continues to fail
-during the coverage phase. The latest run triggered a `KeyError` from the
-`tmp_path` fixture after several minutes, and coverage reports were not
-generated. Dependency pins for `fastapi` (>=0.115.12) and `slowapi` (==0.1.9)
-remain in place.
+As of **March 1, 2026**, tests for all extras run, but `task verify` still
+fails. `tests/unit/test_main_monitor_commands.py::test_serve_a2a_command`
+returned exit code 130, preventing coverage generation. Dependency pins for
+`fastapi` (>=0.115.12) and `slowapi` (==0.1.9) remain in place.
 
 The `[llm]` extra now installs CPU-friendly libraries (`fastembed`, `dspy-ai`)
 to avoid CUDA-heavy downloads. `task verify EXTRAS="llm"` succeeds with these

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -147,7 +147,8 @@ tasks:
             --extra git \
             --extra distributed \
             --extra analysis \
-            --extra parsers{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}} \
+            --extra parsers \
+            --extra llm{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}} \
             {{if and .EXTRAS (contains .EXTRAS "gpu")}}--find-links wheels/gpu{{end}}
       - uv run coverage erase
       - >
@@ -188,7 +189,12 @@ tasks:
             --extra test \
             --extra nlp \
             --extra ui \
-            --extra vss{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}} \
+            --extra vss \
+            --extra git \
+            --extra distributed \
+            --extra analysis \
+            --extra parsers \
+            --extra llm{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}} \
             {{if and .EXTRAS (contains .EXTRAS "gpu")}}--find-links wheels/gpu{{end}}
       - task check-env
       - uv run flake8 src tests

--- a/tests/behavior/steps/local_sources_steps.py
+++ b/tests/behavior/steps/local_sources_steps.py
@@ -5,19 +5,12 @@ from pytest_bdd import scenario, given, when, then, parsers
 from .common_steps import app_running, app_running_with_default, application_running
 from autoresearch.config.models import ConfigModel
 from autoresearch.search import Search
-from pdfminer.high_level import extract_text
-from docx import Document
 import pytest
-import importlib.util
 
-try:
-    _spec = importlib.util.find_spec("git")
-    _git_available = bool(_spec and _spec.origin)
-except Exception:
-    _git_available = False
-
-if not _git_available:
-    pytest.skip("GitPython not installed", allow_module_level=True)
+pdfminer = pytest.importorskip("pdfminer.high_level")
+extract_text = pdfminer.extract_text
+docx = pytest.importorskip("docx")
+Document = docx.Document
 
 
 @given("a directory with text files")

--- a/tests/integration/test_config_hot_reload.py
+++ b/tests/integration/test_config_hot_reload.py
@@ -8,8 +8,6 @@ import tomli_w
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel
 from autoresearch.orchestration import orchestrator as orch_mod
-from tests.conftest import GITPYTHON_INSTALLED
-
 git = pytest.importorskip("git", reason="git extra not installed")
 
 Orchestrator = orch_mod.Orchestrator
@@ -32,7 +30,6 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.slow,
     pytest.mark.requires_git,
-    pytest.mark.skipif(not GITPYTHON_INSTALLED, reason="GitPython not installed"),
 ]
 
 

--- a/tests/integration/test_config_hot_reload_components.py
+++ b/tests/integration/test_config_hot_reload_components.py
@@ -10,15 +10,12 @@ from autoresearch.config.models import ConfigModel
 from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
 from autoresearch.search import Search
 from autoresearch.storage import StorageManager
-from tests.conftest import GITPYTHON_INSTALLED
-
 git = pytest.importorskip("git", reason="git extra not installed")
 
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.slow,
     pytest.mark.requires_git,
-    pytest.mark.skipif(not GITPYTHON_INSTALLED, reason="GitPython not installed"),
 ]
 
 

--- a/tests/integration/test_distributed_node_health.py
+++ b/tests/integration/test_distributed_node_health.py
@@ -1,4 +1,3 @@
-import importlib.util
 import sys
 import types
 from pathlib import Path
@@ -6,8 +5,7 @@ from pathlib import Path
 import pytest
 from prometheus_client import CollectorRegistry
 
-if importlib.util.find_spec("redis") is None:
-    pytest.skip("redis not installed", allow_module_level=True)
+pytest.importorskip("redis")
 
 package = types.ModuleType("autoresearch.monitor")
 package.__path__ = [str(Path(__file__).resolve().parents[2] / "src" / "autoresearch" / "monitor")]

--- a/tests/integration/test_distributed_redis_broker.py
+++ b/tests/integration/test_distributed_redis_broker.py
@@ -1,12 +1,8 @@
-import importlib.util
-
 import pytest
 
 from autoresearch.distributed.broker import RedisBroker
 
-if importlib.util.find_spec("redis") is None:
-    pytest.skip("redis not installed", allow_module_level=True)
-import redis
+redis = pytest.importorskip("redis")
 
 pytestmark = [
     pytest.mark.slow,

--- a/tests/integration/test_knn_benchmark.py
+++ b/tests/integration/test_knn_benchmark.py
@@ -3,23 +3,10 @@ import time
 import numpy as np
 import pytest
 from autoresearch.storage import StorageManager
-import duckdb
-from autoresearch.extensions import VSSExtensionLoader
 from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.config.loader import ConfigLoader
 
-try:
-    _tmp_conn = duckdb.connect(database=":memory:")
-    VSS_AVAILABLE = VSSExtensionLoader.verify_extension(_tmp_conn, verbose=False)
-    _tmp_conn.close()
-except Exception:
-    VSS_AVAILABLE = False
-
-pytestmark = [
-    pytest.mark.slow,
-    pytest.mark.requires_vss,
-    pytest.mark.skipif(not VSS_AVAILABLE, reason="VSS extension not available"),
-]
+pytestmark = [pytest.mark.slow, pytest.mark.requires_vss]
 
 
 def test_knn_latency_benchmark(tmp_path, monkeypatch):

--- a/tests/integration/test_search_backends.py
+++ b/tests/integration/test_search_backends.py
@@ -7,23 +7,12 @@ backends and the main search functionality.
 import subprocess
 
 import pytest
-import importlib.util
-
-try:
-    _spec = importlib.util.find_spec("git")
-    GITPYTHON_INSTALLED = bool(_spec and _spec.origin)
-except Exception:
-    GITPYTHON_INSTALLED = False
 
 from autoresearch.search import Search
 from autoresearch import cache
 from autoresearch.config.models import ConfigModel
 
-pytestmark = [
-    pytest.mark.slow,
-    pytest.mark.requires_git,
-    pytest.mark.skipif(not GITPYTHON_INSTALLED, reason="GitPython not installed"),
-]
+pytestmark = [pytest.mark.slow, pytest.mark.requires_git]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_search_storage.py
+++ b/tests/integration/test_search_storage.py
@@ -9,12 +9,7 @@ from autoresearch.search import Search
 from autoresearch.storage import StorageManager
 from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
-from tests.conftest import VSS_AVAILABLE
-
-pytestmark = [
-    pytest.mark.requires_vss,
-    pytest.mark.skipif(not VSS_AVAILABLE, reason="VSS extension not available"),
-]
+pytestmark = [pytest.mark.requires_vss]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_vector_extension_extended.py
+++ b/tests/integration/test_vector_extension_extended.py
@@ -9,25 +9,12 @@ and error handling in vector search.
 import pytest
 import logging
 from unittest.mock import patch
-import duckdb  # noqa: E402
-from autoresearch.extensions import VSSExtensionLoader  # noqa: E402
 from autoresearch.storage import StorageManager  # noqa: E402
 from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.errors import StorageError  # noqa: E402
 
-try:
-    _tmp_conn = duckdb.connect(database=":memory:")
-    VSS_AVAILABLE = VSSExtensionLoader.verify_extension(_tmp_conn, verbose=False)
-    _tmp_conn.close()
-except Exception:
-    VSS_AVAILABLE = False
-
-pytestmark = [
-    pytest.mark.slow,
-    pytest.mark.requires_vss,
-    pytest.mark.skipif(not VSS_AVAILABLE, reason="VSS extension not available"),
-]
+pytestmark = [pytest.mark.slow, pytest.mark.requires_vss]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_local_git_backend.py
+++ b/tests/unit/test_local_git_backend.py
@@ -9,8 +9,6 @@ from autoresearch.search.core import _local_git_backend
 from autoresearch.storage import StorageManager
 
 git = pytest.importorskip("git", reason="git extra not installed")
-if getattr(git, "Repo", object) is object:
-    pytest.skip("git extra not installed", allow_module_level=True)
 
 
 @pytest.mark.requires_git


### PR DESCRIPTION
## Summary
- remove hard skips so optional extra tests run under their `requires_*` markers
- install all extras, including llm, during `task verify` and coverage runs
- note current verification failure and coverage status in `STATUS.md`

## Testing
- `task check`
- `task verify` *(fails: tests/unit/test_main_monitor_commands.py::test_serve_a2a_command)*


------
https://chatgpt.com/codex/tasks/task_e_68b79a2646cc8333a4165b12597e4637