### PR TITLE
Add cross-platform container builds and release workflow

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,0 +1,19 @@
+name: Release Images
+
+# This workflow is manually triggered only.
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push images
+        run: bash scripts/release_images.sh ghcr.io/${{ github.repository_owner }} latest

--- a/docker/Dockerfile.linux
+++ b/docker/Dockerfile.linux
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1
-# Linux container image with build extras for Autoresearch
+# Linux container image with project extras for Autoresearch
 FROM python:3.12-slim
 
+ARG EXTRAS=full
 WORKDIR /workspace
 COPY . .
 RUN pip install --no-cache-dir uv \
-    && uv pip install '.[build]'
+    && uv pip install ".[${EXTRAS}]"
 CMD ["bash"]

--- a/docker/Dockerfile.macos
+++ b/docker/Dockerfile.macos
@@ -1,10 +1,11 @@
 # syntax=docker/dockerfile:1
-# macOS (ARM) container image with build extras for Autoresearch
+# macOS (ARM) container image with project extras for Autoresearch
 FROM ghcr.io/cirruslabs/macos-runner:sonoma
 
+ARG EXTRAS=full
 WORKDIR /workspace
 COPY . .
 RUN /bin/bash -lc "brew update && brew install python@3.12" \
     && pip3 install --no-cache-dir uv \
-    && uv pip install '.[build]'
+    && uv pip install ".[${EXTRAS}]"
 CMD ["/bin/bash"]

--- a/docker/Dockerfile.windows
+++ b/docker/Dockerfile.windows
@@ -1,10 +1,11 @@
 # escape=`
-# Windows container image with build extras for Autoresearch
+# Windows container image with project extras for Autoresearch
 FROM mcr.microsoft.com/windows/python:3.12
 
+ARG EXTRAS=full
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 WORKDIR C:/workspace
 COPY . .
 RUN pip install --no-cache-dir uv; `
-    uv pip install '.[build]'
+    uv pip install ".[$env:EXTRAS]"
 CMD ["powershell"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,14 +1,20 @@
 # Container Images
 
 This directory provides Dockerfiles for building OCI images of Autoresearch with
-packaging extras installed. Images exist for Linux, macOS, and Windows.
+project extras installed. Images exist for Linux, macOS, and Windows.
 
 ## Build
 
+Use the `EXTRAS` build argument to select optional dependencies; it defaults to
+`full`.
+
 ```bash
-docker build -f docker/Dockerfile.linux -t autoresearch-linux .
-docker build -f docker/Dockerfile.macos -t autoresearch-macos .
-docker build -f docker/Dockerfile.windows -t autoresearch-windows .
+docker build -f docker/Dockerfile.linux --build-arg EXTRAS=minimal \
+    -t autoresearch-linux .
+docker build -f docker/Dockerfile.macos --build-arg EXTRAS=minimal \
+    -t autoresearch-macos .
+docker build -f docker/Dockerfile.windows --build-arg EXTRAS=minimal \
+    -t autoresearch-windows .
 ```
 
 ## Publish
@@ -21,6 +27,11 @@ docker push <registry>/autoresearch:linux
 ```
 
 Repeat for the macOS and Windows tags.
+
+## Release
+
+The `scripts/release_images.sh` script builds and pushes all images in one
+step.
 
 ## Packaging
 

--- a/docs/container_usage.md
+++ b/docs/container_usage.md
@@ -1,31 +1,35 @@
 # Container Usage
 
-Autoresearch provides Dockerfiles under `docker/` for Linux, macOS, and
-Windows. Images include the project's build extras and are tagged by platform.
+Autoresearch ships Dockerfiles for Linux, macOS, and Windows. Each image
+installs project extras via a build argument.
 
 ## Build
 
-Use the Taskfile to build all images via `docker buildx`:
+- Use the `EXTRAS` argument to specify optional dependencies, defaulting to
+  `full`.
+- Replace `podman` with your container engine.
 
 ```bash
-task docker-build
+podman build -f docker/Dockerfile.linux --build-arg EXTRAS=minimal \
+    -t autoresearch-linux .
 ```
 
-Each platform can be built on its own:
-
-```bash
-task docker-build:linux
-task docker-build:macos
-task docker-build:windows
-```
+Repeat with the macOS and Windows Dockerfiles on their respective hosts.
 
 ## Run
 
-Mount your workspace and start a shell inside the container:
+Execute the CLI inside a container to confirm the installation:
 
 ```bash
-docker run --rm -it -v "$PWD:/workspace" autoresearch:linux bash
+podman run --rm autoresearch-linux autoresearch --help
 ```
 
-Replace `autoresearch:linux` with the desired tag. For packaging steps, see
-[docker/README.md](../docker/README.md).
+## Release
+
+The `scripts/release_images.sh` script builds and pushes all images:
+
+```bash
+bash scripts/release_images.sh ghcr.io/OWNER latest
+```
+
+Set `CONTAINER_ENGINE` to `podman` when Docker is unavailable.

--- a/scripts/release_images.sh
+++ b/scripts/release_images.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# release_images.sh - Build and publish Autoresearch container images.
+# Usage: release_images.sh REGISTRY TAG [EXTRAS]
+set -euo pipefail
+
+if [ "${1:-}" = "" ] || [ "${2:-}" = "" ]; then
+  echo "Usage: $0 REGISTRY TAG [EXTRAS]" >&2
+  exit 1
+fi
+
+REGISTRY="$1"
+TAG="$2"
+EXTRAS="${3:-full}"
+ENGINE="${CONTAINER_ENGINE:-docker}"
+
+if ! command -v "$ENGINE" >/dev/null 2>&1; then
+  echo "Container engine '$ENGINE' not found" >&2
+  exit 1
+fi
+
+build_and_push() {
+  local os="$1"
+  local file="$2"
+  "$ENGINE" build -f "$file" --build-arg EXTRAS="$EXTRAS" \
+    -t "$REGISTRY/autoresearch:$os-$TAG" .
+  "$ENGINE" push "$REGISTRY/autoresearch:$os-$TAG"
+}
+
+build_and_push linux docker/Dockerfile.linux
+build_and_push macos docker/Dockerfile.macos
+build_and_push windows docker/Dockerfile.windows


### PR DESCRIPTION
## Summary
- parameterize Dockerfiles for Linux, macOS, and Windows to install optional extras
- add release_images.sh and workflow for building and publishing OCI images
- document container build, run, and release steps

## Testing
- `uv run task check`
- `uv run task verify` *(fails: DeadlineExceeded & download extension fallback test)*
- `uv run mkdocs build`
- `podman build -f docker/Dockerfile.linux --build-arg EXTRAS=minimal -t autoresearch-linux-test .` *(fails: ping_group_range read-only)*

------
https://chatgpt.com/codex/tasks/task_e_68bb155773f883339fe4bb2711033f97