### PR TITLE
Add configuration validation to deployment scripts

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -84,6 +84,12 @@ task wheels  # builds wheels for Linux, Windows and macOS
 
 The wheels will be placed under the `dist/` directory.
 
+Both `scripts/package.sh` and `scripts/package.ps1` validate that a
+configuration file exists before building. Override the default
+`pyproject.toml` path by setting `AUTORESEARCH_BUILD_CONFIG`. The scripts also
+confirm that the `uv` command is available and exit with an error if it is
+missing.
+
 ## Distributed Deployment
 
 For large-scale workloads you can run Autoresearch on a Ray cluster.  Set
@@ -128,6 +134,9 @@ The script ensures required settings such as API keys are present. It examines
 the active configuration and exits with an error listing any missing variables.
 Provide the missing values in your `.env` file or disable the related feature in
 `autoresearch.toml`.
+
+Set `AUTORESEARCH_CONFIG_FILE` to point to a custom configuration file. The
+deployment script verifies that the file exists before loading settings.
 
 Set `AUTORESEARCH_HEALTHCHECK_URL` to change the endpoint or leave it empty to
 skip the check. Example:

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -23,12 +23,23 @@ from autoresearch.config.loader import ConfigLoader, get_config
 from autoresearch.errors import ConfigError
 
 
+CONFIG_FILE_ENV = "AUTORESEARCH_CONFIG_FILE"
+
 REQUIRED_ENV = {
     "SERPER_API_KEY": lambda cfg: "serper" in cfg.search.backends,
     "BRAVE_SEARCH_API_KEY": lambda cfg: "brave" in cfg.search.backends,
     "OPENAI_API_KEY": lambda cfg: "openai" in cfg.llm_backend.lower(),
     "OPENROUTER_API_KEY": lambda cfg: "openrouter" in cfg.llm_backend.lower(),
 }
+
+
+def _ensure_config_file() -> str:
+    """Return path to configuration file, exiting if it does not exist."""
+    path = os.getenv(CONFIG_FILE_ENV, "autoresearch.toml")
+    if not os.path.exists(path):
+        print(f"Configuration file '{path}' not found")
+        sys.exit(1)
+    return path
 
 
 def _check_required_settings() -> list[str]:
@@ -48,6 +59,7 @@ def _check_required_settings() -> list[str]:
 def validate_config() -> None:
     """Load configuration and ensure required settings exist."""
     load_dotenv()
+    _ensure_config_file()
     try:
         _missing = _check_required_settings()
     except ConfigError as exc:

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -3,9 +3,26 @@
 Build source and wheel distributions.
 .DESCRIPTION
 Usage: scripts/package.ps1 [-DistDir <path>]
+The script checks for a configuration file before building. Override the
+default with $env:AUTORESEARCH_BUILD_CONFIG.
 #>
 param(
     [string]$DistDir = "dist"
 )
+
+$ConfigFile = $env:AUTORESEARCH_BUILD_CONFIG
+if (-not $ConfigFile) {
+    $ConfigFile = "pyproject.toml"
+}
+
+if (-not (Test-Path $ConfigFile)) {
+    Write-Error "Configuration file '$ConfigFile' not found."
+    exit 1
+}
+
+if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+    Write-Error "uv is required but not installed."
+    exit 1
+}
 
 uv build --wheel --sdist --out-dir $DistDir

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -11,4 +11,17 @@ fi
 
 dist_dir=${1:-dist}
 
+# Configuration
+config_file="${AUTORESEARCH_BUILD_CONFIG:-pyproject.toml}"
+
+if [ ! -f "$config_file" ]; then
+    echo "Configuration file '$config_file' not found." >&2
+    exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "uv is required but not installed." >&2
+    exit 1
+fi
+
 uv build --wheel --sdist --out-dir "$dist_dir"


### PR DESCRIPTION
## Summary
- validate config file presence in package scripts and verify `uv` installed
- ensure deployment helper checks for a configurable config file
- document configuration options and validation behavior in deployment guide

## Testing
- `AUTORESEARCH_BUILD_CONFIG=/tmp/missing bash scripts/package.sh dist-test`
- `bash scripts/package.sh /tmp/dist-test`
- `pwsh -File scripts/package.ps1` *(fails: command not found)*
- `AUTORESEARCH_CONFIG_FILE=/tmp/missing uv run python scripts/deploy.py`
- `PATH=./.venv/bin:$PATH ./.venv/bin/task check` *(fails: package metadata missing)*
- `PATH=./.venv/bin:$PATH ./.venv/bin/task verify` *(fails: exit status 1)*
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68b8bdef63508333bf89613bbd6eb3b4