### PR TITLE
docs: log failing tests and open integration fixes

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -10,6 +10,9 @@
 
 ## September 5, 2025
 
+- Go Task CLI remains unavailable; `task` command not found.
+- `uv run pytest` reports 57 failed, 1037 passed tests, 27 skipped, 120 deselected, 9 xfailed, 4 xpassed, and 1 error.
+
 - Installing Go Task with the upstream script placed the binary under `.venv/bin`.
   `task check` then failed with "No package metadata was found for GitPython" and
   similar messages for `cibuildwheel`, `duckdb-extension-vss`, `spacy`, and

--- a/issues/fix-storage-integration-test-failures.md
+++ b/issues/fix-storage-integration-test-failures.md
@@ -1,0 +1,15 @@
+# Fix storage integration test failures
+
+## Context
+Recent full-suite testing (`uv run pytest`) revealed multiple failures in storage-related integration tests. Problems span `tests/integration/test_storage_concurrency.py::test_concurrent_writes`, several cases in `tests/integration/test_storage_eviction_sim.py`, `tests/integration/test_storage_schema.py::test_initialize_schema_version_without_fetchone`, and `tests/integration/test_storage_duckdb_fallback.py::test_ram_budget_benchmark`. These issues block the v0.1.0a1 release.
+
+## Dependencies
+None.
+
+## Acceptance Criteria
+- `pytest tests/integration/test_storage_*` runs without failures.
+- `task verify` (or equivalent) completes storage integration tests successfully.
+- Document fixes in the changelog.
+
+## Status
+Open

--- a/issues/prepare-v0-1-0a1-release.md
+++ b/issues/prepare-v0-1-0a1-release.md
@@ -13,6 +13,8 @@ initial proofs. Completing these steps clears the way to tag v0.1.0a1.
 - [formalize-spec-driven-development-standards]
   (archive/formalize-spec-driven-development-standards.md)
 - [fix-streaming-webhook-test-style](fix-streaming-webhook-test-style.md)
+- [fix-storage-integration-test-failures](fix-storage-integration-test-failures.md)
+- [resolve-api-and-search-integration-test-failures](resolve-api-and-search-integration-test-failures.md)
 
 ## Acceptance Criteria
 - `task verify` runs to completion with all extras installed.

--- a/issues/resolve-api-and-search-integration-test-failures.md
+++ b/issues/resolve-api-and-search-integration-test-failures.md
@@ -1,0 +1,16 @@
+# Resolve API and search integration test failures
+
+## Context
+The integration suite reports numerous failures across API authentication, documentation, streaming, and search modules. Examples include `tests/integration/test_api_auth.py`, `tests/integration/test_api_docs.py`, `tests/integration/test_api_streaming.py`, `tests/integration/test_search_error_handling.py`, and `tests/integration/test_ranking_formula_consistency.py`. These must pass to stabilize the alpha release.
+
+## Dependencies
+None.
+
+## Acceptance Criteria
+- All API integration tests pass, covering authentication, docs, and streaming.
+- Search integration tests run without AttributeError or regression failures.
+- Ranking formula consistency tests succeed.
+- `task verify` completes with no API or search test failures.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- record failing test run and missing Go Task CLI
- add issues for storage and API/search integration test failures
- link new issues into v0.1.0a1 release plan

## Testing
- `uv run pytest`
- `uv run pytest tests/unit/test_version.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb10d115748333a30d9a89ddf87cdd