### PR TITLE
refine verify extras and document heavy opt-ins

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -213,17 +213,20 @@ tasks:
       Provide optional groups with EXTRAS; include "gpu" to use wheels/gpu.
 
   verify:
+    vars:
+      EXTRAS: "{{.EXTRAS | default \"\"}}"
     cmds:
       - |
           uv sync \
             --python-platform x86_64-manylinux_2_28 \
             --extra dev-minimal \
-            --extra test
-      - task check-env
+            --extra test \
+            {{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{if (contains .EXTRAS "gpu")}} --find-links wheels/gpu{{end}}{{end}}
+      - task check-env EXTRAS="{{.EXTRAS}}"
       - uv run flake8 src tests
       - uv run mypy src
       - uv run python scripts/check_spec_tests.py
-      - task: coverage
+      - task: coverage EXTRAS="{{.EXTRAS}}"
       - uv run coverage html
       - uv run coverage report --fail-under={{.COVERAGE_MINIMUM}}
       - uv run python scripts/check_token_regression.py --threshold 5
@@ -231,7 +234,8 @@ tasks:
       - uv run pytest tests/benchmark -m "slow and requires_distributed and requires_analysis" -q
     desc: |
       Run linting, type checks, targeted tests, and coverage.
-      Syncs only the dev-minimal and test extras.
+      Syncs only the dev-minimal and test extras by default.
+      Provide optional groups with EXTRAS; include "gpu" to use wheels/gpu.
 
   clean:
     cmds:

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -9,10 +9,12 @@ For environment setup instructions see [installation](installation.md).
 Tests may require optional dependencies. Markers such as `requires_nlp` or
 `requires_parsers` map to extras with the same names. `task install` syncs only
 the `dev-minimal` extra; add groups with `EXTRAS` or set `AR_EXTRAS`
-when using the setup script. `task verify` syncs all extras automatically:
+when using the setup script. `task verify` installs only the `dev-minimal`
+and `test` extras. Include heavy groups by setting `EXTRAS`:
 
 ```bash
 EXTRAS="test nlp parsers" task install
+EXTRAS="nlp parsers" task verify
 ```
 
 Available extras enable optional features:
@@ -48,9 +50,9 @@ Two installation strategies support different workflows:
   subset. It syncs only the `dev-minimal` extra. Add optional features with
   `task install EXTRAS="test nlp ui"` choosing from `analysis`, `distributed`,
   `git`, `llm`, `nlp`, `parsers`, `ui`, `vss`, `gpu`, and `test`.
-- **Full:** `task verify` requires the `dev` and `test` extras and executes the
-  targeted suite with coverage. Install them with `uv sync --extra dev --extra
-  test` and append extras as needed for integration scenarios.
+- **Full:** `task verify` runs linting, type checks, and coverage. It installs
+  the `dev-minimal` and `test` extras by default. Append optional groups with
+  `EXTRAS` for integration scenarios.
 
 `task check` offers fast feedback, while `task verify` enforces coverage and is
 expected before committing.


### PR DESCRIPTION
## Summary
- allow `task verify` to accept optional extras while defaulting to only `dev-minimal` and `test`
- describe how to opt into heavy extras using the `EXTRAS` variable in testing guidelines

## Testing
- `task check`
- `uv run mkdocs build`
- `task verify` *(fails: tests/unit/test_search.py:27:1: E305 expected 2 blank lines after class or function definition, found 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7e25c4a08333bb161883d5de4e8e