### PR TITLE
Document verify failure for optional extras

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -16,6 +16,9 @@
   `tests/unit/search/test_ranking_formula.py::test_rank_results_weighted_combination`.
 - Confirmed all API authentication integration tests pass and archived the
   `fix-api-authentication-integration-tests` issue.
+- `task verify EXTRAS="nlp ui vss git distributed analysis llm parsers"` fails at
+  `tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_query_concurrent`; no
+  coverage data is produced and `uv run coverage report` outputs "No data to report."
 
 ## September 9, 2025
 

--- a/issues/resolve-concurrent-query-interface-regression.md
+++ b/issues/resolve-concurrent-query-interface-regression.md
@@ -2,6 +2,8 @@
 
 ## Context
 Running `uv run --extra test pytest` on September 9, 2025 shows `tests/integration/test_a2a_interface.py::test_concurrent_queries` failing with `assert 0 == 3`, indicating the A2A interface no longer returns results concurrently.
+On September 10, 2025, `task verify EXTRAS="nlp ui vss git distributed analysis llm parsers"` fails at
+`tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_query_concurrent`, further confirming concurrency issues.
 
 ## Dependencies
 None.


### PR DESCRIPTION
## Summary
- note that running `task verify` with optional extras fails on A2A interface concurrency test
- record coverage report missing data
- log ongoing concurrency issue in repo issue tracker

## Testing
- `task check`
- `task verify EXTRAS="nlp ui vss git distributed analysis llm parsers"` *(fails: tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_query_concurrent)*
- `uv run coverage report` *(fails: No data to report)*

------
https://chatgpt.com/codex/tasks/task_e_68c1af3a29dc8333905f0234399418c5