### PR TITLE
Add distributed orchestrator performance simulation

### DIFF
--- a/docs/orchestrator_perf.md
+++ b/docs/orchestrator_perf.md
@@ -16,4 +16,34 @@ arrivals at ninety five percent of capacity to estimate expected queue length.
 Throughput scales nearly linearly while latency falls. Queue length remains high
 when arrivals approach capacity, signaling saturation risk.
 
+## Distributed throughput model
+
+Assumptions follow the M/M/c queue with network delay in
+[algorithms/distributed_perf.md](algorithms/distributed_perf.md):
+
+- Tasks arrive at 100 tasks/s with a 5 ms network delay.
+- Each worker processes 120 tasks/s.
+- Arrivals and service times are exponential with utilization below one.
+
+Formulas:
+
+- Utilization `\rho = \lambda / (c\mu)`.
+- Average queue length `L_q` and waiting time `W_q = L_q / \lambda`.
+- Latency `T = d + W_q + 1/\mu`.
+- Throughput equals `\lambda` when `\rho < 1`.
+
+Results from
+`uv run scripts/distributed_perf_sim.py --max-workers 4 --arrival-rate 100 \\
+    --service-rate 120 --network-delay 0.005`:
+
+| workers | throughput (tasks/s) | latency (ms) | avg queue length |
+| ------- | ------------------- | ------------ | ---------------- |
+| 1 | 100.00 | 55.000 | 4.17 |
+| 2 | 100.00 | 15.084 | 0.18 |
+| 3 | 100.00 | 13.555 | 0.02 |
+| 4 | 100.00 | 13.362 | 0.00 |
+
+Network delay dominates latency; additional workers cut queueing after two
+processes.
+
 [bench]: ../src/autoresearch/orchestrator_perf.py#L71-L112

--- a/issues/simulate-distributed-orchestrator-performance.md
+++ b/issues/simulate-distributed-orchestrator-performance.md
@@ -13,6 +13,10 @@ None.
   latency.
 - Document assumptions and formulas supporting the simulations.
 - Outline follow-up benchmarks or tooling based on results.
+- Link to [scripts/distributed_perf_sim.py](../scripts/distributed_perf_sim.py)
+  and
+  [scripts/distributed_orchestrator_perf_benchmark.py](../scripts/distributed_orchestrator_perf_benchmark.py)
+  for further analysis.
 
 ## Status
 Open

--- a/scripts/distributed_perf_sim.py
+++ b/scripts/distributed_perf_sim.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Simulate distributed orchestrator throughput and latency via queueing theory.
+
+Usage:
+    uv run scripts/distributed_perf_sim.py --max-workers 4 --arrival-rate 100 \
+        --service-rate 120 --network-delay 0.005
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Dict, List
+
+from autoresearch.orchestrator_perf import queue_metrics
+
+
+def simulate(
+    max_workers: int,
+    arrival_rate: float,
+    service_rate: float,
+    network_delay: float = 0.0,
+) -> List[Dict[str, float]]:
+    """Return queueing metrics across worker counts.
+
+    Args:
+        max_workers: Highest number of workers to evaluate.
+        arrival_rate: Task arrival rate (tasks/s).
+        service_rate: Per-worker service rate (tasks/s).
+        network_delay: Network delay before tasks reach workers (s).
+
+    Returns:
+        A list of metrics dictionaries for each worker count.
+    """
+    if max_workers <= 0:
+        raise SystemExit("max_workers must be positive")
+    if arrival_rate <= 0 or service_rate <= 0:
+        raise SystemExit("rates must be positive")
+    if network_delay < 0:
+        raise SystemExit("network_delay cannot be negative")
+
+    results: List[Dict[str, float]] = []
+    for workers in range(1, max_workers + 1):
+        metrics = queue_metrics(workers, arrival_rate, service_rate)
+        wait_q = metrics["avg_queue_length"] / arrival_rate
+        latency = network_delay + wait_q + 1 / service_rate
+        results.append(
+            {
+                "workers": float(workers),
+                "throughput": arrival_rate,
+                "latency_s": latency,
+                "avg_queue_length": metrics["avg_queue_length"],
+            }
+        )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Analytical distributed orchestrator performance simulation"
+    )
+    parser.add_argument("--max-workers", type=int, required=True, help="max workers to model")
+    parser.add_argument("--arrival-rate", type=float, required=True, help="task arrival rate")
+    parser.add_argument("--service-rate", type=float, required=True, help="per-worker service rate")
+    parser.add_argument(
+        "--network-delay", type=float, default=0.0, help="network delay per task in seconds"
+    )
+    args = parser.parse_args()
+
+    results = simulate(args.max_workers, args.arrival_rate, args.service_rate, args.network_delay)
+    print(json.dumps(results))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- model multi-process throughput and latency via an M/M/c queue with network delay
- document assumptions, formulas, and analytic results for distributed scheduling
- reference simulation and benchmark tooling from the follow-up issue

## Testing
- `uv run python scripts/run_task.py check` *(fails: Go Task is not installed)*
- `uv run python scripts/run_task.py verify` *(fails: Go Task is not installed)*
- `uv run black scripts/distributed_perf_sim.py`
- `uv run flake8 scripts/distributed_perf_sim.py` *(fails: No such file or directory)*
- `uv run mkdocs build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6ec50d08833383d9b03405ebea98