### PR TITLE
Link archived performance tuning issue

### DIFF
--- a/issues/reach-stable-performance-and-interfaces.md
+++ b/issues/reach-stable-performance-and-interfaces.md
@@ -12,7 +12,7 @@ stable interfaces and tuned performance.
 
 - [containerize-and-package](containerize-and-package.md)
 - [validate-deployment-configurations](validate-deployment-configurations.md)
-- [tune-system-performance](tune-system-performance.md)
+- [tune-system-performance](archive/tune-system-performance.md) completed.
 
 ## Acceptance Criteria
 - Containerization and packaging succeed across Windows, macOS and Linux.


### PR DESCRIPTION
## Summary
- point performance dependency to archived `tune-system-performance` issue and note completion

## Testing
- `task check`
- `task verify` *(fails: tests/integration/test_api_streaming_webhook.py:76:1: E303 too many blank lines)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b7730088333ad1dfee334a40ce1