### PR TITLE
Add scheduling resource benchmark and docs

### DIFF
--- a/docs/algorithms/distributed_coordination.md
+++ b/docs/algorithms/distributed_coordination.md
@@ -151,11 +151,20 @@ per task.
 ### Scheduling Benchmark
 
 The micro-benchmark dispatches `N` I/O-bound tasks through `P` worker threads
-and reports throughput and resource usage. Throughput is
+and allocates `m` MB per task to model memory pressure. Throughput is
 
 `T = N / t`
 
-where `t` is the elapsed wall-clock time. CPU time and memory use follow:
+where `t` is the elapsed wall-clock time. Peak memory is approximately
+
+`P m`
+
+because only `P` tasks run concurrently, while the simulation assumes total
+usage of
+
+`M = N m`
+
+for `N` outstanding tasks. CPU time and memory readings follow:
 
 ```py
 cpu = end.ru_utime - start.ru_utime

--- a/scripts/scheduling_resource_benchmark.py
+++ b/scripts/scheduling_resource_benchmark.py
@@ -39,7 +39,7 @@ def run_benchmark(
     results: List[Dict[str, float]] = []
     for workers in range(1, max_workers + 1):
         metrics = simulate(workers, arrival_rate, service_rate, tasks, mem_per_task)
-        metrics.update(benchmark_scheduler(workers, tasks))
+        metrics.update(benchmark_scheduler(workers, tasks, mem_per_task))
         metrics["workers"] = workers
         results.append(metrics)
     return results

--- a/tests/analysis/scheduling_resource_benchmark_analysis.py
+++ b/tests/analysis/scheduling_resource_benchmark_analysis.py
@@ -1,0 +1,37 @@
+"""Run task scheduling benchmark and persist metrics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import scheduling_resource_benchmark as bench
+
+
+def run() -> dict[int, dict[str, float]]:
+    """Execute benchmark for 1, 2, and 4 workers."""
+    raw = bench.run_benchmark(
+        max_workers=4,
+        arrival_rate=3,
+        service_rate=5,
+        tasks=50,
+        mem_per_task=5.0,
+    )
+    results: dict[int, dict[str, float]] = {}
+    for item in raw:
+        workers = int(item["workers"])
+        if workers in (1, 2, 4):
+            results[workers] = {
+                "utilization": item["utilization"],
+                "avg_queue_length": item["avg_queue_length"],
+                "throughput": item["throughput"],
+                "mem_kb": item["mem_kb"],
+                "expected_memory": item["expected_memory"],
+            }
+    out_path = Path(__file__).with_name("scheduling_resource_metrics.json")
+    out_path.write_text(json.dumps(results, indent=2) + "\n")
+    return results
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print(json.dumps(run(), indent=2))

--- a/tests/analysis/scheduling_resource_metrics.json
+++ b/tests/analysis/scheduling_resource_metrics.json
@@ -1,0 +1,23 @@
+{
+  "1": {
+    "utilization": 0.6,
+    "avg_queue_length": 0.8999999999999998,
+    "throughput": 491.87682153043994,
+    "mem_kb": 0,
+    "expected_memory": 250.0
+  },
+  "2": {
+    "utilization": 0.3,
+    "avg_queue_length": 0.05934065934065934,
+    "throughput": 1027.3043103486314,
+    "mem_kb": 208,
+    "expected_memory": 250.0
+  },
+  "4": {
+    "utilization": 0.15,
+    "avg_queue_length": 0.0006151976607298826,
+    "throughput": 1481.5581274274462,
+    "mem_kb": 5120,
+    "expected_memory": 250.0
+  }
+}

--- a/tests/analysis/test_scheduling_resource_benchmark.py
+++ b/tests/analysis/test_scheduling_resource_benchmark.py
@@ -1,0 +1,17 @@
+"""Validate scheduling benchmark simulation and resource usage."""
+
+from tests.analysis.scheduling_resource_benchmark_analysis import run
+
+
+def test_scheduling_benchmark_metrics() -> None:
+    metrics = run()
+    assert set(metrics) == {1, 2, 4}
+    assert all(m["utilization"] < 1 for m in metrics.values())
+    assert all(abs(m["expected_memory"] - 250.0) < 1e-6 for m in metrics.values())
+    qlens = [metrics[w]["avg_queue_length"] for w in (1, 2, 4)]
+    assert qlens[1] < qlens[0]
+    assert qlens[2] <= qlens[1]
+    thr = [metrics[w]["throughput"] for w in (1, 2, 4)]
+    assert thr[1] > thr[0]
+    assert thr[2] > thr[1]
+    assert all(m["mem_kb"] >= 0 for m in metrics.values())


### PR DESCRIPTION
## Summary
- extend `benchmark_scheduler` to model per-task memory usage
- document memory and throughput formulas for the scheduling micro-benchmark
- add analysis script and test validating scheduling simulation metrics

## Testing
- `uv run isort src/autoresearch/orchestrator_perf.py scripts/scheduling_resource_benchmark.py tests/analysis/scheduling_resource_benchmark_analysis.py tests/analysis/test_scheduling_resource_benchmark.py`
- `uv run black src/autoresearch/orchestrator_perf.py scripts/scheduling_resource_benchmark.py tests/analysis/scheduling_resource_benchmark_analysis.py tests/analysis/test_scheduling_resource_benchmark.py`
- `uv pip install pre-commit` *(missing pre-commit config)*
- `uv run mkdocs build`
- `uv run --extra test pytest` *(fail: numerous integration tests missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b5afac388333826d4030c1437edb