### PR TITLE
Refine streaming webhooks, config reload logging, and search benchmarks

### DIFF
--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -22,9 +22,11 @@ Core routines enforce invariants by validating inputs and state.
 
 ## Simulation Expectations
 
-Unit tests cover nominal and edge cases for these routines.
-Streaming scenarios post intermediate cycle results to configured webhooks
-alongside final responses.
+Unit tests cover nominal and edge cases for these routines. Streaming
+endpoints send heartbeat lines every 15 seconds to keep connections open
+and retry webhook deliveries up to three times with exponential backoff.
+Streaming scenarios post intermediate cycle results to configured
+webhooks alongside final responses.
 
 ## Traceability
 

--- a/docs/specs/config.md
+++ b/docs/specs/config.md
@@ -21,7 +21,8 @@ Core routines enforce invariants by validating inputs and state.
 
 Unit and behavior tests cover nominal and edge cases for these routines.
 Hot-reload scenarios update agent rosters and loop counts while ignoring
-invalid changes.
+invalid changes. The watcher logs an error and keeps the previous
+configuration active when a source file is removed.
 
 ## Traceability
 
@@ -33,9 +34,11 @@ invalid changes.
   - [tests/unit/test_config_errors.py][t2]
   - [tests/unit/test_config_loader_defaults.py][t3]
   - [tests/behavior/features/configuration_hot_reload.feature][t4]
+  - [tests/integration/test_config_hot_reload_components.py][t5]
 
 [m1]: ../../src/autoresearch/config/
 [t1]: ../../tests/unit/test_config_env_file.py
 [t2]: ../../tests/unit/test_config_errors.py
 [t3]: ../../tests/unit/test_config_loader_defaults.py
 [t4]: ../../tests/behavior/features/configuration_hot_reload.feature
+[t5]: ../../tests/integration/test_config_hot_reload_components.py

--- a/docs/specs/search_ranking.md
+++ b/docs/specs/search_ranking.md
@@ -23,7 +23,10 @@ is stable, proving deterministic rankings for equal scores.
 
 - Compare ranking outputs for varied relevance and recency balances.
 - Stress test with duplicate items to confirm stability.
-- Benchmark precision, recall, and latency across backends.
+- Benchmark precision, recall, and latency across backends with shared
+  datasets. Results appear in [docs/ranking_benchmark.md][d1], and
+  regression thresholds flag precision or recall drops over five
+  percentage points or latency increases above five percent.
 
 ## Traceability
 
@@ -32,8 +35,10 @@ is stable, proving deterministic rankings for equal scores.
   - [tests/behavior/features/search_cli.feature][t1]
   - [tests/behavior/features/hybrid_search.feature][t2]
   - [tests/benchmark/test_hybrid_ranking.py][t3]
+  - [docs/ranking_benchmark.md][d1]
 
 [m1]: ../../src/autoresearch/search/ranking_convergence.py
 [t1]: ../../tests/behavior/features/search_cli.feature
 [t2]: ../../tests/behavior/features/hybrid_search.feature
 [t3]: ../../tests/benchmark/test_hybrid_ranking.py
+[d1]: ../ranking_benchmark.md

--- a/src/autoresearch/config/loader.py
+++ b/src/autoresearch/config/loader.py
@@ -118,8 +118,7 @@ class ConfigLoader:
         if getattr(self, "_initialized", False):  # pragma: no cover - defensive
             return
         self.search_paths: List[Path] = [
-            Path(p)
-            for p in (search_paths or ["autoresearch.toml", "config/autoresearch.toml"])
+            Path(p) for p in (search_paths or ["autoresearch.toml", "config/autoresearch.toml"])
         ]
         self.env_path: Path = Path(env_path) if env_path else Path(".env")
         self.watch_paths: List[str] = [str(p) for p in self.search_paths]
@@ -146,9 +145,7 @@ class ConfigLoader:
     def load_config(self) -> ConfigModel:
         raw_env: Dict[str, str] = {}
         if self.env_path.exists():
-            raw_env.update(
-                {k: v for k, v in dotenv_values(self.env_path).items() if v is not None}
-            )
+            raw_env.update({k: v for k, v in dotenv_values(self.env_path).items() if v is not None})
 
         for key, value in os.environ.items():
             if key.startswith("AUTORESEARCH_"):
@@ -204,9 +201,7 @@ class ConfigLoader:
             "hnsw_m": duckdb_cfg.get("hnsw_m", 16),
             "hnsw_ef_construction": duckdb_cfg.get("hnsw_ef_construction", 200),
             "hnsw_metric": duckdb_cfg.get("hnsw_metric", "l2"),
-            "hnsw_ef_search": duckdb_cfg.get(
-                "hnsw_ef_search", duckdb_cfg.get("vector_nprobe", 10)
-            ),
+            "hnsw_ef_search": duckdb_cfg.get("hnsw_ef_search", duckdb_cfg.get("vector_nprobe", 10)),
             "hnsw_auto_tune": duckdb_cfg.get("hnsw_auto_tune", True),
             "vector_nprobe": duckdb_cfg.get("vector_nprobe", 10),
             "vector_search_batch_size": duckdb_cfg.get("vector_search_batch_size"),
@@ -227,9 +222,7 @@ class ConfigLoader:
             core_settings["distributed"] = bool(distributed_cfg.get("enabled", False))
 
         agent_cfg = raw.get("agent", {})
-        enabled_agents = [
-            name for name, a in agent_cfg.items() if a.get("enabled", True)
-        ]
+        enabled_agents = [name for name, a in agent_cfg.items() if a.get("enabled", True)]
         if enabled_agents:
             core_settings["agents"] = enabled_agents
 
@@ -255,17 +248,13 @@ class ConfigLoader:
                         valid_settings[field] = value
                 return model_cls(**valid_settings)
 
-        core_settings["storage"] = _safe_model(
-            StorageConfig, storage_settings, "storage"
-        )
+        core_settings["storage"] = _safe_model(StorageConfig, storage_settings, "storage")
         core_settings["api"] = _safe_model(APIConfig, api_cfg, "api")
         core_settings["distributed_config"] = _safe_model(
             DistributedConfig, distributed_cfg, "distributed"
         )
         core_settings["user_preferences"] = user_pref_cfg
-        core_settings["analysis"] = _safe_model(
-            AnalysisConfig, analysis_cfg, "analysis"
-        )
+        core_settings["analysis"] = _safe_model(AnalysisConfig, analysis_cfg, "analysis")
         core_settings["agent_config"] = agent_config_dict
 
         self._profiles = raw.get("profiles", {})
@@ -308,9 +297,7 @@ class ConfigLoader:
                     "Error in config observer", observer=str(observer), cause=e
                 ) from e
 
-    def watch_changes(
-        self, callback: Optional[Callable[[ConfigModel], None]] = None
-    ) -> None:
+    def watch_changes(self, callback: Optional[Callable[[ConfigModel], None]] = None) -> None:
         if callback:
             self.register_observer(callback)
         if self._watch_thread and self._watch_thread.is_alive():
@@ -338,9 +325,7 @@ class ConfigLoader:
             atexit.register(self.stop_watching)
             self._atexit_registered = True
         self._watch_thread.start()
-        logger.info(
-            f"Started config watcher for paths: {[str(p) for p in target_files]}"
-        )
+        logger.info(f"Started config watcher for paths: {[str(p) for p in target_files]}")
 
     def stop_watching(self) -> None:
         if self._watch_thread and self._watch_thread.is_alive():
@@ -356,9 +341,7 @@ class ConfigLoader:
             self._config = None
 
     @contextmanager
-    def watching(
-        self, callback: Optional[Callable[[ConfigModel], None]] = None
-    ) -> Iterator[None]:
+    def watching(self, callback: Optional[Callable[[ConfigModel], None]] = None) -> Iterator[None]:
         self.watch_changes(callback)
         try:
             yield
@@ -377,13 +360,12 @@ class ConfigLoader:
             directories = {p.resolve().parent for p in watch_targets}
             target_files = {p.resolve() for p in watch_targets}
         try:
-            for changes in watch(
-                *(str(d) for d in directories), stop_event=self._stop_event
-            ):
+            for changes in watch(*(str(d) for d in directories), stop_event=self._stop_event):
                 for change in changes:
                     file_path = Path(change[1]).resolve()
                     if file_path in target_files:
                         if not file_path.exists():
+                            logger.error("Config file missing: %s", file_path)
                             continue
                         try:
                             new_config = self.load_config()

--- a/tests/data/backend_metrics.json
+++ b/tests/data/backend_metrics.json
@@ -1,16 +1,16 @@
 {
   "tests/benchmark/test_hybrid_ranking.py::test_hybrid_ranking[bm25]::bm25": {
-    "latency": 1.7115934138946502e-06,
+    "latency": 1.8717591980759403e-06,
     "precision": 1.0,
     "recall": 1.0
   },
   "tests/benchmark/test_hybrid_ranking.py::test_hybrid_ranking[hybrid]::hybrid": {
-    "latency": 2.0681789060754015e-06,
+    "latency": 2.2546118563811595e-06,
     "precision": 0.75,
     "recall": 1.0
   },
   "tests/benchmark/test_hybrid_ranking.py::test_hybrid_ranking[semantic]::semantic": {
-    "latency": 1.8048826286237463e-06,
+    "latency": 1.9683167472933056e-06,
     "precision": 0.5,
     "recall": 1.0
   }


### PR DESCRIPTION
## Summary
- log missing configuration files during hot reload
- document heartbeat streaming and webhook retries
- benchmark hybrid search ranking with updated baselines

## Testing
- `uv run --extra test --extra git pytest -m "slow" tests/integration/test_api_streaming_webhook.py::test_stream_emits_keepalive tests/integration/test_api_streaming_webhook.py::test_stream_webhook_partial tests/integration/test_api_streaming_webhook.py::test_streaming_error_triggers_webhook tests/integration/test_config_hot_reload_components.py::test_missing_config_file_logs_error tests/benchmark/test_hybrid_ranking.py::test_hybrid_ranking`
- `uv run mkdocs build` *(fails: Failed to spawn: `mkdocs`)*
- `uv run pre-commit run --files src/autoresearch/config/loader.py tests/integration/test_config_hot_reload_components.py docs/specs/api.md docs/specs/config.md docs/specs/search_ranking.md` *(fails: Failed to spawn: `pre-commit`)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b7194a483339d2f34d8f1f55950