### PR TITLE
Sync test extras by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ processing. Install them on demand with `uv sync --extra <name>`,
 `task install EXTRAS="<name>"`, or
 `pip install "autoresearch[<name>]"`. Heavy groups like `nlp`,
 `distributed`, `analysis`, and `llm` require additional dependencies and
-are excluded from `task verify`.
+are excluded from `task verify`. Set `EXTRAS` when running `task`
+commands to enable them, for example `EXTRAS="nlp distributed" task
+verify`.
 
 A running Redis server is needed only for the `[distributed]` extra or tests
 tagged `requires_distributed`. The test suite's `redis_client` fixture connects
@@ -60,17 +62,18 @@ with:
 uv run pytest -m requires_distributed -q
 ```
 
-To bootstrap a Python 3.12+ environment with the minimal development extras run:
+To bootstrap a Python 3.12+ environment with the minimal development and
+test extras run:
 
 ```bash
 task install
 ```
 
-This syncs the `dev-minimal` extra. Add the `test` group when you need the full
-suite:
+This syncs the `dev-minimal` and `test` extras. Include heavy groups
+only when required:
 
 ```bash
-task install EXTRAS="test"
+task install EXTRAS="nlp distributed"
 ```
 
 To install the `[test]` extras directly without Go Task and download the DuckDB

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,7 +27,7 @@ tasks:
               export PATH="$(pwd)/.venv/bin:$PATH"
           fi
       - |
-          extras="dev-minimal"
+          extras="dev-minimal test"
           uv sync --python-platform x86_64-manylinux_2_28 \
               $(printf ' --extra %s' $extras) \
               {{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}} \
@@ -36,8 +36,8 @@ tasks:
       - uv run flake8 src tests
     desc: |
       Initialize dev env with minimal extras.
-      Syncs the dev-minimal extra by default.
-      Provide optional groups with EXTRAS, e.g. "test", "nlp", or "parsers".
+      Syncs the dev-minimal and test extras by default.
+      Provide optional groups with EXTRAS, e.g. "nlp" or "parsers".
       Set EXTRAS="gpu" to include optional GPU packages.
       Place matching wheels in wheels/gpu to avoid source builds.
   check-env:
@@ -55,16 +55,17 @@ tasks:
   check:
     vars:
       EXTRAS: "{{.EXTRAS | default \"\"}}"
-    # Minimal validation for quick feedback. Syncs only the dev-minimal extra
-    # and exercises version and CLI smoke tests. Skips slow tests and scenarios
-    # requiring optional UI (`.[ui]`) or VSS (`.[vss]`) extras.
+    # Minimal validation for quick feedback. Syncs the dev-minimal and test
+    # extras and exercises version and CLI smoke tests. Skips slow tests and
+    # scenarios requiring optional UI (`.[ui]`) or VSS (`.[vss]`) extras.
     cmds:
       - |
           uv sync \
             --python-platform x86_64-manylinux_2_28 \
             --extra dev-minimal \
+            --extra test \
             {{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}}
-      - task check-env EXTRAS="dev{{if .EXTRAS}} {{.EXTRAS}}{{end}}"
+      - task check-env EXTRAS="{{.EXTRAS}}"
       - uv run flake8 src
       - uv run mypy src --exclude src/autoresearch/distributed
       - task lint-specs

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -7,20 +7,20 @@ reliability of the test suite.
 For environment setup instructions see [installation](installation.md).
 
 Tests may require optional dependencies. Markers such as `requires_nlp` or
-`requires_parsers` map to extras with the same names. `task install` syncs only
-the `dev-minimal` extra; add groups with `EXTRAS` or set `AR_EXTRAS` when using
-the setup script. `task verify` installs the `dev-minimal` and `test` extras by
-default to keep setup light. Include heavy groups such as `nlp`, `distributed`,
-`analysis`, or `llm` only when needed:
+`requires_parsers` map to extras with the same names. `task install` syncs the
+`dev-minimal` and `test` extras by default; add groups with `EXTRAS` or set
+`AR_EXTRAS` when using the setup script. `task verify` also installs the
+`dev-minimal` and `test` extras by default. Include heavy groups such as `nlp`,
+`distributed`, `analysis`, or `llm` only when needed:
 
 ```bash
-EXTRAS="test nlp parsers" task install
+EXTRAS="nlp parsers" task install
 EXTRAS="analysis distributed" task verify
 ```
 
 Available extras enable optional features. Heavy groups require explicit flags:
 
-- `test` - full test suite tools
+- `test` - full test suite tools (installed by default)
 - `nlp` - language processing via spaCy and BERTopic
 - `ui` - Streamlit interface
 - `vss` - DuckDB vector search extension
@@ -48,9 +48,9 @@ Tests are organized into four categories:
 Two installation strategies support different workflows:
 
 - **Minimal:** `task check` runs linting, type checks, and a fast targeted
-  subset. It syncs only the `dev-minimal` extra. Add optional features with
-  `task install EXTRAS="test nlp ui"` choosing from `analysis`, `distributed`,
-  `git`, `llm`, `nlp`, `parsers`, `ui`, `vss`, `gpu`, and `test`.
+  subset. It syncs the `dev-minimal` and `test` extras. Add optional features
+  with `task install EXTRAS="nlp ui"` choosing from `analysis`, `distributed`,
+  `git`, `llm`, `nlp`, `parsers`, `ui`, `vss`, and `gpu`.
 - **Full:** `task verify` runs linting, type checks, and coverage. It installs
   the `dev-minimal` and `test` extras by default. Append optional groups with
   `EXTRAS` for integration scenarios.


### PR DESCRIPTION
## Summary
- default environment sync now includes `dev-minimal` and `test`
- document enabling heavy extras via `EXTRAS` in README and testing guidelines
- clarify quick check uses `dev-minimal`+`test`

## Testing
- `task check`
- `uv run mkdocs build`
- `task verify` *(fails: TestA2AInterface::test_handle_query_concurrent - assert 1757544604.7344816 <= 1757544604.6849024)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ff0ed6ac8333a44659a07ab26fdb