### PR TITLE
Add Go Task bootstrap helper and document manual install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,17 @@ For orchestrator state transitions and API contracts see
 
 Autoresearch requires **Python 3.12+**,
 [uv](https://github.com/astral-sh/uv), and
-[Go Task](https://taskfile.dev/). Both `task install` and
-`./scripts/setup.sh` automatically place `task` in `.venv/bin` when it's
-missing. See [docs/installation.md#after-cloning](docs/installation.md#after-cloning)
-for details. Ensure `.venv/bin` is on your `PATH` so the bundled `task`
-binary resolves:
+[Go Task](https://taskfile.dev/). Run `./scripts/bootstrap.sh` to place
+Go Task in `.venv/bin` when it's missing and ensure the directory is on
+your `PATH`:
 
 ```bash
+./scripts/bootstrap.sh
 export PATH="$(pwd)/.venv/bin:$PATH"
 task --version
 ```
 
-Install Go Task manually if needed:
+Install Go Task manually if the bootstrap script fails:
 
 ```bash
 curl -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,8 @@ This guide is the canonical bootstrap reference for Autoresearch. It covers
 the minimal developer workflow and links to helper scripts for specific
 environments.
 
-For test conventions and workflows see [testing guidelines](testing_guidelines.md).
+For test conventions and workflows see
+[testing guidelines](testing_guidelines.md).
 
 Autoresearch requires **Python 3.12 or newer**,
 [**uv**](https://github.com/astral-sh/uv), and
@@ -29,16 +30,17 @@ Activate the virtual environment in new shells to restore the path:
 source .venv/bin/activate
 ```
 
-The helper downloads Go Task into `.venv/bin` when missing. If you prefer
-manual installation:
+Run `./scripts/bootstrap.sh` to install Go Task without syncing extras. It
+places the `task` binary in `.venv/bin` and adds the directory to `PATH`. If
+the script fails or you want a system-wide binary, install manually:
 
 ```bash
 curl -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
 # macOS: brew install go-task/tap/go-task
 ```
 
-`task install` checks for Go Task and downloads it to `.venv/bin` when missing.
-Manual instructions are below if the setup script fails.
+`task install` also checks for Go Task and downloads it to `.venv/bin` when
+missing.
 
 ## Version checks and troubleshooting
 
@@ -59,21 +61,15 @@ EXTRAS="ui vss" task check-env  # verify optional extras
 If a tool or package is missing, rerun `task install` or sync extras with
 `uv sync --extra <name>`.
 
-## Setup scripts
+## Setup script
 
-Both setup helpers call `install_dev_test_extras` so the `dev` and `test`
-extras from `pyproject.toml` install identically. Set `AR_EXTRAS` to include
-additional groups.
+`scripts/setup.sh` bootstraps local development. It ensures Go Task is
+available, verifies core test packages such as `pytest`, `pytest-bdd`,
+`freezegun`, and `hypothesis`, and expects system dependencies to be
+preinstalled. Set `AR_EXTRAS` to include additional groups.
 
-- `scripts/setup.sh` bootstraps local development. It verifies core test
-  packages such as `pytest`, `pytest-bdd`, `freezegun`, and `hypothesis` and
-  expects system dependencies to be preinstalled.
-- `scripts/codex_setup.sh` prepares the Codex evaluation container. It installs
-  the same core test packages, provisions OS libraries with `apt`, preloads
-  models for offline tests, and logs its runtime.
-
-Both scripts append `.venv/bin` to `PATH`, run `task --version` to validate
-the CLI, and remind you to activate the environment in new shells with:
+The script appends `.venv/bin` to `PATH`, runs `task --version` to validate
+the CLI, and reminds you to activate the environment in new shells with:
 
 ```bash
 source .venv/bin/activate

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/bootstrap.sh
+# Ensure Go Task is installed in .venv/bin.
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+source "$SCRIPT_DIR/setup_common.sh"
+
+VENV_BIN="$(pwd)/.venv/bin"
+TASK_BIN="$VENV_BIN/task"
+
+ensure_uv
+uv venv
+ensure_venv_bin_on_path "$VENV_BIN"
+
+if [ ! -x "$TASK_BIN" ]; then
+    echo "Go Task not found; installing into $VENV_BIN..."
+    if command -v task >/dev/null 2>&1; then
+        ln -sf "$(command -v task)" "$TASK_BIN"
+    else
+        curl -sSL https://taskfile.dev/install.sh | sh -s -- -b "$VENV_BIN" || {
+            echo "Failed to install Go Task. See docs/installation.md for manual steps." >&2
+            exit 1
+        }
+    fi
+fi
+
+"$TASK_BIN" --version

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -3,8 +3,9 @@
 # Codex-only environment bootstrap for this evaluation container; see AGENTS.md
 # for repository-wide guidelines. Do not use or document this script outside the
 # AGENTS.md system. For any other environment, use ./scripts/setup.sh.
-# Installs the project in editable mode with development and test extras. Use
-# AR_EXTRAS to specify optional extras.
+# Installs the project in editable mode with development and test extras. It
+# invokes bootstrap.sh to install Go Task when missing. Use AR_EXTRAS to
+# specify optional extras.
 set -euo pipefail
 
 START_TIME=$(date +%s)
@@ -34,6 +35,9 @@ fi
 
 SCRIPT_DIR="$(dirname "$0")"
 source "$SCRIPT_DIR/setup_common.sh"
+
+# Ensure Go Task is available before platform-specific setup
+"$SCRIPT_DIR/bootstrap.sh"
 
 # Run platform detection and universal setup
 AR_EXTRAS="${AR_EXTRAS:-}" "$SCRIPT_DIR/setup.sh" "$@"


### PR DESCRIPTION
## Summary
- ensure evaluation setup invokes bootstrap for Go Task installation
- streamline installation guide to focus on `scripts/setup.sh` and manual Go Task install steps

## Testing
- `./scripts/bootstrap.sh`
- `task check EXTRAS=dev`
- `task verify` *(fails: DeadlineExceeded in test_message_processing_is_idempotent)*
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68b8bde1bbf483339ecfdc3dea818d66