### PR TITLE
refactor: split check sync and env validation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -65,7 +65,7 @@ tasks:
     # requiring optional UI (`.[ui]`) or VSS (`.[vss]`) extras.
     cmds:
       - uv sync --python-platform x86_64-manylinux_2_28 --extra dev-minimal --extra test{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}}
-        - task check-env EXTRAS="dev{{if .EXTRAS}} {{.EXTRAS}}{{end}}"
+      - task check-env EXTRAS="dev{{if .EXTRAS}} {{.EXTRAS}}{{end}}"
       - uv run flake8 src
       - uv run mypy src --exclude src/autoresearch/distributed
       - uv run python scripts/check_spec_tests.py


### PR DESCRIPTION
## Summary
- run uv sync and environment checks as separate steps in `task check`

## Testing
- `uv run task check EXTRAS=dev`


------
https://chatgpt.com/codex/tasks/task_e_68b87dca35448333a0718a783427b392