### PR TITLE
Increase Hypothesis deadline for rate limit test

### DIFF
--- a/tests/unit/test_property_api_rate_limit_bounds.py
+++ b/tests/unit/test_property_api_rate_limit_bounds.py
@@ -15,7 +15,7 @@ from autoresearch.config.models import APIConfig, ConfigModel
     limit=st.integers(min_value=1, max_value=5),
     requests=st.integers(min_value=0, max_value=10),
 )
-@settings(deadline=100)
+@settings(deadline=500)
 def test_rate_limit_bounds(limit: int, requests: int) -> None:
     """Client never exceeds the configured request limit.
 


### PR DESCRIPTION
## Summary
- extend Hypothesis deadline in rate limit bounds property test to 500ms to avoid deadline failures

## Testing
- `uv run --extra test pytest tests/unit/test_property_api_rate_limit_bounds.py::test_rate_limit_bounds`
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9f439e0883338d2fc0f6a20f17ef