### PR TITLE
docs: record environment gaps

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -20,6 +20,11 @@ References to pre-built wheels for GPU-only packages live under `wheels/gpu`.
 features are required. Setup helpers and Taskfile commands consult this
 directory automatically when GPU extras are installed.
 
+Running without first executing `scripts/setup.sh` leaves the Go Task CLI
+unavailable. `uv run task check` then fails with `command not found: task`, and
+`uv run pytest tests/unit/test_version.py -q` raises
+`ImportError: No module named 'pytest_bdd'`.
+
 ## Bootstrapping without Go Task
 
 If the Go Task CLI cannot be installed, set up the environment with:
@@ -73,6 +78,8 @@ integration tests and did not produce a final report.
   issues/add-test-coverage-for-optional-components.md)
 - [fix-task-verify-coverage-hang](
   issues/fix-task-verify-coverage-hang.md)
+- [clarify-test-extras-installation-without-go-task](
+  issues/clarify-test-extras-installation-without-go-task.md)
 - [prepare-v0-1-0a1-release](
   issues/prepare-v0-1-0a1-release.md)
 - [reach-stable-performance-and-interfaces](
@@ -81,5 +88,3 @@ integration tests and did not produce a final report.
   issues/simulate-distributed-orchestrator-performance.md)
 - [stabilize-api-and-improve-search](
   issues/stabilize-api-and-improve-search.md)
-- [add-distributed-coordination-proofs-and-benchmarks](
-  issues/add-distributed-coordination-proofs-and-benchmarks.md)

--- a/issues/clarify-test-extras-installation-without-go-task.md
+++ b/issues/clarify-test-extras-installation-without-go-task.md
@@ -1,0 +1,21 @@
+# Clarify test extras installation without Go Task
+
+## Context
+Running `uv run task check` fails when the Go Task CLI is absent, and direct
+invocation of `uv run pytest` raises `ImportError: No module named 'pytest_bdd'`
+when test extras are missing. The current status notes a manual workaround, but
+readers may overlook the requirement to install `[test]` extras before executing
+any pytest commands.
+
+## Dependencies
+None.
+
+## Acceptance Criteria
+- Update documentation to emphasize installing `[test]` extras when the Go Task
+  CLI is unavailable.
+- Provide a short example showing `uv pip install -e ".[test]"` before running
+  pytest.
+- Link the documentation from `STATUS.md` or setup instructions.
+
+## Status
+Open

--- a/issues/fix-task-verify-coverage-hang.md
+++ b/issues/fix-task-verify-coverage-hang.md
@@ -17,6 +17,11 @@ On September 3, 2025, `task verify` again failed during coverage, raising a
 `KeyError` from the `tmp_path` fixture before any report was generated. The
 command required manual interruption.
 
+In a fresh environment without the Go Task CLI, running
+`uv run pytest tests/unit/test_version.py -q` raised
+`ImportError: No module named 'pytest_bdd'`, showing the `[test]` extras were
+missing and coverage could not start.
+
 ## Dependencies
 - [fix-idempotent-message-processing-deadline](archive/fix-idempotent-message-processing-deadline.md)
 


### PR DESCRIPTION
## Summary
- note missing Go Task and pytest-bdd when setup script not run
- track missing test extras installation

## Testing
- `uv run task check` *(fails: Failed to spawn: `task`)*
- `uv run pytest tests/unit/test_version.py -q` *(fails: ImportError: No module named 'pytest_bdd')*


------
https://chatgpt.com/codex/tasks/task_e_68b7c75a7e5883338fc6362decfffbf5