### PR TITLE
chore: update issue tracking

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -90,8 +90,6 @@ parsing error, so overall coverage could not be determined.
   issues/add-test-coverage-for-optional-components.md)
 - [fix-task-verify-coverage-hang](
   issues/fix-task-verify-coverage-hang.md)
-- [clarify-test-extras-installation-without-go-task](
-  issues/clarify-test-extras-installation-without-go-task.md)
 - [prepare-v0-1-0a1-release](
   issues/prepare-v0-1-0a1-release.md)
 - [reach-stable-performance-and-interfaces](
@@ -100,3 +98,5 @@ parsing error, so overall coverage could not be determined.
   issues/simulate-distributed-orchestrator-performance.md)
 - [stabilize-api-and-improve-search](
   issues/stabilize-api-and-improve-search.md)
+- [formalize-spec-driven-development-standards](
+  issues/formalize-spec-driven-development-standards.md)

--- a/issues/archive/clarify-test-extras-installation-without-go-task.md
+++ b/issues/archive/clarify-test-extras-installation-without-go-task.md
@@ -18,4 +18,4 @@ None.
 - Link the documentation from `STATUS.md` or setup instructions.
 
 ## Status
-Open
+Archived

--- a/issues/fix-task-verify-coverage-hang.md
+++ b/issues/fix-task-verify-coverage-hang.md
@@ -21,6 +21,8 @@ In a fresh environment without the Go Task CLI, running
 `uv run pytest tests/unit/test_version.py -q` raised
 `ImportError: No module named 'pytest_bdd'`, showing the `[test]` extras were
 missing and coverage could not start.
+Invoking `uv run task check` on the same system failed with
+`error: Failed to spawn: 'task'`, confirming the Go Task CLI was absent.
 
 ## Dependencies
 - [fix-idempotent-message-processing-deadline](archive/fix-idempotent-message-processing-deadline.md)

--- a/issues/formalize-spec-driven-development-standards.md
+++ b/issues/formalize-spec-driven-development-standards.md
@@ -1,0 +1,21 @@
+# Formalize spec-driven development standards
+
+## Context
+The project seeks rigorous research orchestration but lacks unified
+specifications across modules. Some algorithms, such as storage eviction,
+have informal proofs, while others rely on ad hoc behavior. Establishing
+spec-driven, domain-driven, and test-driven guidelines will align
+implementation and aid verification.
+
+## Dependencies
+- [add-storage-eviction-proofs-and-simulations](add-storage-eviction-proofs-and-simulations.md)
+- [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)
+
+## Acceptance Criteria
+- Define a specification template outlining algorithms, invariants, and proofs.
+- Add specs for orchestrator scheduling and search ranking modules.
+- Document where simulations or formal methods are required.
+- Update developer documentation with spec-driven workflow guidance.
+
+## Status
+Open

--- a/issues/prepare-v0-1-0a1-release.md
+++ b/issues/prepare-v0-1-0a1-release.md
@@ -10,6 +10,7 @@ initial proofs. Completing these steps clears the way to tag v0.1.0a1.
 - [resolve-llm-extra-installation-failure](archive/resolve-llm-extra-installation-failure.md)
 - [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)
 - [add-storage-eviction-proofs-and-simulations](add-storage-eviction-proofs-and-simulations.md)
+- [formalize-spec-driven-development-standards](formalize-spec-driven-development-standards.md)
 
 ## Acceptance Criteria
 - `task verify` runs to completion with all extras installed.


### PR DESCRIPTION
## Summary
- archive resolved test extras documentation ticket
- note missing task CLI in coverage hang issue
- add spec-driven development planning issue and link to release
- refresh open issue list in STATUS

## Testing
- `uv run task check` *(fails: Failed to spawn: `task`)*
- `uv run task verify` *(fails: Failed to spawn: `task`)*
- `uv run pytest tests/unit/test_version.py -q` *(fails: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_68b8567d3b288333aa8688fc203c64a9