### PR TITLE
Disable Hypothesis deadlines in coordination tests

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -9,6 +9,11 @@ dependencies and was aborted. With test extras only, the fixed
 previous `tmp_path` `KeyError`. Dependency pins for `fastapi` (>=0.115.12) and
 `slowapi` (==0.1.9) remain in place.
 
+Attempting `uv run task verify` currently fails with
+`yaml: line 190: did not find expected '-' indicator` when parsing the
+Taskfile. The underlying test file now disables Hypothesis deadlines to avoid
+spurious timeouts during coverage runs.
+
 The `[llm]` extra now installs CPU-friendly libraries (`fastembed`, `dspy-ai`)
 to avoid CUDA-heavy downloads. `task verify EXTRAS="llm"` succeeds with these
 lighter dependencies.

--- a/tests/unit/distributed/test_coordination_properties.py
+++ b/tests/unit/distributed/test_coordination_properties.py
@@ -48,11 +48,11 @@ def test_election_converges_to_minimum(tmp_path_env: Path, ids: list[int]) -> No
 
 
 # The processing pipeline can run longer on constrained runners. Limit the
-# workload and relax Hypothesis deadlines to avoid spurious timeouts during
+# workload and disable Hypothesis deadlines to avoid spurious timeouts during
 # coverage runs.
 @settings(
     max_examples=3,
-    deadline=1000,
+    deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
 @given(st.lists(st.text(min_size=0, max_size=5), max_size=5))


### PR DESCRIPTION
## Summary
- prevent Hypothesis from timing out in coordination property tests
- document Taskfile parse failure and new test deadline configuration in STATUS

## Testing
- `uv run pytest tests/unit/distributed/test_coordination_properties.py -vv`
- `uv run task verify` *(fails: yaml: line 190: did not find expected '-' indicator)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c969b98883338610c47c07499acc