### PR TITLE
docs: link algorithms to planning tickets

### DIFF
--- a/docs/algorithms/README.md
+++ b/docs/algorithms/README.md
@@ -64,3 +64,8 @@
 
 ### Pending
 - None
+
+## Contribution Notes
+
+- Add a "Related Issues" section to each algorithm document linking to
+  relevant planning tickets under `../../issues/`.

--- a/docs/algorithms/distributed_coordination.md
+++ b/docs/algorithms/distributed_coordination.md
@@ -156,3 +156,9 @@ worker tuning.
 
 [coord-test]: ../../tests/analysis/test_distributed_coordination.py
 [properties-test]: ../../tests/unit/distributed/test_coordination_properties.py
+
+## Related Issues
+
+- [add-distributed-coordination-proofs-and-benchmarks][dc-issue]
+
+[dc-issue]: ../../issues/archive/add-distributed-coordination-proofs-and-benchmarks.md

--- a/issues/archive/add-distributed-coordination-proofs-and-benchmarks.md
+++ b/issues/archive/add-distributed-coordination-proofs-and-benchmarks.md
@@ -7,7 +7,7 @@ behavior and failure modes remain uncertain, limiting confidence in distributed
 execution.
 
 ## Dependencies
-- [simulate-distributed-orchestrator-performance](simulate-distributed-orchestrator-performance.md)
+- [simulate-distributed-orchestrator-performance](../simulate-distributed-orchestrator-performance.md)
 
 ## Acceptance Criteria
 - Provide a mathematical proof or formal argument for the coordination
@@ -18,4 +18,9 @@ execution.
 - Add tests exercising the proof and simulation paths.
 
 ## Status
-Open
+Archived
+
+## References
+- [docs/algorithms/distributed_coordination.md](../../docs/algorithms/distributed_coordination.md)
+- [tests/analysis/test_distributed_coordination.py](../../tests/analysis/test_distributed_coordination.py)
+- [tests/unit/distributed/test_coordination_properties.py](../../tests/unit/distributed/test_coordination_properties.py)


### PR DESCRIPTION
## Summary
- archive distributed coordination issue with references to proofs and tests
- document issue cross-reference requirement for algorithms
- link distributed coordination doc to its planning ticket

## Testing
- `./.venv/bin/task check`
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/task verify` *(fails: KeyboardInterrupt after tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bfde384883339e926ee030f62455