### PR TITLE
docs: highlight setup prerequisites for testing

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -8,6 +8,11 @@ test extras only, the fixed `tests/unit/distributed/test_coordination_properties
 without the previous `tmp_path` `KeyError`. Dependency pins for `fastapi` (>=0.115.12) and `slowapi`
 (==0.1.9) remain in place.
 
+Run `scripts/setup.sh` or `task install` before executing tests. These
+commands bootstrap Go Task and install the `dev` and `test` extras so
+plugins like `pytest-bdd` are available. Skipping them often leads to test
+collection failures.
+
 Attempting `uv run task verify` previously failed with
 `yaml: line 190: did not find expected '-' indicator` when parsing the
 Taskfile. A mis-indented `cmds` block left the `verify` task without commands
@@ -32,10 +37,10 @@ References to pre-built wheels for GPU-only packages live under `wheels/gpu`.
 features are required. Setup helpers and Taskfile commands consult this
 directory automatically when GPU extras are installed.
 
-Running without first executing `scripts/setup.sh` leaves the Go Task CLI
-unavailable. `uv run task check` then fails with `command not found: task`, and
-`uv run pytest tests/unit/test_version.py -q` raises
-`ImportError: No module named 'pytest_bdd'`.
+Running tests without first executing `scripts/setup.sh` or `task install`
+leaves the Go Task CLI unavailable. `uv run task check` then fails with
+`command not found: task`, and `uv run pytest tests/unit/test_version.py -q`
+raises `ImportError: No module named 'pytest_bdd'`.
 
 Install the test extras with `uv pip install -e ".[test]"` before invoking
 `pytest` directly to avoid this error.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -109,7 +109,8 @@ dependencies. `task check` syncs only these extras so it runs quickly.
 
 Run `task install` after cloning to bootstrap Go Task and the minimal
 development tools. This syncs the `dev-minimal` and `test` extras by
-default:
+default and should be executed before any tests. Missing extras such as
+`pytest-bdd` cause `pytest` to fail during collection:
 
 ```bash
 task install
@@ -130,8 +131,8 @@ required for PDF or DOCX tests.
 
 Use `./scripts/setup.sh` for the full developer bootstrap. It installs Go Task
 into `.venv/bin` when missing, syncs the `dev` and `test` extras (including
-packages such as `pytest_httpx`, `tomli_w`, and `redis`), and exits if
-`task --version` fails.
+packages such as `pytest_httpx`, `tomli_w`, `pytest-bdd`, and `redis`), and
+exits if `task --version` fails.
 
 The setup script verifies Go Task with `task --version`. You can manually
 confirm the CLI and development packages are available:
@@ -150,6 +151,22 @@ uv run python scripts/check_env.py
 ```
 
 The script reports missing tools and version mismatches.
+
+### Without Go Task
+
+If the Go Task CLI cannot be installed, create the environment manually and
+run tests with `uv`:
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install -e ".[test]"
+uv run scripts/download_duckdb_extensions.py --output-dir ./extensions
+uv run pytest tests/unit/test_version.py -q
+```
+
+This workflow installs the `[test]` extras and records the DuckDB vector
+extension path without using `task`.
 
 ### API authentication
 


### PR DESCRIPTION
## Summary
- stress running `scripts/setup.sh` or `task install` before tests to ensure extras like `pytest-bdd` are present
- add uv-based instructions for running tests in environments without Go Task

## Testing
- `task check` *(fails: /workspace/autoresearch/.venv/bin/task: No such file or directory)*
- `task verify` *(fails: /workspace/autoresearch/.venv/bin/task: No such file or directory)*
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68b8a9ae570c8333b6a7ac07a151aaec