### PR TITLE
Warn when Go Task missing in env checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Install these binaries and ensure they are on your `PATH`:
 - [Go Task](https://taskfile.dev/)
 
 Run `uv run python scripts/check_env.py` to confirm they are available. The
-setup script installs a local Go Task binary when missing by invoking
-`scripts/bootstrap.sh` automatically. The minimal bootstrap is:
+script now emits a warning when Go Task is missing and suggests installing it
+from <https://taskfile.dev/> or running `scripts/bootstrap.sh`. The minimal
+bootstrap is:
 
 ```bash
 ./scripts/setup.sh

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -99,7 +99,7 @@ def check_python() -> CheckResult:
     return CheckResult("Python", current, REQUIREMENTS["python"])
 
 
-def check_task() -> CheckResult:
+def check_task() -> CheckResult | None:
     required = REQUIREMENTS["task"]
     try:
         proc = subprocess.run(
@@ -108,12 +108,15 @@ def check_task() -> CheckResult:
             text=True,
             check=False,
         )
-    except FileNotFoundError as exc:
-        hint = (
-            f"Go Task {required}+ is required. Install it from https://taskfile.dev/ "
-            "or run scripts/bootstrap.sh"
+    except FileNotFoundError:
+        warnings.warn(
+            (
+                f"Go Task {required}+ not found; install it from https://taskfile.dev/ "
+                "or run scripts/bootstrap.sh"
+            ),
+            UserWarning,
         )
-        raise VersionError(hint) from exc
+        return None
     if proc.returncode != 0:
         hint = (
             f"Go Task {required}+ is required. Install it from https://taskfile.dev/ "

--- a/tests/unit/test_check_env_warnings.py
+++ b/tests/unit/test_check_env_warnings.py
@@ -40,13 +40,14 @@ def test_missing_pytest_bdd_warns(monkeypatch):
     assert result is None
 
 
-def test_missing_go_task_detected(monkeypatch):
+def test_missing_go_task_warns(monkeypatch):
     def fake_run(*args, **kwargs):
         raise FileNotFoundError
 
     monkeypatch.setattr(check_env.subprocess, "run", fake_run)
-    with pytest.raises(check_env.VersionError, match="Go Task"):
-        check_env.check_task()
+    with pytest.warns(UserWarning, match="Go Task .* not found"):
+        result = check_env.check_task()
+    assert result is None
 
 
 def test_main_ignores_missing_metadata(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- Warn instead of raising when `task` is absent, with installation guidance
- Test missing Go Task warning
- Document Go Task warning behavior in setup instructions

## Testing
- `task check`
- `task verify` *(fails: AssertionError in tests/behavior/steps/query_interface_steps.py::test_visualize_query)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc0fac93c8333afe708540fdb356b