### PR TITLE
feat: ensure go task availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ For orchestrator state transitions and API contracts see
 
 Autoresearch requires **Python 3.12+**,
 [uv](https://github.com/astral-sh/uv), and
-[Go Task](https://taskfile.dev/). Run `./scripts/bootstrap.sh` to place
-Go Task in `.venv/bin` when it's missing and ensure the directory is on
-your `PATH`:
+[Go Task](https://taskfile.dev/). Run `./scripts/setup.sh` to download
+Go Task into `.venv/bin` when it's missing. Append the directory to your
+`PATH`:
 
 ```bash
-./scripts/bootstrap.sh
+./scripts/setup.sh
 export PATH="$(pwd)/.venv/bin:$PATH"
 task --version
 ```
 
-Install Go Task manually if the bootstrap script fails:
+Install Go Task manually if the setup script fails:
 
 ```bash
 curl -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin

--- a/STATUS.md
+++ b/STATUS.md
@@ -38,8 +38,10 @@ without the previous `tmp_path` `KeyError`. Dependency pins for `fastapi` (>=0.1
 
 Run `scripts/setup.sh` or `task install` before executing tests. These
 commands bootstrap Go Task and install the `dev` and `test` extras so
-plugins like `pytest-bdd` are available. Skipping them often leads to test
-collection failures.
+plugins like `pytest-bdd` are available. The setup script downloads Go Task
+into `.venv/bin`; prepend the directory to `PATH` with
+`export PATH="$(pwd)/.venv/bin:$PATH"` before calling `task`. Skipping the
+initial setup often leads to test collection failures.
 
 Attempting `uv run task verify` previously failed with
 `yaml: line 190: did not find expected '-' indicator` when parsing the
@@ -116,7 +118,6 @@ warnings. Coverage data was not produced.
 
 ## Open issues
 - [prepare-v0-1-0a1-release](issues/prepare-v0-1-0a1-release.md)
-  - [ensure-go-task-cli-availability](issues/ensure-go-task-cli-availability.md)
   - [fix-task-verify-coverage-hang](issues/fix-task-verify-coverage-hang.md)
   - [fix-check-env-package-metadata-errors](issues/fix-check-env-package-metadata-errors.md)
   - [add-test-coverage-for-optional-components]

--- a/issues/archive/ensure-go-task-cli-availability.md
+++ b/issues/archive/ensure-go-task-cli-availability.md
@@ -19,4 +19,4 @@ None.
 - Update setup documentation to mention the bootstrap process.
 
 ## Status
-Open
+Archived

--- a/issues/prepare-v0-1-0a1-release.md
+++ b/issues/prepare-v0-1-0a1-release.md
@@ -6,7 +6,7 @@ should work offline, optional extras must install, and core algorithms require
 initial proofs. Completing these steps clears the way to tag v0.1.0a1.
 
 ## Dependencies
-- [ensure-go-task-cli-availability](ensure-go-task-cli-availability.md)
+- [ensure-go-task-cli-availability](archive/ensure-go-task-cli-availability.md)
 - [fix-task-verify-coverage-hang](fix-task-verify-coverage-hang.md)
 - [fix-check-env-package-metadata-errors](fix-check-env-package-metadata-errors.md)
 - [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,28 +10,25 @@ source "$SCRIPT_DIR/setup_common.sh"
 
 VENV_BIN="$(pwd)/.venv/bin"
 TASK_BIN="$VENV_BIN/task"
-ensure_venv_bin_on_path "$VENV_BIN"
-export PATH="$VENV_BIN:$PATH"
 
 install_go_task() {
     echo "Installing Go Task into $VENV_BIN..."
     ensure_uv
     uv venv
-    ensure_venv_bin_on_path "$VENV_BIN"
-    if command -v task >/dev/null 2>&1; then
-        ln -sf "$(command -v task)" "$TASK_BIN"
-    else
-        curl -sSL https://taskfile.dev/install.sh | sh -s -- -b "$VENV_BIN" || {
-            echo "Warning: failed to download Go Task; install manually from" \
-                " https://taskfile.dev/installation/ and re-run setup" >&2
-            return
-        }
-    fi
+    mkdir -p "$VENV_BIN"
+    curl -sSL https://taskfile.dev/install.sh | sh -s -- -b "$VENV_BIN" || {
+        echo "Warning: failed to download Go Task; install manually from" \
+            " https://taskfile.dev/installation/ and re-run setup" >&2
+        return
+    }
 }
 
 if [ ! -x "$TASK_BIN" ]; then
     install_go_task
 fi
+
+ensure_venv_bin_on_path "$VENV_BIN"
+export PATH="$VENV_BIN:$PATH"
 
 case "$(uname -s)" in
 Linux*)

--- a/tests/targeted/test_extras_install.py
+++ b/tests/targeted/test_extras_install.py
@@ -1,3 +1,7 @@
+import os
+import subprocess
+from pathlib import Path
+
 import duckdb
 import pytest
 
@@ -75,3 +79,11 @@ def test_parsers_extra_imports(tmp_path) -> None:
     docx.Document().save(path)
     doc = docx.Document(path)
     assert len(doc.paragraphs) == 0
+
+
+@pytest.mark.slow
+def test_task_check_runs_after_setup() -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["PATH"] = f"{project_root / '.venv' / 'bin'}:{env['PATH']}"
+    subprocess.run(["task", "check", "EXTRAS=dev"], cwd=project_root, env=env, check=True)


### PR DESCRIPTION
## Summary
- ensure `scripts/setup.sh` downloads Go Task into `.venv/bin` and exports the path
- document Go Task setup in README and STATUS
- add smoke test that runs `task check` after setup and archive related issue

## Testing
- `task check EXTRAS="dev"`
- `uv run --extra test pytest tests/targeted/test_extras_install.py::test_task_check_runs_after_setup -m slow -q`

------
https://chatgpt.com/codex/tasks/task_e_68b910a660c08333b76814d597eb607a