### PR TITLE
docs: track rate limit test deadline

### DIFF
--- a/issues/fix-rate-limit-bounds-test-deadline.md
+++ b/issues/fix-rate-limit-bounds-test-deadline.md
@@ -1,0 +1,17 @@
+# Fix rate limit bounds test deadline
+
+## Context
+On 2025-09-07, `task verify` failed because `tests/unit/test_property_api_rate_limit_bounds.py::test_rate_limit_bounds`
+exceeded Hypothesis' 200ms deadline. The test must complete reliably to unblock
+full verification runs.
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- `test_property_api_rate_limit_bounds::test_rate_limit_bounds` runs under the
+  Hypothesis deadline on typical development hardware.
+- `task verify` passes the unit test phase without a DeadlineExceeded error.
+
+## Status
+Open

--- a/issues/resolve-current-integration-test-failures.md
+++ b/issues/resolve-current-integration-test-failures.md
@@ -4,10 +4,13 @@
 Recent `uv run pytest -q` runs pass unit tests but surface 40 failing integration tests. Failures
 include unauthorized API endpoints returning 401/403, storage eviction simulations reporting tuple
 mismatches, AttributeError and PicklingError exceptions, and search ranking calculations accessing
-missing modules. These regressions block the 0.1.0a1 preview.
+missing modules. These regressions block the 0.1.0a1 preview. As of 2025-09-07,
+`task verify` additionally fails early because
+`tests/unit/test_property_api_rate_limit_bounds.py::test_rate_limit_bounds`
+exceeds Hypothesis' default deadline.
 
 ## Dependencies
-- None
+- [fix-rate-limit-bounds-test-deadline](fix-rate-limit-bounds-test-deadline.md)
 
 ## Acceptance Criteria
 - API docs, metrics, health, and streaming endpoints return expected status codes when authenticated


### PR DESCRIPTION
## Summary
- record failing Hypothesis deadline for property API rate limit test
- link integration test cleanup issue to the new unit test issue

## Testing
- `task verify` *(fails: test_property_api_rate_limit_bounds::test_rate_limit_bounds DeadlineExceeded)*
- `task check`


------
https://chatgpt.com/codex/tasks/task_e_68bcce6e55c083339e83e659db6eae14