### PR TITLE
Document heavy extras and limit default installs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,11 +5,10 @@ set:
 
 vars:
   COVERAGE_MINIMUM: 90
-  ALL_EXTRAS: "nlp ui vss git distributed analysis llm parsers gpu"
 
 profiles:
   dev-minimal:
-    desc: "Sync dev-minimal and test extras"
+    desc: "Sync dev-minimal extras"
 
 tasks:
   install:
@@ -56,11 +55,15 @@ tasks:
   check:
     vars:
       EXTRAS: "{{.EXTRAS | default \"\"}}"
-    # Minimal validation for quick feedback. Syncs dev-minimal and test extras
+    # Minimal validation for quick feedback. Syncs only the dev-minimal extra
     # and exercises version and CLI smoke tests. Skips slow tests and scenarios
     # requiring optional UI (`.[ui]`) or VSS (`.[vss]`) extras.
     cmds:
-      - uv sync --python-platform x86_64-manylinux_2_28 --extra dev-minimal --extra test{{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}}
+      - |
+          uv sync \
+            --python-platform x86_64-manylinux_2_28 \
+            --extra dev-minimal \
+            {{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}}
       - task check-env EXTRAS="dev{{if .EXTRAS}} {{.EXTRAS}}{{end}}"
       - uv run flake8 src
       - uv run mypy src --exclude src/autoresearch/distributed
@@ -223,7 +226,8 @@ tasks:
           uv sync \
             --extra dev-minimal \
             --extra test \
-            {{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{if (contains .EXTRAS "gpu")}} --find-links wheels/gpu{{end}}{{end}}
+            {{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}\
+            {{if (contains .EXTRAS "gpu")}} --find-links wheels/gpu{{end}}{{end}}
       - echo "[coverage] erasing previous data"
       - uv run coverage erase
       - echo "[coverage] running unit tests"
@@ -274,7 +278,8 @@ tasks:
             --python-platform x86_64-manylinux_2_28 \
             --extra dev-minimal \
             --extra test \
-            {{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{if (contains .EXTRAS "gpu")}} --find-links wheels/gpu{{end}}{{end}}
+            {{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}\
+            {{if (contains .EXTRAS "gpu")}} --find-links wheels/gpu{{end}}{{end}}
       - task check-env EXTRAS="{{.EXTRAS}}"
       - uv run flake8 src tests
       - uv run mypy src

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -9,15 +9,15 @@ For environment setup instructions see [installation](installation.md).
 Tests may require optional dependencies. Markers such as `requires_nlp` or
 `requires_parsers` map to extras with the same names. `task install` syncs only
 the `dev-minimal` extra; add groups with `EXTRAS` or set `AR_EXTRAS`
-when using the setup script. `task verify` installs only the `dev-minimal`
-and `test` extras. Include heavy groups by setting `EXTRAS`:
+when using the setup script. `task verify` installs the `dev-minimal`
+and `test` extras by default. Include heavy groups by setting `EXTRAS`:
 
 ```bash
 EXTRAS="test nlp parsers" task install
-EXTRAS="nlp parsers" task verify
+EXTRAS="analysis distributed" task verify
 ```
 
-Available extras enable optional features:
+Available extras enable optional features. Heavy groups require explicit flags:
 
 - `test` - full test suite tools
 - `nlp` - language processing via spaCy and BERTopic


### PR DESCRIPTION
## Summary
- install only dev-minimal extras by default and clarify profile
- document heavy extras and how to opt-in via EXTRAS

## Testing
- `task verify` *(fails: tests/behavior/steps/query_interface_steps.py::test_visualize_query assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68c18a29acb48333954bf8cd1018f212