### PR TITLE
feat: version API schemas and refine ranking

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -12,7 +12,8 @@ For details on orchestrator state transitions and the API contract see
 [orchestrator_state.md](orchestrator_state.md).
 
 Requests and responses are versioned. Include `"version": "1"` in request
-bodies; responses echo the same field to signal the contract in use.
+bodies; responses echo the same field to signal the contract in use. The
+`QueryRequestV1` and `QueryResponseV1` models live in `autoresearch.api.models`.
 
 ## Configuration
 

--- a/docs/api_reference/query.md
+++ b/docs/api_reference/query.md
@@ -1,8 +1,10 @@
 # Query API
 
-The Query API provides versioned request and response models for interacting
-with the system. Each payload includes a `version` field so contracts remain
-stable as internal implementations evolve.
+The Query API exposes versioned Pydantic models for interacting with the
+system. `QueryRequestV1`, `QueryResponseV1`, `BatchQueryRequestV1` and
+`BatchQueryResponseV1` live in `autoresearch.api.models`. Each payload includes
+a `version` field so contracts remain stable as internal implementations
+evolve.
 
 ## Request Model
 

--- a/docs/api_reference/search.md
+++ b/docs/api_reference/search.md
@@ -44,7 +44,10 @@ The context-aware search functionality enhances search precision through entity 
 
 ## Relevance Ranking
 
-The relevance ranking functionality enhances search results by combining multiple relevance signals.
+The relevance ranking functionality enhances search results by combining
+multiple relevance signals. Semantic and DuckDB vector similarities are
+normalized before averaging so hybrid and semantic results align on the same
+scale.
 
 ::: autoresearch.config.models.SearchConfig
 

--- a/docs/search_backends.md
+++ b/docs/search_backends.md
@@ -18,7 +18,9 @@ hybrid_query = true
 When `hybrid_query` is `true` every query is converted to a vector embedding in
 addition to regular keyword lookup. Scores from BM25, semantic similarity and
 source credibility are combined according to their weights to produce a unified
-ranking across all backends.
+ranking across all backends. Semantic and DuckDB vector similarities are
+normalized before averaging so hybrid and semantic results share a common
+scale.
 
 Weights are configured as follows and must sum to `1.0`:
 

--- a/src/autoresearch/api/__init__.py
+++ b/src/autoresearch/api/__init__.py
@@ -20,6 +20,12 @@ from .utils import (
     get_request_logger,
     reset_request_log,
 )
+from .models import (
+    BatchQueryRequestV1,
+    BatchQueryResponseV1,
+    QueryRequestV1,
+    QueryResponseV1,
+)
 
 create_app = routing.create_app
 app = routing.app
@@ -43,6 +49,10 @@ __all__ = [
     "RateLimitExceeded",
     "Limiter",
     "query_endpoint",
+    "QueryRequestV1",
+    "QueryResponseV1",
+    "BatchQueryRequestV1",
+    "BatchQueryResponseV1",
     "enforce_permission",
     "create_request_logger",
     "get_request_logger",

--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -612,11 +612,11 @@ class Search:
 
         # Include vector similarity from DuckDB results when available
         duckdb_scores = [r.get("similarity", 0.5) for r in results]
+        semantic_norm = self.normalize_scores(semantic_scores)
+        duckdb_norm = self.normalize_scores(duckdb_scores)
 
-        # Average semantic embedding similarity with DuckDB score
-        embedding_scores = [
-            (semantic_scores[i] + duckdb_scores[i]) / 2 for i in range(len(results))
-        ]
+        # Average normalized semantic and DuckDB similarities
+        embedding_scores = [(semantic_norm[i] + duckdb_norm[i]) / 2 for i in range(len(results))]
 
         # Merge BM25 and semantic scores using weights
         merged_scores = self.merge_rank_scores(
@@ -678,9 +678,7 @@ class Search:
         ):
             model = self.get_sentence_transformer()
             if model is not None and hasattr(model, "embed"):
-                query_embedding = np.array(
-                    list(model.embed([query]))[0], dtype=float
-                )
+                query_embedding = np.array(list(model.embed([query]))[0], dtype=float)
 
         all_ranked: List[Dict[str, Any]] = []
         for name, docs in backend_results.items():


### PR DESCRIPTION
## Summary
- expose versioned API schemas and exports
- normalize hybrid and semantic ranking for search
- document versioned models and ranking harmonization

## Testing
- `uv run pre-commit run --files docs/api.md docs/api_reference/query.md docs/api_reference/search.md docs/search_backends.md src/autoresearch/api/__init__.py src/autoresearch/search/core.py`
- `uv run black --check src/autoresearch/api/__init__.py src/autoresearch/search/core.py`
- `uv run flake8 src/autoresearch/api/__init__.py src/autoresearch/search/core.py`
- `uv run pytest` *(fails: assert 200 == 401, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c19a31b128833395525c7cd7c54183