### PR TITLE
docs: document system time requirement

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -5,3 +5,4 @@
 - Do not enable automatic events such as `push`, `pull_request`, or
   `schedule`.
 - Update `docs/review_guidelines.md` if workflow policies change.
+- Use system time when referencing the current date.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@
 - Keep lines ≤ 100 characters and include docstrings for public APIs.
 - Additional style guidance lives in `CONTRIBUTING.md` (load only if needed).
 - Avoid committing binary artifacts; prefer text formats or generate files during tests.
+- When applying the current date, derive it from the system time.
 
 ## Reasoning and Continuous Improvement
 - Use dialectical and Socratic reasoning: state assumptions, question them,
@@ -55,6 +56,7 @@
 - For extensive details, consult docs under `docs/` as required.
 
 ## Changelog
+- 2025-09-05: Added directive to use system time when applying the current date.
 - 2025-08-22: Added runtime goal for `scripts/codex_setup.sh`.
 - 2025-08-21: Clarified Codex-only scope for `scripts/codex_setup.sh` and
   restricted references to AGENTS files.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -22,6 +22,7 @@ These instructions apply to files in the `docs/` directory.
 - Wrap lines at 80 characters.
 - Use `-` for unordered lists and leave a blank line around headings.
 - Avoid committing binary assets; prefer SVG or text-based diagrams.
+- When applying the current date, derive it from the system time.
 
 ## Reasoning and Continuous Improvement
 - Question assumptions, compare sources, and clarify rationale in prose.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -13,6 +13,7 @@ These instructions apply to files in the `examples/` directory.
 - Assume sample data is covered by the project's AGPL-3.0 license unless noted.
 - Document third-party assets with their original licenses and required
   attribution.
+- When applying the current date, derive it from the system time.
 
 ## Reasoning and Continuous Improvement
 - Explain the problem each example addresses and alternative approaches in

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -15,6 +15,7 @@ These instructions apply to files in the `extensions/` directory.
 - Follow repository coding conventions and organize imports with `isort`'s
   default profile.
 - Use `uv run` when invoking Python modules or scripts directly.
+- When applying the current date, derive it from the system time.
 
 ## Reasoning and Continuous Improvement
 - Document compatibility assumptions and revisit as dependencies evolve.

--- a/issues/AGENTS.md
+++ b/issues/AGENTS.md
@@ -15,6 +15,7 @@ These instructions apply to files in the `issues/` directory.
   `Status` set to `Archived` and do not rename them.
 - Keep this file current as issue tooling evolves.
 - Do not attach binary files; link to external references instead.
+- When applying the current date, derive it from the system time.
 
 ## Reasoning and Continuous Improvement
 - Revisit issue templates as project needs change.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -19,6 +19,7 @@ These instructions apply to files in the `scripts/` directory.
 - Do not require elevated privileges or modify user system settings.
 - Use POSIX-compliant shell features or portable Python constructs.
 - Test on Linux and macOS; avoid hard-coded paths and file extensions.
+- When applying the current date, derive it from the system time.
 
 ## Reasoning and Continuous Improvement
 - Explain nontrivial logic with inline comments referencing design choices.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -18,6 +18,7 @@ These instructions apply to files in the `src/` directory.
   modules, including `Args`, `Returns`, and `Raises` when applicable.
 - Use explicit type hints for function signatures and critical variables.
 - When invoking tools directly, prefix them with `uv run`.
+- When applying the current date, derive it from the system time.
 
 ## Reasoning and Continuous Improvement
 - Challenge algorithmic choices and document trade-offs in comments.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -48,6 +48,7 @@ These instructions apply to files in the `tests/` directory.
 - Prefer fixtures like `tmp_path` and `monkeypatch` to isolate side effects.
 - Run `task clean` if tests generate build artifacts.
 - Avoid committing binary artifacts; keep test outputs ephemeral.
+- When applying the current date, derive it from the system time.
 
 ## Coverage Expectations
 - `[nlp]`: cover spaCy-powered NLP paths.


### PR DESCRIPTION
## Summary
- note that the current date must come from system time
- apply the same directive across all scoped AGENTS guides

## Testing
- `task check`
- `task verify` *(fails: TestDuckDBStorageBackend::test_initialize_schema_version)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6e5eab148333b63ccb9f40e949db