### PR TITLE
docs: model streaming queue growth

### DIFF
--- a/scripts/queue_growth_sim.py
+++ b/scripts/queue_growth_sim.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Simulate queue growth for stalled streaming clients.
+
+Usage:
+    uv run scripts/queue_growth_sim.py --rate 5 --size 1024 --stall 10
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+
+def simulate(rate: float, size: int, stall: float) -> tuple[int, int]:
+    """Return queue length and approximate memory use."""
+    produced = int(rate * stall)
+    items = [b"x" * size for _ in range(produced)]
+    queue: asyncio.Queue[bytes] = asyncio.Queue()
+    for item in items:
+        queue.put_nowait(item)
+    memory = produced * size
+    return queue.qsize(), memory
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Model queue growth under stalled clients.")
+    parser.add_argument("--rate", type=float, default=5.0, help="messages per second")
+    parser.add_argument("--size", type=int, default=1024, help="bytes per message")
+    parser.add_argument("--stall", type=float, default=10.0, help="seconds without consumption")
+    args = parser.parse_args()
+    length, memory = simulate(args.rate, args.size, args.stall)
+    print(f"queue length: {length} items")
+    print(f"approx memory: {memory} bytes")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_api_streaming_webhook.py
+++ b/tests/integration/test_api_streaming_webhook.py
@@ -71,8 +71,6 @@ def test_stream_webhook_partial(monkeypatch, api_client):
     assert calls == ["partial-0", "partial-1", "final"]
 
 
-
-
 @pytest.mark.slow
 def test_streaming_error_triggers_webhook(monkeypatch, httpx_mock):
     """Errors in streaming queries should still trigger webhook delivery."""


### PR DESCRIPTION
## Summary
- document streaming queue growth and memory model
- add queue growth simulation script with sample usage
- clean up extra blank lines in streaming webhook test

## Testing
- `PATH=.venv/bin:$PATH ./bin/task check`
- `uv run scripts/queue_growth_sim.py --rate 5 --size 1024 --stall 10`
- `PATH=.venv/bin:$PATH ./bin/task verify` *(fails: OperationalError: no such table: kb_bec6803d52_literal_statements)*


------
https://chatgpt.com/codex/tasks/task_e_68bb0b7d1f988333bd80049284ec9257