### PR TITLE
feat: add relevance ranking simulation benchmark

### DIFF
--- a/docs/algorithms/relevance_ranking.md
+++ b/docs/algorithms/relevance_ranking.md
@@ -42,15 +42,30 @@ when performed in place.
 
 ## Simulation
 
-Run `uv run scripts/ranking_convergence.py --items 5` to explore convergence.
-[`ranking_convergence.py`](../../scripts/ranking_convergence.py) reports the
-iteration when the ordering stabilizes, which is `1` in practice.
+To confirm convergence empirically, run `M` independent trials and record the
+step count `S_m` for each run. The sample mean
+
+\[\hat{S} = \frac{1}{M} \sum_{m=1}^M S_m\]
+
+estimates the expected steps to a fixed point. Idempotence implies
+`S_m = 1` for all `m`, so `\hat{S}` converges to `1` as `M` grows.
+
+[`ranking_convergence.py`](../../scripts/ranking_convergence.py) implements
+`run_trials` to compute `\hat{S}`. Run
+
+```
+uv run scripts/ranking_convergence.py --items 5 --trials 100
+```
+
+to execute `100` trials and report the mean convergence step.
 
 Regression tests
 [`test_ranking_idempotence.py`](../../tests/unit/test_ranking_idempotence.py)
 and
 [`test_ranking_convergence.py`](../../tests/unit/test_ranking_convergence.py)
-validate idempotence and monotonic improvement.
+validate idempotence and monotonic improvement. Benchmark
+[`test_ranking_convergence_simulation.py`](../../tests/benchmark/test_ranking_convergence_simulation.py)
+records the mean convergence step.
 
 ## References
 

--- a/docs/search_spec.md
+++ b/docs/search_spec.md
@@ -30,6 +30,9 @@ This specification outlines expected behaviors for the
   different backends are first scored individually and then merged and
   re-ranked with the same weights to ensure consistent ordering across
   sources. The formula is detailed in [search ranking](algorithms/search_ranking.md).
+  Simulation trials in
+  [`ranking_convergence.py`](algorithms/relevance_ranking.md#simulation)
+  report a mean convergence step of `1`, confirming the idempotent ranking.
 
 ## Tests
 Property-based tests in `tests/unit/test_relevance_ranking.py` verify:

--- a/tests/benchmark/test_ranking_convergence_simulation.py
+++ b/tests/benchmark/test_ranking_convergence_simulation.py
@@ -1,0 +1,29 @@
+"""Benchmark relevance ranking convergence."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "ranking_convergence.py"
+_spec = importlib.util.spec_from_file_location("ranking_convergence", SCRIPT)
+module = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+_spec.loader.exec_module(module)
+
+pytestmark = [pytest.mark.slow]
+
+
+def test_ranking_convergence_simulation(benchmark, metrics_baseline) -> None:
+    """Mean convergence step remains one across random runs."""
+
+    def run() -> None:
+        module.run_trials(trials=100, items=5)
+
+    benchmark(run)
+    mean = module.run_trials(trials=100, items=5)
+    assert mean == pytest.approx(1.0)
+    latency = benchmark.stats["mean"]
+    metrics_baseline("ranking_convergence", mean, mean, latency)

--- a/tests/data/backend_metrics.json
+++ b/tests/data/backend_metrics.json
@@ -13,5 +13,10 @@
     "latency": 1.9882758211698783e-06,
     "precision": 0.5,
     "recall": 1.0
+  },
+  "tests/benchmark/test_ranking_convergence_simulation.py::test_ranking_convergence_simulation::ranking_convergence": {
+    "latency": 0.0019450484577541952,
+    "precision": 1.0,
+    "recall": 1.0
   }
 }


### PR DESCRIPTION
## Summary
- model convergence steps in relevance ranking spec and search spec
- add multi-trial ranking convergence simulator and benchmark test
- record benchmark baseline metrics

## Testing
- `uv run mkdocs build`
- `uv run pytest tests/unit/test_ranking_idempotence.py tests/unit/test_ranking_convergence.py -q`
- `uv run pytest tests/benchmark/test_ranking_convergence_simulation.py -m slow -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf80a609308333a073b51427746ad6