### PR TITLE
Allow selecting optional extras via EXTRAS

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -28,16 +28,17 @@ tasks:
               export PATH="$(pwd)/.venv/bin:$PATH"
           fi
       - |
-          extras="dev-minimal test nlp ui vss git distributed analysis llm parsers"
+          extras="dev-minimal test"
           uv sync --python-platform x86_64-manylinux_2_28 \
-              $(printf ' --extra %s' $extras){{if .EXTRAS}} --extra {{.EXTRAS}}{{end}} \
-              {{if contains .EXTRAS "gpu"}}--find-links wheels/gpu{{end}}
+              $(printf ' --extra %s' $extras) \
+              {{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}} \
+              {{if and .EXTRAS (contains .EXTRAS "gpu")}}--find-links wheels/gpu{{end}}
       - uv run python -c "import pytest_httpx, tomli_w, redis"
       - uv run flake8 src tests
     desc: |
-      Initialize dev env with all extras.
-      Syncs dev-minimal, test, nlp, ui, vss, git, distributed,
-      analysis, llm, and parsers extras by default.
+      Initialize dev env with minimal extras.
+      Syncs dev-minimal and test extras by default.
+      Provide optional groups with EXTRAS, e.g. "nlp" or "parsers".
       Set EXTRAS="gpu" to include optional GPU packages.
       Place matching wheels in wheels/gpu to avoid source builds.
   check-env:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -111,6 +111,11 @@ default and should be executed before any tests. Missing extras such as
 task install
 ```
 
+Tests use markers like `requires_nlp` or `requires_parsers` to signal
+additional dependencies. Install matching extras with `EXTRAS` when
+invoking `task install` or `AR_EXTRAS` with `scripts/setup.sh` before
+running those tests.
+
 Include extras only when required. Examples:
 
 ```bash

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -6,6 +6,15 @@ reliability of the test suite.
 
 For environment setup instructions see [installation](installation.md).
 
+Tests may require optional dependencies. Markers such as `requires_nlp` or
+`requires_parsers` map to extras with the same names. Install them by setting
+`EXTRAS` when running `task install` or `AR_EXTRAS` when invoking the setup
+script. `task verify` syncs all extras automatically:
+
+```bash
+EXTRAS="nlp parsers" task install
+```
+
 ## Test Organization
 
 Tests are organized into four categories:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Usage: ./scripts/setup.sh
+# Usage: AR_EXTRAS="nlp parsers" ./scripts/setup.sh
 # Verify Python 3.12+, confirm Go Task is installed, and sync dependencies.
 
 set -euo pipefail


### PR DESCRIPTION
## Summary
- Make `task install` sync only minimal extras and honor optional `EXTRAS`
- Clarify `scripts/setup.sh` usage and docs on installing extras for tests
- Explain how to install test extras in `testing_guidelines.md`

## Testing
- `uv run mkdocs build`
- `task install`
- `task verify` *(fails: ValueError: /workspace/autoresearch is not a valid URI from tests/targeted/test_extras_install.py::test_distributed_extra_imports)*

------
https://chatgpt.com/codex/tasks/task_e_68bd09e66dbc833381d84b022817dec6