### PR TITLE
Add deployment configuration validation

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -121,6 +121,23 @@ the executor's `shutdown()` method or a graceful termination signal to stop the
 coordinator. Queues are drained and closed automatically so no messages are
 lost during shutdown.
 
+## Configuration Validation
+
+Confirm required settings before starting services.
+
+- Set `DEPLOY_ENV` to the target environment such as `staging` or
+  `production`.
+- Set `CONFIG_DIR` to the directory containing deployment files.
+- Ensure `deploy.yml` and `.env` exist in `CONFIG_DIR`.
+- Run the validation script:
+
+```bash
+DEPLOY_ENV=production CONFIG_DIR=config uv run scripts/validate_deploy.py
+```
+
+If any variable or file is missing, the script exits with a non-zero status
+and lists the missing items.
+
 ## Deployment Checks
 
 After starting the service, run the deployment script to validate configuration

--- a/issues/archive/validate-deployment-configurations.md
+++ b/issues/archive/validate-deployment-configurations.md
@@ -15,4 +15,4 @@ Reliable deployment requires validated scripts and configuration checks to preve
 - Document deployment procedures and configuration options.
 
 ## Status
-Open
+Archived

--- a/scripts/validate_deploy.py
+++ b/scripts/validate_deploy.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""Validate deployment environment and configuration.
+
+Usage:
+    uv run scripts/validate_deploy.py
+
+This script verifies that required environment variables and configuration
+files exist before deployment.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Sequence
+
+REQUIRED_ENV_VARS = ("DEPLOY_ENV", "CONFIG_DIR")
+REQUIRED_FILES = ("deploy.yml", ".env")
+
+
+def _missing_env() -> list[str]:
+    """Return missing required environment variables."""
+    return [name for name in REQUIRED_ENV_VARS if not os.getenv(name)]
+
+
+def _missing_files(config_dir: Path) -> list[Path]:
+    """Return missing configuration files in ``config_dir``."""
+    return [config_dir / name for name in REQUIRED_FILES if not (config_dir / name).is_file()]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    missing_env = _missing_env()
+    if missing_env:
+        print(
+            f"Missing environment variables: {', '.join(missing_env)}",
+            file=sys.stderr,
+        )
+        return 1
+    config_dir = Path(os.environ["CONFIG_DIR"])
+    missing_files = _missing_files(config_dir)
+    if missing_files:
+        missing = ", ".join(str(p) for p in missing_files)
+        print(f"Missing configuration files: {missing}", file=sys.stderr)
+        return 1
+    print("Deployment configuration validated.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    raise SystemExit(main())

--- a/tests/integration/test_deploy_validation.py
+++ b/tests/integration/test_deploy_validation.py
@@ -1,4 +1,5 @@
 """Integration tests for deployment configuration validation."""
+
 from __future__ import annotations
 
 import os
@@ -8,8 +9,7 @@ from pathlib import Path
 
 
 def _write_config(tmp_path: Path) -> None:
-    cfg_text = (
-        """
+    cfg_text = """
 [core]
 llm_backend = "openai"
 
@@ -22,7 +22,6 @@ llm_backend = "lmstudio"
 [profiles.online]
 llm_backend = "openai"
 """
-    )
     (tmp_path / "autoresearch.toml").write_text(cfg_text)
 
 
@@ -81,3 +80,45 @@ def test_deploy_validation_online(tmp_path: Path) -> None:
     result = _run_deploy(tmp_path, env)
     assert result.returncode == 0
     assert "Configuration valid" in result.stdout
+
+
+def _run_validate(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "validate_deploy.py"
+    return subprocess.run(
+        [sys.executable, str(script)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_validate_deploy_success(tmp_path: Path) -> None:
+    (tmp_path / "deploy.yml").write_text("version: 1\n")
+    (tmp_path / ".env").write_text("KEY=value\n")
+    env = os.environ.copy()
+    env["DEPLOY_ENV"] = "production"
+    env["CONFIG_DIR"] = str(tmp_path)
+    result = _run_validate(env)
+    assert result.returncode == 0
+    assert "validated" in result.stdout.lower()
+
+
+def test_validate_deploy_missing_env(tmp_path: Path) -> None:
+    (tmp_path / "deploy.yml").write_text("version: 1\n")
+    (tmp_path / ".env").write_text("KEY=value\n")
+    env = os.environ.copy()
+    env.pop("DEPLOY_ENV", None)
+    env["CONFIG_DIR"] = str(tmp_path)
+    result = _run_validate(env)
+    assert result.returncode != 0
+    assert "DEPLOY_ENV" in result.stderr
+
+
+def test_validate_deploy_missing_file(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("KEY=value\n")
+    env = os.environ.copy()
+    env["DEPLOY_ENV"] = "production"
+    env["CONFIG_DIR"] = str(tmp_path)
+    result = _run_validate(env)
+    assert result.returncode != 0
+    assert "deploy.yml" in result.stderr


### PR DESCRIPTION
## Summary
- add script to validate deployment environment variables and config files
- cover deployment validation logic with integration tests
- document configuration validation steps and archive related issue

## Testing
- `task check` *(fails: No package metadata found for GitPython, cibuildwheel, duckdb-extension-vss, spacy, types-networkx, types-protobuf, types-requests, types-tabulate)*
- `uv run mkdocs build`
- `task verify` *(fails: tests/unit/test_core_modules_additional.py::test_storage_setup_teardown - KeyError: 'kuzu')*
- `uv run pytest tests/integration/test_deploy_validation.py::test_validate_deploy_success tests/integration/test_deploy_validation.py::test_validate_deploy_missing_env tests/integration/test_deploy_validation.py::test_validate_deploy_missing_file -q`

------
https://chatgpt.com/codex/tasks/task_e_68b910d6805083338de6b5de3dcb0373