### PR TITLE
feat: audit spec templates recursively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
         run: task --version
       - name: Validate tool versions
         run: uv run python scripts/check_env.py
+      - name: Audit spec files
+        run: uv run task lint-specs
       - name: Run task check
         run: uv run task check
       - name: Install extras

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,6 +67,10 @@ tasks:
           uv run python -c 'import pytest_benchmark' ||
           (echo "pytest-benchmark missing; run 'task install'." && exit 1)
     desc: "Validate required tool versions"
+  lint-specs:
+    cmds:
+      - uv run python scripts/lint_specs.py
+    desc: "Audit spec files for required sections"
   check:
     vars:
       EXTRAS: "{{.EXTRAS | default \"\"}}"
@@ -78,7 +82,7 @@ tasks:
       - task check-env EXTRAS="dev{{if .EXTRAS}} {{.EXTRAS}}{{end}}"
       - uv run flake8 src
       - uv run mypy src --exclude src/autoresearch/distributed
-      - uv run python scripts/lint_specs.py
+      - task lint-specs
       - uv run python scripts/check_spec_tests.py
       - uv run pytest -c /dev/null tests/unit/test_version.py tests/unit/test_cli_help.py -q
     desc: "Run lint, type check, and selected fast tests"
@@ -225,6 +229,7 @@ tasks:
       - task check-env EXTRAS="{{.EXTRAS}}"
       - uv run flake8 src tests
       - uv run mypy src
+      - task lint-specs
       - uv run python scripts/check_spec_tests.py
       - task: coverage EXTRAS="{{.EXTRAS}}"
       - uv run coverage html

--- a/scripts/lint_specs.py
+++ b/scripts/lint_specs.py
@@ -21,19 +21,24 @@ REQUIRED_HEADINGS = [
 
 def main() -> int:
     root = Path(__file__).resolve().parents[1]
-    specs = list((root / "docs" / "specs").glob("*.md"))
+    specs_dir = root / "docs" / "specs"
+    specs = list(specs_dir.rglob("*.md"))
     specs.append(root / "docs" / "spec_template.md")
     missing: dict[Path, list[str]] = {}
     for path in specs:
         if path.name == "README.md":
             continue
-        text = path.read_text()
+        text = path.read_text(encoding="utf-8")
         missing_headings = [h for h in REQUIRED_HEADINGS if h not in text]
         if missing_headings:
             missing[path] = missing_headings
     if missing:
         for path, heads in missing.items():
-            print(f"{path} missing headings: {', '.join(heads)}", file=sys.stderr)
+            rel = path.relative_to(root)
+            print(
+                f"{rel} missing headings: {', '.join(heads)}",
+                file=sys.stderr,
+            )
         return 1
     return 0
 


### PR DESCRIPTION
## Summary
- extend spec linter to recurse through docs/specs and emit relative paths for missing sections
- add dedicated lint-specs task and wire into check and verify
- run spec audit in CI to capture template drift

## Testing
- `uv run task lint-specs`
- `uv run task check`

------
https://chatgpt.com/codex/tasks/task_e_68bf80a179ac8333ba94ed686818bccc