### PR TITLE
feat: enforce absolute config paths in deploy validator

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,6 +9,7 @@ The project uses **uv** for dependency management. Example commands use `uv`.
 Verify configuration before deploying:
 
 - Set `DEPLOY_ENV` and `CONFIG_DIR` to select the configuration set.
+- Use an absolute path for `CONFIG_DIR`; relative paths are rejected.
 - Run the validator:
 
   ```bash

--- a/scripts/validate_deploy.py
+++ b/scripts/validate_deploy.py
@@ -186,6 +186,9 @@ def _preflight(env: Mapping[str, str]) -> tuple[Path | None, list[str]]:
         errors.append(f"DEPLOY_ENV must be one of {allowed}")
         return None, errors
     config_dir = Path(env["CONFIG_DIR"])
+    if not config_dir.is_absolute():
+        errors.append(f"CONFIG_DIR must be an absolute path: {config_dir}")
+        return None, errors
     if not config_dir.is_dir():
         errors.append(f"CONFIG_DIR not found: {config_dir}")
         return None, errors

--- a/tests/integration/test_validate_deploy.py
+++ b/tests/integration/test_validate_deploy.py
@@ -183,6 +183,15 @@ def test_validate_deploy_missing_config_dir(tmp_path: Path) -> None:
     assert "CONFIG_DIR not found" in result.stderr
 
 
+def test_validate_deploy_relative_config_dir(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+    env = os.environ.copy()
+    env.update({"DEPLOY_ENV": "production", "CONFIG_DIR": "relative"})
+    result = _run(env, tmp_path)
+    assert result.returncode != 0
+    assert "absolute" in result.stderr
+
+
 @pytest.mark.slow
 def test_validate_deploy_scans_all_configs(tmp_path: Path) -> None:
     deploy_dir = tmp_path / "deploy"


### PR DESCRIPTION
## Summary
- enforce use of absolute paths for CONFIG_DIR during deployment validation
- test relative CONFIG_DIR handling in validate_deploy integration tests
- document requirement for absolute CONFIG_DIR in deployment guide

## Testing
- `uv run pre-commit run --files scripts/validate_deploy.py tests/integration/test_validate_deploy.py docs/deployment.md`
- `uv run --extra test pytest tests/integration/test_validate_deploy.py::test_validate_deploy_relative_config_dir -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c18a5980b08333aa635ec0b052394f