### PR TITLE
feat: add cross-platform docker targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM python:3.12-slim
+# syntax=docker/dockerfile:1
+
+ARG BASE_IMAGE=python:3.12-slim
+FROM ${BASE_IMAGE}
+
 WORKDIR /app
 COPY uv.lock pyproject.toml /app/
-RUN pip install --no-cache-dir uv \
-    && uv pip sync uv.lock
+RUN pip install --no-cache-dir uv && uv pip sync uv.lock
 COPY . /app
 EXPOSE 8000
 CMD ["uv", "run", "uvicorn", "autoresearch.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
 version: '3.8'
 services:
   autoresearch:
-    build: .
+    build:
+      context: .
+      args:
+        BASE_IMAGE: ${BASE_IMAGE:-python:3.12-slim}
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     ports:
       - "8000:8000"
     env_file:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,6 +70,33 @@ Launch with:
 docker compose up --build
 ```
 
+### Building and pushing images
+
+Use Docker Buildx to build and push per-platform images from the top-level
+Dockerfile:
+
+```bash
+# Linux (x86_64)
+docker buildx build --platform linux/amd64 \
+  -t youruser/autoresearch:linux --push .
+
+# macOS (ARM64)
+docker buildx build --platform linux/arm64 \
+  -t youruser/autoresearch:macos --push .
+
+# Windows
+docker buildx build --platform windows/amd64 \
+  --build-arg BASE_IMAGE=python:3.12-windowsservercore \
+  -t youruser/autoresearch:windows --push .
+```
+
+Test an image locally before pushing:
+
+```bash
+docker buildx build --platform linux/amd64 -t autoresearch:test --load .
+docker run --rm -p 8000:8000 autoresearch:test
+```
+
 ## Building Wheels for Distribution
 
 Platform-specific wheels can be generated using Go Task:


### PR DESCRIPTION
## Summary
- allow overriding the Docker base image to build Linux, macOS, or Windows containers
- expose platform and base-image args in docker-compose
- document per-platform build and push commands

## Testing
- `task check` *(failed: command not found)*
- `uv run pre-commit run --files Dockerfile docker-compose.yml docs/deployment.md`
- `uv run pytest` *(failed: No module named 'pytest_bdd')*
- `docker version` *(failed: Cannot connect to the Docker daemon)*
- `docker build -t autoresearch:test .` *(failed: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b538d7c8333a87d461fff5a9141