### PR TITLE
docs: add proof sketches for core specs

### DIFF
--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1,4 +1,4 @@
-# Api
+# API
 
 ## Overview
 
@@ -18,39 +18,35 @@ FastAPI app aggregator for Autoresearch. See these algorithm references:
 - Heartbeats occur at least once per connection.
 - The ``END`` sentinel terminates the stream.
 
-## Proof Steps
+## Proof Sketch
 
-1. Produce a finite chunk list.
-2. Iterate over the stream collecting data and heartbeats.
-3. Assert collected chunks match the expected sequence and a heartbeat occurs.
-4. Verify success in [api_streaming_metrics.json][r1].
+Streaming a finite chunk list while recording data and heartbeats shows the
+ordering and liveness invariants hold. Tests cover nominal and error paths,
+and the simulation in [api_streaming_metrics.json][r1] confirms ordered
+delivery and heartbeat retries.
 
 ## Simulation Expectations
 
-Unit tests cover nominal and edge cases for these routines. Streaming endpoints
-send heartbeat lines every 15 seconds to keep connections open and retry
-webhook deliveries up to three times with exponential backoff. The simulation
-confirms ordering and heartbeat delivery by streaming three chunks and recording
-metrics in [api_streaming_metrics.json][r1]. Streaming scenarios post
-intermediate cycle results to configured webhooks alongside final responses.
+Streaming simulations send three chunks and record metrics in
+[api_streaming_metrics.json][r1].
 
 ## Traceability
 
 
 - Modules
   - [src/autoresearch/api/][m1]
-  - Tests
-    - [tests/unit/test_api.py][t1]
-    - [tests/unit/test_api_error_handling.py][t2]
-    - [tests/unit/test_api_imports.py][t3]
-    - [tests/unit/test_api_auth_middleware.py][t4]
-    - [tests/unit/test_api_auth_deps.py][t5]
-    - [tests/integration/test_api_auth.py][t6]
-    - [tests/integration/test_api_auth_middleware.py][t7]
-    - [tests/integration/test_api_streaming.py][t8]
-    - [tests/integration/test_api_streaming_webhook.py][t10]
-    - [tests/integration/test_api_docs.py][t9]
-    - [tests/analysis/test_api_streaming_sim.py][t11]
+- Tests
+  - [tests/unit/test_api.py][t1]
+  - [tests/unit/test_api_error_handling.py][t2]
+  - [tests/unit/test_api_imports.py][t3]
+  - [tests/unit/test_api_auth_middleware.py][t4]
+  - [tests/unit/test_api_auth_deps.py][t5]
+  - [tests/integration/test_api_auth.py][t6]
+  - [tests/integration/test_api_auth_middleware.py][t7]
+  - [tests/integration/test_api_streaming.py][t8]
+  - [tests/integration/test_api_streaming_webhook.py][t10]
+  - [tests/integration/test_api_docs.py][t9]
+  - [tests/analysis/test_api_streaming_sim.py][t11]
 
 [m1]: ../../src/autoresearch/api/
 [t1]: ../../tests/unit/test_api.py

--- a/docs/specs/cli-utils.md
+++ b/docs/specs/cli-utils.md
@@ -1,4 +1,4 @@
-# Cli Utils
+# CLI Utils
 
 ## Overview
 
@@ -14,15 +14,17 @@ CLI utilities for consistent formatting and accessibility.
 - Output formatting preserves ANSI codes and width constraints.
 - Help text lists commands in alphabetical order.
 
-## Proof Steps
+## Proof Sketch
 
-1. Parse an empty argument list and record resolved defaults.
-2. Override options to confirm user input supersedes defaults.
-3. Inspect help output and verify alphabetical ordering.
+The parser resolves defaults for empty input, accepts user overrides, and
+outputs alphabetical help text. The simulation in
+[tests/unit/test_cli_utils_extra.py][t1] exercises these paths and
+confirms all invariants.
 
 ## Simulation Expectations
 
-Unit tests cover nominal and edge cases for these routines.
+Unit tests simulate argument parsing and help output for nominal and edge
+cases.
 
 ## Traceability
 

--- a/docs/specs/config.md
+++ b/docs/specs/config.md
@@ -15,20 +15,18 @@ algorithm](../algorithms/config_hot_reload.md) for reload behavior.
 - Reloads are atomic; readers never observe partially written state.
 - Unknown or malformed fields leave prior values unchanged.
 
-## Proof Steps
+## Proof Sketch
 
-1. Write baseline configuration and capture active state.
-2. Modify the file and trigger a reload.
-3. Compare active state to modified file; ensure unmodified fields persist.
-4. Confirm metrics in [config_hot_reload_metrics.json][r1] report success.
+Reloading a modified file updates ``state.active`` atomically while preserving
+unchanged fields. Tests exercise reload paths, and the simulation
+increments a value from 1 to 2, recording metrics in
+[config_hot_reload_metrics.json][r1] to verify success and fallback
+behavior when files disappear.
 
 ## Simulation Expectations
 
-Unit and behavior tests cover nominal and edge cases for these routines.
-The hot-reload simulation validates these invariants by updating a config
-value from 1 to 2 and recording metrics in [config_hot_reload_metrics.json][r1].
-The watcher logs an error and keeps the previous configuration active when a
-source file is removed.
+The hot-reload simulation updates a value from 1 to 2 and records metrics in
+[config_hot_reload_metrics.json][r1].
 
 ## Traceability
 


### PR DESCRIPTION
## Summary
- expand cli utilities spec with proof sketch and simulation expectations
- document api aggregator proof sketch and streaming simulation
- describe config proof sketch with hot-reload simulation

## Testing
- `uv run python scripts/lint_specs.py`
- `PATH="$PWD/bin:$PATH" uv run task check`


------
https://chatgpt.com/codex/tasks/task_e_68bb5d61fee883339d5284523f2b2b64