### PR TITLE
Handle missing package metadata gracefully

### DIFF
--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -149,14 +149,18 @@ def check_package(pkg: str) -> CheckResult | None:
     return CheckResult(pkg, current, required)
 
 
-def check_pytest_bdd() -> CheckResult:
+def check_pytest_bdd() -> CheckResult | None:
     """Ensure pytest-bdd is installed and importable."""
 
     try:
         import pytest_bdd  # noqa: F401
     except ModuleNotFoundError as exc:  # pragma: no cover - failure path
         raise VersionError("pytest-bdd import failed; run 'task install'.") from exc
-    current = metadata.version("pytest-bdd")
+    try:
+        current = metadata.version("pytest-bdd")
+    except metadata.PackageNotFoundError:
+        warnings.warn("package metadata not found for pytest-bdd")
+        return None
     required = REQUIREMENTS["pytest-bdd"]
     return CheckResult("pytest-bdd", current, required)
 
@@ -185,9 +189,7 @@ def main() -> None:
             if result.ok():
                 print(f"{result.name} {result.current}")
             else:
-                errors.append(
-                    f"{result.name} {result.current} < required {result.required}"
-                )
+                errors.append(f"{result.name} {result.current} < required {result.required}")
         except Exception as exc:  # pragma: no cover - failure paths
             errors.append(str(exc))
 

--- a/tests/unit/test_check_env_warnings.py
+++ b/tests/unit/test_check_env_warnings.py
@@ -19,7 +19,7 @@ def test_missing_package_metadata_warns(monkeypatch):
     def fake_version(name):
         raise metadata.PackageNotFoundError
 
-    monkeypatch.setattr(check_env.metadata, "version", lambda name: fake_version(name))
+    monkeypatch.setattr(check_env.metadata, "version", fake_version)
     with pytest.warns(UserWarning, match="package metadata not found for fakepkg"):
         result = check_env.check_package("fakepkg")
     assert result is None


### PR DESCRIPTION
## Summary
- warn instead of error when pytest-bdd metadata is missing
- assert warning emission in env check tests

## Testing
- `uv run task verify` *(fails: Failed to spawn: `task` No such file or directory)*
- `uv run --extra test pytest tests/unit/test_check_env_warnings.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcb98105048333822a07cb54d62a1c