### PR TITLE
Fix API rate limiting spec and sync issue tracker

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,11 +4,13 @@
 
 - Installed Go Task 3.44.1 so `task` commands are available.
 - Added `.venv/bin` to `PATH` and confirmed `task --version` prints 3.44.1.
+- Added a `Simulation Expectations` section to `docs/specs/api_rate_limiting.md`
+  so spec linting succeeds.
 - `task check` runs 8 targeted tests and passes, warning that package metadata
   for GitPython, cibuildwheel, duckdb-extension-vss, spacy, types-networkx,
   types-protobuf, types-requests, and types-tabulate is missing.
-- `task verify` runs 8 targeted unit tests successfully. A subsequent coverage
-  run was interrupted, producing a `KeyboardInterrupt` stack trace.
+- `task verify` fails at
+  `tests/unit/search/test_ranking_formula.py::test_rank_results_weighted_combination`.
 - Confirmed all API authentication integration tests pass and archived the
   `fix-api-authentication-integration-tests` issue.
 

--- a/docs/specs/api_rate_limiting.md
+++ b/docs/specs/api_rate_limiting.md
@@ -50,6 +50,12 @@ for step in range(6):
 
 Tokens rise linearly and stop at ``C``, demonstrating convergence.
 
+## Simulation Expectations
+
+The simulation must show the bucket refilling linearly until it reaches
+capacity ``C``. Once full, further iterations should leave the level
+unchanged, proving convergence under the configured rate ``R``.
+
 ## Traceability
 
 

--- a/issues/containerize-and-package.md
+++ b/issues/containerize-and-package.md
@@ -7,9 +7,6 @@ checks in [validate-deployment-configurations](validate-deployment-configuration
 and broader performance goals in
 [reach-stable-performance-and-interfaces](reach-stable-performance-and-interfaces.md).
 
-## Milestone
-- 2026-09-01
-
 ## Dependencies
 None.
 

--- a/issues/fix-ranking-convergence-script-output.md
+++ b/issues/fix-ranking-convergence-script-output.md
@@ -1,7 +1,9 @@
 # Fix ranking convergence script output
 
 ## Context
-`tests/integration/test_search_ranking_convergence.py::test_ranking_convergence_script` fails because the script prints `mean convergence step: 1.0` without the expected `converged in` text.
+`tests/integration/test_search_ranking_convergence.py::test_ranking_convergence_script`
+fails because the script prints `mean convergence step: 1.0` without the
+expected `converged in` text.
 
 ## Dependencies
 None.

--- a/issues/fix-weighted-ranking-formula-order.md
+++ b/issues/fix-weighted-ranking-formula-order.md
@@ -1,0 +1,15 @@
+# Fix weighted ranking formula order
+
+## Context
+`task verify` fails in `tests/unit/search/test_ranking_formula.py::test_rank_results_weighted_combination`
+which expects results sorted by weight but receives them reversed.
+
+## Dependencies
+None.
+
+## Acceptance Criteria
+- Adjust ranking formula so weighted combinations return highest scores first.
+- `tests/unit/search/test_ranking_formula.py::test_rank_results_weighted_combination` passes.
+
+## Status
+Open

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -1,12 +1,15 @@
 # Prepare first alpha release
 
 ## Context
-The project remains unreleased even though the codebase and documentation are publicly available. To tag version v0.1.0a1, we need a coordinated effort to finalize outstanding testing, documentation, and packaging tasks while keeping workflows dispatch-only.
+The project remains unreleased even though the codebase and documentation are
+publicly available. To tag version v0.1.0a1, we need a coordinated effort to
+finalize outstanding testing, documentation, and packaging tasks while keeping
+workflows dispatch-only.
 
 ## Dependencies
 - [add-test-coverage-for-optional-components](add-test-coverage-for-optional-components.md)
 - [resolve-package-metadata-warnings](resolve-package-metadata-warnings.md)
-- [fix-api-authentication-integration-tests](fix-api-authentication-integration-tests.md)
+- [fix-api-authentication-integration-tests](archive/fix-api-authentication-integration-tests.md)
 - [streamline-task-verify-extras](streamline-task-verify-extras.md)
 
 ## Acceptance Criteria

--- a/issues/reach-stable-performance-and-interfaces.md
+++ b/issues/reach-stable-performance-and-interfaces.md
@@ -4,9 +4,6 @@
 The 1.0.0 milestone aims to provide a polished, production-ready system with
 stable interfaces and tuned performance.
 
-## Milestone
-- 1.0.0 (2027-06-01)
-
 ## Dependencies
 - [containerize-and-package](containerize-and-package.md)
 - [validate-deployment-configurations](./validate-deployment-configurations.md)

--- a/issues/validate-deployment-configurations.md
+++ b/issues/validate-deployment-configurations.md
@@ -5,9 +5,6 @@ Reliable deployment requires validated scripts and configuration checks to
 prevent runtime errors. Builds on containerization work and supports
 [reach-stable-performance-and-interfaces](reach-stable-performance-and-interfaces.md).
 
-## Milestone
-- 2027-01-15
-
 ## Dependencies
 - [containerize-and-package](containerize-and-package.md)
 


### PR DESCRIPTION
## Summary
- add missing Simulation Expectations section to API rate-limiting spec
- harmonize issue files with template and fix broken dependency link
- track failing weighted ranking formula test

## Testing
- `task check`
- `task verify` *(fails: tests/unit/search/test_ranking_formula.py::test_rank_results_weighted_combination)*
- `uv run mkdocs build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c19deef0dc8333866d0fd9884cd130