### PR TITLE
Document distributed benchmarking results

### DIFF
--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -57,3 +57,46 @@ uv run scripts/distributed_orchestrator_sim.py --workers 2 --tasks 20 \
 
 These formulas and metrics help tune worker counts and latency budgets when
 deploying the distributed orchestrator.
+
+## Performance benchmark
+
+We evaluated `distributed_orchestrator_perf_benchmark.py`:
+
+```
+PYTHONPATH=. uv run scripts/distributed_orchestrator_perf_benchmark.py \
+    --max-workers 4 --network-latency 0.005 --tasks N
+```
+
+Tasks take 5 ms, giving a service rate of 200 tasks/s per worker.
+
+### 500 tasks
+
+| workers | avg latency (ms) | throughput (tasks/s) | memory (MB) |
+| ------- | ---------------- | ------------------- | ----------- |
+| 1 | 12.22 | 81.82 | 50.56 |
+| 2 | 7.32 | 136.58 | 50.81 |
+| 3 | 5.72 | 174.90 | 50.94 |
+| 4 | 4.79 | 208.98 | 50.93 |
+
+### 800 tasks
+
+| workers | avg latency (ms) | throughput (tasks/s) | memory (MB) |
+| ------- | ---------------- | ------------------- | ----------- |
+| 1 | 12.21 | 81.93 | 51.41 |
+| 2 | 7.33 | 136.35 | 51.66 |
+| 3 | 5.51 | 181.54 | 51.79 |
+| 4 | 4.75 | 210.57 | 51.79 |
+
+### 1200 tasks
+
+| workers | avg latency (ms) | throughput (tasks/s) | memory (MB) |
+| ------- | ---------------- | ------------------- | ----------- |
+| 1 | 11.71 | 85.40 | 52.19 |
+| 2 | 6.98 | 143.26 | 52.21 |
+| 3 | 5.63 | 177.77 | 52.24 |
+| 4 | 4.56 | 219.53 | 52.37 |
+
+## Follow-up benchmarks and monitoring
+
+- Vary task processing time to study sensitivity to service rate changes.
+- Emit latency and memory metrics to a monitoring system for live tuning.

--- a/docs/orchestrator_perf.md
+++ b/docs/orchestrator_perf.md
@@ -19,11 +19,9 @@ when arrivals approach capacity, signaling saturation risk.
 ## Distributed throughput model
 
 Assumptions follow the M/M/c queue with network delay in
-[algorithms/distributed_perf.md](algorithms/distributed_perf.md):
-
-- Tasks arrive at 100 tasks/s with a 5 ms network delay.
-- Each worker processes 120 tasks/s.
-- Arrivals and service times are exponential with utilization below one.
+[algorithms/distributed_perf.md](algorithms/distributed_perf.md). Tasks arrive
+at rate `\lambda` with network delay `d`, each worker processes `\mu` tasks/s,
+and arrivals and service times are exponential with utilization below one.
 
 Formulas:
 
@@ -32,19 +30,38 @@ Formulas:
 - Latency `T = d + W_q + 1/\mu`.
 - Throughput equals `\lambda` when `\rho < 1`.
 
-Results from
-`uv run scripts/distributed_perf_sim.py --max-workers 4 --arrival-rate 100 \\
-    --service-rate 120 --network-delay 0.005`:
+We varied arrival and service rates using
+`uv run scripts/distributed_perf_sim.py --max-workers 4 --network-delay 0.005`.
+
+### Arrival 50 tasks/s, service 80 tasks/s
 
 | workers | throughput (tasks/s) | latency (ms) | avg queue length |
 | ------- | ------------------- | ------------ | ---------------- |
-| 1 | 100.00 | 55.000 | 4.17 |
-| 2 | 100.00 | 15.084 | 0.18 |
-| 3 | 100.00 | 13.555 | 0.02 |
-| 4 | 100.00 | 13.362 | 0.00 |
+| 1 | 50.00 | 38.33 | 1.04 |
+| 2 | 50.00 | 18.85 | 0.07 |
+| 3 | 50.00 | 17.64 | 0.01 |
+| 4 | 50.00 | 17.51 | 0.00 |
 
-Network delay dominates latency; additional workers cut queueing after two
-processes.
+### Arrival 80 tasks/s, service 100 tasks/s
+
+| workers | throughput (tasks/s) | latency (ms) | avg queue length |
+| ------- | ------------------- | ------------ | ---------------- |
+| 1 | 80.00 | 55.00 | 3.20 |
+| 2 | 80.00 | 16.90 | 0.15 |
+| 3 | 80.00 | 15.24 | 0.02 |
+| 4 | 80.00 | 15.03 | 0.00 |
+
+### Arrival 120 tasks/s, service 150 tasks/s
+
+| workers | throughput (tasks/s) | latency (ms) | avg queue length |
+| ------- | ------------------- | ------------ | ---------------- |
+| 1 | 120.00 | 38.33 | 3.20 |
+| 2 | 120.00 | 12.94 | 0.15 |
+| 3 | 120.00 | 11.82 | 0.02 |
+| 4 | 120.00 | 11.69 | 0.00 |
+
+Higher service rates relative to arrivals shrink queues and drive latency
+toward the 5 ms network delay.
 
 ## Mitigation strategies
 
@@ -52,3 +69,10 @@ processes.
 - Adaptive worker pools expand or shrink based on backlog and utilization.
 
 [bench]: ../src/autoresearch/orchestrator_perf.py#L71-L112
+
+## Follow-up benchmarks and monitoring
+
+- Benchmark scenarios with non-exponential arrivals to stress test bursty
+  workloads.
+- Expose queue length and latency metrics via a monitoring hook to detect
+  saturation in production.


### PR DESCRIPTION
## Summary
- expand distributed throughput model with multiple arrival/service rate scenarios
- record orchestrator performance benchmark results across varied task loads
- suggest follow-up benchmarks and monitoring hooks for saturation alerts

## Testing
- `task check` *(fails: command not found)*
- `uv run scripts/distributed_perf_sim.py --max-workers 4 --arrival-rate 50 --service-rate 80 --network-delay 0.005`
- `uv run scripts/distributed_perf_sim.py --max-workers 4 --arrival-rate 80 --service-rate 100 --network-delay 0.005`
- `uv run scripts/distributed_perf_sim.py --max-workers 4 --arrival-rate 120 --service-rate 150 --network-delay 0.005`
- `PYTHONPATH=. uv run scripts/distributed_orchestrator_perf_benchmark.py --max-workers 4 --tasks 500 --network-latency 0.005 | tail -n 1`
- `PYTHONPATH=. uv run scripts/distributed_orchestrator_perf_benchmark.py --max-workers 4 --tasks 800 --network-latency 0.005 | tail -n 1`
- `PYTHONPATH=. uv run scripts/distributed_orchestrator_perf_benchmark.py --max-workers 4 --tasks 1200 --network-latency 0.005 | tail -n 1`
- `uv run mkdocs build` *(fails: theme 'material' not found)*
- `task verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcde599cc8333b2b9659dec9c0e29