### PR TITLE
docs: document task check failure and add repair ticket

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,13 +1,13 @@
 # Status
 
-As of **September 3, 2025**, `scripts/setup.sh` installs the Go Task CLI and
-syncs optional extras. `task check` now invokes `scripts/check_env.py` and
-passes. A full
-`uv run --all-extras task verify` attempt began downloading large GPU
-dependencies and was aborted. With test extras only, the fixed
-`tests/unit/distributed/test_coordination_properties.py` now runs without the
-previous `tmp_path` `KeyError`. Dependency pins for `fastapi` (>=0.115.12) and
-`slowapi` (==0.1.9) remain in place.
+As of **September 3, 2025**, `scripts/setup.sh` installs the Go Task CLI and syncs optional extras.
+Yet `task check` fails with `error: unexpected argument '-' found` because `Taskfile.yml` combines
+`uv sync` and `task check-env` in one line. After adding `.venv/bin` to `PATH`, running `flake8`,
+`mypy`, `scripts/check_spec_tests.py`, and targeted `pytest` manually succeeded. A full `uv run
+--all-extras task verify` attempt began downloading large GPU dependencies and was aborted. With
+test extras only, the fixed `tests/unit/distributed/test_coordination_properties.py` now runs
+without the previous `tmp_path` `KeyError`. Dependency pins for `fastapi` (>=0.115.12) and `slowapi`
+(==0.1.9) remain in place.
 
 Attempting `uv run task verify` previously failed with
 `yaml: line 190: did not find expected '-' indicator` when parsing the
@@ -64,12 +64,11 @@ with smoke tests, allowing offline environments to initialize without vector
 search.
 
 ## Lint, type checks, and spec tests
-`task check` runs `scripts/check_env.py` to validate tool versions.
-Set `EXTRAS` to verify optional extras. The command completed successfully.
+Manual runs of `flake8`, `mypy`, and `scripts/check_spec_tests.py` succeeded because `task check`
+fails to execute.
 
 ## Targeted tests
-`tests/unit/test_version.py` and `tests/unit/test_cli_help.py` passed under
-`task check`.
+`tests/unit/test_version.py` and `tests/unit/test_cli_help.py` passed when invoked manually.
 
 ## Integration tests
 Not executed.
@@ -78,6 +77,8 @@ Not executed.
 Not executed.
 
 ## Coverage
+Running `pytest tests/unit -q` manually completed with 479 passed, 4 skipped, 22 deselected, and 1
+xpassed.
 Targeted coverage for `tests/unit/distributed/test_coordination_properties.py`
 completed, reporting **32%** combined coverage for
 `src/autoresearch/orchestration/budgeting.py` and
@@ -88,6 +89,7 @@ attempt to execute the full suite with coverage failed due to a `Taskfile.yml`
 parsing error, so overall coverage could not be determined.
 
 ## Open issues
+- [fix-task-check-command-block](issues/fix-task-check-command-block.md)
 - [add-storage-eviction-proofs-and-simulations](
   issues/add-storage-eviction-proofs-and-simulations.md)
 - [add-test-coverage-for-optional-components](

--- a/issues/fix-task-check-command-block.md
+++ b/issues/fix-task-check-command-block.md
@@ -1,0 +1,16 @@
+# Fix task check command block
+
+## Context
+Running `task check` fails with `error: unexpected argument '-' found` because
+`Taskfile.yml` embeds `task check-env` on the same line as `uv sync`. The `-`
+argument reaches `uv sync`, so lint and tests never run.
+
+## Dependencies
+- [fix-task-verify-coverage-hang](fix-task-verify-coverage-hang.md)
+
+## Acceptance Criteria
+- Separate `uv sync` and `task check-env` into distinct commands in `Taskfile.yml`.
+- `task check` runs flake8, mypy, spec tests, and targeted unit tests.
+
+## Status
+Open

--- a/issues/fix-task-verify-coverage-hang.md
+++ b/issues/fix-task-verify-coverage-hang.md
@@ -24,6 +24,12 @@ missing and coverage could not start.
 Invoking `uv run task check` on the same system failed with
 `error: Failed to spawn: 'task'`, confirming the Go Task CLI was absent.
 
+On September 3, 2025, running `task check` produced `error: unexpected argument '-' found`.
+Exporting `.venv/bin` to `PATH` and executing `flake8`, `mypy`,
+`scripts/check_spec_tests.py`, and `pytest -c /dev/null tests/unit/test_version.py
+tests/unit/test_cli_help.py -q` succeeded, indicating the hang stems from the Taskfile layout
+rather than test failures.
+
 ## Dependencies
 - [fix-idempotent-message-processing-deadline](archive/fix-idempotent-message-processing-deadline.md)
 

--- a/issues/prepare-v0-1-0a1-release.md
+++ b/issues/prepare-v0-1-0a1-release.md
@@ -6,6 +6,7 @@ should work offline, optional extras must install, and core algorithms require
 initial proofs. Completing these steps clears the way to tag v0.1.0a1.
 
 ## Dependencies
+- [fix-task-check-command-block](fix-task-check-command-block.md)
 - [fix-task-verify-coverage-hang](fix-task-verify-coverage-hang.md)
 - [resolve-llm-extra-installation-failure](archive/resolve-llm-extra-installation-failure.md)
 - [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)


### PR DESCRIPTION
## Summary
- note `task check` failure and manual test execution in STATUS
- expand coverage-hang ticket with latest observations
- add new issue to repair `task check` command block and list as release dependency

## Testing
- `uv run flake8 src`
- `uv run mypy src --exclude src/autoresearch/distributed`
- `uv run python scripts/check_spec_tests.py`
- `uv run pytest -c /dev/null tests/unit/test_version.py tests/unit/test_cli_help.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b877617e408333a9d1b45d419779e3