### PR TITLE
Archive check-env warnings test issue

### DIFF
--- a/issues/archive/fix-check-env-warnings-test-failure.md
+++ b/issues/archive/fix-check-env-warnings-test-failure.md
@@ -14,4 +14,4 @@ instead so verification can complete.
 - `scripts/check_env.py` emits a warning rather than raising when optional packages are missing.
 
 ## Status
-Open
+Archived


### PR DESCRIPTION
## Summary
- archive resolved check-env warnings test issue

## Testing
- `task verify` *(fails: tests/unit/test_token_budget_convergence.py::test_convergence_from_any_start)*
- `uv run pytest tests/unit/test_check_env_warnings.py::test_missing_package_metadata_warns -vv`

------
https://chatgpt.com/codex/tasks/task_e_68bc722c490c8333b0eae92fbff45b72