### PR TITLE
Add deployment validation and platform scripts

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -172,6 +172,13 @@ CONTAINER_ENGINE=docker uv run scripts/validate_deploy.py
 If any variable, file, or key is missing, the script exits with a non-zero
 status and lists the missing items.
 
+Use the platform helpers under `scripts/deploy/` to run the validator and the
+deployment helper in one step:
+
+- `bash scripts/deploy/linux.sh`
+- `bash scripts/deploy/macos.sh`
+- `pwsh scripts/deploy/windows.ps1`
+
 The validator also checks the schemas for both files and reports any
 violations. For example, `version` must be a string or integer and `KEY` cannot
 be empty.

--- a/scripts/deploy/linux.sh
+++ b/scripts/deploy/linux.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Usage: bash scripts/deploy/linux.sh
+# Validate configuration and deploy on Linux.
+set -euo pipefail
+
+uv run scripts/validate_deploy.py
+uv run python scripts/deploy.py

--- a/scripts/deploy/macos.sh
+++ b/scripts/deploy/macos.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Usage: bash scripts/deploy/macos.sh
+# Validate configuration and deploy on macOS.
+set -euo pipefail
+
+uv run scripts/validate_deploy.py
+uv run python scripts/deploy.py

--- a/scripts/deploy/windows.ps1
+++ b/scripts/deploy/windows.ps1
@@ -1,0 +1,10 @@
+#!/usr/bin/env pwsh
+<##
+.SYNOPSIS
+    Validate configuration and deploy on Windows.
+.DESCRIPTION
+    Runs validation and then executes the deployment helper.
+#>
+
+uv run scripts/validate_deploy.py
+uv run python scripts/deploy.py

--- a/tests/integration/test_validate_deploy.py
+++ b/tests/integration/test_validate_deploy.py
@@ -80,9 +80,7 @@ def test_validate_deploy_missing_env_key(tmp_path: Path) -> None:
 def test_validate_deploy_valid_extra(tmp_path: Path) -> None:
     _write_config(tmp_path)
     env = os.environ.copy()
-    env.update(
-        {"DEPLOY_ENV": "production", "CONFIG_DIR": str(tmp_path), "EXTRAS": "analysis"}
-    )
+    env.update({"DEPLOY_ENV": "production", "CONFIG_DIR": str(tmp_path), "EXTRAS": "analysis"})
     result = _run(env, tmp_path)
     assert result.returncode == 0
     assert "validated" in result.stdout.lower()
@@ -91,9 +89,7 @@ def test_validate_deploy_valid_extra(tmp_path: Path) -> None:
 def test_validate_deploy_unknown_extra(tmp_path: Path) -> None:
     _write_config(tmp_path)
     env = os.environ.copy()
-    env.update(
-        {"DEPLOY_ENV": "production", "CONFIG_DIR": str(tmp_path), "EXTRAS": "unknown"}
-    )
+    env.update({"DEPLOY_ENV": "production", "CONFIG_DIR": str(tmp_path), "EXTRAS": "unknown"})
     result = _run(env, tmp_path)
     assert result.returncode != 0
     assert "Unknown extras" in result.stderr
@@ -112,6 +108,25 @@ def test_validate_deploy_missing_container_engine(tmp_path: Path) -> None:
     result = _run(env, tmp_path)
     assert result.returncode != 0
     assert "Container engine" in result.stderr
+
+
+def test_validate_deploy_invalid_yaml(tmp_path: Path) -> None:
+    (tmp_path / "deploy.yml").write_text("version: [\n")
+    (tmp_path / ".env").write_text("KEY=value\n")
+    env = os.environ.copy()
+    env.update({"DEPLOY_ENV": "production", "CONFIG_DIR": str(tmp_path)})
+    result = _run(env, tmp_path)
+    assert result.returncode != 0
+    assert "Invalid YAML" in result.stderr
+
+
+def test_validate_deploy_duplicate_env_key(tmp_path: Path) -> None:
+    _write_config(tmp_path, env_content="KEY=one\nKEY=two\n")
+    env = os.environ.copy()
+    env.update({"DEPLOY_ENV": "production", "CONFIG_DIR": str(tmp_path)})
+    result = _run(env, tmp_path)
+    assert result.returncode != 0
+    assert "Duplicate key" in result.stderr
 
 
 @pytest.mark.parametrize("os_name", ["linux", "macos", "windows"])


### PR DESCRIPTION
## Summary
- harden deployment validator with YAML and env file checks
- add platform-specific deployment helpers for Linux, macOS, and Windows
- document validation flow and add tests for parse errors and duplicates

## Testing
- `uv run python scripts/run_task.py check` *(fails: Go Task is not installed)*
- `uv run python scripts/run_task.py verify` *(fails: Go Task is not installed)*
- `uv run black scripts/validate_deploy.py tests/integration/test_validate_deploy.py`
- `uv run flake8 scripts/validate_deploy.py tests/integration/test_validate_deploy.py`
- `uv run --extra test pytest tests/integration/test_validate_deploy.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdac6d10108333a6d4143b53324d44