### PR TITLE
Add token memory benchmark regression test and tuning guide

### DIFF
--- a/docs/performance_tuning.md
+++ b/docs/performance_tuning.md
@@ -1,0 +1,16 @@
+# Performance Tuning
+
+The benchmark script `scripts/benchmark_token_memory.py` measures the token
+usage, memory impact, and elapsed time of a minimal query. The current baseline
+records a duration of 0.0048 seconds, no measurable memory growth, and 2 input
+and 7 output tokens for the Dummy agent.
+
+To keep regressions in check:
+
+- Profile representative queries with `uv run scripts/benchmark_token_memory.py`.
+- Investigate runs exceeding 10% of baseline time or memory.
+- Reduce token budgets or simplify agents if usage grows beyond the baseline.
+- Cache external resources to avoid unpredictable memory spikes.
+
+These measurements are enforced in `tests/benchmark/test_token_memory.py`. Update
+the baseline file when deliberate tuning changes expected resource usage.

--- a/tests/benchmark/test_token_memory.py
+++ b/tests/benchmark/test_token_memory.py
@@ -1,0 +1,29 @@
+"""Benchmark regression for token usage, memory, and latency."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+pdf_ns = types.SimpleNamespace(extract_text=lambda *a, **k: "")
+sys.modules.setdefault("docx", types.SimpleNamespace(Document=object))
+sys.modules.setdefault("pdfminer", types.SimpleNamespace(high_level=pdf_ns))
+sys.modules.setdefault("pdfminer.high_level", pdf_ns)
+
+from scripts.benchmark_token_memory import run_benchmark
+
+pytestmark = [pytest.mark.slow]
+
+
+def test_token_memory_baseline(token_memory_baseline) -> None:
+    """Check token, memory, and duration metrics against baselines."""
+    metrics = run_benchmark()
+    tokens = metrics["tokens"]["Dummy"]
+    token_memory_baseline(
+        tokens["in"],
+        tokens["out"],
+        metrics["memory_delta_mb"],
+        metrics["duration_seconds"],
+    )

--- a/tests/data/token_memory_benchmark.json
+++ b/tests/data/token_memory_benchmark.json
@@ -1,0 +1,10 @@
+{
+  "tests/benchmark/test_token_memory.py::test_token_memory_baseline": {
+    "duration_seconds": 0.004791448000105447,
+    "memory_delta_mb": 0.0,
+    "tokens": {
+      "in": 2,
+      "out": 7
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document baseline token, memory, and CPU metrics and tuning guidance
- add fixture and regression test to guard token and memory usage
- store benchmark baseline for future comparisons

## Testing
- `task install` *(fails: command not found)*
- `uv run mkdocs build` *(fails: No such file or directory (os error 2))*
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run pytest tests/benchmark/test_token_memory.py -q` *(fails: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_68b88bba3f708333ae9e40f058728c46