### PR TITLE
chore: prune outdated issue dependencies

### DIFF
--- a/issues/add-test-coverage-for-optional-components.md
+++ b/issues/add-test-coverage-for-optional-components.md
@@ -14,7 +14,7 @@ On **September 15, 2025**, `task verify` stalled during the coverage step after
 syncing all extras, preventing optional-component tests from running.
 
 ## Dependencies
-- [address-task-verify-dependency-builds](archive/address-task-verify-dependency-builds.md)
+None.
 
 ## Acceptance Criteria
 - Enable running tests that require each optional extra (`[nlp]`, `[ui]`,

--- a/issues/fix-task-check-command-block.md
+++ b/issues/fix-task-check-command-block.md
@@ -6,7 +6,7 @@ Running `task check` fails with `error: unexpected argument '-' found` because
 argument reaches `uv sync`, so lint and tests never run.
 
 ## Dependencies
-- [fix-task-verify-coverage-hang](fix-task-verify-coverage-hang.md)
+None.
 
 ## Acceptance Criteria
 - Separate `uv sync` and `task check-env` into distinct commands in `Taskfile.yml`.

--- a/issues/fix-task-verify-coverage-hang.md
+++ b/issues/fix-task-verify-coverage-hang.md
@@ -31,7 +31,7 @@ tests/unit/test_cli_help.py -q` succeeded, indicating the hang stems from the Ta
 rather than test failures.
 
 ## Dependencies
-- [fix-idempotent-message-processing-deadline](archive/fix-idempotent-message-processing-deadline.md)
+None.
 
 ## Acceptance Criteria
 - Identify the cause of the coverage hang during `task verify`.

--- a/issues/formalize-spec-driven-development-standards.md
+++ b/issues/formalize-spec-driven-development-standards.md
@@ -8,7 +8,6 @@ spec-driven, domain-driven, and test-driven guidelines will align
 implementation and aid verification.
 
 ## Dependencies
-- [add-storage-eviction-proofs-and-simulations](add-storage-eviction-proofs-and-simulations.md)
 - [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)
 
 ## Acceptance Criteria

--- a/issues/prepare-v0-1-0a1-release.md
+++ b/issues/prepare-v0-1-0a1-release.md
@@ -8,9 +8,7 @@ initial proofs. Completing these steps clears the way to tag v0.1.0a1.
 ## Dependencies
 - [fix-task-check-command-block](fix-task-check-command-block.md)
 - [fix-task-verify-coverage-hang](fix-task-verify-coverage-hang.md)
-- [resolve-llm-extra-installation-failure](archive/resolve-llm-extra-installation-failure.md)
 - [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)
-- [add-storage-eviction-proofs-and-simulations](add-storage-eviction-proofs-and-simulations.md)
 - [formalize-spec-driven-development-standards](formalize-spec-driven-development-standards.md)
 
 ## Acceptance Criteria

--- a/issues/reach-stable-performance-and-interfaces.md
+++ b/issues/reach-stable-performance-and-interfaces.md
@@ -13,11 +13,6 @@ stable interfaces and tuned performance.
 - [containerize-and-package](containerize-and-package.md)
 - [validate-deployment-configurations](validate-deployment-configurations.md)
 - [tune-system-performance](tune-system-performance.md)
-- [support-distributed-execution-and-monitoring][sdem]
-- [formalize-algorithm-proofs-for-research-modules][fap]
-
-[sdem]: archive/support-distributed-execution-and-monitoring.md
-[fap]: archive/formalize-algorithm-proofs-for-research-modules.md
 
 ## Acceptance Criteria
 - Containerization and packaging succeed across Windows, macOS and Linux.

--- a/issues/stabilize-api-and-improve-search.md
+++ b/issues/stabilize-api-and-improve-search.md
@@ -10,8 +10,7 @@ discrete sub-issues that refine streaming, configuration and search behavior.
 - 0.2.0 (2026-12-01)
 
 ## Dependencies
-
-- [deliver-bug-fixes-and-docs-update](archive/deliver-bug-fixes-and-docs-update.md)
+None.
 
 ## Acceptance Criteria
 - [streaming-webhook-refinements](archive/streaming-webhook-refinements.md) completed.


### PR DESCRIPTION
## Summary
- remove dependencies on archived tickets
- drop unnecessary link between task-check and task-verify issues
- keep release and milestone issues focused on active prerequisites

## Testing
- `task check` *(fails: No package metadata for several dependencies)*
- `task verify` *(fails: exit status 1 during flake8)*

------
https://chatgpt.com/codex/tasks/task_e_68b88bc6fa44833396b3d172a1f97d9a