### PR TITLE
feat: validate deploy extras and engine

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -154,10 +154,15 @@ Confirm required settings before starting services.
 - Ensure `deploy.yml` and `.env` exist in `CONFIG_DIR`.
 - Include required entries such as `version` in `deploy.yml` and `KEY` in
   `.env`.
+- Optionally set `EXTRAS` to space-separated dependency groups; unknown values
+  cause the script to fail fast.
+- Optionally set `CONTAINER_ENGINE` to `docker` or `podman` to verify the
+  container CLI is available.
 - Run the validation script:
 
 ```bash
-DEPLOY_ENV=production CONFIG_DIR=config uv run scripts/validate_deploy.py
+DEPLOY_ENV=production CONFIG_DIR=config EXTRAS="analysis" \
+CONTAINER_ENGINE=docker uv run scripts/validate_deploy.py
 ```
 
 If any variable, file, or key is missing, the script exits with a non-zero

--- a/tests/integration/test_validate_deploy.py
+++ b/tests/integration/test_validate_deploy.py
@@ -73,3 +73,40 @@ def test_validate_deploy_missing_env_key(tmp_path: Path) -> None:
     result = _run(env, tmp_path)
     assert result.returncode != 0
     assert "KEY" in result.stderr
+
+
+def test_validate_deploy_valid_extra(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+    env = os.environ.copy()
+    env.update(
+        {"DEPLOY_ENV": "production", "CONFIG_DIR": str(tmp_path), "EXTRAS": "analysis"}
+    )
+    result = _run(env, tmp_path)
+    assert result.returncode == 0
+    assert "validated" in result.stdout.lower()
+
+
+def test_validate_deploy_unknown_extra(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+    env = os.environ.copy()
+    env.update(
+        {"DEPLOY_ENV": "production", "CONFIG_DIR": str(tmp_path), "EXTRAS": "unknown"}
+    )
+    result = _run(env, tmp_path)
+    assert result.returncode != 0
+    assert "Unknown extras" in result.stderr
+
+
+def test_validate_deploy_missing_container_engine(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+    env = os.environ.copy()
+    env.update(
+        {
+            "DEPLOY_ENV": "production",
+            "CONFIG_DIR": str(tmp_path),
+            "CONTAINER_ENGINE": "no-such-engine",
+        }
+    )
+    result = _run(env, tmp_path)
+    assert result.returncode != 0
+    assert "Container engine" in result.stderr


### PR DESCRIPTION
## Summary
- extend deployment validator with optional extras and container engine checks
- document EXTRAS and CONTAINER_ENGINE usage for deployment
- test deployment validator with extras and missing container engine

## Testing
- `uv run task check EXTRAS="dev"`
- `uv run pytest tests/integration/test_validate_deploy.py -q`
- `uv run mkdocs build`
- `uv run task verify EXTRAS="dev"` *(fails: exit status 130)*

------
https://chatgpt.com/codex/tasks/task_e_68bb796ffac08333b189fd6f3f534e3f