### PR TITLE
docs: formalize search algorithms and proofs

### DIFF
--- a/issues/archive/expand-search-spec-with-proofs.md
+++ b/issues/archive/expand-search-spec-with-proofs.md
@@ -1,0 +1,18 @@
+# Expand search spec with proofs
+
+## Context
+The search specification lacked detail on retrieval algorithms and formal
+assurances. This issue captures the work to document keyword, vector, and
+hybrid search behaviors along with invariants and validation tests.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Describe keyword, vector, and hybrid algorithms in the search spec.
+- Document invariants such as result ordering and idempotent indexing.
+- Provide proof sketches for the invariants.
+- Reference simulations or tests demonstrating these behaviors.
+
+## Status
+Archived


### PR DESCRIPTION
## Summary
- detail keyword, vector, and hybrid search strategies
- specify ordering and idempotent indexing invariants with proof sketches
- archive issue for expanded search specification with proofs

## Testing
- `uv run mkdocs build` *(fails: missing docs, warnings)*
- `PATH=$PATH:$(pwd)/bin ./bin/task check` *(fails: missing headings in orchestration spec)*
- `PATH=$PATH:$(pwd)/bin ./bin/task verify` *(fails: distributed perf sim test)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc0ed97108333809ad23c40491d89