### PR TITLE
Initialize metrics before monitor CLI commands

### DIFF
--- a/tests/unit/test_monitor_metrics_init.py
+++ b/tests/unit/test_monitor_metrics_init.py
@@ -1,0 +1,17 @@
+from typer.testing import CliRunner
+
+from autoresearch.main import app as cli_app
+
+
+def test_monitor_cli_initializes_metrics(monkeypatch):
+    called = {"done": False}
+
+    def fake_init() -> None:
+        called["done"] = True
+
+    monkeypatch.setattr("autoresearch.monitor.orch_metrics.ensure_counters_initialized", fake_init)
+    monkeypatch.setattr("autoresearch.monitor._collect_system_metrics", lambda: {})
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["monitor", "metrics"])
+    assert result.exit_code == 0
+    assert called["done"]


### PR DESCRIPTION
## Summary
- ensure orchestration counters are initialized before any `monitor` subcommand runs
- add regression test for metric initialization
- adjust monitor integration tests for new initialization behavior

## Testing
- `uv run --extra test pytest tests/unit/test_monitor_metrics_init.py tests/integration/test_monitor_metrics.py::test_monitor_resources_cli -q`
- `uv run --extra test pytest -m slow tests/integration/test_monitor_metrics.py::test_monitor_start_cli tests/integration/test_monitor_metrics.py::test_monitor_cli_increments_counter -q`
- `uv run --extra test black --check src/autoresearch/monitor/__init__.py tests/unit/test_monitor_metrics_init.py tests/integration/test_monitor_metrics.py`
- `uv run --extra test flake8 src/autoresearch/monitor/__init__.py tests/unit/test_monitor_metrics_init.py tests/integration/test_monitor_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdd5ccdee8833396b1ae49818184f2