### PR TITLE
Add issue for Go Task CLI bootstrapping

### DIFF
--- a/issues/ensure-go-task-cli-availability.md
+++ b/issues/ensure-go-task-cli-availability.md
@@ -1,0 +1,18 @@
+# Ensure Go Task CLI availability
+
+## Context
+The project relies on the Go Task CLI to run `task check` and `task verify`. In
+clean environments the CLI is absent, leading to errors such as `error: Failed
+to spawn: 'task'` and blocking test workflows. Developers must manually install
+the tool, but setup guidance does not cover this requirement.
+
+## Dependencies
+None.
+
+## Acceptance Criteria
+- Provide a bootstrap script or documented steps to install the Go Task CLI.
+- After installation `task check` runs successfully in a fresh environment.
+- Update setup documentation to mention the bootstrap process.
+
+## Status
+Open

--- a/issues/prepare-v0-1-0a1-release.md
+++ b/issues/prepare-v0-1-0a1-release.md
@@ -6,6 +6,7 @@ should work offline, optional extras must install, and core algorithms require
 initial proofs. Completing these steps clears the way to tag v0.1.0a1.
 
 ## Dependencies
+- [ensure-go-task-cli-availability](ensure-go-task-cli-availability.md)
 - [fix-task-check-command-block](fix-task-check-command-block.md)
 - [fix-task-verify-coverage-hang](fix-task-verify-coverage-hang.md)
 - [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)


### PR DESCRIPTION
## Summary
- track missing Go Task CLI with an in-repo issue
- block the v0.1.0a1 release on installing the task runner

## Testing
- `task check` *(fails: command not found)*
- `uv run --extra dev pytest tests/unit/test_version.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8a1e3ee608333b7f6edb7f39c3a8c