### PR TITLE
Reopen Task CLI issue and track flake8 verification failure

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,9 @@
 
 ## September 8, 2025
 
+- `task check` passes after adding Go Task to the `PATH`.
+- `task verify` fails during flake8 with unused imports in
+  `tests/unit/test_ui_save_config.py` and `tests/unit/test_vss_has_vss.py`.
 - Installed Go Task 3.44.1 and synchronized `dev-minimal` and `test` extras.
 - `task check` succeeded.
 - `task verify` failed at

--- a/issues/fix-flake8-errors-in-tests.md
+++ b/issues/fix-flake8-errors-in-tests.md
@@ -1,0 +1,16 @@
+# Fix flake8 errors in tests
+
+## Context
+`task verify` fails flake8 because `tests/unit/test_ui_save_config.py` and
+`tests/unit/test_vss_has_vss.py` include unused imports.
+
+## Dependencies
+None.
+
+## Acceptance Criteria
+- Remove unused imports or apply proper suppression so flake8 reports no F401
+  errors in these tests.
+- `task verify` completes the flake8 stage without failures.
+
+## Status
+Open

--- a/issues/restore-task-cli-availability.md
+++ b/issues/restore-task-cli-availability.md
@@ -15,4 +15,4 @@ None.
 - `task check` and `task verify` run successfully in a clean environment.
 
 ## Status
-Archived
+Open


### PR DESCRIPTION
## Summary
- Reopen Task CLI availability ticket since environment still lacks the `task` command by default
- Document flake8 failures in tests and add a dedicated issue
- Note current verification status in STATUS.md

## Testing
- `task check`
- `task verify` *(fails: F401 unused imports in tests/unit/test_ui_save_config.py and tests/unit/test_vss_has_vss.py)*

------
https://chatgpt.com/codex/tasks/task_e_68be6160938883338caacf61fa857252