### PR TITLE
Document API schemas and normalize search ranking

### DIFF
--- a/docs/api_reference/query.md
+++ b/docs/api_reference/query.md
@@ -8,6 +8,8 @@ evolve.
 
 ## Request Model
 
+::: autoresearch.api.models.QueryRequestV1
+
 Example request to `/query`:
 
 ```json
@@ -18,6 +20,8 @@ Example request to `/query`:
 ```
 
 ## Response Model
+
+::: autoresearch.api.models.QueryResponseV1
 
 A successful response includes reasoning and citations:
 
@@ -31,7 +35,13 @@ A successful response includes reasoning and citations:
 }
 ```
 
+## Batch Request
+
+::: autoresearch.api.models.BatchQueryRequestV1
+
 ## Batch Response
+
+::: autoresearch.api.models.BatchQueryResponseV1
 
 The batch endpoint wraps individual responses with pagination metadata:
 

--- a/docs/specs/search.md
+++ b/docs/specs/search.md
@@ -23,14 +23,15 @@ and hybrid queries and exposes a CLI entry point.
 ### Hybrid
 
 - Computes keyword and vector scores separately.
+- Normalizes semantic and DuckDB similarities before averaging.
 - Combines results with a weighted sum of keyword, vector, and source
   credibility weights.
-- Normalizes scores and resolves ties by deterministic document identifier.
+- Resolves ties by deterministic document identifier.
 
 ## Invariants
 
 - Results are ordered by descending final score and are stable for repeated
-  queries.
+  queries, yielding consistent ordering across hybrid and semantic modes.
 - Indexing is idempotent: re-ingesting an existing document updates the record
   without creating duplicates.
 - Search does not mutate stored documents outside explicit persist or update


### PR DESCRIPTION
## Summary
- document versioned API request/response schemas and stream semantics
- normalize semantic and DuckDB scores for stable hybrid ranking
- clarify hybrid ranking behavior in specs and API reference

## Testing
- `task check`
- `task verify` *(fails: tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_query_concurrent - assert 1757532920.3513608 <= 1757532920.3014264)*
- `uv run mkdocs build` *(fails: AttributeError: 'dict' object has no attribute 'link_titles')*

------
https://chatgpt.com/codex/tasks/task_e_68c1cf0b58708333955d84c30868a5d7