### PR TITLE
Add deployment config validation script and tests

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -125,14 +125,16 @@ Confirm required settings before starting services.
   `production`.
 - Set `CONFIG_DIR` to the directory containing deployment files.
 - Ensure `deploy.yml` and `.env` exist in `CONFIG_DIR`.
+- Include required entries such as `version` in `deploy.yml` and `KEY` in
+  `.env`.
 - Run the validation script:
 
 ```bash
 DEPLOY_ENV=production CONFIG_DIR=config uv run scripts/validate_deploy.py
 ```
 
-If any variable or file is missing, the script exits with a non-zero status
-and lists the missing items.
+If any variable, file, or key is missing, the script exits with a non-zero
+status and lists the missing items.
 
 ## Deployment Checks
 

--- a/issues/validate-deployment-configurations.md
+++ b/issues/validate-deployment-configurations.md
@@ -13,6 +13,8 @@ Reliable deployment requires validated scripts and configuration checks to preve
 - Deliver deployment scripts with automated configuration validation.
 - Test scripts across supported environments.
 - Document deployment procedures and configuration options.
+- Include [scripts/validate_deploy.py](../scripts/validate_deploy.py) for
+  preflight checks.
 
 ## Status
 Open

--- a/scripts/validate_deploy.py
+++ b/scripts/validate_deploy.py
@@ -12,10 +12,14 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Mapping, Sequence
+
+import yaml
 
 REQUIRED_ENV_VARS = ("DEPLOY_ENV", "CONFIG_DIR")
 REQUIRED_FILES = ("deploy.yml", ".env")
+REQUIRED_YAML_KEYS = ("version",)
+REQUIRED_ENV_FILE_KEYS = ("KEY",)
 
 
 def _missing_env() -> list[str]:
@@ -26,6 +30,29 @@ def _missing_env() -> list[str]:
 def _missing_files(config_dir: Path) -> list[Path]:
     """Return missing configuration files in ``config_dir``."""
     return [config_dir / name for name in REQUIRED_FILES if not (config_dir / name).is_file()]
+
+
+def _load_yaml(path: Path) -> Mapping[str, Any]:
+    """Load YAML data from ``path``."""
+    with path.open() as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def _load_env_file(path: Path) -> Mapping[str, str]:
+    """Parse simple ``.env`` files into a mapping."""
+    data: dict[str, str] = {}
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        data[key.strip()] = value.strip()
+    return data
+
+
+def _missing_keys(data: Mapping[str, Any], required: Sequence[str]) -> list[str]:
+    """Return missing keys from ``data``."""
+    return [key for key in required if key not in data]
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -41,6 +68,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     if missing_files:
         missing = ", ".join(str(p) for p in missing_files)
         print(f"Missing configuration files: {missing}", file=sys.stderr)
+        return 1
+    yaml_data = _load_yaml(config_dir / "deploy.yml")
+    missing_yaml = _missing_keys(yaml_data, REQUIRED_YAML_KEYS)
+    if missing_yaml:
+        missing = ", ".join(missing_yaml)
+        print(f"Missing keys in deploy.yml: {missing}", file=sys.stderr)
+        return 1
+    env_data = _load_env_file(config_dir / ".env")
+    missing_env_file = _missing_keys(env_data, REQUIRED_ENV_FILE_KEYS)
+    if missing_env_file:
+        missing = ", ".join(missing_env_file)
+        print(f"Missing keys in .env: {missing}", file=sys.stderr)
         return 1
     print("Deployment configuration validated.")
     return 0

--- a/tests/integration/test_deploy_config.py
+++ b/tests/integration/test_deploy_config.py
@@ -1,0 +1,48 @@
+"""Integration tests for deploy configuration content validation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_validate(tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "validate_deploy.py"
+    env = os.environ.copy()
+    env["DEPLOY_ENV"] = "production"
+    env["CONFIG_DIR"] = str(tmp_path)
+    return subprocess.run(
+        [sys.executable, str(script)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_configs(tmp_path: Path, yaml_text: str, env_text: str) -> None:
+    (tmp_path / "deploy.yml").write_text(yaml_text)
+    (tmp_path / ".env").write_text(env_text)
+
+
+def test_validate_success(tmp_path: Path) -> None:
+    _write_configs(tmp_path, "version: 1\n", "KEY=value\n")
+    result = _run_validate(tmp_path)
+    assert result.returncode == 0
+    assert "validated" in result.stdout.lower()
+
+
+def test_missing_yaml_key(tmp_path: Path) -> None:
+    _write_configs(tmp_path, "other: 1\n", "KEY=value\n")
+    result = _run_validate(tmp_path)
+    assert result.returncode != 0
+    assert "version" in result.stderr
+
+
+def test_missing_env_key(tmp_path: Path) -> None:
+    _write_configs(tmp_path, "version: 1\n", "")
+    result = _run_validate(tmp_path)
+    assert result.returncode != 0
+    assert "KEY" in result.stderr


### PR DESCRIPTION
## Summary
- load deployment YAML and .env files to enforce required keys before deployment
- test configuration validation against sample configs
- document deployment validation steps and reference helper script in issue tracker

## Testing
- `task check`
- `uv run --extra test pytest tests/integration/test_deploy_config.py -q`
- `uv run mkdocs build`
- `task verify` *(fails: exit status 130)*

------
https://chatgpt.com/codex/tasks/task_e_68ba23438dcc8333ad2eb808e95c097d