### PR TITLE
Refine webhook retries and document search benchmarks

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,11 +33,11 @@ before running tests.
   - [stabilize-api-and-improve-search](
     issues/stabilize-api-and-improve-search.md)
     - [streaming-webhook-refinements](
-      issues/streaming-webhook-refinements.md)
+      issues/archive/streaming-webhook-refinements.md)
     - [configuration-hot-reload-tests](
-      issues/configuration-hot-reload-tests.md)
+      issues/archive/configuration-hot-reload-tests.md)
     - [hybrid-search-ranking-benchmarks](
-      issues/hybrid-search-ranking-benchmarks.md)
+      issues/archive/hybrid-search-ranking-benchmarks.md)
 - 0.3.0 (2027-03-01, status: planned): Distributed execution support and
   monitoring utilities.
   - [simulate-distributed-orchestrator-performance](

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,7 +55,8 @@ curl -X POST http://localhost:8000/query \
 ```
 
 Pass `stream=true` as a query parameter to receive incremental updates instead
-of a single response:
+of a single response. When no data is available a blank heartbeat line keeps
+the connection open:
 
 ```bash
 curl -X POST 'http://localhost:8000/query?stream=true' \
@@ -117,8 +118,9 @@ curl -X POST http://localhost:8000/query \
 
 Additionally, any URLs listed under `[api].webhooks` in
 `autoresearch.toml` receive the same payload after each query completes.
-Delivery is retried up to three times with exponential backoff. Failures are
-logged and do not affect the main response.
+Delivery is retried up to three times with exponential backoff for both
+network errors and non-2xx responses. After the final attempt a failure is
+logged, but the main response is unaffected.
 
 ### `GET /metrics`
 

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -37,11 +37,11 @@ are mirrored in [../STATUS.md](../STATUS.md).
   - [stabilize-api-and-improve-search](
     ../issues/stabilize-api-and-improve-search.md)
     - [streaming-webhook-refinements](
-      ../issues/streaming-webhook-refinements.md)
+      ../issues/archive/streaming-webhook-refinements.md)
     - [configuration-hot-reload-tests](
-      ../issues/configuration-hot-reload-tests.md)
+      ../issues/archive/configuration-hot-reload-tests.md)
     - [hybrid-search-ranking-benchmarks](
-      ../issues/hybrid-search-ranking-benchmarks.md)
+      ../issues/archive/hybrid-search-ranking-benchmarks.md)
 - **0.3.0** (2027-03-01, status: planned): Distributed execution support and
   monitoring utilities.
   - [simulate-distributed-orchestrator-performance](

--- a/docs/search_backends.md
+++ b/docs/search_backends.md
@@ -32,3 +32,9 @@ source_credibility_weight = 0.1
 Use `scripts/optimize_search_weights.py` with a labelled evaluation dataset to
 automatically discover good values. The script runs a grid search and updates
 the configuration file with the best-performing weights.
+
+## Benchmarking
+
+To guard against regressions, run `tests/benchmark/test_hybrid_ranking.py`
+with the shared dataset in `tests/data/backend_benchmark.csv`. Example
+results and thresholds live in [ranking_benchmark.md](ranking_benchmark.md).

--- a/issues/stabilize-api-and-improve-search.md
+++ b/issues/stabilize-api-and-improve-search.md
@@ -14,9 +14,9 @@ discrete sub-issues that refine streaming, configuration and search behavior.
 - [deliver-bug-fixes-and-docs-update](archive/deliver-bug-fixes-and-docs-update.md)
 
 ## Acceptance Criteria
-- [streaming-webhook-refinements](streaming-webhook-refinements.md) completed.
-- [configuration-hot-reload-tests](configuration-hot-reload-tests.md) completed.
-- [hybrid-search-ranking-benchmarks](hybrid-search-ranking-benchmarks.md) completed.
+- [streaming-webhook-refinements](archive/streaming-webhook-refinements.md) completed.
+- [configuration-hot-reload-tests](archive/configuration-hot-reload-tests.md) completed.
+- [hybrid-search-ranking-benchmarks](archive/hybrid-search-ranking-benchmarks.md) completed.
 
 ## Status
 Open

--- a/src/autoresearch/api/webhooks.py
+++ b/src/autoresearch/api/webhooks.py
@@ -28,7 +28,14 @@ def notify_webhook(
             resp = httpx.post(url, json=result.model_dump(), timeout=timeout)
             resp.raise_for_status()
             return
-        except httpx.RequestError as exc:
-            log.warning("Webhook request to %s failed on attempt %s: %s", url, attempt + 1, exc)
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            log.warning(
+                "Webhook request to %s failed on attempt %s: %s",
+                url,
+                attempt + 1,
+                exc,
+            )
             if attempt < retries - 1:
                 time.sleep(backoff * 2**attempt)
+
+    log.error("Webhook delivery to %s failed after %s attempts", url, retries)

--- a/tests/integration/test_api_hot_reload.py
+++ b/tests/integration/test_api_hot_reload.py
@@ -1,0 +1,34 @@
+import time
+import tomllib
+import tomli_w
+
+import pytest
+from fastapi.testclient import TestClient
+
+import autoresearch.api as api
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_api_detects_config_file_change(example_autoresearch_toml, monkeypatch):
+    cfg_file = example_autoresearch_toml
+    cfg_file.write_text(tomli_w.dumps({"loops": 1}))
+
+    def load_config(self):
+        data = tomllib.loads(cfg_file.read_text())
+        data.setdefault("api", {})
+        data["api"].setdefault("role_permissions", {"anonymous": ["config"]})
+        return ConfigModel.from_dict(data)
+
+    monkeypatch.setattr(ConfigLoader, "load_config", load_config, raising=False)
+    loader = ConfigLoader.new_for_tests(search_paths=[cfg_file])
+    app = api.create_app(loader)
+    client = TestClient(app)
+
+    assert client.get("/config").json()["loops"] == 1
+
+    cfg_file.write_text(tomli_w.dumps({"loops": 2}))
+    time.sleep(0.1)
+    assert client.get("/config").json()["loops"] == 2

--- a/tests/integration/test_streaming_webhook.py
+++ b/tests/integration/test_streaming_webhook.py
@@ -2,7 +2,9 @@ import json
 import time
 
 import pytest
+from fastapi.testclient import TestClient
 
+import autoresearch.api as api
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import APIConfig, ConfigModel
 from autoresearch.models import QueryResponse
@@ -38,9 +40,10 @@ def test_stream_emits_keepalive(monkeypatch, api_client):
 def test_webhook_retries(monkeypatch, api_client, httpx_mock):
     """Webhook delivery should be retried on failure."""
 
-    cfg = ConfigModel(api=APIConfig(webhooks=["http://hook"], webhook_timeout=0.1))
+    cfg = ConfigModel(api=APIConfig(webhooks=["http://hook"], webhook_timeout=1))
     cfg.api.role_permissions["anonymous"] = ["query"]
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    api_client.app.state.config_loader._config = cfg
     monkeypatch.setattr(
         Orchestrator,
         "run_query",
@@ -55,3 +58,31 @@ def test_webhook_retries(monkeypatch, api_client, httpx_mock):
     resp = api_client.post("/query", json={"query": "hi"})
     assert resp.status_code == 200
     assert len(httpx_mock.get_requests()) == 2
+
+
+@pytest.mark.slow
+def test_streaming_error_triggers_webhook(monkeypatch, httpx_mock):
+    """Errors in streaming queries should still trigger webhook delivery."""
+
+    cfg = ConfigModel(api=APIConfig(webhooks=["http://hook"], webhook_timeout=1))
+    cfg.api.role_permissions["anonymous"] = ["query"]
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg, raising=False)
+    loader = ConfigLoader.new_for_tests()
+    app = api.create_app(loader)
+    client = TestClient(app)
+
+    def failing_query(self, query, config, callbacks=None, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(Orchestrator, "run_query", failing_query)
+    httpx_mock.add_response(method="POST", url="http://hook", status_code=200)
+
+    with client.stream("POST", "/query?stream=true", json={"query": "q"}) as resp:
+        assert resp.status_code == 200
+        lines = [line for line in resp.iter_lines() if line]
+
+    time.sleep(0.1)
+    assert json.loads(lines[-1])["answer"].startswith("Error:")
+    req = httpx_mock.get_requests()[0]
+    payload = json.loads(req.content.decode())
+    assert payload["answer"].startswith("Error:")


### PR DESCRIPTION
## Summary
- tighten webhook retry logic and log final failures
- test streaming error webhooks and API config hot reload
- document streaming heartbeats and search ranking benchmarks
- fix roadmap links to archived sub-issues

## Testing
- `task check` *(fails: command not found)*
- `uv run --extra test pytest tests/integration/test_streaming_webhook.py::test_streaming_error_triggers_webhook tests/integration/test_api_hot_reload.py::test_api_detects_config_file_change -m slow -vv`

------
https://chatgpt.com/codex/tasks/task_e_68b7bfd8fce4833381d14de206b89f8e