### PR TITLE
chore: remove unused imports in unit tests

### DIFF
--- a/tests/unit/test_ui_save_config.py
+++ b/tests/unit/test_ui_save_config.py
@@ -1,7 +1,6 @@
 import importlib
 import sys
 import types
-import os
 
 import pytest
 

--- a/tests/unit/test_vss_has_vss.py
+++ b/tests/unit/test_vss_has_vss.py
@@ -1,5 +1,4 @@
 import pytest
-from types import SimpleNamespace
 
 from autoresearch import storage
 
@@ -7,6 +6,7 @@ from autoresearch import storage
 @pytest.mark.requires_vss
 def test_has_vss_with_dummy_backend(monkeypatch):
     """StorageManager.has_vss should reflect backend capability."""
+
     class DummyBackend:
         def __init__(self, flag: bool) -> None:
             self._flag = flag


### PR DESCRIPTION
## Summary
- remove unused os import from test_ui_save_config
- drop unused SimpleNamespace import from test_vss_has_vss

## Testing
- `uvx flake8 tests/unit/test_ui_save_config.py tests/unit/test_vss_has_vss.py`


------
https://chatgpt.com/codex/tasks/task_e_68be650f4d7c83339fdd1313816cfd80