### PR TITLE
Align orchestration spec with template and archive issue

### DIFF
--- a/issues/archive/complete-orchestration-spec.md
+++ b/issues/archive/complete-orchestration-spec.md
@@ -14,4 +14,4 @@ expectations.
 - `task check` passes without spec lint errors.
 
 ## Status
-Open
+Archived


### PR DESCRIPTION
## Summary
- restructure orchestration specification to match template sections
- archive complete-orchestration-spec issue after spec passes lint

## Testing
- `uvx pre-commit run --files docs/specs/orchestration.md`
- `task check`


------
https://chatgpt.com/codex/tasks/task_e_68bcc0ea4cd4833396c14d0ad3c0ea49