### PR TITLE
Document DuckDB stub fallback

### DIFF
--- a/docs/duckdb_vss_fallback.md
+++ b/docs/duckdb_vss_fallback.md
@@ -1,0 +1,31 @@
+# DuckDB VSS Fallback
+
+When network access is limited, Autoresearch falls back to a stubbed vector
+search extension for DuckDB. The stub allows tests to run while
+disabling vector search features.
+
+## Stub mechanism
+
+- [`download_duckdb_extensions.py`][dde] installs the VSS extension.
+- On repeated failures it creates an empty file in `extensions/vss/` and warns
+  that the stub is in use.
+- [`setup.sh`][setup] logs when the stub is selected and records its
+  location for reuse.
+
+## Environment variable usage
+
+- The stub path is stored in `.env.offline` under `VECTOR_EXTENSION_PATH`.
+- Later runs load this file so `download_duckdb_extensions.py` can copy the
+  recorded extension instead of downloading it again.
+- Update or create `.env.offline` with:
+
+```
+VECTOR_EXTENSION_PATH=/path/to/vss.duckdb_extension
+```
+
+- The unit test [`test_download_duckdb_extensions.py`][test] demonstrates this
+  fallback.
+
+[dde]: ../scripts/download_duckdb_extensions.py
+[setup]: ../scripts/setup.sh
+[test]: ../tests/unit/test_download_duckdb_extensions.py

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -60,6 +60,9 @@ install_test_extras() {
         mkdir -p "$(dirname "$VSS_EXTENSION")"
         : >"$VSS_EXTENSION"
     fi
+    if [ ! -s "$VSS_EXTENSION" ]; then
+        echo "Using stub VSS extension at $VSS_EXTENSION" >&2
+    fi
     record_vector_extension_path "$VSS_EXTENSION"
 }
 

--- a/tests/unit/test_download_duckdb_extensions.py
+++ b/tests/unit/test_download_duckdb_extensions.py
@@ -151,3 +151,19 @@ def test_setup_sh_ignores_smoke_failure_with_stub(monkeypatch, tmp_path):
     )
     assert completed.returncode == 0
     assert "fail" not in completed.stdout
+
+
+def test_load_offline_env_sets_vector_extension_path(monkeypatch, tmp_path, caplog):
+    """Documentation example for VECTOR_EXTENSION_PATH is honored."""
+    env_file = tmp_path / ".env.offline"
+    stub_path = tmp_path / "extensions" / "vss_stub.duckdb_extension"
+    stub_path.parent.mkdir(parents=True, exist_ok=True)
+    stub_path.write_text("stub")
+    env_file.write_text(f"VECTOR_EXTENSION_PATH={stub_path}\n")
+
+    monkeypatch.chdir(tmp_path)
+    caplog.set_level(logging.INFO)
+    vars_loaded = dde.load_offline_env()
+    assert vars_loaded["VECTOR_EXTENSION_PATH"] == str(stub_path)
+    assert os.environ["VECTOR_EXTENSION_PATH"] == str(stub_path)
+    assert "Loaded offline configuration" in caplog.text


### PR DESCRIPTION
## Summary
- Document DuckDB VSS stub fallback and environment variable usage
- Log when setup.sh uses a stub and always write `.env.offline`
- Test offline env loading for VECTOR_EXTENSION_PATH

## Testing
- `PATH=.venv/bin:$PATH task check`
- `pytest tests/unit/test_download_duckdb_extensions.py::test_load_offline_env_sets_vector_extension_path -q`
- `PATH=.venv/bin:$PATH task verify` *(fails: exit status 130)*
- `mkdocs build` *(fails: No module named 'autoresearch')*


------
https://chatgpt.com/codex/tasks/task_e_68ba22f84c0483339ccf787de01a6b9d