### PR TITLE
feat: add scheduler benchmarking simulations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@
 - Format with **black** and ensure **flake8** passes.
 - Keep lines ≤ 100 characters and include docstrings for public APIs.
 - Additional style guidance lives in `CONTRIBUTING.md` (load only if needed).
+- Avoid committing binary artifacts; prefer text formats or generate files during tests.
 
 ## Reasoning and Continuous Improvement
 - Use dialectical and Socratic reasoning: state assumptions, question them,

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -21,6 +21,7 @@ These instructions apply to files in the `docs/` directory.
 - Write Markdown with a single `#` heading at the top.
 - Wrap lines at 80 characters.
 - Use `-` for unordered lists and leave a blank line around headings.
+- Avoid committing binary assets; prefer SVG or text-based diagrams.
 
 ## Reasoning and Continuous Improvement
 - Question assumptions, compare sources, and clarify rationale in prose.

--- a/docs/scheduler_benchmark.md
+++ b/docs/scheduler_benchmark.md
@@ -1,28 +1,55 @@
-# Scheduler Resource Benchmark
+# Scheduler benchmark
 
-This benchmark measures CPU and memory impact of the backup scheduler.
+This benchmark models a simple queue where tasks arrive at rate \(\lambda\).
+Each agent handles tasks at rate \(\mu\). We assume Poisson arrivals and
+exponential service times so the system behaves like an M/M/c queue with
+\(c\) identical agents.
 
-## Methodology
+## Assumptions
+- Poisson task arrivals at \(\lambda = 5\) tasks per second.
+- Each agent processes tasks at \(\mu = 2\) tasks per second.
+- Agents share a single queue and work independently.
 
-- Patch the backup creation routine to a no-op to isolate scheduler overhead.
-- Start the scheduler with a one-second interval and run for a short duration.
-- Measure CPU time and resident memory before and after using
-  `resource.getrusage`.
+## Queueing formulas
+Throughput is bounded by the lesser of arrival rate and total service
+capacity:
 
-CPU time is computed as:
+\(T(c) = \min(\lambda, c\mu)\)
 
+Average latency uses an M/M/c approximation where per-agent utilization must be
+below 1:
+
+\(L(c) = 1 / (\mu - \lambda / c)\)
+
+## Results
+Throughput scales linearly until capacity is reached:
+
+```mermaid
+plot
+    title Estimated throughput
+    x-axis workers
+    y-axis tasks/sec
+    line
+        throughput : 1,2,4,8; 2,4,5,5
 ```
-cpu_time = end.ru_utime - start.ru_utime
+
+Latency diverges when arrivals near capacity. Saturated cases (one or two
+workers) are omitted below:
+
+```mermaid
+plot
+    title Estimated latency
+    x-axis workers
+    y-axis seconds
+    line
+        latency : 4,8; 1.33,0.73
 ```
 
-Memory use is calculated with:
+## Follow-up
+Latency diverges when arrival rate approaches capacity, suggesting further
+benchmarking. See [benchmark-scheduler-queue-saturation][queue-issue] for a
+detailed plan and [simulate-distributed-orchestrator-performance]
+[orchestrator-issue] for broader orchestrator benchmarks.
 
-```
-mem_kb = end.ru_maxrss - start.ru_maxrss
-```
-
-## Results and Tuning
-
-The test [test_scheduler_benchmark.py](../tests/unit/test_scheduler_benchmark.py)
-reports measured CPU and memory. Rising values suggest increasing the backup
-interval or optimizing the backup routine.
+[queue-issue]: ../issues/benchmark-scheduler-queue-saturation.md
+[orchestrator-issue]: ../issues/simulate-distributed-orchestrator-performance.md

--- a/issues/AGENTS.md
+++ b/issues/AGENTS.md
@@ -14,6 +14,7 @@ These instructions apply to files in the `issues/` directory.
 - Open tickets stay in this directory. Move completed ones to `archive/` with
   `Status` set to `Archived` and do not rename them.
 - Keep this file current as issue tooling evolves.
+- Do not attach binary files; link to external references instead.
 
 ## Reasoning and Continuous Improvement
 - Revisit issue templates as project needs change.

--- a/issues/benchmark-scheduler-queue-saturation.md
+++ b/issues/benchmark-scheduler-queue-saturation.md
@@ -1,0 +1,18 @@
+# Benchmark scheduler under queue saturation
+
+## Context
+Simulations show latency spikes when task arrivals near total service capacity.
+We need real-world benchmarks to validate mitigation strategies.
+
+## Dependencies
+[simulate-distributed-orchestrator-performance][orchestrator-bench]
+
+## Acceptance Criteria
+- Benchmark scheduler with arrival rates approaching total service capacity.
+- Record latency and throughput for at least three worker counts.
+- Propose mitigation strategies for identified bottlenecks.
+
+## Status
+Open
+
+[orchestrator-bench]: simulate-distributed-orchestrator-performance.md

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -47,6 +47,7 @@ These instructions apply to files in the `tests/` directory.
 - Remove temporary files such as `kg.duckdb` and `rdf_store`.
 - Prefer fixtures like `tmp_path` and `monkeypatch` to isolate side effects.
 - Run `task clean` if tests generate build artifacts.
+- Avoid committing binary artifacts; keep test outputs ephemeral.
 
 ## Coverage Expectations
 - `[nlp]`: cover spaCy-powered NLP paths.

--- a/tests/analysis/distributed/__init__.py
+++ b/tests/analysis/distributed/__init__.py
@@ -1,0 +1,1 @@
+"""Simulations for distributed scheduler performance."""

--- a/tests/analysis/distributed/agent_latency_sim.py
+++ b/tests/analysis/distributed/agent_latency_sim.py
@@ -1,0 +1,46 @@
+"""Estimate scheduler latency across worker counts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def latency_model(arrival_rate: float, service_rate: float, workers: int) -> float:
+    """Approximate mean response time for an M/M/c queue."""
+    if arrival_rate <= 0 or service_rate <= 0 or workers <= 0:
+        raise ValueError("parameters must be positive")
+    per_worker_arrival = arrival_rate / workers
+    if per_worker_arrival >= service_rate:
+        return float("inf")
+    return 1.0 / (service_rate - per_worker_arrival)
+
+
+def run(arrival_rate: float = 5.0, service_rate: float = 2.0) -> dict[int, float]:
+    """Compute latency for varying worker counts and optionally plot results."""
+    results: dict[int, float] = {}
+    for workers in (1, 2, 4, 8):
+        results[workers] = latency_model(arrival_rate, service_rate, workers)
+    out_dir = Path(__file__).resolve().parent
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        xs = sorted(results)
+        ys = [results[w] for w in xs]
+        plt.figure()
+        plt.plot(xs, ys, marker="o")
+        plt.xlabel("workers")
+        plt.ylabel("seconds")
+        plt.title("Estimated latency")
+        plt.savefig(out_dir / "agent_latency.svg", format="svg")
+        plt.close()
+    except Exception:  # pragma: no cover
+        pass
+    return results
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print(json.dumps(run(), indent=2))

--- a/tests/analysis/distributed/agent_throughput_sim.py
+++ b/tests/analysis/distributed/agent_throughput_sim.py
@@ -1,0 +1,44 @@
+"""Estimate scheduler throughput across worker counts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def throughput_model(arrival_rate: float, service_rate: float, workers: int) -> float:
+    """Return throughput using ``min(arrival_rate, workers * service_rate)"""
+    if arrival_rate <= 0 or service_rate <= 0 or workers <= 0:
+        raise ValueError("parameters must be positive")
+    capacity = workers * service_rate
+    return arrival_rate if arrival_rate < capacity else capacity
+
+
+def run(arrival_rate: float = 5.0, service_rate: float = 2.0) -> dict[int, float]:
+    """Compute throughput for varying worker counts and optionally plot results."""
+    results: dict[int, float] = {}
+    for workers in (1, 2, 4, 8):
+        results[workers] = throughput_model(arrival_rate, service_rate, workers)
+    out_dir = Path(__file__).resolve().parent
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        xs = sorted(results)
+        ys = [results[w] for w in xs]
+        plt.figure()
+        plt.plot(xs, ys, marker="o")
+        plt.xlabel("workers")
+        plt.ylabel("tasks/sec")
+        plt.title("Estimated throughput")
+        plt.savefig(out_dir / "agent_throughput.svg", format="svg")
+        plt.close()
+    except Exception:  # pragma: no cover
+        pass
+    return results
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print(json.dumps(run(), indent=2))


### PR DESCRIPTION
## Summary
- model scheduler throughput and latency without committing binary artifacts
- document assumptions with mermaid charts and update AGENTS guidelines to forbid binaries
- record planned benchmarking work in dedicated issue file

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra test pytest tests/analysis/distributed`
- `uv run --with mkdocs-material --with mkdocstrings --with mkdocstrings-python mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68bb154a81648333b7ce39f9d2eca20c