### PR TITLE
feat: clarify ranking convergence output

### DIFF
--- a/docs/ranking_benchmark.md
+++ b/docs/ranking_benchmark.md
@@ -19,3 +19,14 @@ Regression thresholds:
 
 - precision and recall may drop by at most 5 percentage points
 - latency may increase by no more than 5%
+
+## Convergence Simulation
+
+Run the convergence script to estimate ranking stability:
+
+```bash
+uv run scripts/ranking_convergence.py --items 5 --trials 100
+```
+
+The command reports the mean step count,
+e.g. `converged in 1.0 steps on average`.

--- a/scripts/ranking_convergence.py
+++ b/scripts/ranking_convergence.py
@@ -70,7 +70,7 @@ def main() -> None:
     if args.items <= 0:
         raise SystemExit("--items must be positive")
     mean = run_trials(args.trials, args.items)
-    print(f"mean convergence step: {mean}")
+    print(f"converged in {mean:.1f} steps on average")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_search_ranking_convergence.py
+++ b/tests/integration/test_search_ranking_convergence.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -15,4 +16,5 @@ def test_ranking_convergence_script() -> None:
         text=True,
         check=True,
     )
-    assert "converged in" in result.stdout
+    match = re.search(r"converged in (\d+(?:\.\d+)?) steps", result.stdout)
+    assert match, result.stdout


### PR DESCRIPTION
## Summary
- report convergence steps with "converged in" messaging
- verify convergence steps in integration test
- document convergence simulation usage

## Testing
- `uv run python scripts/run_task.py check` (failed: Go Task is not installed)
- `uv run python scripts/run_task.py verify` (failed: Go Task is not installed)
- `uv run --extra test pytest` (failed: 32 failed, 1090 passed)
- `uv run --extra test pytest tests/integration/test_search_ranking_convergence.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf9744fe1c83339a9b81932eee8c21