### PR TITLE
Add distributed message simulation and performance docs

### DIFF
--- a/docs/orchestrator_perf.md
+++ b/docs/orchestrator_perf.md
@@ -1,29 +1,34 @@
 # Orchestrator Performance
 
 Efficient orchestration depends on balancing scheduling throughput with
-resource limits. The distributed simulation measures how many tasks can be
-completed per second and the CPU and memory costs of that workload.
+resource limits. The distributed simulation models message handling across
+worker processes and records CPU and memory use.
+
+## Methodology
+
+- Workers square integers to mimic message processing.
+- `messages` defines items sent per loop and `loops` controls repetition.
+- `ResourceMonitor` samples CPU and memory every 50 ms.
+- Metrics include total messages processed, elapsed time, throughput, CPU
+  percentage, and memory footprint.
 
 ## Formulas
 
-- **Throughput:** `throughput = total_tasks / duration_seconds`
-- **CPU usage:** Average process CPU percentage reported by the resource
-  monitor.
-- **Memory usage:** Maximum resident set size in megabytes.
+- **Throughput:** `throughput = total_messages / duration_seconds`
+- **CPU usage:** mean process CPU percent reported by the monitor.
+- **Memory usage:** maximum resident set size in megabytes.
 
 ## Assumptions
 
-- Tasks are CPU bound and split across processes, enabling near-linear
-  scaling when additional workers are available.
+- Messages are CPU bound and split across processes, enabling near-linear
+  scaling as worker count increases.
 - Sampling uses a short 50 ms interval to minimize monitoring overhead.
 - GPU statistics are optional and may report zeros when unavailable.
 
 ## Tuning Guidance
 
-- Increase `--workers` until CPU utilization approaches the number of
-  cores. Additional workers beyond that point may offer diminishing
-  throughput gains.
-- Adjust `--tasks` and `--loops` to keep total work large enough to amortize
-  startup costs.
-- Watch memory usage when tasks hold significant state; the monitor reports
+- Increase `--workers` until CPU utilization approaches the number of cores.
+  Extra workers beyond that point show diminishing throughput gains.
+- Adjust `--messages` and `--loops` so total work amortizes startup costs.
+- Watch memory usage when messages hold significant state; the monitor reports
   megabytes consumed by the parent process.

--- a/scripts/distributed_sim.py
+++ b/scripts/distributed_sim.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Simulate message throughput and resource consumption.
+
+Usage:
+    uv run python scripts/distributed_sim.py --workers 2 --messages 100
+
+The simulation routes synthetic messages through multiple worker processes and
+records throughput along with CPU and memory usage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from concurrent.futures import ProcessPoolExecutor
+
+from autoresearch.resource_monitor import ResourceMonitor
+
+
+def _handle_message(n: int) -> int:
+    """Perform trivial work to simulate message handling."""
+
+    return n * n
+
+
+def run_simulation(workers: int, messages: int, loops: int = 10) -> dict[str, float]:
+    """Process messages across processes and gather performance metrics.
+
+    Args:
+        workers: Number of worker processes.
+        messages: Messages handled per loop.
+        loops: Scheduling loops to execute.
+
+    Returns:
+        Dictionary with total messages, duration, throughput, CPU percentage, and
+        memory usage.
+    """
+
+    if workers <= 0 or messages <= 0 or loops <= 0:
+        raise SystemExit("workers, messages, and loops must be positive")
+
+    monitor = ResourceMonitor(interval=0.05)
+    monitor.start()
+    start = time.perf_counter()
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        for _ in range(loops):
+            list(executor.map(_handle_message, range(messages)))
+    duration = time.perf_counter() - start
+    monitor.stop()
+
+    total_messages = messages * loops
+    throughput = total_messages / duration if duration > 0 else float("inf")
+    cpu = float(monitor.cpu_gauge._value.get())
+    mem = float(monitor.mem_gauge._value.get())
+    return {
+        "messages": float(total_messages),
+        "duration_s": duration,
+        "throughput": throughput,
+        "cpu_percent": cpu,
+        "memory_mb": mem,
+    }
+
+
+def main(workers: int, messages: int, loops: int = 10) -> dict[str, float]:
+    """Run the simulation and print summary metrics."""
+
+    metrics = run_simulation(workers=workers, messages=messages, loops=loops)
+    print(
+        f"Processed {int(metrics['messages'])} messages in "
+        f"{metrics['duration_s']:.3f}s with {workers} workers"
+    )
+    print(
+        json.dumps(
+            {
+                "throughput": metrics["throughput"],
+                "cpu_percent": metrics["cpu_percent"],
+                "memory_mb": metrics["memory_mb"],
+            }
+        )
+    )
+    return metrics
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Distributed message throughput simulation")
+    parser.add_argument("--workers", type=int, default=2, help="number of worker processes")
+    parser.add_argument("--messages", type=int, default=100, help="messages per scheduling loop")
+    parser.add_argument("--loops", type=int, default=10, help="scheduling loops")
+    args = parser.parse_args()
+    main(args.workers, args.messages, args.loops)

--- a/tests/analysis/distributed_sim_analysis.py
+++ b/tests/analysis/distributed_sim_analysis.py
@@ -1,0 +1,42 @@
+"""Analyze message throughput scaling for the distributed simulation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import distributed_sim
+
+
+def run() -> dict[int, dict[str, float]]:
+    """Run simulations for multiple worker counts and store metrics."""
+
+    results: dict[int, dict[str, float]] = {}
+    for workers in (1, 2, 4):
+        metrics = distributed_sim.run_simulation(workers=workers, messages=100, loops=5)
+        results[workers] = {
+            "throughput": metrics["throughput"],
+            "cpu_percent": metrics["cpu_percent"],
+            "memory_mb": metrics["memory_mb"],
+        }
+    out_dir = Path(__file__).resolve().parent
+    out_dir.joinpath("distributed_sim_metrics.json").write_text(json.dumps(results, indent=2))
+
+    try:  # optional visualization
+        import matplotlib.pyplot as plt
+
+        xs = sorted(results)
+        ys = [results[w]["throughput"] for w in xs]
+        plt.figure()
+        plt.plot(xs, ys, marker="o")
+        plt.xlabel("workers")
+        plt.ylabel("messages/sec")
+        plt.title("Message throughput scaling")
+        plt.savefig(out_dir / "distributed_sim_plot.png")
+    except Exception:  # pragma: no cover
+        pass
+    return results
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print(json.dumps(run(), indent=2))

--- a/tests/analysis/distributed_sim_metrics.json
+++ b/tests/analysis/distributed_sim_metrics.json
@@ -1,0 +1,17 @@
+{
+  "1": {
+    "throughput": 155.81923179308106,
+    "cpu_percent": 22.2,
+    "memory_mb": 126.703125
+  },
+  "2": {
+    "throughput": 197.1418029703611,
+    "cpu_percent": 23.0,
+    "memory_mb": 127.078125
+  },
+  "4": {
+    "throughput": 1361.5581060975444,
+    "cpu_percent": 19.8,
+    "memory_mb": 127.078125
+  }
+}

--- a/tests/analysis/test_distributed_sim.py
+++ b/tests/analysis/test_distributed_sim.py
@@ -1,0 +1,12 @@
+"""Validate message throughput scaling for the distributed simulation."""
+
+from tests.analysis.distributed_sim_analysis import run
+
+
+def test_message_throughput_scales() -> None:
+    metrics = run()
+    assert set(metrics) == {1, 2, 4}
+    throughputs = [metrics[w]["throughput"] for w in (1, 2, 4)]
+    assert throughputs[1] > throughputs[0]
+    assert throughputs[2] > throughputs[1]
+    assert all(m["memory_mb"] > 0 for m in metrics.values())


### PR DESCRIPTION
## Summary
- simulate message throughput and resource consumption in `scripts/distributed_sim.py`
- document methodology and formulas in `docs/orchestrator_perf.md`
- add analysis and test suite for message scaling metrics

## Testing
- `uv run black --check scripts/distributed_sim.py tests/analysis/distributed_sim_analysis.py tests/analysis/test_distributed_sim.py`
- `uv run flake8 scripts/distributed_sim.py tests/analysis/distributed_sim_analysis.py tests/analysis/test_distributed_sim.py`
- `uv run mkdocs build`
- `uv run pytest tests/analysis/test_distributed_sim.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7bfd266948333919c95a68d1ecb55