### PR TITLE
Add interfaces spec and QueryStateLike tests

### DIFF
--- a/docs/specs/interfaces.md
+++ b/docs/specs/interfaces.md
@@ -1,0 +1,43 @@
+# Interfaces
+
+## Overview
+
+Common project interfaces unify orchestration components. `CallbackMap` maps
+hook names to callables. `QueryStateLike` defines the contract for state objects
+shared across dialectical cycles.
+
+## Algorithms
+
+- Callback dispatch uses `CallbackMap` to invoke registered hooks.
+- `QueryStateLike.update` merges agent results into the state.
+- `QueryStateLike.synthesize` composes a `QueryResponse` from accumulated
+  data.
+
+## Invariants
+
+- `cycle` monotonically increases and starts at zero.
+- Implementations retain previously collected claims, sources, and metadata.
+- `synthesize` must return a `QueryResponse` object.
+
+## Proof Sketch
+
+`QueryStateLike` requires `update` and `synthesize`, ensuring every state object
+can absorb new information and produce final responses. Maintaining the `cycle`
+attribute and preserving context uphold the invariants across orchestrator
+steps.
+
+## Simulation Expectations
+
+Unit tests instantiate compliant and non-compliant objects. They verify
+`QueryState` and a minimal toy implementation satisfy the protocol while a
+partial implementation fails runtime checks.
+
+## Traceability
+
+- Modules
+  - [src/autoresearch/interfaces.py][m1]
+- Tests
+  - [tests/unit/test_interfaces.py][t1]
+
+[m1]: ../../src/autoresearch/interfaces.py
+[t1]: ../../tests/unit/test_interfaces.py

--- a/src/autoresearch/interfaces.py
+++ b/src/autoresearch/interfaces.py
@@ -1,4 +1,7 @@
-"""Common interfaces shared across the project."""
+"""Common interfaces shared across the project.
+
+Spec: docs/specs/interfaces.md
+"""
 
 from __future__ import annotations
 

--- a/tests/unit/test_interfaces.py
+++ b/tests/unit/test_interfaces.py
@@ -1,0 +1,42 @@
+"""Interface protocol tests.
+
+Spec: docs/specs/interfaces.md
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from autoresearch.interfaces import QueryStateLike
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.state import QueryState
+
+
+def test_query_state_complies() -> None:
+    state = QueryState(query="test")
+    assert isinstance(state, QueryStateLike)
+
+
+def test_custom_state_complies() -> None:
+    @dataclass
+    class ToyState:
+        cycle: int = 0
+
+        def update(self, result: dict[str, object]) -> None:  # pragma: no cover
+            self.data = result
+
+        def synthesize(self) -> QueryResponse:  # pragma: no cover
+            return QueryResponse(answer="", citations=[], reasoning=[], metrics={})
+
+    assert isinstance(ToyState(), QueryStateLike)
+
+
+def test_incomplete_state_rejected() -> None:
+    class BrokenState:
+        cycle = 0
+
+        def update(self, result: dict[str, object]) -> None:  # pragma: no cover
+            self.data = result
+
+    assert not isinstance(BrokenState(), QueryStateLike)
+


### PR DESCRIPTION
## Summary
- Document interface contracts and invariants in a new spec for QueryStateLike.
- Link the spec from the shared interfaces module.
- Validate QueryStateLike compliance with new unit tests.

## Testing
- `task check`
- `uv run --extra test pytest tests/unit/test_interfaces.py -q`
- `uv run pre-commit run --files docs/specs/interfaces.md src/autoresearch/interfaces.py tests/unit/test_interfaces.py`


------
https://chatgpt.com/codex/tasks/task_e_68beec8429808333a1217bf5a0d015c8