### PR TITLE
docs: document container image validation across platforms

### DIFF
--- a/docs/container_usage.md
+++ b/docs/container_usage.md
@@ -36,3 +36,31 @@ Set `CONTAINER_IMAGE` to select a different image such as
 `autoresearch-macos`. Generated files appear in the directory supplied on the
 host.
 
+## Validate images
+
+Run a basic command in each image to confirm it starts correctly.
+
+- Linux:
+
+  ```
+  docker run --rm autoresearch-linux-amd64 --version
+  ```
+
+- macOS:
+
+  ```
+  docker run --rm autoresearch-macos --version
+  ```
+
+- Windows (PowerShell):
+
+  ```
+  docker run --rm autoresearch-windows --version
+  ```
+
+If you built OCI archives, load them before running the checks:
+
+```
+docker load < dist/autoresearch-linux-amd64.oci
+```
+


### PR DESCRIPTION
## Summary
- expand container usage guide with commands to validate images on Linux, macOS, and Windows
- ensure release image workflow remains manual-only

## Testing
- `task check`
- `bash scripts/build_images.sh` *(fails: Container engine 'docker' not found)*
- `uv run --with mkdocs --with mkdocs-material --with 'mkdocstrings[python]' mkdocs build`
- `task verify` *(fails: tests/behavior/steps/query_interface_steps.py::test_visualize_query)*

------
https://chatgpt.com/codex/tasks/task_e_68c18a5492908333b71286fa0b830685