### PR TITLE
docs: record failing checks and reopen task cli issue

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,15 @@
 # Status
 
+## September 8, 2025
+
+- `uv run flake8 src tests` failed: command not found.
+- `uv run mypy src` succeeded with no issues.
+- `task verify` and `task coverage` could not run because the `task` CLI is
+  missing even after `scripts/codex_setup.sh`.
+- `uv run python scripts/publish_dev.py --dry-run --repository testpypi`
+  built the package and skipped upload.
+- Release remains blocked pending environment setup and passing tests.
+
 ## September 7, 2025
 
 - Installed test extras with `uv pip install -e "[test]"` to enable plugins.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,10 +1,12 @@
 # Autoresearch Project - Task Progress
 
 This document tracks the progress of tasks for the Autoresearch project,
-organized by phases from the code complete plan. As of **August 27, 2025**, see
+organized by phases from the code complete plan. As of **September 8, 2025**, `flake8`
+is missing, `mypy` passes, and `task verify` and `task coverage` cannot run
+because the Task CLI is unavailable. See
 [docs/release_plan.md](docs/release_plan.md) for current test and coverage
 status. An **0.1.0-alpha.1** preview is re-targeted for **2026-06-15**, with the
-final **0.1.0** release targeted for **July 1, 2026**.
+final **0.1.0** release targeted for **July 1, 2026**.
 
 ## Phase 1: Core System Completion (Weeks 1-2)
 

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -9,7 +9,7 @@ The publishing workflow follows the steps in
 [ROADMAP.md](../ROADMAP.md) for high-level milestones.
 
 The project kicked off in **May 2025** (see the initial commit dated
-`2025-05-18`). This schedule was last updated on **September 7, 2025** and
+`2025-05-18`). This schedule was last updated on **September 8, 2025** and
 reflects that the codebase currently sits at the **unreleased 0.1.0a1** version
 defined in `autoresearch.__version__`. Phase 3
 (stabilization/testing/documentation) and Phase 4 activities remain planned.
@@ -17,13 +17,12 @@ defined in `autoresearch.__version__`. Phase 3
 ## Status
 
 The dependency pins for `fastapi` (>=0.115.12) and `slowapi` (==0.1.9) are
-confirmed in `pyproject.toml` and [installation.md](installation.md).
-`flake8` and `mypy` pass. `uv run pytest -q` reports 35 failing tests out of
-1280 collected. Coverage reports **100%** (57/57 lines) for targeted modules.
-Instrumentation and skipping slow tests resolved earlier coverage hangs.
-Outstanding gaps are tracked in
-[resolve-pre-alpha-release-blockers][coverage-gap-issue]. Current test results
-are mirrored in [../STATUS.md](../STATUS.md).
+confirmed in `pyproject.toml` and [installation.md](installation.md). `uv run
+flake8 src tests` failed because `flake8` is missing, while `uv run mypy src`
+reports success. The `task` CLI is unavailable, so `task verify` and `task
+coverage` could not run. A dry-run publish built the package and skipped
+upload. Outstanding gaps are tracked in [integration-issue] and [task-issue].
+Current test results are mirrored in [../STATUS.md](../STATUS.md).
 
 ## Milestones
 
@@ -62,8 +61,8 @@ while packaging tasks are resolved.
 - [ ] Confirm STATUS.md and this plan share the same coverage details before
   tagging. CI runs `scripts/update_coverage_docs.py` after `task coverage` to
   sync the value.
-- [x] Ensure Task CLI available ([restore-task-cli-availability](
-  ../issues/archive/restore-task-cli-availability.md)).
+- [ ] Ensure Task CLI available ([restore-task-cli-availability](
+  ../issues/restore-task-cli-availability.md)).
 - [x] Resolve coverage hang ([fix-task-verify-coverage-hang](
   ../issues/archive/fix-task-verify-coverage-hang.md)).
 
@@ -72,9 +71,10 @@ These tasks completed in order: environment bootstrap → packaging verification
 
 ### Prerequisites for tagging 0.1.0a1
 
-- `flake8` and `mypy` pass, but several unit and integration tests still fail.
-- After resolving the ImportError in `task`, current coverage is **100%**;
-  documentation reflects this result.
+- `uv run flake8 src tests` failed: command not found.
+- `uv run mypy src` passed with no issues.
+- `task verify` and `task coverage` could not run because the `task` CLI is
+  unavailable.
 - Dry-run publish to TestPyPI succeeded using `uv run scripts/publish_dev.py`
   with `--dry-run --repository testpypi`.
 
@@ -123,3 +123,5 @@ skips GPU-only packages unless `EXTRAS="gpu"` is set:
   syncs docs with `baseline/coverage.xml`
 
 [coverage-gap-issue]: ../issues/archive/resolve-pre-alpha-release-blockers.md
+[integration-issue]: ../issues/resolve-current-integration-test-failures.md
+[task-issue]: ../issues/restore-task-cli-availability.md

--- a/issues/resolve-current-integration-test-failures.md
+++ b/issues/resolve-current-integration-test-failures.md
@@ -10,6 +10,9 @@ The storage eviction simulation tuple mismatch was resolved on 2025-09-07, and t
 `test_property_api_rate_limit_bounds` deadline issue is fixed. These regressions continue to block
 the 0.1.0a1 preview.
 
+As of 2025-09-08, the `task` CLI is missing, preventing `task verify` from
+running and revalidating integration tests.
+
 ## Dependencies
 - [fix-gitpython-integration-tests](fix-gitpython-integration-tests.md)
 - [fix-monitor-resources-cli-test](fix-monitor-resources-cli-test.md)

--- a/issues/restore-task-cli-availability.md
+++ b/issues/restore-task-cli-availability.md
@@ -1,9 +1,10 @@
 # Restore task cli availability
 
 ## Context
-The environment originally lacked the `task` command, preventing `task check`
-and `task verify` from running. Setup now installs Go Task so both commands can
-execute.
+The environment lacks the `task` command, preventing `task check`, `task verify`,
+and `task coverage` from running. Attempts to run `scripts/setup.sh` and
+`scripts/codex_setup.sh` report "Go Task not found." This issue tracks restoring
+the CLI.
 
 ## Dependencies
 None.
@@ -14,4 +15,4 @@ None.
 - `task check` and `task verify` run successfully in a clean environment.
 
 ## Status
-Archived
+Open


### PR DESCRIPTION
## Summary
- log failing flake8 and missing task CLI in STATUS and release docs
- note unavailable verification tooling in task progress and integration issue
- reopen restore-task-cli-availability issue for missing task command

## Testing
- `uv run flake8 src tests` *(fails: No such file or directory)*
- `uv run mypy src`
- `task verify` *(fails: command not found)*
- `task coverage` *(fails: command not found)*
- `uv run mkdocs build` *(fails: command not found)*
- `uv run python scripts/publish_dev.py --dry-run --repository testpypi`


------
https://chatgpt.com/codex/tasks/task_e_68be1f08dc8083339accfb07e9f575e9