### PR TITLE
Mark optional-extra tests

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -11,6 +11,9 @@ Taskfile commands.
   during coverage, leaving a multiprocessing resource tracker `KeyError`.
 - `uv run pytest tests/unit/test_version.py -q` passes without
   `bdd_features_base_dir` warnings.
+- Added `requires_*` markers to behavior step files and adjusted LLM extra test.
+- `task coverage` with all extras failed with a segmentation fault; coverage
+  could not be determined.
 - Archived
   [ensure-pytest-bdd-plugin-available-for-tests](issues/archive/ensure-pytest-bdd-plugin-available-for-tests.md)
   after confirming `pytest-bdd` is installed.

--- a/tests/behavior/steps/cross_modal_integration_steps.py
+++ b/tests/behavior/steps/cross_modal_integration_steps.py
@@ -5,6 +5,8 @@ import pytest
 from .common_steps import application_running
 from autoresearch.models import QueryResponse
 
+pytestmark = pytest.mark.requires_ui
+
 
 @given("the Autoresearch system is running")
 def autoresearch_system_running(tmp_path, monkeypatch):

--- a/tests/behavior/steps/gui_history_steps.py
+++ b/tests/behavior/steps/gui_history_steps.py
@@ -9,6 +9,8 @@ from pytest_bdd import scenario, given, when, then
 from autoresearch.models import QueryResponse
 from autoresearch.config.models import ConfigModel
 
+pytestmark = pytest.mark.requires_ui
+
 
 @given("the Streamlit application has a stored query history")
 def streamlit_app_with_history(monkeypatch, tmp_path, bdd_context):

--- a/tests/behavior/steps/local_sources_steps.py
+++ b/tests/behavior/steps/local_sources_steps.py
@@ -10,6 +10,8 @@ from docx import Document
 import pytest
 import importlib.util
 
+pytestmark = [pytest.mark.requires_git, pytest.mark.requires_parsers]
+
 try:
     _spec = importlib.util.find_spec("git")
     _git_available = bool(_spec and _spec.origin)

--- a/tests/behavior/steps/reasoning_mode_ui_steps.py
+++ b/tests/behavior/steps/reasoning_mode_ui_steps.py
@@ -1,8 +1,11 @@
 from pytest_bdd import scenarios
+import pytest
 
 pytest_plugins = [
     "tests.behavior.steps.streamlit_gui_steps",
     "tests.behavior.steps.reasoning_modes_steps",
 ]
+
+pytestmark = pytest.mark.requires_ui
 
 scenarios("../features/reasoning_mode_ui.feature")

--- a/tests/behavior/steps/streamlit_gui_steps.py
+++ b/tests/behavior/steps/streamlit_gui_steps.py
@@ -14,6 +14,8 @@ from .common_steps import (
 pytest_plugins = ["tests.behavior.steps.common_steps"]
 from autoresearch.models import QueryResponse
 
+pytestmark = pytest.mark.requires_ui
+
 
 @given("the Streamlit application is running")
 def streamlit_app_running(monkeypatch, bdd_context, isolate_network, restore_environment):

--- a/tests/behavior/steps/ui_accessibility_steps.py
+++ b/tests/behavior/steps/ui_accessibility_steps.py
@@ -5,6 +5,8 @@ import pytest
 from .common_steps import application_running
 from autoresearch.cli_utils import format_error, format_success, format_info
 
+pytestmark = pytest.mark.requires_ui
+
 
 @given("the Autoresearch system is running")
 def autoresearch_system_running(tmp_path, monkeypatch):

--- a/tests/behavior/steps/vector_extension_handling_steps.py
+++ b/tests/behavior/steps/vector_extension_handling_steps.py
@@ -14,6 +14,8 @@ from autoresearch.storage import StorageManager, teardown
 
 logger = get_logger(__name__)
 
+pytestmark = pytest.mark.requires_vss
+
 
 # Scenarios
 @scenario(

--- a/tests/behavior/steps/vector_search_performance_steps.py
+++ b/tests/behavior/steps/vector_search_performance_steps.py
@@ -2,7 +2,11 @@ from pytest_bdd import scenario, when, then
 from unittest.mock import patch
 import time
 
+import pytest
+
 from autoresearch.storage import StorageManager
+
+pytestmark = pytest.mark.requires_vss
 
 
 @scenario("../features/vector_search_performance.feature", "Vector search executes quickly")

--- a/tests/integration/extras/test_llm_extra.py
+++ b/tests/integration/extras/test_llm_extra.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import pytest
 
-from autoresearch.search.context import _try_import_sentence_transformers
 
 
 @pytest.mark.requires_llm
 def test_fastembed_available() -> None:
     """The LLM extra installs fast embedding models."""
-    assert _try_import_sentence_transformers() is True
+    fastembed = pytest.importorskip("fastembed")
+    assert hasattr(fastembed, "TextEmbedding")


### PR DESCRIPTION
## Summary
- mark optional extra test files with `requires_*` markers
- simplify LLM extra test to rely on fastembed availability
- document coverage attempt outcome

## Testing
- `task check`
- `task coverage` *(fails: segmentation fault before coverage report)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d16982108333b6638da27bd17473