### PR TITLE
Fix lint issues and track verify failures

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,17 @@
 
 ## September 6, 2025
 
+- Removed an unused import so `task install` completes without flake8 errors.
+- Added an "Algorithms" heading to `docs/specs/distributed.md` to satisfy spec
+  linting.
+- `task check` passes.
+- `task verify` runs unit tests but exits with multiprocessing resource tracker
+  errors before integration tests.
+- `tests/integration/test_api_auth_middleware.py::test_webhook_auth` now
+  passes when run directly.
+
+## September 6, 2025
+
 - Deployment validator now checks configs and env vars with tests and docs;
   archived the related issue.
 - Installed Go Task CLI and synchronized extras with `task install`.

--- a/docs/specs/distributed.md
+++ b/docs/specs/distributed.md
@@ -5,7 +5,7 @@
 Distributed execution utilities. See [distributed coordination][dc] for
 coalition and scheduling details.
 
-## Scheduling Algorithms
+## Algorithms
 
 - **Round-robin** assigns each incoming task to the next worker in turn for
   balanced workloads.

--- a/issues/fix-check-env-warnings-test-failure.md
+++ b/issues/fix-check-env-warnings-test-failure.md
@@ -1,0 +1,16 @@
+# Fix check env warnings test failure
+
+## Context
+`task verify` fails at `tests/unit/test_check_env_warnings.py::test_missing_package_metadata_warns`
+with `VersionError: fakepkg not installed; run 'task install'.`
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- `test_missing_package_metadata_warns` passes during `task verify`.
+- `check_env` handles missing package metadata without raising `VersionError`.
+- Regression coverage captures expected warning behavior.
+
+## Status
+Open

--- a/issues/prepare-v0-1-0a1-release.md
+++ b/issues/prepare-v0-1-0a1-release.md
@@ -20,6 +20,7 @@ initial proofs. Completing these steps clears the way to tag v0.1.0a1.
 - [fix-duckdb-storage-table-creation-failure](archive/fix-duckdb-storage-table-creation-failure.md)
 - [resolve-package-metadata-warnings](archive/resolve-package-metadata-warnings.md)
 - [fix-check-env-warnings-test-failure](fix-check-env-warnings-test-failure.md)
+- [resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md)
 
 ## Acceptance Criteria
 - `task verify` runs to completion with all extras installed.

--- a/issues/resolve-resource-tracker-errors-in-verify.md
+++ b/issues/resolve-resource-tracker-errors-in-verify.md
@@ -1,0 +1,16 @@
+# Resolve resource tracker errors in verify
+
+## Context
+`task verify` exits with multiprocessing resource tracker `KeyError` messages
+after unit tests, preventing integration tests and coverage from completing.
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- `task verify` completes without resource tracker errors.
+- Integration tests and coverage reporting run to completion.
+- Root cause and mitigation are documented.
+
+## Status
+Open

--- a/tests/integration/test_api_auth_middleware.py
+++ b/tests/integration/test_api_auth_middleware.py
@@ -18,7 +18,7 @@ def test_webhook_auth(monkeypatch, api_client):
     called: list[str] = []
     monkeypatch.setattr(
         "autoresearch.api.webhooks.notify_webhook",
-        lambda url, result, timeout=5: called.append(url),
+        lambda url, result, timeout=5, retries=3, backoff=0.5: called.append(url),
     )
 
     resp = api_client.post(

--- a/tests/integration/test_config_hot_reload_components.py
+++ b/tests/integration/test_config_hot_reload_components.py
@@ -1,4 +1,3 @@
-import time
 from pathlib import Path
 
 from autoresearch.config.loader import ConfigLoader, get_config


### PR DESCRIPTION
## Summary
- remove unused import in hot reload integration test
- sync distributed spec with required "Algorithms" heading
- document verify resource-tracker failure and missing check-env warnings test

## Testing
- `task check`
- `uv run pytest tests/integration/test_api_auth_middleware.py::test_webhook_auth -q`
- `task verify` *(fails: multiprocessing resource tracker KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_68bcaa2d7c648333b208237846b0dfaf