### PR TITLE
feat: validate database connectivity before deploy

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -16,6 +16,8 @@ Verify configuration before deploying:
 - Optionally set `EXTRAS` to validate required optional dependencies.
 - Set `CONTAINER_ENGINE` to ensure Docker or Podman is available.
 - Set `DEPLOY_DIR` to scan other configuration trees.
+- Set `DATABASE_URL` to verify the application database is reachable. The
+  validator supports `sqlite:///` URLs and runs a simple query.
 - Run the validator:
 
   ```bash
@@ -26,7 +28,9 @@ Verify configuration before deploying:
   schema violations.
 
   The validator loads `deploy.yml` and `.env` from `CONFIG_DIR` and exits with
-  an error if required keys, services, or files are missing.
+  an error if required keys, services, or files are missing. When
+  `DATABASE_URL` is set it performs a lightweight connection test and fails if
+  the database cannot be reached.
 
 Proceed with the deployment steps only after the command exits without
 errors.

--- a/tests/integration/deploy/test_database_check.py
+++ b/tests/integration/deploy/test_database_check.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Database connectivity checks for ``scripts/validate_deploy.py``."""
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "validate_deploy.py"
+
+
+def _write_config(tmp_path: Path) -> None:
+    (tmp_path / "deploy.yml").write_text("version: 1\nservices: [api]\n")
+    (tmp_path / ".env").write_text("KEY=value\n")
+
+
+def _run(env: dict[str, str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_database_available(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+    db_path = tmp_path / "db.sqlite"
+    sqlite3.connect(db_path).close()
+    env = os.environ.copy()
+    env.update(
+        {
+            "DEPLOY_ENV": "production",
+            "CONFIG_DIR": str(tmp_path),
+            "DATABASE_URL": f"sqlite:///{db_path}",
+        }
+    )
+    result = _run(env, tmp_path)
+    assert result.returncode == 0
+    assert "validated" in result.stdout.lower()
+
+
+def test_database_unavailable(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+    bad_path = tmp_path / "missing" / "db.sqlite"
+    env = os.environ.copy()
+    env.update(
+        {
+            "DEPLOY_ENV": "production",
+            "CONFIG_DIR": str(tmp_path),
+            "DATABASE_URL": f"sqlite:///{bad_path}",
+        }
+    )
+    result = _run(env, tmp_path)
+    assert result.returncode != 0
+    assert "database unavailable" in result.stderr.lower()


### PR DESCRIPTION
## Summary
- ensure `validate_deploy.py` checks optional database connectivity
- document `DATABASE_URL` preflight option in deployment guide
- test deployment validator database success and failure cases

## Testing
- `task check`
- `task verify` *(fails: tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_query_concurrent - assert 1757544528.6986258 <= 1757544528.636327)*
- `uv run mkdocs build`
- `uv run pytest tests/integration/deploy/test_database_check.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1ff1c9e348333992f34f0b9d091e7