### PR TITLE
doc: track release prep and env warnings

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,12 +2,12 @@
 
 ## September 10, 2025
 
+- Installed Go Task 3.44.1 so `task` commands are available.
 - `task check` runs 8 targeted tests and passes, warning that package metadata
   for GitPython, cibuildwheel, duckdb-extension-vss, spacy, types-networkx,
   types-protobuf, types-requests, and types-tabulate is missing.
-- `task verify` runs 844 unit tests (34 skipped, 25 deselected, 8 xfailed, 4
-  xpassed) and reports 95% coverage for budgeting and HTTP modules (57
-  statements) before the run is interrupted.
+- `task verify` runs 8 targeted unit tests successfully. A subsequent coverage
+  run was interrupted, producing a `KeyboardInterrupt` stack trace.
 
 ## September 9, 2025
 

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -1,0 +1,19 @@
+# Prepare first alpha release
+
+## Context
+The project remains unreleased even though the codebase and documentation are publicly available. To tag version v0.1.0a1, we need a coordinated effort to finalize outstanding testing, documentation, and packaging tasks while keeping workflows dispatch-only.
+
+## Dependencies
+- [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)
+- [resolve-package-metadata-warnings](resolve-package-metadata-warnings.md)
+- [fix-api-authentication-integration-tests](fix-api-authentication-integration-tests.md)
+- [streamline-task-verify-extras](streamline-task-verify-extras.md)
+
+## Acceptance Criteria
+- All dependency issues are closed.
+- Release notes for v0.1.0a1 are drafted in CHANGELOG.md.
+- Git tag v0.1.0a1 is created only after tests pass and documentation is updated.
+- Workflows remain manual or dispatch-only.
+
+## Status
+Open

--- a/issues/resolve-package-metadata-warnings.md
+++ b/issues/resolve-package-metadata-warnings.md
@@ -2,11 +2,11 @@
 
 ## Context
 Running `task check` reports missing package metadata for `GitPython`,
-`cibuildwheel`, `duckdb-extension-vss`, `spacy`, and several `types-*`
-stubs. As of September 9, 2025, `uv run python scripts/check_env.py`
-aborts early with `ERROR: Go Task 3.0.0+ is required`, so these warnings
-cannot be evaluated. The script should run to completion without
-emitting package metadata warnings.
+`cibuildwheel`, `duckdb-extension-vss`, `spacy`, and the `types-networkx`,
+`types-protobuf`, `types-requests`, and `types-tabulate` stubs. As of
+September 10, 2025, after installing Go Task 3.44.1, `uv run python
+scripts/check_env.py` completes but emits the same warnings. The script
+should run to completion without package metadata warnings.
 
 ## Dependencies
 None.


### PR DESCRIPTION
## Summary
- note Go Task availability and `task verify` interruption in STATUS
- clarify package metadata warnings in issue tracker
- add issue to coordinate first alpha release

## Testing
- `task check`
- `task verify` *(fails: exit status 1 due to KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c0feba68d08333b7651a3b49194d82