### PR TITLE
Add Go Task installation guidance and env checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,17 @@ task check
 syncs the `dev-minimal` and `test` extras. It exits with an error if Go Task is
 missing or the dependency sync fails.
 
-Install Go Task manually if it is not on `PATH`:
+Install Go Task manually if it is not on `PATH` and verify the installation:
 
 ```bash
 curl -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
 # macOS: brew install go-task/tap/go-task
+```
+
+Confirm Go Task is available:
+
+```bash
+task --version
 ```
 
 Optional extras provide features such as NLP, a UI, or distributed

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,11 +31,18 @@ source .venv/bin/activate
 
 Run `./scripts/bootstrap.sh` to install Go Task without syncing extras. It
 places the `task` binary in `.venv/bin` and requires adding that directory to
-`PATH`. If the script fails or you want a system-wide binary, install manually:
+`PATH`. If the script fails or you want a system-wide binary, install
+manually and confirm the installation:
 
 ```bash
 curl -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
 # macOS: brew install go-task/tap/go-task
+```
+
+Verify Go Task is installed:
+
+```bash
+task --version
 ```
 
 `task install` also checks for Go Task and downloads it to `.venv/bin` when

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,10 +29,12 @@ check_go_task() {
         echo "Go Task not found. Install it from https://taskfile.dev/" >&2
         exit 1
     fi
-    task --version >/dev/null 2>&1 || {
+    local version
+    if ! version=$(task --version 2>/dev/null); then
         echo "Go Task installation is broken; reinstall it." >&2
         exit 1
-    }
+    fi
+    echo "$version"
 }
 
 ensure_uv() {

--- a/tests/unit/test_check_env_warnings.py
+++ b/tests/unit/test_check_env_warnings.py
@@ -40,6 +40,15 @@ def test_missing_pytest_bdd_warns(monkeypatch):
     assert result is None
 
 
+def test_missing_go_task_detected(monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(check_env.subprocess, "run", fake_run)
+    with pytest.raises(check_env.VersionError, match="Go Task"):
+        check_env.check_task()
+
+
 def test_main_ignores_missing_metadata(monkeypatch, capsys):
     monkeypatch.setattr(check_env, "EXTRA_REQUIREMENTS", {"fakepkg": "1.0"})
     monkeypatch.setattr(check_env, "REQUIREMENTS", {"fakepkg": "1.0"})


### PR DESCRIPTION
## Summary
- document Go Task installation and version verification in README and installation guide
- verify `task --version` during setup and surface version
- add unit test ensuring missing Go Task raises a VersionError

## Testing
- `uv run mkdocs build`
- `task check`
- `uv run pytest tests/unit/test_check_env_warnings.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdac851fbc83339cb7b21b1a74e570