### PR TITLE
Fix streaming and auth compatibility with updated FastAPI

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,8 @@
 
 ## September 9, 2025
 
+- `uv run --extra test pytest tests/integration/test_api_auth.py tests/integration/test_api_auth_middleware.py tests/integration/test_api_auth_permissions.py tests/integration/test_api_docs.py` reports **31 passed** and 1 deselected test.
+- Running `uv run --extra test pytest tests/integration/test_api_auth_streaming.py tests/integration/test_api_streaming.py tests/integration/test_api_streaming_webhook.py -m slow` reports **12 passed** with 3 deselections.
 - Go Task CLI is unavailable; `task check` and `task verify` report
   `command not found`.
 - `uv run --extra test pytest` executes the suite with **33 failing tests**,

--- a/src/autoresearch/api/auth.py
+++ b/src/autoresearch/api/auth.py
@@ -1,10 +1,21 @@
-"""Compatibility shim for authentication middleware.
+"""Compatibility layer re-exporting API middlewares.
 
-This module re-exports :class:`AuthMiddleware` so older imports targeting
-``autoresearch.api.auth`` continue to function after the middleware was
-relocated to :mod:`autoresearch.api.middleware`.
+Historically authentication and rate limiting helpers lived under
+``autoresearch.api.auth``.  The implementation now resides in
+``autoresearch.api.middleware`` but imports from the old path are kept for
+backward compatibility.
 """
 
-from .middleware import AuthMiddleware
+from .middleware import (
+    AuthMiddleware,
+    FallbackRateLimitMiddleware,
+    RateLimitMiddleware,
+    dynamic_limit,
+)
 
-__all__ = ["AuthMiddleware"]
+__all__ = [
+    "AuthMiddleware",
+    "FallbackRateLimitMiddleware",
+    "RateLimitMiddleware",
+    "dynamic_limit",
+]


### PR DESCRIPTION
## Summary
- re-export rate limiting helpers from `api.auth`
- harden middleware against sync/async FastAPI security changes
- make streaming and routing resilient to patched orchestrator calls and webhook differences
- cover QueryResponse streaming with new regression test

## Testing
- `uv run --extra test pytest tests/integration/test_api_auth.py tests/integration/test_api_auth_middleware.py tests/integration/test_api_auth_permissions.py tests/integration/test_api_docs.py -q`
- `uv run --extra test pytest tests/integration/test_api_auth_streaming.py tests/integration/test_api_streaming.py tests/integration/test_api_streaming_webhook.py -m slow -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf973fc6c083339d092541c625afeb