### PR TITLE
Archive add-missing-git-search-spec-sections issue

### DIFF
--- a/issues/archive/add-missing-git-search-spec-sections.md
+++ b/issues/archive/add-missing-git-search-spec-sections.md
@@ -13,4 +13,4 @@ None.
 - `task check` succeeds.
 
 ## Status
-Open
+Archived


### PR DESCRIPTION
## Summary
- mark add-missing-git-search-spec-sections issue as archived and move to `issues/archive/`

## Testing
- `task check`
- `task verify` *(fails: Task "coverage EXTRAS=""" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9728719c8333bbf7b8f30fa2202b