### PR TITLE
Ensure multiprocessing queues close cleanly

### DIFF
--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -19,6 +19,15 @@ coordinator and agent results are aggregated asynchronously. Each broker
 supports a `publish` method and a `queue` attribute with `put` and `get`
 operations.
 
+## Resource cleanup
+
+Multiprocessing queues spawn feeder threads that must be terminated
+explicitly. Before tests exit, call `close()` and `join_thread()` on every
+queue. The brokers' `shutdown()` method performs this cleanup, so tests should
+invoke it whenever a broker is created. Likewise, ensure any custom pools or
+queues created in tests are closed in a `finally` block to prevent resource
+tracker errors.
+
 ## Analytical performance model
 
 We model the orchestrator as an M/M/c queue with a fixed dispatch delay

--- a/tests/behavior/fixtures/__init__.py
+++ b/tests/behavior/fixtures/__init__.py
@@ -5,7 +5,11 @@ from typer.testing import CliRunner
 @pytest.fixture
 def bdd_context() -> dict:
     """Mutable mapping for sharing data between BDD steps."""
-    return {}
+    ctx: dict = {}
+    yield ctx
+    broker = ctx.get("broker")
+    if broker and hasattr(broker, "shutdown"):
+        broker.shutdown()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- close and join multiprocessing queues in storage and result coordinators
- shut down message brokers in BDD context fixture
- document queue cleanup strategy for distributed executors

## Testing
- `task verify` *(fails: command not found)*
- `uv run --extra test pytest -q` *(fails: authentication-related tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f264b72c8333a5aa5aa712bf79d7