### PR TITLE
Reopen deployment validation issue and update roadmap references

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,7 @@ before running tests.
   - [reach-stable-performance-and-interfaces](issues/reach-stable-performance-and-interfaces.md)
     - [containerize-and-package](issues/containerize-and-package.md) (2026-09-01)
     - [validate-deployment-configurations](issues/validate-deployment-configurations.md)
-      (2027-01-15, depends on containerization)
+      (2027-01-15, depends on containerization; reopened)
     - [tune-system-performance](issues/archive/tune-system-performance.md)
       (2027-04-01, depends on deployment validation)
 
@@ -146,7 +146,7 @@ The 1.0.0 milestone aims for a polished, production-ready system:
 
 - [containerize-and-package](issues/containerize-and-package.md) (2026-09-01)
 - [validate-deployment-configurations](issues/validate-deployment-configurations.md)
-  (2027-01-15, depends on containerization)
+  (2027-01-15, depends on containerization; reopened)
 - [tune-system-performance](issues/archive/tune-system-performance.md)
   (2027-04-01, depends on deployment validation)
 

--- a/issues/archive/tune-system-performance.md
+++ b/issues/archive/tune-system-performance.md
@@ -7,8 +7,8 @@ Performance tuning ensures efficient operation and scalability under production 
 2027-04-01
 
 ## Dependencies
-- [containerize-and-package](containerize-and-package.md)
-- [validate-deployment-configurations](validate-deployment-configurations.md)
+- [containerize-and-package](../containerize-and-package.md)
+- [validate-deployment-configurations](../validate-deployment-configurations.md)
 
 ## Acceptance Criteria
 - Profile critical components and resolve bottlenecks.

--- a/issues/reach-stable-performance-and-interfaces.md
+++ b/issues/reach-stable-performance-and-interfaces.md
@@ -10,7 +10,7 @@ stable interfaces and tuned performance.
 ## Dependencies
 
 - [containerize-and-package](containerize-and-package.md)
-- [validate-deployment-configurations](validate-deployment-configurations.md)
+- [validate-deployment-configurations](validate-deployment-configurations.md) reopened.
 - [tune-system-performance](archive/tune-system-performance.md) completed.
 
 ## Acceptance Criteria

--- a/issues/validate-deployment-configurations.md
+++ b/issues/validate-deployment-configurations.md
@@ -7,14 +7,14 @@ Reliable deployment requires validated scripts and configuration checks to preve
 2027-01-15
 
 ## Dependencies
-- [containerize-and-package](../containerize-and-package.md)
+- [containerize-and-package](containerize-and-package.md)
 
 ## Acceptance Criteria
 - Deliver deployment scripts with automated configuration validation.
 - Test scripts across supported environments.
 - Document deployment procedures and configuration options.
-- Include [scripts/validate_deploy.py](../../scripts/validate_deploy.py) for
+- Include [scripts/validate_deploy.py](../scripts/validate_deploy.py) for
   preflight checks.
 
 ## Status
-Archived
+Open


### PR DESCRIPTION
## Summary
- Reopen `validate-deployment-configurations` issue and fix internal links.
- Note reopened status in dependency lists and roadmap.
- Correct archived `tune-system-performance` dependency paths.

## Testing
- `task check` *(fails: command not found)*
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*


------
https://chatgpt.com/codex/tasks/task_e_68bcbcbb69a88333814a59f6b22f79f0