### PR TITLE
chore: track spec gaps and failing sim tests

### DIFF
--- a/issues/complete-orchestration-spec.md
+++ b/issues/complete-orchestration-spec.md
@@ -1,0 +1,17 @@
+# Complete orchestration spec
+
+## Context
+`task check` fails because `docs/specs/orchestration.md` lacks required
+sections for algorithms, invariants, proof sketch, and simulation
+expectations.
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- `orchestration.md` includes algorithm descriptions, invariants, proof
+  sketch, and simulation expectations.
+- `task check` passes without spec lint errors.
+
+## Status
+Open

--- a/issues/fix-distributed-perf-sim-cli-failure.md
+++ b/issues/fix-distributed-perf-sim-cli-failure.md
@@ -1,0 +1,19 @@
+# Fix distributed perf sim CLI failure
+
+## Context
+`task verify` fails at
+`tests/unit/test_distributed_perf_sim_script.py::test_cli_execution`
+because `scripts/distributed_perf_sim.py` exits with an error when
+invoked via `uv run`.
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- `test_distributed_perf_sim_script.py::test_cli_execution` passes during
+  `task verify`.
+- `distributed_perf_sim.py` handles CLI arguments and completes without
+  errors.
+
+## Status
+Open

--- a/issues/prepare-v0-1-0a1-release.md
+++ b/issues/prepare-v0-1-0a1-release.md
@@ -21,6 +21,8 @@ initial proofs. Completing these steps clears the way to tag v0.1.0a1.
 - [resolve-package-metadata-warnings](archive/resolve-package-metadata-warnings.md)
 - [fix-check-env-warnings-test-failure](fix-check-env-warnings-test-failure.md)
 - [resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md)
+- [complete-orchestration-spec](complete-orchestration-spec.md)
+- [fix-distributed-perf-sim-cli-failure](fix-distributed-perf-sim-cli-failure.md)
 
 ## Acceptance Criteria
 - `task verify` runs to completion with all extras installed.


### PR DESCRIPTION
## Summary
- add issue for missing sections in the orchestration spec
- track failing distributed perf sim CLI invocation
- link new blockers in the v0.1.0a1 release ticket

## Testing
- `task check` *(fails: docs/specs/orchestration.md missing headings)*
- `task verify` *(fails: test_distributed_perf_sim_script.py::test_cli_execution)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbe1cdb1483338a0d29f59da44711