### PR TITLE
Add distributed orchestrator recovery simulation and docs

### DIFF
--- a/docs/algorithms/distributed_overhead.md
+++ b/docs/algorithms/distributed_overhead.md
@@ -1,0 +1,18 @@
+# Distributed Overhead and Scalability
+
+Network delay `d`, service time `s`, and failure probability `p` drive overhead.
+Each task executes once on success and once more on failure. The expected number
+of executions per task is
+
+$$E[e] = \frac{1}{1-p}.$$
+
+Average latency combines dispatch and service time with retry overhead:
+
+$$T = (d + s) E[e] = \frac{d + s}{1 - p}.$$
+
+With `w` workers the throughput upper bound becomes
+
+$$\Theta \le \frac{w (1 - p)}{d + s}.$$
+
+This complements the [distributed orchestrator performance](distributed_perf.md)
+model by adding failure cost.

--- a/docs/specs/distributed.md
+++ b/docs/specs/distributed.md
@@ -15,6 +15,9 @@ coalition and scheduling details.
   urgent work executes first.
 - Detailed complexity and performance models appear in
   [distributed coordination][dc].
+- Failure recovery adds an overhead factor `1/(1-p)` as described in
+  [distributed overhead](../algorithms/distributed_overhead.md) and modeled by
+  [`orchestrator_distributed_sim.py`][sim].
 
 ## Invariants
 
@@ -38,7 +41,9 @@ coalition and scheduling details.
 
 ## Simulation Expectations
 
-Unit tests cover nominal and edge cases for these routines.
+Unit tests cover nominal and edge cases for these routines. Benchmarks such as
+[distributed_recovery_benchmark.py][drb] record CPU and memory usage during
+retries.
 
 ## Traceability
 
@@ -51,6 +56,7 @@ Unit tests cover nominal and edge cases for these routines.
   - [tests/unit/test_distributed_extra.py][t3]
   - [tests/analysis/test_distributed_coordination.py][t4]
   - [tests/unit/distributed/test_coordination_properties.py][t5]
+  - [tests/benchmark/test_orchestrator_distributed_sim.py][t6]
 
 [m1]: ../../src/autoresearch/distributed/
 [t1]: ../../tests/integration/test_distributed_agent_storage.py
@@ -58,5 +64,9 @@ Unit tests cover nominal and edge cases for these routines.
 [t3]: ../../tests/unit/test_distributed_extra.py
 [t4]: ../../tests/analysis/test_distributed_coordination.py
 [t5]: ../../tests/unit/distributed/test_coordination_properties.py
+[t6]: ../../tests/benchmark/test_orchestrator_distributed_sim.py
+
+[drb]: ../../scripts/distributed_recovery_benchmark.py
+[sim]: ../../scripts/orchestrator_distributed_sim.py
 
 [dc]: ../algorithms/distributed_coordination.md

--- a/scripts/distributed_recovery_benchmark.py
+++ b/scripts/distributed_recovery_benchmark.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Benchmark recovery overhead in a distributed orchestrator.
+
+Usage:
+    uv run scripts/distributed_recovery_benchmark.py --workers 2 --tasks 100 \
+        --fail-rate 0.1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from scripts.orchestrator_distributed_sim import run_simulation
+
+
+def main(workers: int, tasks: int, fail_rate: float) -> dict[str, float]:
+    """Execute benchmark and print summary metrics."""
+
+    metrics = run_simulation(workers=workers, tasks=tasks, fail_rate=fail_rate)
+    print(
+        json.dumps(
+            {
+                "throughput": metrics["throughput"],
+                "recovery_ratio": metrics["recovery_ratio"],
+                "cpu_percent": metrics["cpu_percent"],
+                "memory_mb": metrics["memory_mb"],
+            }
+        )
+    )
+    return metrics
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Distributed recovery benchmark")
+    parser.add_argument("--workers", type=int, default=2, help="worker processes")
+    parser.add_argument("--tasks", type=int, default=100, help="tasks to execute")
+    parser.add_argument("--fail-rate", type=float, default=0.1, help="failure probability per task")
+    args = parser.parse_args()
+    main(args.workers, args.tasks, args.fail_rate)

--- a/scripts/orchestrator_distributed_sim.py
+++ b/scripts/orchestrator_distributed_sim.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Simulate distributed orchestrator with failure recovery.
+
+Usage:
+    uv run scripts/orchestrator_distributed_sim.py --workers 2 --tasks 100 \
+        --network-latency 0.005 --task-time 0.01 --fail-rate 0.1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import time
+from concurrent.futures import ProcessPoolExecutor
+from itertools import repeat
+
+from autoresearch.resource_monitor import ResourceMonitor
+
+
+def _handle_task(network_latency: float, task_time: float, fail_rate: float) -> int:
+    """Execute a task and simulate a single retry on failure.
+
+    Returns 1 when a recovery path executes, 0 otherwise.
+    """
+
+    time.sleep(network_latency)
+    if random.random() < fail_rate:
+        # Retry once after another dispatch delay and service time.
+        time.sleep(network_latency)
+        time.sleep(task_time)
+        return 1
+    time.sleep(task_time)
+    return 0
+
+
+def run_simulation(
+    workers: int,
+    tasks: int,
+    network_latency: float = 0.005,
+    task_time: float = 0.005,
+    fail_rate: float = 0.0,
+) -> dict[str, float]:
+    """Process tasks across workers, collecting performance and recovery metrics.
+
+    Args:
+        workers: Number of worker processes.
+        tasks: Total tasks to dispatch.
+        network_latency: Simulated dispatch latency per task in seconds.
+        task_time: Simulated processing time per task in seconds.
+        fail_rate: Probability a task fails once and requires recovery.
+
+    Returns:
+        Dictionary with average latency, throughput, CPU percentage, memory usage,
+        and recovery ratio.
+    """
+
+    if (
+        workers <= 0
+        or tasks <= 0
+        or network_latency < 0
+        or task_time <= 0
+        or not 0.0 <= fail_rate < 1.0
+    ):
+        raise SystemExit(
+            "workers, tasks, latency, and task_time must be > 0;"
+            " fail_rate must satisfy 0 <= fail_rate < 1"
+        )
+
+    monitor = ResourceMonitor(interval=0.05)
+    monitor.start()
+    start = time.perf_counter()
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        recoveries = sum(
+            executor.map(
+                _handle_task,
+                repeat(network_latency, tasks),
+                repeat(task_time, tasks),
+                repeat(fail_rate, tasks),
+            )
+        )
+    duration = time.perf_counter() - start
+    monitor.stop()
+
+    throughput = tasks / duration if duration > 0 else float("inf")
+    avg_latency = duration / tasks
+    cpu = float(monitor.cpu_gauge._value.get())
+    mem = float(monitor.mem_gauge._value.get())
+    recovery_ratio = recoveries / tasks
+    return {
+        "avg_latency_s": avg_latency,
+        "throughput": throughput,
+        "cpu_percent": cpu,
+        "memory_mb": mem,
+        "recovery_ratio": recovery_ratio,
+    }
+
+
+def main(
+    workers: int,
+    tasks: int,
+    network_latency: float,
+    task_time: float,
+    fail_rate: float,
+) -> dict[str, float]:
+    """Run the simulation and print summary metrics."""
+
+    metrics = run_simulation(
+        workers=workers,
+        tasks=tasks,
+        network_latency=network_latency,
+        task_time=task_time,
+        fail_rate=fail_rate,
+    )
+    print(json.dumps(metrics))
+    return metrics
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Distributed orchestrator simulation with recovery"
+    )
+    parser.add_argument("--workers", type=int, default=2, help="number of worker processes")
+    parser.add_argument("--tasks", type=int, default=100, help="tasks to schedule")
+    parser.add_argument(
+        "--network-latency",
+        type=float,
+        default=0.005,
+        help="simulated dispatch latency per task (s)",
+    )
+    parser.add_argument(
+        "--task-time", type=float, default=0.005, help="simulated compute time per task (s)"
+    )
+    parser.add_argument(
+        "--fail-rate",
+        type=float,
+        default=0.0,
+        help="probability a task fails and triggers recovery",
+    )
+    args = parser.parse_args()
+    main(args.workers, args.tasks, args.network_latency, args.task_time, args.fail_rate)

--- a/tests/benchmark/test_orchestrator_distributed_sim.py
+++ b/tests/benchmark/test_orchestrator_distributed_sim.py
@@ -1,0 +1,29 @@
+"""Validate recovery metrics in the distributed orchestrator simulation."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.orchestrator_distributed_sim import run_simulation
+
+pytestmark = [pytest.mark.slow]
+
+
+def test_recovery_ratio_reflects_fail_rate() -> None:
+    """Observed recovery ratio approximates the specified failure rate."""
+    metrics = run_simulation(
+        workers=2,
+        tasks=50,
+        network_latency=0.01,
+        task_time=0.005,
+        fail_rate=0.2,
+    )
+    assert metrics["recovery_ratio"] == pytest.approx(0.2, rel=0.5)
+
+
+def test_invalid_parameters_raise() -> None:
+    """Invalid arguments exit with an error."""
+    with pytest.raises(SystemExit):
+        run_simulation(workers=0, tasks=10)
+    with pytest.raises(SystemExit):
+        run_simulation(workers=1, tasks=10, fail_rate=1.0)


### PR DESCRIPTION
## Summary
- simulate distributed orchestrator with failure recovery and resource metrics
- benchmark recovery overhead and document distributed overhead formulas
- test and spec updates for distributed recovery behavior

## Testing
- `task install` *(fails: command not found)*
- `uv run black scripts/orchestrator_distributed_sim.py scripts/distributed_recovery_benchmark.py tests/benchmark/test_orchestrator_distributed_sim.py`
- `uv run flake8 scripts/orchestrator_distributed_sim.py scripts/distributed_recovery_benchmark.py tests/benchmark/test_orchestrator_distributed_sim.py` *(fails: No such file or directory)*
- `uv run mkdocs build` *(fails: No such file or directory)*
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run pytest -m slow tests/benchmark/test_orchestrator_distributed_sim.py`


------
https://chatgpt.com/codex/tasks/task_e_68be13a797bc83339f3af0d075cff9b7