### PR TITLE
docs: detail config resolution and failure modes

### DIFF
--- a/docs/specs/config-utils.md
+++ b/docs/specs/config-utils.md
@@ -6,22 +6,43 @@ Configuration helper utilities for the Streamlit app.
 
 ## Algorithms
 
-- Implement core behaviors described above.
+- Start from embedded defaults.
+- Load the base configuration file.
+- Merge selected profiles in the order provided.
+- Apply environment variable overrides.
+- Validate and freeze the resolved state.
 
 ## Invariants
 
-- Preserve documented state across operations.
+- Merge order yields deterministic values.
+- Profiles override only declared keys.
+- Validation ensures required fields and types.
+- The resolved configuration is immutable.
+
+## Failure Modes
+
+- Unknown profile name.
+- Missing or unreadable configuration file.
+- Conflicting environment override.
+- Invalid value that fails validation.
 
 ## Proof Sketch
 
-Core routines enforce invariants by validating inputs and state.
+Deterministic layering ensures that any combination of profiles produces the
+same state regardless of evaluation path. Validation checks run after each
+merge, preventing propagation of invalid data. Immutability prevents later
+mutation from violating assumptions.
 
 ## Simulation Expectations
+
+- Default profile alone yields baseline settings.
+- Base plus a user profile merges expected overrides.
+- Multiple profiles composed in order preserve precedence.
+- Conflicting profiles raise validation errors.
 
 Unit tests cover nominal and edge cases for these routines.
 
 ## Traceability
-
 
 - Modules
   - [src/autoresearch/config_utils.py][m1]


### PR DESCRIPTION
## Summary
- document stepwise config resolution for deterministic merges and env overrides
- capture invariants and failure modes for profile handling
- outline proof and simulation scenarios linked to relevant tests

## Testing
- `task check`
- `uv run mkdocs build` *(fails: PythonConfig.__init__() got an unexpected keyword argument 'selection')*
- `task verify` *(fails: tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_query_concurrent)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cf1f60fc8333b6fca9232e06ad4a