### PR TITLE
test: mark extras and update verify task

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -60,6 +60,10 @@ completed, reporting **32%** combined coverage for
 `src/autoresearch/orchestration/budgeting.py` and
 `src/autoresearch/search/http.py`.
 
+`task verify` was updated to install all extras and run marked tests. An
+attempt to execute the full suite with coverage encountered failing
+integration tests and did not produce a final report.
+
 ## Open issues
 - [add-storage-eviction-proofs-and-simulations](
   issues/add-storage-eviction-proofs-and-simulations.md)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -147,6 +147,7 @@ tasks:
             --extra git \
             --extra distributed \
             --extra analysis \
+            --extra llm \
             --extra parsers{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}} \
             {{if and .EXTRAS (contains .EXTRAS "gpu")}}--find-links wheels/gpu{{end}}
       - uv run coverage erase
@@ -188,7 +189,12 @@ tasks:
             --extra test \
             --extra nlp \
             --extra ui \
-            --extra vss{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}} \
+            --extra vss \
+            --extra git \
+            --extra distributed \
+            --extra analysis \
+            --extra llm \
+            --extra parsers{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}} \
             {{if and .EXTRAS (contains .EXTRAS "gpu")}}--find-links wheels/gpu{{end}}
       - task check-env
       - uv run flake8 src tests

--- a/tests/analysis/test_evaluate_ranking.py
+++ b/tests/analysis/test_evaluate_ranking.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.requires_parsers
+
 # Skip if optional parsers are unavailable
 pytest.importorskip("docx")
 pytest.importorskip("pdfminer.high_level")

--- a/tests/unit/test_kuzu_polars.py
+++ b/tests/unit/test_kuzu_polars.py
@@ -3,6 +3,8 @@ import pytest
 from autoresearch.data_analysis import metrics_dataframe
 from autoresearch.storage_backends import KuzuStorageBackend
 
+pytestmark = pytest.mark.requires_analysis
+
 pytest.importorskip("polars")
 
 


### PR DESCRIPTION
## Summary
- mark parser and analysis tests with dedicated markers
- sync all optional extras during `task verify` and `task coverage`
- note coverage run outcome in status document

## Testing
- `.venv/bin/task check`
- `PATH=$PWD/.venv/bin:$PATH .venv/bin/task verify` *(fails: integration tests failing)*


------
https://chatgpt.com/codex/tasks/task_e_68b7ba6f37b48333b2393c26a4ca376b