### PR TITLE
docs: document container builds

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -275,15 +275,24 @@ tasks:
 
   docker-build:linux:
     cmds:
-      - docker buildx build --platform linux/amd64 -f docker/Dockerfile.linux -t autoresearch:linux .
+      - |
+          docker buildx build --load --platform linux/amd64 \
+            -f docker/Dockerfile.linux \
+            -t autoresearch:linux .
     desc: "Build Linux container image"
 
   docker-build:macos:
     cmds:
-      - docker buildx build --platform linux/arm64 -f docker/Dockerfile.macos -t autoresearch:macos-arm .
+      - |
+          docker buildx build --load --platform linux/arm64 \
+            -f docker/Dockerfile.macos \
+            -t autoresearch:macos-arm .
     desc: "Build macOS ARM container image"
 
   docker-build:windows:
     cmds:
-      - docker buildx build --platform windows/amd64 -f docker/Dockerfile.windows -t autoresearch:windows .
+      - |
+          docker buildx build --load --platform windows/amd64 \
+            -f docker/Dockerfile.windows \
+            -t autoresearch:windows .
     desc: "Build Windows container image"

--- a/docs/container_usage.md
+++ b/docs/container_usage.md
@@ -1,0 +1,31 @@
+# Container Usage
+
+Autoresearch provides Dockerfiles under `docker/` for Linux, macOS, and
+Windows. Images include the project's build extras and are tagged by platform.
+
+## Build
+
+Use the Taskfile to build all images via `docker buildx`:
+
+```bash
+task docker-build
+```
+
+Each platform can be built on its own:
+
+```bash
+task docker-build:linux
+task docker-build:macos
+task docker-build:windows
+```
+
+## Run
+
+Mount your workspace and start a shell inside the container:
+
+```bash
+docker run --rm -it -v "$PWD:/workspace" autoresearch:linux bash
+```
+
+Replace `autoresearch:linux` with the desired tag. For packaging steps, see
+[docker/README.md](../docker/README.md).


### PR DESCRIPTION
## Summary
- document how to build and run project containers
- load buildx images for linux, macOS, and windows in Taskfile

## Testing
- `task check`
- `uv run mkdocs build`
- `task verify` *(fails: sqlite3 OperationalError: no such table: kb_bec6803d52_literal_statements)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2329ccb4833381491f0d77798b07