### PR TITLE
docs: add correctness and complexity analyses for ranking algorithms

### DIFF
--- a/docs/algorithms/bm25.md
+++ b/docs/algorithms/bm25.md
@@ -32,6 +32,29 @@ s(d) = w_{bm} b(d) + w_{sem} m(d) + w_{cred} c(d)
 where `b(d)` is the normalized BM25 value, `m(d)` the semantic score,
 and `c(d)` the source credibility.
 
+## Correctness
+
+BM25 approximates the log odds that a document is relevant for a query. For a
+term \(q_i\), the inverse document frequency \(IDF(q_i)\) grows as the term
+appears in fewer documents, so rare matches carry more weight. The saturation
+term
+
+\[
+\frac{f(q_i, D) (k_1 + 1)}{f(q_i, D) + k_1 (1 - b + b |D| / avgdl)}
+\]
+
+is monotone in the term frequency \(f(q_i, D)\) and bounded above by
+\(k_1 + 1\). Thus increasing matches never decreases the score. Summing over
+query terms preserves the ordering induced by these relevance estimates.
+
+## Complexity
+
+With an inverted index, scoring a query of length \(|Q|\) touches postings
+lists for its terms. The runtime is
+\(O(\sum_{q_i \in Q} df(q_i))\) where \(df(q_i)\) is document frequency. In
+the worst case \(df(q_i) = N\) for all terms, giving \(O(|Q| N)\) time. The
+index requires \(O(N)\) space.
+
 ## References
 
 - Stephen Robertson and Hugo Zaragoza. "The Probabilistic Relevance Framework:

--- a/docs/algorithms/relevance_ranking.md
+++ b/docs/algorithms/relevance_ranking.md
@@ -5,7 +5,9 @@ Autoresearch orders search results by a weighted score
 \(b\), \(m\), and \(c\) are BM25, semantic similarity, and source
 credibility scores. The non‑negative weights satisfy \(w_b + w_s + w_c = 1\).
 
-## Proof of score bounds
+## Correctness
+
+### Score bounds
 
 Each component score lies in :math:`[0, 1]` and the weights form a convex
 combination. Therefore the final score :math:`s(d)` also lies in
@@ -16,13 +18,13 @@ the list sorted by \(s\). Because the scores are fixed, applying \(T\)
 again leaves the order unchanged: \(T(T(R)) = T(R)\). Thus repeated ranking
 converges in one step to a fixed point.
 
-## Convergence rate
+### Convergence rate
 
 Idempotence implies zero inversions after the first pass. Any initial order
 has at most \(n(n-1)/2\) inversions for \(n\) results. After sorting once,
 all inversions vanish, giving geometric decay with ratio \(0\).
 
-## Monotonic improvement
+### Monotonic improvement
 
 Let :math:`R_t` be the ranking after :math:`t` iterations and let
 :math:`I(R_t)` count inversions relative to the final order
@@ -32,6 +34,11 @@ Let :math:`R_t` be the ranking after :math:`t` iterations and let
 Since :math:`I(R_1) = 0`, the sequence :math:`I(R_t)` decreases monotonically
 to zero. This derivation uses the inversion count formula
 :math:`I(R) = |\{(i, j) : i < j, R_i \succ R_j\}|`.
+
+## Complexity
+
+Sorting `n` results by score uses `O(n log n)` time and `O(1)` extra space
+when performed in place.
 
 ## Simulation
 

--- a/issues/add-proof-sketches-to-core-specs.md
+++ b/issues/add-proof-sketches-to-core-specs.md
@@ -1,9 +1,65 @@
 # Add proof sketches to core specs
 
 ## Context
-The spec linter reports missing `Proof Sketch` sections in `docs/specs/cli-utils.md`,
-`docs/specs/api.md`, and `docs/specs/config.md`. The API spec also lacks a top-level
-heading. These gaps block specification compliance and cause `task check` to fail.
+The spec linter reports missing `Proof Sketch` sections in
+`docs/specs/cli-utils.md`, `docs/specs/api.md`, and `docs/specs/config.md`.
+The API spec also lacks a top-level heading. These gaps block specification
+compliance and cause `task check` to fail.
+
+## Additional specs
+The following algorithm documents lack `## Correctness` or `## Complexity`
+sections and may need proof sketches:
+
+- docs/algorithms/README.md
+- docs/algorithms/__init__.md
+- docs/algorithms/__main__.md
+- docs/algorithms/a2a_interface.md
+- docs/algorithms/api_auth_error_paths.md
+- docs/algorithms/api_authentication.md
+- docs/algorithms/api_rate_limiting.md
+- docs/algorithms/api_streaming.md
+- docs/algorithms/cli_backup.md
+- docs/algorithms/cli_helpers.md
+- docs/algorithms/cli_utils.md
+- docs/algorithms/config_hot_reload.md
+- docs/algorithms/config_utils.md
+- docs/algorithms/data_analysis.md
+- docs/algorithms/dialectical_coordination.md
+- docs/algorithms/distributed_coordination.md
+- docs/algorithms/distributed_perf.md
+- docs/algorithms/distributed_workflows.md
+- docs/algorithms/error_recovery.md
+- docs/algorithms/error_utils.md
+- docs/algorithms/errors.md
+- docs/algorithms/extensions.md
+- docs/algorithms/interfaces.md
+- docs/algorithms/kg_reasoning.md
+- docs/algorithms/llm_adapter.md
+- docs/algorithms/logging_utils.md
+- docs/algorithms/mcp_interface.md
+- docs/algorithms/models.md
+- docs/algorithms/monitor_cli.md
+- docs/algorithms/orchestration.md
+- docs/algorithms/output_format.md
+- docs/algorithms/ranking_formula.md
+- docs/algorithms/resource_monitor.md
+- docs/algorithms/search.md
+- docs/algorithms/search_ranking.md
+- docs/algorithms/semantic_similarity.md
+- docs/algorithms/source_credibility.md
+- docs/algorithms/storage.md
+- docs/algorithms/storage_backends.md
+- docs/algorithms/storage_backup.md
+- docs/algorithms/storage_eviction.md
+- docs/algorithms/streamlit_app.md
+- docs/algorithms/streamlit_ui.md
+- docs/algorithms/synthesis.md
+- docs/algorithms/test_tools.md
+- docs/algorithms/token_budgeting.md
+- docs/algorithms/tracing.md
+- docs/algorithms/validation.md
+- docs/algorithms/visualization.md
+- docs/algorithms/weight_tuning.md
 
 ## Dependencies
 None.


### PR DESCRIPTION
## Summary
- clarify BM25 ranking by adding correctness and complexity discussions
- restructure relevance ranking spec with explicit correctness and complexity sections
- track missing proof sketches across algorithm docs

## Testing
- `uv run mkdocs build`
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6eec639483338f88d3826df0fd2e