### PR TITLE
docs: track flake8 regression

### DIFF
--- a/issues/fix-streaming-webhook-test-style.md
+++ b/issues/fix-streaming-webhook-test-style.md
@@ -1,0 +1,14 @@
+# Fix streaming webhook test style
+
+## Context
+Flake8 fails at `tests/integration/test_api_streaming_webhook.py` due to excessive blank lines, preventing `task verify` from passing.
+
+## Dependencies
+None.
+
+## Acceptance Criteria
+- `tests/integration/test_api_streaming_webhook.py` conforms to `flake8` rules.
+- `task verify` completes the flake8 stage without errors.
+
+## Status
+Open

--- a/issues/prepare-v0-1-0a1-release.md
+++ b/issues/prepare-v0-1-0a1-release.md
@@ -12,6 +12,7 @@ initial proofs. Completing these steps clears the way to tag v0.1.0a1.
 - [add-test-coverage-for-optional-components](archive/add-test-coverage-for-optional-components.md)
 - [formalize-spec-driven-development-standards]
   (archive/formalize-spec-driven-development-standards.md)
+- [fix-streaming-webhook-test-style](fix-streaming-webhook-test-style.md)
 
 ## Acceptance Criteria
 - `task verify` runs to completion with all extras installed.


### PR DESCRIPTION
## Summary
- track flake8 failure in streaming webhook integration tests
- add release dependency to address flake8 regression before v0.1.0a1

## Testing
- `uv run task check`
- `uv run task verify` *(fails: tests/integration/test_api_streaming_webhook.py:76:1: E303 too many blank lines (4))*

------
https://chatgpt.com/codex/tasks/task_e_68baef60fa8883338b9dfe71acf074cb