### PR TITLE
feat: safeguard optional Kuzu path

### DIFF
--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -152,13 +152,13 @@ def setup(
             ctx.db_backend.setup(db_path)
 
         # Initialize Kuzu backend when enabled
-        if getattr(cfg, "use_kuzu", False):
-            if KuzuBackend is None:
-                log.warning("Kuzu backend requested but not available")
-            else:
-                _kuzu_backend = KuzuBackend()
-                kuzu_path = getattr(cfg, "kuzu_path", StorageConfig().kuzu_path)
-                _kuzu_backend.setup(kuzu_path)
+        use_kuzu = getattr(cfg, "use_kuzu", False)
+        if use_kuzu and KuzuBackend is None:
+            log.warning("Kuzu backend requested but not available")
+        elif use_kuzu:
+            _kuzu_backend = KuzuBackend()
+            kuzu_path = getattr(cfg, "kuzu_path", StorageConfig().kuzu_path)
+            _kuzu_backend.setup(kuzu_path)
 
         # Initialize RDF store
         if cfg.rdf_backend == "memory":


### PR DESCRIPTION
## Summary
- guard Kuzu backend setup by checking `use_kuzu` once and pulling `kuzu_path` via `getattr`
- restructure storage tests to avoid missing attributes and ensure cached config reset

## Testing
- `uv run --extra test pytest tests/unit/test_core_modules_additional.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb0b32ae9083339db2c2e0cad06a89