### PR TITLE
Add queue limit utility and document scheduling mitigations

### DIFF
--- a/docs/orchestrator_perf.md
+++ b/docs/orchestrator_perf.md
@@ -46,4 +46,9 @@ Results from
 Network delay dominates latency; additional workers cut queueing after two
 processes.
 
+## Mitigation strategies
+
+- Backpressure caps the number of in-flight tasks when queues grow too long.
+- Adaptive worker pools expand or shrink based on backlog and utilization.
+
 [bench]: ../src/autoresearch/orchestrator_perf.py#L71-L112

--- a/src/autoresearch/orchestration/utils.py
+++ b/src/autoresearch/orchestration/utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, Deque
+
 from ..models import QueryResponse
 
 
@@ -44,3 +46,26 @@ def calculate_result_confidence(result: QueryResponse) -> float:
             confidence -= min(0.4, 0.1 * error_count)
 
     return max(0.1, min(1.0, confidence))
+
+
+def enqueue_with_limit(queue: Deque[Any], item: Any, limit: int) -> bool:
+    """Append an item if the queue is below a size limit.
+
+    Args:
+        queue: Target queue to append to.
+        item: Item to enqueue.
+        limit: Maximum allowed queue size.
+
+    Returns:
+        ``True`` when the item is enqueued, ``False`` when dropped.
+
+    Raises:
+        ValueError: If ``limit`` is not positive.
+    """
+
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    if len(queue) >= limit:
+        return False
+    queue.append(item)
+    return True

--- a/tests/unit/test_scheduler_benchmark.py
+++ b/tests/unit/test_scheduler_benchmark.py
@@ -1,5 +1,10 @@
 """Micro-benchmark tests for scheduler resource usage."""
 
+from collections import deque
+
+import pytest
+
+from autoresearch.orchestration.utils import enqueue_with_limit
 from autoresearch.scheduler_benchmark import benchmark_scheduler
 
 
@@ -8,3 +13,18 @@ def test_benchmark_scheduler_resources():
     cpu_time, mem_kb = benchmark_scheduler(0.05)
     assert 0.0 <= cpu_time < 1.0
     assert 0 <= mem_kb < 50000
+
+
+def test_enqueue_with_limit_drops_items() -> None:
+    """Queue drops items when the limit is reached."""
+    q = deque()
+    assert enqueue_with_limit(q, 1, 1) is True
+    assert enqueue_with_limit(q, 2, 1) is False
+    assert list(q) == [1]
+
+
+def test_enqueue_with_limit_invalid_limit() -> None:
+    """Invalid limits raise a ValueError."""
+    q = deque()
+    with pytest.raises(ValueError):
+        enqueue_with_limit(q, 1, 0)


### PR DESCRIPTION
## Summary
- document backpressure and adaptive worker pools for orchestrator performance
- add `enqueue_with_limit` helper to prototype queue caps
- test queue limit behavior alongside scheduler benchmark

## Testing
- `EXTRAS="dev-minimal test nlp ui vss git distributed analysis llm parsers" task check`
- `uv run mkdocs build`
- `EXTRAS="dev-minimal test nlp ui vss git distributed analysis llm parsers" task verify` *(fails: check_env.VersionError: fakepkg not installed; run 'task install')*
- `uv run pytest tests/unit/test_scheduler_benchmark.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbc61a745c833380e283e3ab6c6cf1