### PR TITLE
Ensure ranking convergence script reports convergence

### DIFF
--- a/scripts/ranking_convergence.py
+++ b/scripts/ranking_convergence.py
@@ -70,7 +70,10 @@ def main() -> None:
     if args.items <= 0:
         raise SystemExit("--items must be positive")
     mean = run_trials(args.trials, args.items)
-    print(f"converged in {mean:.1f} steps on average")
+    if args.trials == 1:
+        print(f"converged in {mean:.1f} steps")
+    else:
+        print(f"converged in {mean:.1f} steps on average")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure ranking_convergence.py prints the expected "converged in" message when the script runs

## Testing
- `uv run --extra test pytest tests/integration/test_search_ranking_convergence.py::test_ranking_convergence_script -q`

------
https://chatgpt.com/codex/tasks/task_e_68c18a3aec388333b90e28bbd704a92b