### PR TITLE
feat: add multi-platform image support

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Verify images build
+        run: bash scripts/build_images.sh
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:

--- a/docker/Dockerfile.macos
+++ b/docker/Dockerfile.macos
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
-# macOS (ARM) container image with project extras for Autoresearch
-FROM ghcr.io/cirruslabs/macos-runner:sonoma
+# macOS container image with project extras for Autoresearch
+FROM --platform=$TARGETPLATFORM ghcr.io/cirruslabs/macos-runner:sonoma
 
 ARG EXTRAS="full,test"
 ARG OFFLINE="0"

--- a/docker/Dockerfile.windows
+++ b/docker/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 # Windows container image with project extras for Autoresearch
-FROM mcr.microsoft.com/windows/python:3.12
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/windows/python:3.12
 
 ARG EXTRAS="full,test"
 ARG OFFLINE="0"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,24 +43,27 @@ On a dedicated server you can run the API in the background using a process mana
 
 ## Containerized Deployment (Docker)
 
-Autoresearch can also be containerized using the multi-stage `Dockerfile` in
-the project root. Named stages `linux`, `macos`, and `windows` produce platform
-images.
+Autoresearch provides platform Dockerfiles under `docker/`. The Linux file
+supports `linux/amd64` and `linux/arm64` through Docker Buildx.
 
-Build and push all images with the release script:
-
-```bash
-bash scripts/release_images.sh ghcr.io/OWNER latest
-```
-
-To build a single target use Docker Buildx:
+Build all images locally for verification:
 
 ```bash
-docker buildx build --target linux --platform linux/amd64 \
-  -t youruser/autoresearch:linux .
+bash scripts/build_images.sh
 ```
 
-Replace `linux` with `macos` or `windows` and adjust `--platform` as needed.
+Publish multi-platform images to a registry:
+
+```bash
+bash scripts/release_images.sh ghcr.io/OWNER/autoresearch v1.2.3
+```
+
+To build a single target manually with Buildx:
+
+```bash
+docker buildx build -f docker/Dockerfile.linux \\
+  --platform linux/amd64 -t youruser/autoresearch:linux --load .
+```
 
 ## Using docker-compose
 
@@ -82,24 +85,6 @@ Launch with:
 ```bash
 docker compose up --build
 ```
-
-### Building and pushing images
-
-The release script wraps Docker Buildx and publishes images with pinned base
-digests:
-
-```bash
-bash scripts/release_images.sh ghcr.io/OWNER v1.2.3
-```
-
-For manual pushes run:
-
-```bash
-docker buildx build --target macos --platform linux/amd64 \
-  -t youruser/autoresearch:macos --push .
-```
-
-Update the digests in `Dockerfile` when upstream images change and rebuild.
 
 ## Building Wheels for Distribution
 


### PR DESCRIPTION
## Summary
- enable cross-platform builds for macOS and Windows Dockerfiles
- document multi-arch build process and add release script
- verify image builds in release workflow before pushing

## Testing
- `PATH="$PWD/bin:$PATH" ./bin/task check`
- `uv run mkdocs build`
- `PATH="$PWD/bin:$PATH" ./bin/task verify` *(fails: tests/behavior/steps/query_interface_steps.py::test_visualize_query)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc0e2e1a88333995ad9178fb680db