### PR TITLE
Validate deploy scans config directory

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,6 +4,23 @@ Autoresearch can be deployed in several ways depending on your needs. This guide
 
 The project uses **uv** for dependency management. Example commands use `uv`.
 
+## Preflight Checks
+
+Verify configuration before deploying:
+
+- Set `DEPLOY_ENV` and `CONFIG_DIR` to select the configuration set.
+- Run the validator:
+
+  ```bash
+  uv run scripts/validate_deploy.py
+  ```
+
+  It scans every `.env` and `*.yml` file under `scripts/deploy/` and reports
+  schema violations.
+
+Proceed with the deployment steps only after the command exits without
+errors.
+
 ## Local Installation
 
 For personal use, run Autoresearch directly on your machine. Install the dependencies and invoke the CLI or API:


### PR DESCRIPTION
## Summary
- scan all `.env` and YAML files in the deploy directory and validate each
- add integration coverage for multiple config sets
- document deployment preflight validation

## Testing
- `task check`
- `task verify` *(fails: DeadlineExceeded in tests/unit/distributed/test_coordination_properties.py)*
- `uv run pytest tests/integration/test_validate_deploy.py::test_validate_deploy_scans_all_configs tests/integration/test_validate_deploy.py::test_validate_deploy_scans_and_fails -q`


------
https://chatgpt.com/codex/tasks/task_e_68be6965129483338874ef6e14c8f759