### PR TITLE
docs: revise 0.1.0a1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Reference issues by slugged filename (for example,
   403) with **95%** coverage achieved.
   - Add rich configuration context fixtures with sample data for tests.
     [create-more-comprehensive-test-contexts]
+- Revised `docs/release_notes/v0.1.0a1.md` with new 2026-09-15 target date
+  and unresolved gaps.
 - Optimize mypy configuration to skip site packages, preventing hangs during
 verification. [investigate-mypy-hang](issues/archive/investigate-mypy-hang.md).
 - Document virtual environment best practices in the developer guide.

--- a/docs/release_notes/v0.1.0a1.md
+++ b/docs/release_notes/v0.1.0a1.md
@@ -1,4 +1,4 @@
-# Autoresearch 0.1.0a1 (2025-09-06)
+# Autoresearch 0.1.0a1 (2026-09-15)
 
 ## Features
 
@@ -37,9 +37,9 @@
 
 - Integration tests are skipped.
 - Coverage reflects only modules exercised by the test suite.
-- Unit tests in `tests/unit/test_check_env_warnings.py` fail due to missing
-  warnings.
+- `check_env` warnings cause
+  `tests/unit/test_check_env_warnings.py::test_missing_package_metadata_warns`
+  to fail.
+- TestPyPI dry run returns HTTP 403.
 - Installing all extras pulls large wheels and may require significant disk
   space.
-- Packaging commands use `uv run python -m build` followed by
-  `uv run scripts/publish_dev.py --dry-run`.


### PR DESCRIPTION
## Summary
- update 0.1.0a1 release notes with the new 2026-09-15 target date and outstanding issues
- note the release notes revision in the changelog

## Testing
- `uv run --with mkdocs --with mkdocs-material --with mkdocstrings[python] mkdocs build`
- `PATH="$(pwd)/bin:$PATH" ./bin/task check`


------
https://chatgpt.com/codex/tasks/task_e_68c1a70de13883339af717e6c1881a9c