### PR TITLE
Track environment gaps and coverage issues

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,14 @@
 # Status
 
+## September 5, 2025
+
+- Installing Go Task with the upstream script placed the binary under `.venv/bin`.
+  `task check` then failed with "No package metadata was found for GitPython" and
+  similar messages for `cibuildwheel`, `duckdb-extension-vss`, `spacy`, and
+  several `types-*` stubs.
+- `task verify` synced all extras and began unit tests but produced no output
+  during coverage. The run was interrupted manually, leaving no report.
+
 ## September 4, 2025
 
 - `uv run task check EXTRAS="nlp ui vss git distributed analysis llm parsers"`
@@ -109,11 +118,15 @@ warnings. Coverage data was not produced.
 - [prepare-v0-1-0a1-release](issues/prepare-v0-1-0a1-release.md)
   - [ensure-go-task-cli-availability](issues/ensure-go-task-cli-availability.md)
   - [fix-task-verify-coverage-hang](issues/fix-task-verify-coverage-hang.md)
-  - [add-test-coverage-for-optional-components](issues/add-test-coverage-for-optional-components.md)
-  - [formalize-spec-driven-development-standards](issues/formalize-spec-driven-development-standards.md)
+  - [fix-check-env-package-metadata-errors](issues/fix-check-env-package-metadata-errors.md)
+  - [add-test-coverage-for-optional-components]
+    (issues/add-test-coverage-for-optional-components.md)
+  - [formalize-spec-driven-development-standards]
+    (issues/formalize-spec-driven-development-standards.md)
 - [reach-stable-performance-and-interfaces](issues/reach-stable-performance-and-interfaces.md)
   - [containerize-and-package](issues/containerize-and-package.md)
   - [validate-deployment-configurations](issues/validate-deployment-configurations.md)
   - [tune-system-performance](issues/tune-system-performance.md)
-- [simulate-distributed-orchestrator-performance](issues/simulate-distributed-orchestrator-performance.md)
+- [simulate-distributed-orchestrator-performance]
+  (issues/simulate-distributed-orchestrator-performance.md)
 - [stabilize-api-and-improve-search](issues/stabilize-api-and-improve-search.md)

--- a/issues/ensure-go-task-cli-availability.md
+++ b/issues/ensure-go-task-cli-availability.md
@@ -6,6 +6,10 @@ clean environments the CLI is absent, leading to errors such as `error: Failed
 to spawn: 'task'` and blocking test workflows. Developers must manually install
 the tool, but setup guidance does not cover this requirement.
 
+On September 5, 2025, installing the CLI via the official script placed the
+binary under `.venv/bin`, but `task check` still failed with "executable file
+not found in $PATH" until the directory was exported to `PATH`.
+
 ## Dependencies
 None.
 

--- a/issues/fix-check-env-package-metadata-errors.md
+++ b/issues/fix-check-env-package-metadata-errors.md
@@ -1,0 +1,20 @@
+# Fix check env package metadata errors
+
+## Context
+Running `task check` fails because `scripts/check_env.py` reports missing
+package metadata for packages such as `GitPython`, `cibuildwheel`,
+`duckdb-extension-vss`, `spacy`, and several `types-*` stubs. The script
+assumes these dependencies are installed, but minimal environments omit them,
+causing the check to exit early.
+
+## Dependencies
+None.
+
+## Acceptance Criteria
+- Update `scripts/check_env.py` to handle absent packages gracefully or adjust
+  installation extras.
+- `task check` succeeds in a fresh environment after running `task install`.
+- Document any required extras or fallback behavior in `STATUS.md`.
+
+## Status
+Open

--- a/issues/fix-task-verify-coverage-hang.md
+++ b/issues/fix-task-verify-coverage-hang.md
@@ -30,6 +30,10 @@ Exporting `.venv/bin` to `PATH` and executing `flake8`, `mypy`,
 tests/unit/test_cli_help.py -q` succeeded, indicating the hang stems from the Taskfile layout
 rather than test failures.
 
+On September 5, 2025, running `task verify` after installing all extras produced no output
+for several minutes during coverage.
+The process was interrupted manually, exiting with status 2.
+
 ## Dependencies
 None.
 

--- a/issues/prepare-v0-1-0a1-release.md
+++ b/issues/prepare-v0-1-0a1-release.md
@@ -8,6 +8,7 @@ initial proofs. Completing these steps clears the way to tag v0.1.0a1.
 ## Dependencies
 - [ensure-go-task-cli-availability](ensure-go-task-cli-availability.md)
 - [fix-task-verify-coverage-hang](fix-task-verify-coverage-hang.md)
+- [fix-check-env-package-metadata-errors](fix-check-env-package-metadata-errors.md)
 - [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)
 - [formalize-spec-driven-development-standards](formalize-spec-driven-development-standards.md)
 


### PR DESCRIPTION
## Summary
- document missing package metadata errors in `task check`
- note PATH requirements for Go Task CLI
- record latest `task verify` hang and extend release dependencies
- refresh status log and open issue list

## Testing
- `task check` *(fails: No package metadata for GitPython, cibuildwheel, duckdb-extension-vss, spacy, types stubs)*
- `task verify` *(fails: interrupted during coverage)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cb2b1b808333918a796d914263f3