### PR TITLE
Fix Taskfile verify command indentation and coverage

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -9,10 +9,14 @@ dependencies and was aborted. With test extras only, the fixed
 previous `tmp_path` `KeyError`. Dependency pins for `fastapi` (>=0.115.12) and
 `slowapi` (==0.1.9) remain in place.
 
-Attempting `uv run task verify` currently fails with
+Attempting `uv run task verify` previously failed with
 `yaml: line 190: did not find expected '-' indicator` when parsing the
-Taskfile. The underlying test file now disables Hypothesis deadlines to avoid
-spurious timeouts during coverage runs.
+Taskfile. A mis-indented `cmds` block left the `verify` task without commands
+and embedded `task check-env` inside the preceding `uv sync` heredoc. Indenting
+`cmds` under `verify` and separating the `task check-env` invocation restored
+the task structure. After removing a trailing blank line in
+`tests/integration/test_optional_extras.py`, `task verify` executes fully and
+emits coverage data without hanging.
 
 The `[llm]` extra now installs CPU-friendly libraries (`fastembed`, `dspy-ai`)
 to avoid CUDA-heavy downloads. `task verify EXTRAS="llm"` succeeds with these

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -187,7 +187,7 @@ tasks:
   verify:
     vars:
       EXTRAS: "{{.EXTRAS | default \"\"}}"
-  cmds:
+    cmds:
       - |
           uv sync \
             --python-platform x86_64-manylinux_2_28 \
@@ -203,7 +203,7 @@ tasks:
             --extra llm \
             --extra parsers{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}} \
             {{if and .EXTRAS (contains .EXTRAS "gpu")}}--find-links wheels/gpu{{end}}
-        - task check-env EXTRAS="dev{{if .EXTRAS}} {{.EXTRAS}}{{end}}"
+      - task check-env EXTRAS="dev{{if .EXTRAS}} {{.EXTRAS}}{{end}}"
       - uv run flake8 src tests
       - uv run mypy src
       - uv run python scripts/check_spec_tests.py

--- a/tests/integration/test_optional_extras.py
+++ b/tests/integration/test_optional_extras.py
@@ -102,4 +102,3 @@ def test_local_file_backend_docx(tmp_path) -> None:
     with temporary_config(cfg):
         results = _local_file_backend("hello", max_results=1)
     assert results and "hello" in results[0]["snippet"].lower()
-


### PR DESCRIPTION
## Summary
- realign `verify` task so its commands execute instead of hanging during coverage setup
- trim stray blank line in optional extras test to satisfy flake8
- document YAML indentation root cause and remediation in STATUS

## Testing
- `task install`
- `uv run task verify`

------
https://chatgpt.com/codex/tasks/task_e_68b86cd81ffc8333b40bd41d7ec02790