### PR TITLE
feat: add cross-platform container build script and docs

### DIFF
--- a/docs/container_usage.md
+++ b/docs/container_usage.md
@@ -6,16 +6,22 @@ contains all required wheels.
 
 ## Building images
 
-Use the release script to build images locally:
+Run the build script to create images for all platforms:
 
 ```
-./scripts/release_images.sh
+./scripts/build_images.sh
 ```
 
 Set `OFFLINE=1` to install from local wheels during the build:
 
 ```
-OFFLINE=1 ./scripts/release_images.sh
+OFFLINE=1 ./scripts/build_images.sh
+```
+
+Use the release script to build and push images:
+
+```
+./scripts/release_images.sh --push
 ```
 
 ## Running with docker compose

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -4,6 +4,16 @@
 # Set OFFLINE=1 to install from local wheels during the build.
 set -euo pipefail
 
+usage() {
+    echo "Usage: build_images.sh [EXTRAS]" >&2
+    echo "Set OFFLINE=1 to install from local wheels." >&2
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    usage
+    exit 0
+fi
+
 EXTRAS="${1:-full,test}"
 ENGINE="${CONTAINER_ENGINE:-docker}"
 OFFLINE="${OFFLINE:-0}"
@@ -13,12 +23,17 @@ if ! command -v "$ENGINE" >/dev/null 2>&1; then
     exit 1
 fi
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
 build_image() {
     local tag="$1"
     local file="$2"
     local platform="$3"
-    "$ENGINE" buildx build -f "$file" --build-arg EXTRAS="$EXTRAS" \
-        --build-arg OFFLINE="$OFFLINE" --platform "$platform" \
+    "$ENGINE" buildx build -f "$file" \
+        --build-arg EXTRAS="$EXTRAS" \
+        --build-arg OFFLINE="$OFFLINE" \
+        --platform "$platform" \
         -t "autoresearch-$tag" --load .
 }
 


### PR DESCRIPTION
## Summary
- add build_images.sh to build Linux, macOS, and Windows container images
- document container build and release scripts

## Testing
- `task check`
- `uv run mkdocs build`
- `task verify` *(fails: ValueError: /workspace/autoresearch is not a valid URI)*
- `docker build -f docker/Dockerfile.linux -t autoresearch-linux .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9f590a548333a247cd9be05ea75b