### PR TITLE
feat: validate deployment configuration

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -123,7 +123,7 @@ Confirm required settings before starting services.
 
 - Set `DEPLOY_ENV` to the target environment such as `staging` or
   `production`.
-- Set `CONFIG_DIR` to the directory containing deployment files.
+- Set `CONFIG_DIR` to the directory containing deployment files; it must exist.
 - Ensure `deploy.yml` and `.env` exist in `CONFIG_DIR`.
 - Include required entries such as `version` in `deploy.yml` and `KEY` in
   `.env`.

--- a/scripts/validate_deploy.py
+++ b/scripts/validate_deploy.py
@@ -64,6 +64,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 1
     config_dir = Path(os.environ["CONFIG_DIR"])
+    if not config_dir.is_dir():
+        print(f"CONFIG_DIR not found: {config_dir}", file=sys.stderr)
+        return 1
+
     missing_files = _missing_files(config_dir)
     if missing_files:
         missing = ", ".join(str(p) for p in missing_files)

--- a/tests/integration/test_validate_deploy.py
+++ b/tests/integration/test_validate_deploy.py
@@ -1,0 +1,75 @@
+"""Tests for ``scripts/validate_deploy.py``."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "validate_deploy.py"
+
+
+def _run(env: dict[str, str], tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_config(
+    tmp_path: Path,
+    yaml_content: str = "version: 1\n",
+    env_content: str = "KEY=value\n",
+) -> None:
+    (tmp_path / "deploy.yml").write_text(yaml_content)
+    (tmp_path / ".env").write_text(env_content)
+
+
+def test_validate_deploy_success(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+    env = os.environ.copy()
+    env.update({"DEPLOY_ENV": "production", "CONFIG_DIR": str(tmp_path)})
+    result = _run(env, tmp_path)
+    assert result.returncode == 0
+    assert "validated" in result.stdout.lower()
+
+
+def test_validate_deploy_missing_env(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+    env = os.environ.copy()
+    env.pop("DEPLOY_ENV", None)
+    env["CONFIG_DIR"] = str(tmp_path)
+    result = _run(env, tmp_path)
+    assert result.returncode != 0
+    assert "DEPLOY_ENV" in result.stderr
+
+
+def test_validate_deploy_missing_file(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("KEY=value\n")
+    env = os.environ.copy()
+    env.update({"DEPLOY_ENV": "production", "CONFIG_DIR": str(tmp_path)})
+    result = _run(env, tmp_path)
+    assert result.returncode != 0
+    assert "deploy.yml" in result.stderr
+
+
+def test_validate_deploy_missing_yaml_key(tmp_path: Path) -> None:
+    _write_config(tmp_path, yaml_content="{}\n")
+    env = os.environ.copy()
+    env.update({"DEPLOY_ENV": "production", "CONFIG_DIR": str(tmp_path)})
+    result = _run(env, tmp_path)
+    assert result.returncode != 0
+    assert "version" in result.stderr
+
+
+def test_validate_deploy_missing_env_key(tmp_path: Path) -> None:
+    _write_config(tmp_path, env_content="OTHER=value\n")
+    env = os.environ.copy()
+    env.update({"DEPLOY_ENV": "production", "CONFIG_DIR": str(tmp_path)})
+    result = _run(env, tmp_path)
+    assert result.returncode != 0
+    assert "KEY" in result.stderr


### PR DESCRIPTION
## Summary
- ensure deployment validation script checks config directory and required keys
- add integration tests for success and failure scenarios
- document how to run the validator before deployment

## Testing
- `uv run black scripts/validate_deploy.py tests/integration/test_validate_deploy.py`
- `uv run flake8 scripts/validate_deploy.py tests/integration/test_validate_deploy.py`
- `uv run pre-commit run --files scripts/validate_deploy.py tests/integration/test_validate_deploy.py docs/deployment.md`
- `uv run --extra test pytest tests/integration/test_validate_deploy.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb0b5e576c8333ac4b01b76e35c8bf