### PR TITLE
Add cross-platform container release tooling

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -16,4 +16,4 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push images
-        run: bash scripts/release_images.sh ghcr.io/${{ github.repository_owner }} latest
+        run: bash scripts/release_images.sh ghcr.io/${{ github.repository_owner }}/autoresearch latest

--- a/docker/Dockerfile.macos
+++ b/docker/Dockerfile.macos
@@ -2,11 +2,13 @@
 # macOS (ARM) container image with project extras for Autoresearch
 FROM ghcr.io/cirruslabs/macos-runner:sonoma
 
-ARG EXTRAS=full
+ARG EXTRAS="full,test"
 WORKDIR /workspace
 COPY . .
 RUN /bin/bash -lc "brew update && brew install python@3.12" \
     && pip3 install --no-cache-dir uv \
-    && uv pip install ".[${EXTRAS}]"
+    && uv pip install ".[${EXTRAS}]" \
+    && autoresearch --help >/dev/null \
+    && uv run pytest tests/unit/test_cli_help.py::test_cli_help_no_ansi -q
 ENTRYPOINT ["autoresearch"]
 CMD ["--help"]

--- a/docker/Dockerfile.windows
+++ b/docker/Dockerfile.windows
@@ -2,11 +2,14 @@
 # Windows container image with project extras for Autoresearch
 FROM mcr.microsoft.com/windows/python:3.12
 
-ARG EXTRAS=full
+ARG EXTRAS="full,test"
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 WORKDIR C:/workspace
 COPY . .
+# Validate the CLI and a small test
 RUN pip install --no-cache-dir uv; `
-    uv pip install ".[$env:EXTRAS]"
+    uv pip install ".[$env:EXTRAS]"; `
+    autoresearch --help | Out-Null; `
+    uv run pytest tests/unit/test_cli_help.py::test_cli_help_no_ansi -q
 ENTRYPOINT ["autoresearch"]
 CMD ["--help"]

--- a/docs/container_usage.md
+++ b/docs/container_usage.md
@@ -1,56 +1,36 @@
 # Container Usage
 
-Autoresearch ships a multi-stage Dockerfile targeting Linux, macOS, and
-Windows. Each stage installs project extras via a build argument and starts the
-`autoresearch` CLI.
+This guide explains how to build, run, and maintain Autoresearch container images.
 
 ## Build
 
-- Use the `EXTRAS` argument to specify optional dependencies, defaulting to
-  `full`.
-- Replace `podman` with your container engine.
+- Run [docker/build_images.sh](../docker/build_images.sh) to build local images
+  for Linux, macOS, and Windows.
+- Pass extras using an argument, for example:
 
-Build and push all platforms:
-
-```bash
-bash scripts/release_images.sh ghcr.io/OWNER latest
-```
-
-Manual builds for a single platform use Docker Buildx targets:
-
-```bash
-podman buildx build --target linux --platform linux/amd64 \
-    -t autoresearch-linux .
-```
-
-Use `macos` or `windows` with the matching `--platform` value to build other
-images.
-
-The `docker/build_images.sh` helper builds Linux images for both `amd64` and
-`arm64`:
-
-```bash
-bash docker/build_images.sh
-```
+  ```bash
+  bash docker/build_images.sh full,test
+  ```
 
 ## Run
 
-Images run the CLI automatically. Pass additional flags to invoke commands:
+- Each build produces images tagged `autoresearch-linux-amd64`,
+  `autoresearch-macos`, and `autoresearch-windows`.
+- To run the Linux image:
 
-```bash
-podman run --rm autoresearch-linux --version
-```
+  ```bash
+  docker run --rm autoresearch-linux-amd64 --help
+  ```
 
-Run CLI or tests offline by disabling network access:
+## Maintenance
 
-```bash
-podman run --rm --network none autoresearch-linux-amd64 --version
-podman run --rm --network none autoresearch-linux-amd64 \
-    uv run pytest tests/unit/test_cli_help.py::test_cli_help_no_ansi -q
-```
+- Push images to GitHub Container Registry with
+  [scripts/release_images.sh](../scripts/release_images.sh):
 
-## Release
+  ```bash
+  bash scripts/release_images.sh ghcr.io/OWNER/autoresearch 0.1.0
+  ```
+- The dispatch-only workflow
+  [release-images.yml](../.github/workflows/release-images.yml) runs the same
+  script in CI when triggered manually.
 
-`scripts/release_images.sh` builds Linux (amd64, arm64), macOS, and Windows
-images using pinned base digests to ensure reproducibility. Set
-`CONTAINER_ENGINE` to `podman` when Docker is unavailable.

--- a/scripts/release_images.sh
+++ b/scripts/release_images.sh
@@ -1,35 +1,47 @@
 #!/usr/bin/env bash
-# release_images.sh - Build and publish Autoresearch container images.
-# Usage: release_images.sh REGISTRY TAG [EXTRAS]
+# release_images.sh - Build and publish Autoresearch container images to GHCR.
+# Usage: release_images.sh IMAGE TAG [EXTRAS]
+#
+# IMAGE should include the registry and repository, for example
+# "ghcr.io/my-user/autoresearch". TAG defaults to "latest" and EXTRAS
+# defaults to "full,test".
 set -euo pipefail
 
 if [ -z "${1:-}" ] || [ -z "${2:-}" ]; then
-  echo "Usage: $0 REGISTRY TAG [EXTRAS]" >&2
-  exit 1
+    echo "Usage: $0 IMAGE TAG [EXTRAS]" >&2
+    exit 1
 fi
 
-REGISTRY="$1"
+IMAGE="$1"
 TAG="$2"
-EXTRAS="${3:-full}"
+EXTRAS="${3:-full,test}"
 ENGINE="${CONTAINER_ENGINE:-docker}"
 
 if ! command -v "$ENGINE" >/dev/null 2>&1; then
-  echo "Container engine '$ENGINE' not found" >&2
-  exit 1
+    echo "Container engine '$ENGINE' not found" >&2
+    exit 1
 fi
 
 build_and_push() {
-  local target="$1"
-  local platforms="$2"
-  "$ENGINE" buildx build \
-    --file Dockerfile \
-    --target "$target" \
-    --build-arg EXTRAS="$EXTRAS" \
-    --platform "$platforms" \
-    --tag "$REGISTRY/autoresearch:$target-$TAG" \
-    --push .
+    local file="$1"
+    local platforms="$2"
+    local suffix="$3"
+    local tag="$IMAGE:$TAG"
+    if [ -n "$suffix" ]; then
+        tag="$IMAGE:${suffix}-$TAG"
+    fi
+    "$ENGINE" buildx build \
+        --file "$file" \
+        --platform "$platforms" \
+        --build-arg EXTRAS="$EXTRAS" \
+        --tag "$tag" \
+        --push .
 }
 
-build_and_push linux "linux/amd64,linux/arm64"
-build_and_push macos "linux/amd64"
-build_and_push windows "windows/amd64"
+# Linux: multi-arch manifest (amd64, arm64)
+build_and_push docker/Dockerfile.linux "linux/amd64,linux/arm64" ""
+# macOS: single-arch (amd64)
+build_and_push docker/Dockerfile.macos "linux/amd64" "macos"
+# Windows: single-arch (amd64)
+build_and_push docker/Dockerfile.windows "windows/amd64" "windows"
+


### PR DESCRIPTION
## Summary
- unify macOS and Windows Dockerfiles with Linux by installing test extras and validating CLI
- add release_images.sh script that pushes multi-arch images to GHCR
- document building and maintaining container images
- wire up manual release workflow to use the new script

## Testing
- `CONTAINER_ENGINE=echo bash scripts/release_images.sh ghcr.io/test/autoresearch testtag`
- `uv run mkdocs build`
- `task verify` *(fails: DeadlineExceeded in test_message_processing_is_idempotent)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb9af2478833391cbea019c1b98d1