### PR TITLE
docs: document core domain model

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 This roadmap summarizes planned features for upcoming releases.
 Dates and milestones align with the [release plan](docs/release_plan.md).
 Installation and environment details are covered in the [README](README.md).
-Last updated **September 3, 2025**.
+Last updated **September 7, 2025**.
 
 ## Status
 
@@ -96,6 +96,7 @@ activities include:
 - Running all unit, integration and behavior tests (see [STATUS.md](STATUS.md)).
 - Finalizing API reference and user guides.
 - Verifying packaging metadata and TestPyPI uploads.
+- Document domain model for agents, queries, storage, and search.
 
 Type checking and unit tests currently fail; see [STATUS.md](STATUS.md) for
 details. The **0.1.0** milestone is targeted for **July 1, 2026** while

--- a/docs/domain_model.md
+++ b/docs/domain_model.md
@@ -1,0 +1,45 @@
+# Domain Model
+
+This document maps the core bounded contexts in Autoresearch and their
+relationships.
+
+## Agents
+
+Agents drive the dialectical reasoning cycle. Each agent implements the base
+interface and uses prompts and models defined in `AgentConfig`.
+
+- Spec: [specs/agents.md](specs/agents.md)
+- Code: [../src/autoresearch/agents/base.py](../src/autoresearch/agents/base.py)
+
+## Queries
+
+Queries define user intent and orchestrator responses. `QueryRequest` captures
+incoming parameters, while `QueryResponse` records final answers.
+
+- Spec: [specs/models.md](specs/models.md)
+- Code: [../src/autoresearch/models.py](../src/autoresearch/models.py)
+
+## Storage
+
+Storage persists claims and supports graph and vector retrieval via a unified
+`StorageManager` over NetworkX, DuckDB, and RDFLib backends.
+
+- Spec: [specs/storage.md](specs/storage.md)
+- Code: [../src/autoresearch/storage.py](../src/autoresearch/storage.py)
+
+## Search
+
+Search generates query variants and federates lookups across registered
+backends, caching results and ranking sources.
+
+- Spec: [specs/search.md](specs/search.md)
+- Code: [../src/autoresearch/search/core.py](../src/autoresearch/search/core.py)
+
+## Relationships
+
+- Agents create `QueryRequest` objects and consume `QueryResponse` results.
+- Search uses queries to gather data and may persist findings through Storage.
+- Storage indexes content that Search retrieves and ranks.
+- Agents rely on Search for external knowledge and on Storage for accumulated
+  claims.
+


### PR DESCRIPTION
## Summary
- draft domain model for agents, queries, storage, and search with cross-links to specs and code
- update roadmap milestone to include domain model documentation

## Testing
- `task check`
- `task verify` *(fails: tests/unit/test_main_monitor_commands.py::test_monitor_command - assert 2 == 0)*
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68be177257c083339fe07071e7b8df1b