### PR TITLE
Add Redis-based coordination simulation tests and document orchestrator overhead

### DIFF
--- a/docs/orchestrator_perf.md
+++ b/docs/orchestrator_perf.md
@@ -18,7 +18,8 @@ Utilization:
 \(\rho = \lambda / (c\mu)\)
 
 Probability of zero tasks:
-\(P_0 = \Big(\sum_{n=0}^{c-1} (\lambda/\mu)^n / n! + (\lambda/\mu)^c /(c!(1-\rho))\Big)^{-1}\)
+\(P_0 = \Big(\sum_{n=0}^{c-1} (\lambda/\mu)^n / n! +\
+(\lambda/\mu)^c /(c!(1-\rho))\Big)^{-1}\)
 
 Average queue length:
 \(L_q = P_0 (\lambda/\mu)^c \rho / (c!(1-\rho)^2)\)
@@ -29,8 +30,19 @@ Wait time in queue:
 Total latency:
 \(L = d + W_q + 1/\mu\)
 
-## Example
+## Coordination Overhead
 
+Each task requires dispatch and result collection, adding coordination delay
+\(t_c\) per task. The effective service rate becomes
+\(\mu_{\text{eff}} = 1 / (1/\mu + t_c)\). The relative overhead is
+\(O = 1 - \mu_{\text{eff}}/\mu = t_c \mu / (1 + t_c \mu)\).
+Latency with coordination is
+\(L = d + W_q + 1/\mu_{\text{eff}}\).
+
+## Throughput and Latency Curves
+
+Throughput saturates at \(\min(\lambda, c\mu_{\text{eff}})\), while
+latency drops sharply once \(c\mu_{\text{eff}} > \lambda\).
 Example curves for \(\lambda = 120\) tasks/s, \(\mu = 50\) tasks/s, and
 \(d = 5\) ms are shown below.
 
@@ -42,11 +54,20 @@ Example curves for \(\lambda = 120\) tasks/s, \(\mu = 50\) tasks/s, and
 | 4 | 120 | 0.0286 |
 | 5 | 120 | 0.0259 |
 
+## Failure Recovery
+
+If a worker fails, remaining workers drain the queue. Throughput temporarily
+falls to \(\min(\lambda, (c-1)\mu_{\text{eff}})\) but no tasks are lost.
+Safety and liveness are preserved by the result aggregator. See
+[distributed coordination](algorithms/distributed_coordination.md) for more
+background.
+
 ## Benchmark
 
 We validated the analytical model with a discrete-event simulation running
 100 tasks while varying workers and adding 5 ms of dispatch latency. The
-throughput curve matches the \(\min(\lambda, c\mu)\) prediction, and
-latency decreases as workers scale.
+throughput curve matches the \(\min(\lambda, c\mu_{\text{eff}})\)
+prediction, and latency decreases as workers scale.
 
-![Benchmark throughput and latency](images/distributed_orchestrator_perf_benchmark.svg)
+![Benchmark throughput and latency]
+(images/distributed_orchestrator_perf_benchmark.svg)

--- a/tests/benchmark/distributed/test_redis_coordination_sim.py
+++ b/tests/benchmark/distributed/test_redis_coordination_sim.py
@@ -1,0 +1,83 @@
+"""Validate Redis-backed coordination via a simple simulation."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import List
+
+import pytest
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.requires_distributed,
+    pytest.mark.redis,
+]
+
+
+def run_redis_simulation(
+    redis_client,
+    workers: int,
+    tasks: int,
+    network_latency: float,
+    task_time: float,
+    fail_worker: bool = False,
+) -> dict[str, float]:
+    """Execute a Redis-based coordination simulation and return metrics."""
+    redis_client.flushdb()
+    for i in range(tasks):
+        redis_client.rpush("tasks", i)
+
+    results: List[int] = []
+    lock = threading.Lock()
+
+    def worker(idx: int) -> None:
+        processed = 0
+        while True:
+            item = redis_client.blpop(["tasks"], timeout=1)
+            if item is None:
+                break
+            time.sleep(network_latency)
+            time.sleep(task_time)
+            with lock:
+                results.append(int(item[1]))
+            processed += 1
+            if fail_worker and idx == 0 and processed >= tasks // workers:
+                return
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(workers)]
+    start = time.perf_counter()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    duration = time.perf_counter() - start
+    throughput = len(results) / duration if duration else float("inf")
+    return {"tasks": float(len(results)), "duration_s": duration, "throughput": throughput}
+
+
+def test_throughput_matches_theory(redis_client) -> None:
+    """Measured throughput follows 1/(task_time + latency) per worker."""
+    metrics = run_redis_simulation(
+        redis_client,
+        workers=2,
+        tasks=60,
+        network_latency=0.05,
+        task_time=0.01,
+    )
+    expected = 2 / (0.05 + 0.01)
+    assert metrics["throughput"] <= expected
+    assert metrics["throughput"] > expected * 0.5
+
+
+def test_failure_recovery(redis_client) -> None:
+    """Remaining workers drain the queue when one stops processing."""
+    metrics = run_redis_simulation(
+        redis_client,
+        workers=3,
+        tasks=30,
+        network_latency=0.0,
+        task_time=0.005,
+        fail_worker=True,
+    )
+    assert metrics["tasks"] == 30


### PR DESCRIPTION
## Summary
- expand orchestrator performance docs with coordination overhead formulas, throughput/latency curve notes, and failure recovery behavior
- add Redis-backed simulation suite validating throughput bounds and worker failure handling

## Testing
- `task check`
- `uv run --extra test --extra distributed pytest tests/benchmark/distributed -m slow -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9f4b886c8333a71fa39e695b703b