### PR TITLE
refine storage eviction simulation interface

### DIFF
--- a/issues/resolve-current-integration-test-failures.md
+++ b/issues/resolve-current-integration-test-failures.md
@@ -1,11 +1,11 @@
 # Resolve current integration test failures
 
 ## Context
-Recent `uv run pytest -q` runs pass unit tests but surface 40 failing integration tests. Failures
-include unauthorized API endpoints returning 401/403, storage eviction simulations reporting tuple
-mismatches, AttributeError and PicklingError exceptions, and search ranking calculations accessing
-missing modules. These regressions block the 0.1.0a1 preview. As of 2025-09-07,
-`task verify` additionally fails early because
+Recent `uv run pytest -q` runs pass unit tests but surface 39 failing integration tests. Failures
+include unauthorized API endpoints returning 401/403, AttributeError and PicklingError exceptions,
+and search ranking calculations accessing missing modules. The storage eviction simulation tuple
+mismatch was resolved on 2025-09-07. These regressions continue to block the 0.1.0a1 preview. As of
+2025-09-07, `task verify` additionally fails early because
 `tests/unit/test_property_api_rate_limit_bounds.py::test_rate_limit_bounds`
 exceeds Hypothesis' default deadline.
 


### PR DESCRIPTION
## Summary
- add optional runtime metrics to storage eviction simulation `_run`
- update issue log with current integration test status

## Testing
- `uv run black scripts/storage_eviction_sim.py`
- `uv run flake8 scripts/storage_eviction_sim.py`
- `uv run pytest tests/integration/test_storage_eviction_sim.py -q`
- `uv run pytest -q` *(fails: assert 403 == 200, _pickle.PicklingError, AttributeError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bcd599c6108333bb0b4fb25c023156