### PR TITLE
feat: add multi-platform container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,37 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.4
 
-ARG BASE_IMAGE=python:3.12-slim
-FROM ${BASE_IMAGE}
+ARG EXTRAS=full
 
-WORKDIR /app
-COPY uv.lock pyproject.toml /app/
-RUN pip install --no-cache-dir uv && uv pip sync uv.lock
-COPY . /app
-EXPOSE 8000
-CMD ["uv", "run", "uvicorn", "autoresearch.api:app", "--host", "0.0.0.0", "--port", "8000"]
+ARG PYTHON_IMAGE=python:3.12-slim@sha256:
+ARG PYTHON_DIGEST=d67a7b66b989ad6b6d6b10d428dcc5e0bfc3e5f88906e67d490c4d3daac57047
+FROM ${PYTHON_IMAGE}${PYTHON_DIGEST} AS linux
+WORKDIR /workspace
+COPY . .
+RUN pip install --no-cache-dir uv \
+    && uv pip install ".[${EXTRAS}]"
+ENTRYPOINT ["autoresearch"]
+CMD ["--help"]
+
+ARG MACOS_IMAGE=ghcr.io/cirruslabs/macos-runner:sonoma@sha256:
+ARG MACOS_DIGEST=7331fefa25f3e8bca983bea2271ac28b5761a31ce88ea868d477483df9acb50b
+FROM ${MACOS_IMAGE}${MACOS_DIGEST} AS macos
+ARG EXTRAS
+WORKDIR /workspace
+COPY . .
+RUN /bin/bash -lc "brew update && brew install python@3.12" \
+    && pip3 install --no-cache-dir uv \
+    && uv pip install ".[${EXTRAS}]"
+ENTRYPOINT ["autoresearch"]
+CMD ["--help"]
+
+ARG WINDOWS_IMAGE=python:3.12-windowsservercore-ltsc2022@sha256:
+ARG WINDOWS_DIGEST=035418c04b5e8fcb13c6b23f6c801a52c510c43e8bf27e2379d26ad8c40c87a7
+FROM ${WINDOWS_IMAGE}${WINDOWS_DIGEST} AS windows
+ARG EXTRAS
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+WORKDIR C:/workspace
+COPY . .
+RUN pip install --no-cache-dir uv; \
+    uv pip install ".[$env:EXTRAS]"
+ENTRYPOINT ["autoresearch"]
+CMD ["--help"]

--- a/docs/container_usage.md
+++ b/docs/container_usage.md
@@ -1,8 +1,8 @@
 # Container Usage
 
-Autoresearch ships Dockerfiles for Linux, macOS, and Windows. Each image
-installs project extras via a build argument and starts the `autoresearch`
-CLI.
+Autoresearch ships a multi-stage Dockerfile targeting Linux, macOS, and
+Windows. Each stage installs project extras via a build argument and starts the
+`autoresearch` CLI.
 
 ## Build
 
@@ -10,20 +10,21 @@ CLI.
   `full`.
 - Replace `podman` with your container engine.
 
+Build and push all platforms:
+
 ```bash
-bash docker/build_images.sh
+bash scripts/release_images.sh ghcr.io/OWNER latest
 ```
 
-The script builds Linux, macOS, and Windows images. Pass an argument to
-override `EXTRAS`.
+Manual builds for a single platform use Docker Buildx targets:
 
 ```bash
-podman build -f docker/Dockerfile.linux --build-arg EXTRAS=minimal \
+podman buildx build --target linux --platform linux/amd64 \
     -t autoresearch-linux .
 ```
 
-Repeat manual builds with the macOS and Windows Dockerfiles on their
-respective hosts when a native build is required.
+Use `macos` or `windows` with the matching `--platform` value to build other
+images.
 
 ## Run
 
@@ -35,10 +36,6 @@ podman run --rm autoresearch-linux --version
 
 ## Release
 
-The `scripts/release_images.sh` script builds and pushes all images:
-
-```bash
-bash scripts/release_images.sh ghcr.io/OWNER latest
-```
-
-Set `CONTAINER_ENGINE` to `podman` when Docker is unavailable.
+`scripts/release_images.sh` builds Linux (amd64, arm64), macOS, and Windows
+images using pinned base digests to ensure reproducibility. Set
+`CONTAINER_ENGINE` to `podman` when Docker is unavailable.


### PR DESCRIPTION
## Summary
- support Linux, macOS, and Windows stages in Dockerfile
- build and push multi-platform images via release script
- document container workflow and add container smoke test

## Testing
- `task check` *(fails: docs/specs/storage.md missing headings)*
- `task verify` *(fails: exit status 1 during coverage run)*
- `uv run mkdocs build` *(fails: mkdocs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd1b5fde48333818024851f9fab59