### PR TITLE
docs: add spec template and scheduling/ranking specs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,6 +271,11 @@ Good documentation is crucial for the project. Please follow these guidelines:
 - Update or create documentation in the `docs/` directory as needed
 - Use clear, concise language and provide examples where appropriate
 
+### Specification workflow
+- Draft specs for new modules in `docs/specs/` using the template in
+  [docs/specs/README.md](docs/specs/README.md).
+- Capture algorithms, invariants, proofs, and traceability links.
+
 ## Community
 
 - Join the discussion in [GitHub Discussions](https://github.com/ravenoak/autoresearch/discussions)

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,14 @@
+# Development Workflow
+
+This guide summarizes the development process and specification workflow.
+
+## Specification workflow
+- Begin new modules by drafting a spec using the template in
+  [docs/specs/README.md](specs/README.md).
+- Document algorithms, invariants, and proofs for each module.
+- Add a **Traceability** section linking modules and tests.
+
+## Contribution steps
+- Implement code and spec together on a feature branch.
+- Run `task check` early and `task verify` before submitting a pull request.
+- Build documentation with `uv run mkdocs build` to ensure it compiles.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -54,6 +54,26 @@ documented behaviour.
 - When adding new behaviour or features, create or update a feature file
   and link to it from the relevant spec.
 
+## Spec template
+
+Start new specs with the following structure:
+
+```markdown
+# Module name
+
+## Overview
+Brief summary of responsibilities and interfaces.
+
+## Algorithms
+Explain key algorithms and decision logic.
+
+## Invariants
+List conditions maintained across operations.
+
+## Proofs
+Reasoning or links showing the invariants hold.
+```
+
 ## Extending specs
 
 1. Create a new spec file in this directory named after the module.

--- a/docs/specs/orchestrator-scheduling.md
+++ b/docs/specs/orchestrator-scheduling.md
@@ -1,0 +1,26 @@
+# Orchestrator Scheduling
+
+## Overview
+The orchestrator assigns work to agents while balancing priority and load.
+
+## Algorithms
+- Maintain a priority queue of pending tasks.
+- Dispatch tasks round-robin among available agents.
+
+## Invariants
+- Each task is executed at most once.
+- Agent concurrency never exceeds the configured limit.
+
+## Proofs
+The priority queue ensures higher priority tasks run first, and the round-
+robin dispatcher guarantees fair agent utilization, preserving the
+invariants.
+
+## Traceability
+- [src/autoresearch/orchestrator_perf.py][m1]
+- [tests/unit/test_orchestrator_perf_sim.py][t1]
+- [tests/unit/test_scheduler_benchmark.py][t2]
+
+[m1]: ../../src/autoresearch/orchestrator_perf.py
+[t1]: ../../tests/unit/test_orchestrator_perf_sim.py
+[t2]: ../../tests/unit/test_scheduler_benchmark.py

--- a/docs/specs/search-ranking.md
+++ b/docs/specs/search-ranking.md
@@ -1,0 +1,26 @@
+# Search Ranking
+
+## Overview
+The ranking pipeline orders results by combining relevance and recency
+scores.
+
+## Algorithms
+- Weight cosine similarity and metadata freshness.
+- Normalize scores before applying a deterministic sort.
+
+## Invariants
+- Scores stay within the 0 to 1 range after normalization.
+- Equal inputs yield the same ranked order.
+
+## Proofs
+Normalization preserves order within each scoring component, and the final
+sort is stable, proving deterministic rankings for equal scores.
+
+## Traceability
+- [src/autoresearch/search/ranking_convergence.py][m1]
+- [tests/behavior/features/search_cli.feature][t1]
+- [tests/behavior/features/hybrid_search.feature][t2]
+
+[m1]: ../../src/autoresearch/search/ranking_convergence.py
+[t1]: ../../tests/behavior/features/search_cli.feature
+[t2]: ../../tests/behavior/features/hybrid_search.feature


### PR DESCRIPTION
## Summary
- add template for module specs emphasizing algorithms, invariants, and proofs
- document orchestrator scheduling and search ranking using the new template
- reference spec workflow from CONTRIBUTING and new development guide

## Testing
- `task check` *(fails: yaml: line 190: did not find expected '-' indicator)*
- `uv run mkdocs build`
- `task verify` *(fails: yaml: line 190: did not find expected '-' indicator)*

------
https://chatgpt.com/codex/tasks/task_e_68b86cddf5f88333aa006e830ec4285b