### PR TITLE
feat: improve environment checks and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ The project is built around a modular Python package located under `src/autorese
 CLI utilities are provided via Typer and the HTTP API is powered by FastAPI.
 
 **Note:** [docs/installation.md](docs/installation.md) is the authoritative
-source for environment setup and optional features.
+source for environment setup and optional features. Run `task install`
+immediately after cloning to bootstrap the required `dev-minimal` and `test`
+extras; skipping this step often yields missing plugin errors when running
+`task check` or any tests.
 
 For orchestrator state transitions and API contracts see
 [docs/orchestrator_state.md](docs/orchestrator_state.md).

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,16 +5,19 @@ Taskfile commands.
 
 ## September 13, 2025
 
-- Updated `scripts/check_env.py` to fail on unsupported Python versions and
-  missing extras, and wired it into `task check`.
-- README and installation guide now direct users to run `task install` before
-  executing tests.
+- Updated `scripts/check_env.py` to flag unknown extras and Python versions
+  outside 3.12–<4.0, and invoked it via the `check-env` task inside `task`
+  `check`.
+- README and installation guide now emphasize running `task install` before any
+  tests.
 - Ran `scripts/setup.sh` to install Task 3.44.1 and sync development extras.
 - `task check` succeeds.
-- `task verify` runs unit tests (245 passed, 6 skipped) but was interrupted
-  during coverage, leaving a multiprocessing resource tracker `KeyError`.
+- `task verify` attempted to run but terminated with a `KeyboardInterrupt`
+  while syncing optional extras; the full suite did not execute.
 - `uv run pytest tests/unit/test_version.py -q` passes without
   `bdd_features_base_dir` warnings.
+- `uv run mkdocs build` completes after installing `mkdocs-material` and
+  `mkdocstrings`, though numerous missing-link warnings remain.
 - Added `requires_*` markers to behavior step files and adjusted LLM extra test.
 - `task coverage` with all extras failed with a segmentation fault; coverage
   could not be determined.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,7 +67,7 @@ tasks:
             --extra dev-minimal \
             --extra test \
             {{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}}
-      - EXTRAS="{{.EXTRAS}}" uv run python scripts/check_env.py
+      - task check-env EXTRAS="{{.EXTRAS}}"
       - uv run flake8 src
       - uv run mypy src --exclude src/autoresearch/distributed
       - task lint-specs

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,8 @@ Autoresearch requires these binaries on your `PATH`:
 
 Run `task install` immediately after installing these prerequisites. It
 syncs the `dev-minimal` and `test` extras so `task check` and `pytest` have
-the required plugins.
+the required plugins. Skipping this step typically yields missing dependency
+errors.
 
 Run `uv run python scripts/check_env.py` to confirm they are available. The
 script exits with an error when Go Task is missing; install it with


### PR DESCRIPTION
## Summary
- stress running `task install` before tests
- validate Python range and unknown extras in `check_env`
- invoke `check-env` from `task check`

## Testing
- `uv run flake8 scripts/check_env.py`
- `uv run mkdocs build` *(fails: missing links, numerous warnings)*
- `task check`
- `task verify EXTRAS=""` *(fails: KeyboardInterrupt while syncing extras)*

------
https://chatgpt.com/codex/tasks/task_e_68c5007b86e48333ac88f30b23dee531