### PR TITLE
Streamline setup bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Install these binaries and ensure they are on your `PATH`:
 - [uv](https://github.com/astral-sh/uv)
 - [Go Task](https://taskfile.dev/)
 
-Run `uv run python scripts/check_env.py` to confirm they are available. Install
-Go Task via your package manager or the upstream script if needed. The minimal
-bootstrap is:
+Run `uv run python scripts/check_env.py` to confirm they are available. The
+setup script installs a local Go Task binary when missing by invoking
+`scripts/bootstrap.sh` automatically. The minimal bootstrap is:
 
 ```bash
 ./scripts/setup.sh
@@ -31,9 +31,9 @@ task --version
 task check
 ```
 
-`scripts/setup.sh` verifies the Python version, confirms Go Task and `uv` are
-installed, and syncs the `dev-minimal` and `test` extras. It exits with an error
-if a tool is missing or the dependency sync fails.
+`scripts/setup.sh` verifies the Python version, installs Go Task when needed,
+confirms `uv` is functional, and syncs the `dev-minimal` and `test` extras. It
+exits with an error if a tool is missing or the dependency sync fails.
 
 To install a system-wide Go Task binary instead, run:
 
@@ -80,9 +80,10 @@ uv pip install -e ".[test]"
 uv run scripts/download_duckdb_extensions.py --output-dir ./extensions
 ```
 
-### Bootstrapping without Go Task
+### Manual setup without Go Task
 
-If the Go Task CLI is unavailable, install the test extras manually:
+`scripts/setup.sh` installs Go Task automatically. If you cannot use the
+bootstrap script, install the test extras manually:
 
 ```bash
 uv venv

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,9 +13,8 @@ Autoresearch requires these binaries on your `PATH`:
 - [uv](https://github.com/astral-sh/uv)
 - [Go Task](https://taskfile.dev/) for Taskfile commands
 
-Run `uv run python scripts/check_env.py` to confirm they are available. Install
-Go Task with your package manager or `scripts/bootstrap.sh`. After installing
-the tools, sync minimal dependencies:
+Run `uv run python scripts/check_env.py` to confirm they are available. The
+setup script installs a local Go Task binary automatically when it is missing:
 
 ```bash
 ./scripts/setup.sh
@@ -24,9 +23,9 @@ task --version
 task check
 ```
 
-The script checks the Python version, verifies Go Task and `uv` are installed,
-and syncs the `dev-minimal` and `test` extras. It exits with an error if a tool
-is missing or the dependency sync fails.
+The script checks the Python version, installs Go Task when absent, verifies
+`uv` is functional, and syncs the `dev-minimal` and `test` extras. It exits with
+an error if a tool is missing or the dependency sync fails.
 
 Activate the virtual environment in new shells to restore the path:
 
@@ -34,8 +33,9 @@ Activate the virtual environment in new shells to restore the path:
 source .venv/bin/activate
 ```
 
-Run `./scripts/bootstrap.sh` to install Go Task without syncing extras. It
-places the `task` binary in `.venv/bin`. For a system-wide binary, install
+Run `./scripts/bootstrap.sh` directly to install Go Task without syncing extras.
+This is usually unnecessary because `scripts/setup.sh` invokes it automatically.
+It places the `task` binary in `.venv/bin`. For a system-wide binary, install
 manually and confirm the installation:
 
 ```bash

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,6 +5,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 export PATH="$PATH:$(pwd)/.venv/bin"
 
 EXTRAS=${AR_EXTRAS:-}
@@ -29,8 +31,11 @@ PY
 
 ensure_go_task() {
     if ! command -v task >/dev/null 2>&1; then
-        echo "Go Task not found. Install it from https://taskfile.dev/ or run" >&2
-        echo "scripts/bootstrap.sh, then re-run this script." >&2
+        echo "Go Task not found; running scripts/bootstrap.sh..." >&2
+        "$SCRIPT_DIR/bootstrap.sh"
+    fi
+    if ! command -v task >/dev/null 2>&1; then
+        echo "Go Task installation failed. See docs/installation.md for manual steps." >&2
         exit 1
     fi
     if ! task --version >/dev/null 2>&1; then

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -24,6 +24,7 @@ def _cfg() -> ConfigModel:
     cfg.search.use_semantic_similarity = False
     return cfg
 
+
 pytestmark = pytest.mark.skipif(
     not GITPYTHON_INSTALLED, reason="GitPython not installed"
 )


### PR DESCRIPTION
## Summary
- Auto-install Go Task from `scripts/setup.sh` by invoking `scripts/bootstrap.sh` when the `task` CLI is missing
- Document the streamlined bootstrap in `README.md` and `docs/installation.md`
- Fix a flake8 newline issue in `tests/unit/test_search.py`

## Testing
- `task check`
- `uv run mkdocs build` *(fails: missing links, but build completed with warnings)*
- `task verify` *(fails: tests/unit/test_check_env_warnings.py::test_missing_package_metadata_warns)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7e3c719c833388cdab8f42f2abf6