### PR TITLE
docs: clarify storage invariants and benchmarks

### DIFF
--- a/tests/integration/storage/test_simulation_benchmarks.py
+++ b/tests/integration/storage/test_simulation_benchmarks.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from scripts.storage_concurrency_sim import _run as concurrency_run
+
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel, StorageConfig
+from autoresearch import storage as storage_module
+from autoresearch.storage import StorageContext, StorageManager, StorageState
+
+
+def test_concurrency_benchmark() -> None:
+    remaining = concurrency_run(threads=2, items=3)
+    assert remaining == 0
+
+
+def _ram_budget_run(items: int) -> int:
+    cfg = ConfigModel(
+        storage=StorageConfig(
+            duckdb_path=":memory:", ontology_reasoner_max_triples=1
+        ),
+        ram_budget_mb=1,
+        graph_eviction_policy="lru",
+    )
+    loader = ConfigLoader.new_for_tests()
+    loader._config = cfg
+
+    st = StorageState()
+    ctx = StorageContext()
+    StorageManager.state = st
+    StorageManager.context = ctx
+
+    original = StorageManager._current_ram_mb
+    StorageManager._current_ram_mb = staticmethod(lambda: 1000)
+    original_reasoner = storage_module.run_ontology_reasoner
+    storage_module.run_ontology_reasoner = lambda *a, **k: None
+    try:
+        StorageManager.setup(db_path=":memory:", context=ctx, state=st)
+        for i in range(items):
+            StorageManager.persist_claim(
+                {"id": f"c{i}", "type": "fact", "content": "c"}
+            )
+            StorageManager._enforce_ram_budget(cfg.ram_budget_mb)
+        remaining = StorageManager.get_graph().number_of_nodes()
+    finally:
+        StorageManager.teardown(remove_db=True, context=ctx, state=st)
+        StorageManager.state = StorageState()
+        StorageManager.context = StorageContext()
+        StorageManager._current_ram_mb = original  # type: ignore[assignment]
+        storage_module.run_ontology_reasoner = original_reasoner
+        ConfigLoader.reset_instance()
+
+    return remaining
+
+
+def test_ram_budget_benchmark() -> None:
+    remaining = _ram_budget_run(items=5)
+    assert remaining == 0


### PR DESCRIPTION
## Summary
- document storage invariants with lock and eviction details
- add eviction termination sketch and RAM budget proof
- record simulation benchmarks and link new integration tests

## Testing
- `uv run mkdocs build` *(fails: PythonConfig.__init__() got an unexpected keyword argument 'selection')*
- `uv run --extra test pytest tests/integration/storage/test_simulation_benchmarks.py -q`
- `pre-commit run --files docs/specs/storage.md tests/integration/storage/test_simulation_benchmarks.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd9f47c4388333bb39554fe2c5d6aa