### PR TITLE
Add async API response model and refine search ranking

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -14,7 +14,8 @@ For details on orchestrator state transitions and the API contract see
 Requests and responses are versioned. Include `"version": "1"` in request
 bodies; responses echo the same field to signal the contract in use. The
 `QueryRequestV1` and `QueryResponseV1` models live in
-`autoresearch.api.models`.
+`autoresearch.api.models`. The `/query/async` endpoint acknowledges accepted
+jobs with `AsyncQueryResponseV1` containing the `query_id`.
 
 Deprecated versions remain available for two minor releases and return
 **410 Gone** once support is removed. Unknown versions yield

--- a/docs/search_backends.md
+++ b/docs/search_backends.md
@@ -20,7 +20,8 @@ addition to regular keyword lookup. Scores from BM25, semantic similarity and
 source credibility are combined according to their weights to produce a unified
 ranking across all backends. Semantic and DuckDB vector similarities are
 normalized before averaging so hybrid and semantic results share a common
-scale.
+scale. If the vector store yields no matches the semantic scores are used
+directly to avoid downscaling.
 
 Weights are configured as follows and must sum to `1.0`:
 

--- a/src/autoresearch/api/__init__.py
+++ b/src/autoresearch/api/__init__.py
@@ -13,18 +13,19 @@ from .middleware import (
     get_remote_address,
     parse,
 )
+from .models import (
+    AsyncQueryResponseV1,
+    BatchQueryRequestV1,
+    BatchQueryResponseV1,
+    QueryRequestV1,
+    QueryResponseV1,
+)
 from .utils import (
     RequestLogger,
     create_request_logger,
     enforce_permission,
     get_request_logger,
     reset_request_log,
-)
-from .models import (
-    BatchQueryRequestV1,
-    BatchQueryResponseV1,
-    QueryRequestV1,
-    QueryResponseV1,
 )
 
 create_app = routing.create_app
@@ -53,6 +54,7 @@ __all__ = [
     "QueryResponseV1",
     "BatchQueryRequestV1",
     "BatchQueryResponseV1",
+    "AsyncQueryResponseV1",
     "enforce_permission",
     "create_request_logger",
     "get_request_logger",

--- a/src/autoresearch/api/models.py
+++ b/src/autoresearch/api/models.py
@@ -69,10 +69,19 @@ class BatchQueryResponseV1(VersionedModel):
     results: List[QueryResponseV1]
 
 
+class AsyncQueryResponseV1(VersionedModel):
+    """Async query acknowledgement model for version 1."""
+
+    __version__ = "1"
+    version: str = Field(default="1", description="API version for the response")
+    query_id: str = Field(description="Identifier for tracking the async query")
+
+
 __all__ = [
     "ReasoningMode",
     "QueryRequestV1",
     "QueryResponseV1",
     "BatchQueryRequestV1",
     "BatchQueryResponseV1",
+    "AsyncQueryResponseV1",
 ]

--- a/src/autoresearch/api/routing.py
+++ b/src/autoresearch/api/routing.py
@@ -36,6 +36,7 @@ from .middleware import (
     get_remote_address,
 )
 from .models import (
+    AsyncQueryResponseV1,
     BatchQueryRequestV1,
     BatchQueryResponseV1,
     QueryRequestV1,
@@ -260,7 +261,9 @@ async def batch_query_endpoint(
 
 
 @router.post("/query/async", dependencies=[require_permission("query")])
-async def async_query_endpoint(request: QueryRequestV1, http_request: Request) -> dict:
+async def async_query_endpoint(
+    request: QueryRequestV1, http_request: Request
+) -> AsyncQueryResponseV1:
     """Run a query asynchronously and return its task identifier.
 
     Args:
@@ -268,7 +271,7 @@ async def async_query_endpoint(request: QueryRequestV1, http_request: Request) -
         http_request: Raw ``Request`` object for storing task state.
 
     Returns:
-        dict: Mapping containing the ``query_id`` of the background task.
+        AsyncQueryResponseV1: ``query_id`` for tracking the background task.
     """
     validate_version(request.version)
     config = get_config()
@@ -311,7 +314,7 @@ async def async_query_endpoint(request: QueryRequestV1, http_request: Request) -
 
     future: asyncio.Future = asyncio.create_task(runner())
     http_request.app.state.async_tasks[task_id] = future
-    return {"query_id": task_id}
+    return AsyncQueryResponseV1(query_id=task_id)
 
 
 @router.get("/query/{query_id}", dependencies=[require_permission("query")])

--- a/tests/integration/test_api_versioning.py
+++ b/tests/integration/test_api_versioning.py
@@ -35,3 +35,19 @@ def test_batch_response_includes_version(monkeypatch, api_client) -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["version"] == "1"
+
+
+def test_async_endpoint_returns_version(monkeypatch, api_client) -> None:
+    """Async query acknowledgements include the schema version."""
+    _setup(monkeypatch)
+
+    class Dummy:
+        async def run_query_async(self, query, config):
+            return QueryResponseV1(answer=query, citations=[], reasoning=[], metrics={})
+
+    monkeypatch.setattr("autoresearch.api.routing.create_orchestrator", lambda: Dummy())
+    resp = api_client.post("/query/async", json={"query": "hi"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] == "1"
+    assert "query_id" in body

--- a/tests/integration/test_search_duckdb_semantic_merge.py
+++ b/tests/integration/test_search_duckdb_semantic_merge.py
@@ -1,0 +1,32 @@
+from autoresearch.config import ConfigModel, SearchConfig
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.search.core import Search
+
+
+def _config(monkeypatch) -> None:
+    cfg = ConfigModel(
+        search=SearchConfig(
+            bm25_weight=0.0,
+            semantic_similarity_weight=1.0,
+            source_credibility_weight=0.0,
+            use_bm25=False,
+            use_source_credibility=False,
+            use_semantic_similarity=True,
+        )
+    )
+    ConfigLoader.reset_instance()
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+
+
+def test_semantic_scores_ignore_zero_vectors(monkeypatch) -> None:
+    _config(monkeypatch)
+    results = [{"title": "a", "similarity": 0.0}, {"title": "b", "similarity": 0.0}]
+    monkeypatch.setattr(
+        Search,
+        "calculate_semantic_similarity",
+        lambda self, q, docs, query_embedding=None: [0.9, 0.1],
+    )
+    ranked = Search.rank_results("q", results)
+    assert [r["title"] for r in ranked] == ["a", "b"]
+    assert ranked[0]["relevance_score"] == 1.0
+    assert ranked[1]["relevance_score"] < 0.2


### PR DESCRIPTION
## Summary
- add `AsyncQueryResponseV1` and use it for `/query/async`
- guard semantic score merging when vector store returns no matches
- document versioned API schemas and hybrid ranking fallback

## Testing
- `uv run pre-commit run --files src/autoresearch/api/models.py src/autoresearch/api/routing.py src/autoresearch/api/__init__.py src/autoresearch/search/core.py docs/api.md docs/search_backends.md tests/integration/test_api_versioning.py tests/integration/test_search_duckdb_semantic_merge.py`
- `uv run black --check src/autoresearch/api/models.py src/autoresearch/api/routing.py src/autoresearch/api/__init__.py src/autoresearch/search/core.py tests/integration/test_api_versioning.py tests/integration/test_search_duckdb_semantic_merge.py`
- `uv run isort --check-only --diff src/autoresearch/api/models.py src/autoresearch/api/routing.py src/autoresearch/api/__init__.py src/autoresearch/search/core.py tests/integration/test_api_versioning.py tests/integration/test_search_duckdb_semantic_merge.py`
- `uv run flake8 -v src/autoresearch/api/models.py src/autoresearch/api/routing.py src/autoresearch/api/__init__.py src/autoresearch/search/core.py tests/integration/test_api_versioning.py tests/integration/test_search_duckdb_semantic_merge.py`
- `uv run pytest tests/integration/test_api_versioning.py::test_async_endpoint_returns_version tests/integration/test_search_duckdb_semantic_merge.py::test_semantic_scores_ignore_zero_vectors`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c4f51bc9cc833394dcefdc085b7379