### PR TITLE
chore: track A2A concurrency proof

### DIFF
--- a/issues/add-a2a-concurrency-proofs-and-simulations.md
+++ b/issues/add-a2a-concurrency-proofs-and-simulations.md
@@ -1,0 +1,20 @@
+# Add A2A concurrency proofs and simulations
+
+## Context
+The A2A interface handles concurrent queries but lacks formal proof or
+simulation validating its behavior. The failing
+`tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_query_concurrent`
+points to gaps in our reasoning and documentation. Formalizing this module
+will prevent future regressions.
+
+## Dependencies
+- [resolve-concurrent-query-interface-regression](resolve-concurrent-query-interface-regression.md)
+
+## Acceptance Criteria
+- Provide a proof sketch or formal argument for the A2A concurrency model.
+- Supply a simulation demonstrating expected concurrent behavior.
+- Add tests exercising the proof and simulation paths.
+- Reference proofs and simulations from the relevant specs and docs.
+
+## Status
+Open

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -11,6 +11,7 @@ workflows dispatch-only.
 - [resolve-package-metadata-warnings](resolve-package-metadata-warnings.md)
 - [fix-api-authentication-integration-tests](archive/fix-api-authentication-integration-tests.md)
 - [streamline-task-verify-extras](streamline-task-verify-extras.md)
+- [resolve-concurrent-query-interface-regression](resolve-concurrent-query-interface-regression.md)
 
 ## Acceptance Criteria
 - All dependency issues are closed.


### PR DESCRIPTION
## Summary
- track missing proof and simulation for A2A concurrent queries
- note concurrency regression dependency for alpha release prep

## Testing
- `task check`
- `task verify` *(fails: tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_query_concurrent)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fa9460948333bf0b5588afdee991