### PR TITLE
Handle DuckDB extension download failures

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -309,11 +309,10 @@ uv run python scripts/publish_dev.py --dry-run
 ```
 
 If the DuckDB VSS extension cannot be downloaded,
-`scripts/download_duckdb_extensions.py` reads `.env.offline` and uses
-`VECTOR_EXTENSION_PATH` so the project works without vector search support.
-`scripts/setup.sh` now writes a stub ``vss.duckdb_extension`` to the bundled
-``extensions`` directory when no binary is available, ensuring tests and
-``task check`` continue to run.
+`scripts/download_duckdb_extensions.py` creates an empty
+`extensions/vss/vss.duckdb_extension` stub. When `.env.offline` defines
+`VECTOR_EXTENSION_PATH`, that file is copied instead. The stub ensures tests
+and `task check` continue to run without vector search support.
 
 ### Offline installation
 

--- a/tests/integration/test_download_extension_stub.py
+++ b/tests/integration/test_download_extension_stub.py
@@ -1,0 +1,36 @@
+"""Test DuckDB extension download fallback."""
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "download_duckdb_extensions.py"
+spec = importlib.util.spec_from_file_location("download_duckdb_extensions", MODULE_PATH)
+download_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(download_mod)
+
+
+def test_network_failure_creates_stub(tmp_path, monkeypatch):
+    """Ensure a stub is created when downloads fail."""
+
+    class FailingConn:
+        def execute(self, *args, **kwargs):
+            return self
+
+        def fetchall(self):
+            return []
+
+        def install_extension(self, name):
+            raise download_mod.duckdb.Error("network unreachable")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(download_mod, "load_offline_env", lambda *_: {})
+    monkeypatch.setattr(download_mod.duckdb, "connect", lambda *_: FailingConn())
+
+    dest = download_mod.download_extension("vss", str(tmp_path))
+    stub = tmp_path / "vss" / "vss.duckdb_extension"
+    assert Path(dest) == stub
+    assert stub.exists()
+    assert stub.stat().st_size == 0


### PR DESCRIPTION
## Summary
- detect network errors when downloading DuckDB extensions and fall back to an empty `vss.duckdb_extension`
- add integration test ensuring a stub is created when downloads fail
- document the stub fallback in the installation guide

## Testing
- `uv run flake8 scripts/download_duckdb_extensions.py tests/integration/test_download_extension_stub.py`
- `uv run mypy src`
- `uv run pytest tests/integration/test_download_extension_stub.py`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68bb0b3cf970833380c111c70b74074b