### PR TITLE
Ensure thread-safe storage writes and schema init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ verification. [investigate-mypy-hang](issues/archive/investigate-mypy-hang.md).
     [align-environment-with-requirements]
 - Enable Pydantic plugin for static type analysis.
 - Harden storage against concurrency and initialization edge cases.
+- Track storage module coverage: `storage.py` **52%** and
+  `storage_backends.py` **47%** after thread-safety fixes.
 - Document final release workflow and TestPyPI publishing steps.
 - Clarified directory scopes and noted missing instructions for `src/`, `scripts/`, and `examples/`.
 - Drafted preliminary release notes and validated README installation steps.


### PR DESCRIPTION
## Summary
- guard NetworkX writes with a reentrant lock to keep LRU updates consistent
- use a reentrant lock in DuckDB backend and lock schema helpers to avoid race conditions
- note current storage coverage metrics in changelog

## Testing
- `uv run isort src/autoresearch/storage.py src/autoresearch/storage_backends.py CHANGELOG.md`
- `uv run black src/autoresearch/storage.py src/autoresearch/storage_backends.py`
- `uv run flake8 src/autoresearch/storage.py src/autoresearch/storage_backends.py`
- `uv run mypy src/autoresearch/storage.py src/autoresearch/storage_backends.py`
- `uv run --extra test coverage run --source=src/autoresearch -m pytest tests/integration/test_storage_concurrency.py tests/integration/test_storage_eviction_sim.py tests/integration/test_storage_schema.py tests/integration/test_storage_duckdb_fallback.py`
- `uv run coverage report --include="src/autoresearch/storage.py,src/autoresearch/storage_backends.py" -m`

------
https://chatgpt.com/codex/tasks/task_e_68bb5d826c288333920a85d66655c254