### PR TITLE
chore: tidy streaming webhook test

### DIFF
--- a/tests/integration/test_api_streaming_webhook.py
+++ b/tests/integration/test_api_streaming_webhook.py
@@ -9,7 +9,6 @@ from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import APIConfig, ConfigModel
 from autoresearch.models import QueryResponse
 from autoresearch.orchestration.orchestrator import Orchestrator
-
 import autoresearch.api.streaming as streaming_module
 
 


### PR DESCRIPTION
## Summary
- remove redundant blank line in streaming webhook integration test

## Testing
- `uv run flake8 tests/integration/test_api_streaming_webhook.py`
- `task verify` *(fails: tests/unit/test_download_duckdb_extensions.py::test_download_extension_network_fallback - assert 1 == 3)*

------
https://chatgpt.com/codex/tasks/task_e_68bb15399fc88333990105098e6e6c0e