### PR TITLE
chore: streamline setup and env checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,32 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-env:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        run: python -m pip install uv
+      - name: Sync minimal extras
+        run: uv sync --extra dev-minimal --extra test
+      - name: Install Go Task
+        run: |
+          curl -sL https://taskfile.dev/install.sh | sh -s -- -b ~/.local/bin
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Check environment
+        run: |
+          set -e
+          output=$(uv run python scripts/check_env.py 2>&1)
+          echo "$output"
+          if echo "$output" | grep -q 'WARNING: package metadata not found'; then
+            echo 'Missing package metadata' >&2
+            exit 1
+          fi
   verify:
+    needs: check-env
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -14,19 +14,21 @@ For orchestrator state transitions and API contracts see
 
 ## Prerequisites
 
-Autoresearch requires **Python 3.12+**,
-[uv](https://github.com/astral-sh/uv), and
-[Go Task](https://taskfile.dev/). Run `./scripts/setup.sh` to download
-Go Task into `.venv/bin` when it's missing. Append the directory to your
-`PATH`:
+Autoresearch requires **Python 3.12+**, [uv](https://github.com/astral-sh/uv),
+and [Go Task](https://taskfile.dev/). Install Go Task via your package manager
+or the upstream script. The minimal bootstrap is:
 
 ```bash
 ./scripts/setup.sh
 export PATH="$(pwd)/.venv/bin:$PATH"
-task --version
+task check
 ```
 
-Install Go Task manually if the setup script fails:
+`scripts/setup.sh` verifies the Python version, ensures `uv` is available, and
+syncs the `dev-minimal` and `test` extras. It exits with an error if Go Task is
+missing or the dependency sync fails.
+
+Install Go Task manually if it is not on `PATH`:
 
 ```bash
 curl -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,20 +9,19 @@ For test conventions and workflows see
 
 Autoresearch requires **Python 3.12 or newer**,
 [**uv**](https://github.com/astral-sh/uv), and
-[**Go Task**](https://taskfile.dev/) for Taskfile commands. Run the following
-one-step bootstrap to install them along with all extras needed for unit,
-integration, and behavior tests:
+[**Go Task**](https://taskfile.dev/) for Taskfile commands. Install Go Task
+with your package manager or `scripts/bootstrap.sh`. Then verify the setup and
+sync minimal dependencies:
 
 ```bash
 ./scripts/setup.sh
+export PATH="$(pwd)/.venv/bin:$PATH"
+task check
 ```
 
-After bootstrapping, `.venv/bin` is added to `PATH` and `task --version`
-should report the installed CLI:
-
-```bash
-task --version
-```
+The script checks the Python version, confirms Go Task is available, and syncs
+the `dev-minimal` and `test` extras. It exits with an error if Go Task is
+missing or the dependency sync fails.
 
 Activate the virtual environment in new shells to restore the path:
 
@@ -31,8 +30,8 @@ source .venv/bin/activate
 ```
 
 Run `./scripts/bootstrap.sh` to install Go Task without syncing extras. It
-places the `task` binary in `.venv/bin` and adds the directory to `PATH`. If
-the script fails or you want a system-wide binary, install manually:
+places the `task` binary in `.venv/bin` and requires adding that directory to
+`PATH`. If the script fails or you want a system-wide binary, install manually:
 
 ```bash
 curl -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
@@ -63,15 +62,15 @@ If a tool or package is missing, rerun `task install` or sync extras with
 
 ## Setup script
 
-`scripts/setup.sh` bootstraps local development. It ensures Go Task is
-available, verifies core test packages such as `pytest`, `pytest-bdd`,
-`freezegun`, and `hypothesis`, and expects system dependencies to be
-preinstalled. Set `AR_EXTRAS` to include additional groups.
+`scripts/setup.sh` bootstraps local development. It verifies Python 3.12+,
+checks for Go Task, ensures `uv` is installed, and syncs the `dev-minimal` and
+`test` extras. Set `AR_EXTRAS` to include additional groups.
 
-The script appends `.venv/bin` to `PATH`, runs `task --version` to validate
-the CLI, and reminds you to activate the environment in new shells with:
+The script does not modify `PATH`; add `.venv/bin` manually and activate the
+environment in new shells:
 
 ```bash
+export PATH="$(pwd)/.venv/bin:$PATH"
 source .venv/bin/activate
 ```
 
@@ -125,13 +124,11 @@ AR_EXTRAS="nlp ui" ./scripts/setup.sh  # extras via setup script
 `task verify` always includes the `parsers` extra, so no additional flags are
 required for PDF or DOCX tests.
 
-Use `./scripts/setup.sh` for the full developer bootstrap. It installs Go Task
-into `.venv/bin` when missing, syncs the `dev` and `test` extras (including
-packages such as `pytest_httpx`, `tomli_w`, `pytest-bdd`, and `redis`), and
-exits if `task --version` fails.
+Use `./scripts/setup.sh` for the full developer bootstrap. It syncs the `dev`
+and `test` extras (including packages such as `pytest_httpx`, `tomli_w`,
+`pytest-bdd`, and `redis`) and verifies Go Task is installed.
 
-The setup script verifies Go Task with `task --version`. You can manually
-confirm the CLI and development packages are available:
+You can manually confirm the CLI and development packages are available:
 
 ```bash
 task --version

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,89 +1,66 @@
 #!/usr/bin/env bash
 # Usage: ./scripts/setup.sh
-# Set AR_SKIP_GPU=0 to include GPU-only dependencies.
-# Detects the host platform, ensures uv and Go Task are installed, and installs
-# all extras required for unit, integration, and behavior tests.
+# Verify Python 3.12+, confirm Go Task is installed, and sync dependencies.
+
 set -euo pipefail
 
-SCRIPT_DIR="$(dirname "$0")"
-source "$SCRIPT_DIR/setup_common.sh"
+EXTRAS=${AR_EXTRAS:-}
 
-VENV_BIN="$(pwd)/.venv/bin"
-TASK_BIN="$VENV_BIN/task"
+check_python() {
+    local major minor
+    major=$(python3 - <<'PY'
+import sys
+print(sys.version_info.major)
+PY
+)
+    minor=$(python3 - <<'PY'
+import sys
+print(sys.version_info.minor)
+PY
+)
+    if [ "$major" -lt 3 ] || { [ "$major" -eq 3 ] && [ "$minor" -lt 12 ]; }; then
+        echo "Python 3.12+ required, found ${major}.${minor}" >&2
+        exit 1
+    fi
+}
 
-install_go_task() {
-    echo "Installing Go Task into $VENV_BIN..."
-    ensure_uv
-    uv venv
-    mkdir -p "$VENV_BIN"
-    curl -sSL https://taskfile.dev/install.sh | sh -s -- -b "$VENV_BIN" || {
-        echo "Warning: failed to download Go Task; install manually from" \
-            " https://taskfile.dev/installation/ and re-run setup" >&2
-        return
+check_go_task() {
+    if ! command -v task >/dev/null 2>&1; then
+        echo "Go Task not found. Install it from https://taskfile.dev/" >&2
+        exit 1
+    fi
+    task --version >/dev/null 2>&1 || {
+        echo "Go Task installation is broken; reinstall it." >&2
+        exit 1
     }
 }
 
-if [ ! -x "$TASK_BIN" ]; then
-    install_go_task
-fi
-
-ensure_venv_bin_on_path "$VENV_BIN"
-export PATH="$VENV_BIN:$PATH"
-
-case "$(uname -s)" in
-Linux*)
-    "$SCRIPT_DIR/setup_linux.sh" "$@"
-    ;;
-Darwin*)
-    "$SCRIPT_DIR/setup_macos.sh" "$@"
-    ;;
-*)
-    echo "Unsupported platform; skipping platform-specific setup." >&2
-    ;;
-esac
-
-install_test_extras() {
-    # Install test dependencies when Go Task is unavailable so pytest can run.
-    ensure_uv
-    uv venv
-    ensure_venv_bin_on_path "$(pwd)/.venv/bin"
-    uv pip install -e ".[test]"
-    mkdir -p extensions
-    if uv run "$SCRIPT_DIR/download_duckdb_extensions.py" --output-dir ./extensions; then
-        # Ignore stub files by selecting only non-empty extensions.
-        VSS_EXTENSION=$(find ./extensions -name "vss*.duckdb_extension" -size +0c | head -n 1)
-    else
-        echo "Warning: duckdb extension download failed; falling back to stub" >&2
+ensure_uv() {
+    if ! command -v uv >/dev/null 2>&1; then
+        if ! python3 -m pip install uv >/dev/null; then
+            echo "Failed to install uv. See https://github.com/astral-sh/uv" >&2
+            exit 1
+        fi
     fi
-    VSS_EXTENSION="${VSS_EXTENSION:-./extensions/vss/vss.duckdb_extension}"
-    if [ ! -f "$VSS_EXTENSION" ]; then
-        mkdir -p "$(dirname "$VSS_EXTENSION")"
-        : >"$VSS_EXTENSION"
-    fi
-    if [ ! -s "$VSS_EXTENSION" ]; then
-        echo "Using stub VSS extension at $VSS_EXTENSION" >&2
-    fi
-    record_vector_extension_path "$VSS_EXTENSION"
 }
 
-if [ ! -x "$TASK_BIN" ]; then
-    echo "Go Task not found; installing test extras..."
-    install_test_extras
-else
-    AR_SKIP_SMOKE_TEST=1 \
-        AR_EXTRAS="${AR_EXTRAS:-nlp ui vss parsers git distributed analysis}" \
-        "$SCRIPT_DIR/setup_universal.sh" "$@" || {
-        echo "setup_universal.sh failed; installing test extras without Go Task..."
-        install_test_extras
-    }
-fi
+sync_deps() {
+    local extras="dev-minimal test $EXTRAS"
+    local args=""
+    for extra in $extras; do
+        [ -n "$extra" ] && args+=" --extra $extra"
+    done
+    echo "Syncing dependencies ($extras)..."
+    if ! uv sync$args; then
+        echo "uv sync failed. Resolve the errors above and re-run." >&2
+        exit 1
+    fi
+}
 
-# Run the smoke test even if the VSS extension is missing; the script
-# handles the zero-byte stub and prints warnings when vector search is
-# unavailable.
-echo "Running smoke test to verify environment..."
-if ! uv run python scripts/smoke_test.py; then
-    echo "Smoke test failed; environment may be incomplete" >&2
-fi
+check_python
+check_go_task
+ensure_uv
+sync_deps
 
-task --version || echo "task --version failed; continuing without Go Task" >&2
+echo "Environment ready. Activate with 'source .venv/bin/activate'."
+


### PR DESCRIPTION
## Summary
- simplify setup script to validate Python, Go Task, and dependencies
- add dedicated CI job to run environment checks and fail on missing metadata
- document minimal bootstrap steps in README and installation guide

## Testing
- `task check`
- `uv run mkdocs build`
- `task verify` *(fails: tests/unit/test_download_duckdb_extensions.py::test_download_extension_network_fallback - assert 1 == 3)*

------
https://chatgpt.com/codex/tasks/task_e_68bb156b63cc8333ad28bf6ce02a3364