### PR TITLE
chore: tidy streaming webhook test formatting

### DIFF
--- a/tests/integration/test_api_streaming_webhook.py
+++ b/tests/integration/test_api_streaming_webhook.py
@@ -71,8 +71,6 @@ def test_stream_webhook_partial(monkeypatch, api_client):
     assert calls == ["partial-0", "partial-1", "final"]
 
 
-
-
 @pytest.mark.slow
 def test_streaming_error_triggers_webhook(monkeypatch, httpx_mock):
     """Errors in streaming queries should still trigger webhook delivery."""


### PR DESCRIPTION
## Summary
- trim redundant blank lines in streaming webhook test
- ensure lines respect 100-character limit

## Testing
- `uv run flake8 tests/integration/test_api_streaming_webhook.py`
- `uv run task verify` *(fails: Failed to spawn: `task` (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b2e1c5c8333ba75c17726f6b524