### PR TITLE
docs: sync unreleased status for v0.1.0a1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Reference issues by slugged filename (for example,
 - Documented ranking formula test failure in
   [fix-search-ranking-and-extension-tests](issues/archive/fix-search-ranking-and-extension-tests.md).
 
-## [0.1.0a1] - 2025-09-12
+## [0.1.0a1] - Unreleased
 - Local-first orchestrator coordinating multiple agents for research
   workflows.
 - CLI, HTTP API, and Streamlit interfaces for executing queries.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap summarizes planned features for upcoming releases.
 Dates and milestones align with the [release plan](docs/release_plan.md).
 See [STATUS.md](STATUS.md) and [CHANGELOG.md](CHANGELOG.md) for current results
 and recent changes. Installation and environment details are covered in the
-[README](README.md). Last updated **September 12, 2025**.
+[README](README.md). Last updated **September 13, 2025**.
 
 ## Status
 

--- a/docs/release_notes/v0.1.0a1.md
+++ b/docs/release_notes/v0.1.0a1.md
@@ -1,4 +1,4 @@
-# Autoresearch 0.1.0a1 (2025-09-11)
+# Autoresearch 0.1.0a1 (Unreleased)
 
 ## Features
 

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -9,7 +9,7 @@ The publishing workflow follows the steps in
 [ROADMAP.md](../ROADMAP.md) for high-level milestones.
 
 The project kicked off in **May 2025** (see the initial commit dated
-`2025-05-18`). This schedule was last updated on **September 11, 2025** and
+`2025-05-18`). This schedule was last updated on **September 13, 2025** and
 reflects that the codebase currently sits at the **unreleased 0.1.0a1** version
 defined in `autoresearch.__version__`. The project targets **0.1.0a1** for
 **September 15, 2026** and **0.1.0** for **October 1, 2026**. See

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -18,6 +18,8 @@ workflows dispatch-only.
 - [ensure-pytest-bdd-plugin-available-for-tests](archive/ensure-pytest-bdd-plugin-available-for-tests.md)
 - [reduce-cache-backend-test-runtime](reduce-cache-backend-test-runtime.md)
 - [avoid-large-downloads-in-task-verify](archive/avoid-large-downloads-in-task-verify.md)
+- [add-test-coverage-for-optional-components](archive/add-test-coverage-for-optional-components.md)
+- [fix-task-verify-coverage-hang](archive/fix-task-verify-coverage-hang.md)
 
 ## Acceptance Criteria
 - All dependency issues are closed.


### PR DESCRIPTION
## Summary
- mark v0.1.0a1 as Unreleased across changelog, roadmap, and release plan
- draft release notes for v0.1.0a1 and refresh roadmap dates
- track coverage gaps in prepare-first-alpha-release issue

## Testing
- `uv run mkdocs build`
- `task check`
- `task verify` *(fails: tests/unit/test_relevance_ranking.py::test_rank_results_with_unavailable_libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f7d0eb70833393a4a4b92e51f92e