### PR TITLE
feat: add versioned API schemas and normalized ranking

### DIFF
--- a/docs/api_reference/index.md
+++ b/docs/api_reference/index.md
@@ -61,4 +61,5 @@ For detailed documentation of each module, see the corresponding pages in this s
 - [Search](search.md): Search functionality and backends
 - [Config](config.md): Configuration loading and management
 - [Distributed](distributed.md): Executors and helper utilities for distributed execution
+- [Query API](query.md): Versioned request and response models
 

--- a/docs/api_reference/query.md
+++ b/docs/api_reference/query.md
@@ -1,0 +1,52 @@
+# Query API
+
+The Query API provides versioned request and response models for interacting
+with the system. Each payload includes a `version` field so contracts remain
+stable as internal implementations evolve.
+
+## Request Model
+
+Example request to `/query`:
+
+```json
+{
+  "version": "1",
+  "query": "What is machine learning?"
+}
+```
+
+## Response Model
+
+A successful response includes reasoning and citations:
+
+```json
+{
+  "version": "1",
+  "answer": "Machine learning studies algorithms that learn from data.",
+  "citations": ["https://example.com"],
+  "reasoning": ["step 1", "step 2"],
+  "metrics": {"cycles_completed": 1}
+}
+```
+
+## Batch Response
+
+The batch endpoint wraps individual responses with pagination metadata:
+
+```json
+{
+  "version": "1",
+  "page": 1,
+  "page_size": 2,
+  "results": [
+    {"version": "1", "answer": "a", "citations": [], "reasoning": [], "metrics": {}},
+    {"version": "1", "answer": "b", "citations": [], "reasoning": [], "metrics": {}}
+  ]
+}
+```
+
+## References
+
+- [API models][m1]
+
+[m1]: ../../src/autoresearch/api/models.py

--- a/docs/specs/search_ranking.md
+++ b/docs/specs/search_ranking.md
@@ -11,6 +11,21 @@ applied uniformly across search backends.
 - Weight cosine similarity and metadata freshness.
 - Normalize scores before applying a deterministic sort.
 
+## Example
+
+Consider two documents with raw scores:
+
+```
+bm25 = [3, 1]
+semantic = [0.8, 0.2]
+credibility = [0.9, 0.5]
+```
+
+After normalizing BM25 to `1` and `0.33` and applying weights of `0.5`, `0.3`,
+and `0.2` respectively, the combined scores become `1.0` and `0.53`. The final
+normalization scales them to `1.0` and `0.53`, keeping values within the
+`0` to `1` range.
+
 ## Invariants
 
 - Scores stay within the 0 to 1 range after normalization.
@@ -18,8 +33,10 @@ applied uniformly across search backends.
 
 ## Proof Sketch
 
-Normalization preserves order within each scoring component, and the final sort
-is stable, proving deterministic rankings for equal scores.
+Normalization maps all component scores to the unit interval while maintaining
+their relative ordering. The weighted sum is therefore bounded by `0` and `1`,
+and the subsequent stable sort ensures that ties preserve input order. Thus,
+equal inputs deterministically produce the same ranking.
 
 ## Simulation Expectations
 

--- a/src/autoresearch/api/models.py
+++ b/src/autoresearch/api/models.py
@@ -6,9 +6,9 @@ declares an explicit ``version`` field which currently defaults to
 ``"1"``.
 """
 
-from typing import Literal, List
+from typing import List, Literal
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from ..models import BatchQueryRequest, QueryRequest, QueryResponse
 from ..orchestration.reasoning import ReasoningMode
@@ -47,9 +47,25 @@ class BatchQueryRequestV1(BatchQueryRequest):
     queries: List[QueryRequestV1]
 
 
+class BatchQueryResponseV1(BaseModel):
+    """Batch query response model for version 1.
+
+    Args:
+        version: API version identifier.
+    """
+
+    version: Literal["1"] = Field(
+        default="1", description="API version for the response"
+    )
+    page: int = Field(ge=1, description="Current page number")
+    page_size: int = Field(ge=1, description="Number of results per page")
+    results: List[QueryResponseV1]
+
+
 __all__ = [
     "ReasoningMode",
     "QueryRequestV1",
     "QueryResponseV1",
     "BatchQueryRequestV1",
+    "BatchQueryResponseV1",
 ]

--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -524,6 +524,24 @@ class Search:
             merged.append(bm25 * bm25_weight + semantic * semantic_weight)
         return merged
 
+    @staticmethod
+    def normalize_scores(scores: List[float]) -> List[float]:
+        """Scale scores to the 0–1 range.
+
+        Args:
+            scores: Raw relevance scores.
+
+        Returns:
+            List[float]: Normalized scores bounded by 0 and 1.
+        """
+
+        if not scores:
+            return scores
+        max_score = max(scores)
+        if max_score <= 0:
+            return [0.0 for _ in scores]
+        return [s / max_score for s in scores]
+
     @hybridmethod
     def rank_results(
         self,
@@ -615,6 +633,8 @@ class Search:
                 credibility_scores[i] * search_cfg.source_credibility_weight
             )
             final_scores.append(score)
+
+        final_scores = self.normalize_scores(final_scores)
 
         # Add scores to results for debugging/transparency
         for i, result in enumerate(results):

--- a/tests/behavior/steps/visualization_cli_steps.py
+++ b/tests/behavior/steps/visualization_cli_steps.py
@@ -4,15 +4,18 @@ from pytest_bdd import scenario, when, then
 from autoresearch.main import app as cli_app
 
 
-@when('I run `autoresearch visualize "What is quantum computing?" graph.png`')
-def run_visualize_query(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
-    def fake_visualize(query, output, layout='spring'):
+@when('I run `autoresearch visualize "{query}" graph.png`')
+def run_visualize_query(
+    cli_runner, bdd_context, monkeypatch, temp_config, isolate_network, query
+):
+    output_path = Path.cwd() / 'graph.png'
+
+    def fake_visualize(q, output, layout='spring'):
         Path(output).touch()
+
     monkeypatch.setattr('autoresearch.main.app._cli_visualize_query', fake_visualize)
     result = cli_runner.invoke(
-        cli_app,
-        ['visualize', 'What is quantum computing?', 'graph.png'],
-        catch_exceptions=False,
+        cli_app, ['visualize', query, str(output_path)], catch_exceptions=False
     )
     bdd_context['result'] = result
 

--- a/tests/integration/test_api_versioning.py
+++ b/tests/integration/test_api_versioning.py
@@ -1,0 +1,37 @@
+"""Integration tests for versioned API schemas."""
+
+from autoresearch.api.models import QueryResponseV1
+from autoresearch.config import APIConfig, ConfigModel
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.orchestration.orchestrator import Orchestrator
+
+
+def _setup(monkeypatch) -> None:
+    cfg = ConfigModel(api=APIConfig())
+    ConfigLoader.reset_instance()
+    cfg.api.role_permissions["anonymous"] = ["query"]
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+
+
+def test_rejects_unknown_version(monkeypatch, api_client) -> None:
+    """Requests with an unsupported version fail validation."""
+    _setup(monkeypatch)
+    resp = api_client.post("/query", json={"query": "hi", "version": "2"})
+    assert resp.status_code == 422
+
+
+def test_batch_response_includes_version(monkeypatch, api_client) -> None:
+    """Batch endpoint wraps responses with a version field."""
+    _setup(monkeypatch)
+    monkeypatch.setattr(
+        Orchestrator,
+        "run_query",
+        lambda q, c, callbacks=None, **k: QueryResponseV1(
+            answer=q, citations=[], reasoning=[], metrics={}
+        ),
+    )
+    payload = {"queries": [{"query": "a"}, {"query": "b"}]}
+    resp = api_client.post("/query/batch", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] == "1"

--- a/tests/integration/test_ranking_formula_consistency.py
+++ b/tests/integration/test_ranking_formula_consistency.py
@@ -39,11 +39,13 @@ def test_convex_combination_matches_docs(monkeypatch):
     w_b = search_cfg.bm25_weight
     w_c = search_cfg.source_credibility_weight
     expected = [w_b * bm25[i] + w_s * semantic[i] + w_c * cred[i] for i in range(2)]
+    max_score = max(expected)
+    normalized = [e / max_score for e in expected] if max_score > 0 else [0.0] * 2
 
     ranked_ids = [r["id"] for r in ranked]
-    expected_ids = [i for i, _ in sorted(enumerate(expected), key=lambda p: p[1], reverse=True)]
+    expected_ids = [i for i, _ in sorted(enumerate(normalized), key=lambda p: p[1], reverse=True)]
     assert ranked_ids == expected_ids
 
     for r in ranked:
         idx = r["id"]
-        assert r["relevance_score"] == pytest.approx(expected[idx])
+        assert r["relevance_score"] == pytest.approx(normalized[idx])

--- a/tests/integration/test_search_score_normalization.py
+++ b/tests/integration/test_search_score_normalization.py
@@ -1,0 +1,24 @@
+"""Verify hybrid ranking scores are normalized."""
+
+from autoresearch.config import ConfigModel, SearchConfig
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.search.core import Search
+
+
+def _config(monkeypatch) -> None:
+    cfg = ConfigModel(search=SearchConfig())
+    ConfigLoader.reset_instance()
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+
+
+def test_rank_results_normalizes_scores(monkeypatch) -> None:
+    """Scores are scaled to the unit interval."""
+    _config(monkeypatch)
+    results = [
+        {"title": "a", "similarity": 2.0},
+        {"title": "b", "similarity": 0.5},
+    ]
+    ranked = Search.rank_results("test", results)
+    scores = [r["relevance_score"] for r in ranked]
+    assert all(0 <= s <= 1 for s in scores)
+    assert scores[0] == 1.0

--- a/tests/unit/search/test_ranking_formula.py
+++ b/tests/unit/search/test_ranking_formula.py
@@ -40,8 +40,12 @@ def test_rank_results_weighted_combination(monkeypatch: pytest.MonkeyPatch) -> N
     for i in range(len(docs)):
         merged = bm25[i] * 0.3 + semantic[i] * 0.4
         scores.append(merged + credibility[i] * 0.3)
+    max_score = max(scores)
+    normalized = [s / max_score for s in scores]
     assert [r["title"] for r in ranked] == ["B", "A"]
-    assert [r["relevance_score"] for r in ranked] == pytest.approx(sorted(scores, reverse=True))
+    assert [r["relevance_score"] for r in ranked] == pytest.approx(
+        sorted(normalized, reverse=True)
+    )
 
 
 def test_rank_results_invalid_weights(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_property_search_ranking.py
+++ b/tests/unit/test_property_search_ranking.py
@@ -95,8 +95,10 @@ def test_rank_results_orders_by_weighted_scores(
         bm25_scores[i] * weights[0] + semantic_scores[i] * weights[1] for i in range(len(docs))
     ]
     final = [merged[i] + credibility_scores[i] * weights[2] for i in range(len(docs))]
-    expected_order = sorted(range(len(docs)), key=lambda i: final[i], reverse=True)
+    max_score = max(final)
+    normalized = [f / max_score for f in final] if max_score > 0 else [0.0] * len(final)
+    expected_order = sorted(range(len(docs)), key=lambda i: normalized[i], reverse=True)
     ranked_titles = [r["title"] for r in ranked]
     assert ranked_titles == [titles[i] for i in expected_order]
     for r, i in zip(ranked, expected_order):
-        assert r["relevance_score"] == pytest.approx(final[i])
+        assert r["relevance_score"] == pytest.approx(normalized[i])


### PR DESCRIPTION
## Summary
- add BatchQueryResponse model and document versioned request/response schemas
- normalize hybrid search scores and document ranking proof
- cover API versioning and score normalization with integration tests

## Testing
- `task check`
- `task verify` *(fails: interrupted during behavior test run)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc0debdec8333b626ed060795f465