### PR TITLE
docs: update status and release metrics

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,18 +4,20 @@ This roadmap summarizes planned features for upcoming releases.
 Dates and milestones align with the [release plan](docs/release_plan.md).
 See [STATUS.md](STATUS.md) and [CHANGELOG.md](CHANGELOG.md) for current results
 and recent changes. Installation and environment details are covered in the
-[README](README.md). Last updated **September 9, 2025**.
+[README](README.md). Last updated **September 10, 2025**.
 
 ## Status
 
 See [STATUS.md](STATUS.md) for current results and
 [CHANGELOG.md](CHANGELOG.md) for recent updates. 0.1.0a1 remains untagged and
 targets **September 15, 2026**, with **0.1.0** planned for **October 1, 2026**
-across project documentation.
-`task verify` now fails in
-`tests/unit/test_check_env_warnings.py::test_missing_package_metadata_warns`.
-`task check` passes. Targeted integration tests pass except
-`tests/integration/test_api_docs.py::test_query_endpoint`.
+across project documentation. `task check` runs 8 targeted tests and passes,
+warning that package metadata for GitPython, cibuildwheel,
+duckdb-extension-vss, spacy, types-networkx, types-protobuf, types-requests,
+and types-tabulate is missing. `task verify` runs 844 unit tests (34 skipped,
+25 deselected, 8 xfailed, 4 xpassed) and reports 100% coverage for budgeting
+and HTTP modules (57 statements) before the run is interrupted. Integration
+tests were not executed.
 Scheduler resource benchmarks (`scripts/scheduling_resource_benchmark.py`)
 offer utilization and memory estimates documented in
 `docs/orchestrator_perf.md`. Dependency pins: `fastapi>=0.115.12` and

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,14 @@
 # Status
 
+## September 10, 2025
+
+- `task check` runs 8 targeted tests and passes, warning that package metadata
+  for GitPython, cibuildwheel, duckdb-extension-vss, spacy, types-networkx,
+  types-protobuf, types-requests, and types-tabulate is missing.
+- `task verify` runs 844 unit tests (34 skipped, 25 deselected, 8 xfailed, 4
+  xpassed) and reports 100% coverage for budgeting and HTTP modules (57
+  statements) before the run is interrupted.
+
 ## September 9, 2025
 
 - `task check` completes successfully, logging warnings when package
@@ -236,7 +245,6 @@ Not executed.
 so coverage reports are not generated.
 
 ## Open issues
-- [add-missing-git-search-spec-sections](issues/add-missing-git-search-spec-sections.md)
 - [add-test-coverage-for-optional-components](issues/add-test-coverage-for-optional-components.md)
 - [fix-api-authentication-integration-tests](issues/fix-api-authentication-integration-tests.md)
 - [resolve-package-metadata-warnings](issues/resolve-package-metadata-warnings.md)

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -9,7 +9,7 @@ The publishing workflow follows the steps in
 [ROADMAP.md](../ROADMAP.md) for high-level milestones.
 
 The project kicked off in **May 2025** (see the initial commit dated
-`2025-05-18`). This schedule was last updated on **September 9, 2025** and
+`2025-05-18`). This schedule was last updated on **September 10, 2025** and
 reflects that the codebase currently sits at the **unreleased 0.1.0a1** version
 defined in `autoresearch.__version__`. The project targets **0.1.0a1** for
 **September 15, 2026** and **0.1.0** for **October 1, 2026**. See
@@ -22,17 +22,15 @@ defined in `autoresearch.__version__`. The project targets **0.1.0a1** for
 The dependency pins for `fastapi` (>=0.115.12) and `slowapi` (==0.1.9) are
 confirmed in `pyproject.toml` and [installation.md](installation.md).
 `uv run flake8 src tests` now passes, and `uv run mypy src` reports success.
-The `task` CLI installs via `scripts/setup.sh`, allowing `task check` to
-complete. `task verify` now syncs only the `dev-minimal` and `test` extras by
-default. Provide additional groups by setting `EXTRAS`, for example
-`EXTRAS="nlp ui"`. A dry-run publish built the package and skipped upload.
-Outstanding gaps are tracked in [int-tests] and [task-issue].
-Current test results are mirrored in [../STATUS.md](../STATUS.md).
-Coverage from `uv run coverage report` holds at **32%** overall (budgeting
-17%, HTTP 38%). Optional extras—`nlp`, `ui`, `vss`, `git`, `distributed`,
-`analysis`, `llm`, `parsers`, and `gpu`—each remain at **32%** baseline
-coverage.
-
+The `task` CLI installs via `scripts/setup.sh`, allowing `task check` to run
+8 targeted tests and pass while warning that package metadata for GitPython,
+cibuildwheel, duckdb-extension-vss, spacy, types-networkx, types-protobuf,
+types-requests, and types-tabulate is missing.
+`task verify` runs 844 unit tests (34 skipped, 25 deselected, 8 xfailed, 4
+ xpassed) and reports 100% coverage for budgeting and HTTP modules
+ (57 statements) before the run is interrupted. Outstanding gaps are tracked
+ in [int-tests] and [task-issue]. Current test results are mirrored in
+ [../STATUS.md](../STATUS.md).
 ## Milestones
 
 - **0.1.0a1** (2026-09-15, status: in progress): Alpha preview to collect


### PR DESCRIPTION
## Summary
- document current task check and verify results with coverage details
- sync roadmap and release plan metrics with latest test run
- drop archived git-search spec issue from open items

## Testing
- `task check`
- `task verify` *(fails: interrupt after coverage report)*


------
https://chatgpt.com/codex/tasks/task_e_68c0f7d6224c8333a7da7e86c9a0fb0d