### PR TITLE
refactor: speed up rate limit property test

### DIFF
--- a/tests/unit/test_property_api_rate_limit_bounds.py
+++ b/tests/unit/test_property_api_rate_limit_bounds.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from autoresearch.api.middleware import FallbackRateLimitMiddleware, Limiter
@@ -11,7 +11,11 @@ from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import APIConfig, ConfigModel
 
 
-@given(limit=st.integers(min_value=1, max_value=5), requests=st.integers(min_value=0, max_value=10))
+@given(
+    limit=st.integers(min_value=1, max_value=5),
+    requests=st.integers(min_value=0, max_value=10),
+)
+@settings(deadline=100)
 def test_rate_limit_bounds(limit: int, requests: int) -> None:
     """Client never exceeds the configured request limit.
 
@@ -30,8 +34,15 @@ def test_rate_limit_bounds(limit: int, requests: int) -> None:
             return {"status": "ok"}
 
         client = TestClient(app)
-        responses = [client.get("/health") for _ in range(requests)]
-        allowed = sum(r.status_code == 200 for r in responses)
+
+        allowed = 0
+        last_status = 200
+        for _ in range(min(requests, limit + 1)):
+            status = client.get("/health").status_code
+            last_status = status
+            if status == 200:
+                allowed += 1
+
         assert allowed <= limit
         if requests > limit:
-            assert responses[-1].status_code == 429
+            assert last_status == 429


### PR DESCRIPTION
## Summary
- reduce HTTP calls in rate limit property test
- tighten Hypothesis deadline to catch slowdowns

## Testing
- `uv run --extra test pytest tests/unit/test_property_api_rate_limit_bounds.py::test_rate_limit_bounds -vv --maxfail=1 --hypothesis-show-statistics`
- `task check`
- `task verify` *(fails: duplicate validator function "weasel.schemas.ProjectConfigSchema.check_legacy_keys")*


------
https://chatgpt.com/codex/tasks/task_e_68bcd5a65e0c8333a19cd815794d32cb