### PR TITLE
feat: enable multi-arch container builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,9 @@ services:
   autoresearch:
     build:
       context: .
+      dockerfile: docker/Dockerfile.linux
       args:
-        BASE_IMAGE: ${BASE_IMAGE:-python:3.12-slim}
+        EXTRAS: ${EXTRAS:-full,test}
     platform: ${DOCKER_PLATFORM:-linux/amd64}
     ports:
       - "8000:8000"

--- a/docker/Dockerfile.linux
+++ b/docker/Dockerfile.linux
@@ -1,11 +1,15 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.5
 # Linux container image with project extras for Autoresearch
-FROM python:3.12-slim
+FROM --platform=$TARGETPLATFORM python:3.12-slim
 
-ARG EXTRAS=full
+ARG EXTRAS="full,test"
 WORKDIR /workspace
 COPY . .
 RUN pip install --no-cache-dir uv \
     && uv pip install ".[${EXTRAS}]"
+# Validate the CLI and a small test without network access
+RUN --network=none autoresearch --help >/dev/null
+RUN --network=none uv run pytest \
+    tests/unit/test_cli_help.py::test_cli_help_no_ansi -q
 ENTRYPOINT ["autoresearch"]
 CMD ["--help"]

--- a/docker/build_images.sh
+++ b/docker/build_images.sh
@@ -3,7 +3,7 @@
 # Usage: build_images.sh [EXTRAS]
 set -euo pipefail
 
-EXTRAS="${1:-full}"
+EXTRAS="${1:-full,test}"
 ENGINE="${CONTAINER_ENGINE:-docker}"
 
 if ! command -v "$ENGINE" >/dev/null 2>&1; then
@@ -12,12 +12,14 @@ if ! command -v "$ENGINE" >/dev/null 2>&1; then
 fi
 
 build_image() {
-    local os="$1"
+    local tag="$1"
     local file="$2"
-    "$ENGINE" build -f "$file" --build-arg EXTRAS="$EXTRAS" \
-        -t "autoresearch-$os" .
+    local platform="$3"
+    "$ENGINE" buildx build -f "$file" --build-arg EXTRAS="$EXTRAS" \
+        --platform "$platform" -t "autoresearch-$tag" --load .
 }
 
-build_image linux docker/Dockerfile.linux
-build_image macos docker/Dockerfile.macos
-build_image windows docker/Dockerfile.windows
+build_image linux-amd64 docker/Dockerfile.linux linux/amd64
+build_image linux-arm64 docker/Dockerfile.linux linux/arm64
+build_image macos docker/Dockerfile.macos linux/amd64
+build_image windows docker/Dockerfile.windows windows/amd64

--- a/docs/container_usage.md
+++ b/docs/container_usage.md
@@ -26,12 +26,27 @@ podman buildx build --target linux --platform linux/amd64 \
 Use `macos` or `windows` with the matching `--platform` value to build other
 images.
 
+The `docker/build_images.sh` helper builds Linux images for both `amd64` and
+`arm64`:
+
+```bash
+bash docker/build_images.sh
+```
+
 ## Run
 
 Images run the CLI automatically. Pass additional flags to invoke commands:
 
 ```bash
 podman run --rm autoresearch-linux --version
+```
+
+Run CLI or tests offline by disabling network access:
+
+```bash
+podman run --rm --network none autoresearch-linux-amd64 --version
+podman run --rm --network none autoresearch-linux-amd64 \
+    uv run pytest tests/unit/test_cli_help.py::test_cli_help_no_ansi -q
 ```
 
 ## Release

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -39,6 +39,16 @@ If the upload fails with a 403 response:
   uv run twine upload dist/*
   ```
 
+## Container images
+
+Build and push multi-arch images with Buildx:
+
+```bash
+bash scripts/release_images.sh ghcr.io/OWNER v1.2.3
+```
+
+The script publishes Linux (amd64, arm64), macOS, and Windows images.
+
 - Configure authentication in `config.yml` using `api.api_key`,
   `api.api_keys`, or `api.bearer_token`. Any supplied credential must be valid
   or the server returns a 401 error.


### PR DESCRIPTION
## Summary
- add multi-arch Linux Dockerfile with offline CLI and test validation
- build per-architecture images via buildx and compose with test extras
- document container usage and release image build steps

## Testing
- `uv run task check`
- `uv run task verify` *(fails: tests/integration/test_api_auth_middleware.py::test_webhook_auth)*
- `uv run mkdocs build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc82d05d9c8333ab538a1af32ff24d