### PR TITLE
docs: note PATH requirement for Task CLI

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -3,6 +3,7 @@
 ## September 10, 2025
 
 - Installed Go Task 3.44.1 so `task` commands are available.
+- Added `.venv/bin` to `PATH` and confirmed `task --version` prints 3.44.1.
 - `task check` runs 8 targeted tests and passes, warning that package metadata
   for GitPython, cibuildwheel, duckdb-extension-vss, spacy, types-networkx,
   types-protobuf, types-requests, and types-tabulate is missing.


### PR DESCRIPTION
## Summary
- document that `.venv/bin` must be in `PATH` so the Task CLI is reachable

## Testing
- `task --version`
- `task check`


------
https://chatgpt.com/codex/tasks/task_e_68c18a4c44d48333862554a68350eca1