### PR TITLE
docs: track check env warning failure

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -28,11 +28,15 @@ Taskfile commands.
   after confirming `pytest-bdd` is installed.
 - `task verify` reports `test_cache_is_backend_specific` and its variant each
   taking ~64s and emitting `rdflib_sqlalchemy` deprecation warnings.
- - `tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::`
+- `tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::`
    `test_initialize_schema_version` and
     `tests/unit/test_storage_persistence.py::
-    test_initialize_creates_tables_and_teardown_removes_file`
-   now pass; related issues were archived.
+   test_initialize_creates_tables_and_teardown_removes_file`
+  now pass; related issues were archived.
+- A fresh `task verify` run fails in
+  `tests/unit/test_check_env_warnings.py::test_missing_package_metadata_warns`
+  and still ends with a multiprocessing resource tracker `KeyError`; opened
+  [fix-check-env-warnings-test](issues/fix-check-env-warnings-test.md).
 
 ## September 12, 2025
 
@@ -393,6 +397,7 @@ incomplete.
 - [add-storage-initialization-proofs](issues/add-storage-initialization-proofs.md)
 - [resolve-resource-tracker-errors-in-verify](issues/resolve-resource-tracker-errors-in-verify.md)
 - [resolve-deprecation-warnings-in-tests](issues/resolve-deprecation-warnings-in-tests.md)
+- [fix-check-env-warnings-test](issues/fix-check-env-warnings-test.md)
 - [reduce-cache-backend-test-runtime](issues/reduce-cache-backend-test-runtime.md)
 - [stabilize-api-and-improve-search](issues/stabilize-api-and-improve-search.md)
 - [prepare-first-alpha-release](issues/prepare-first-alpha-release.md)

--- a/issues/fix-check-env-warnings-test.md
+++ b/issues/fix-check-env-warnings-test.md
@@ -1,0 +1,17 @@
+# Fix check env warnings test
+
+## Context
+`tests/unit/test_check_env_warnings.py::test_missing_package_metadata_warns`
+fails because `scripts/check_env.py` emits no warning when package metadata is
+present, causing the test to expect a warning that never occurs.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- The check env warnings test passes.
+- The test only expects warnings when metadata is missing.
+- `task verify` proceeds past this test.
+
+## Status
+Open

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -16,6 +16,7 @@ workflows dispatch-only.
 - [add-storage-initialization-proofs](add-storage-initialization-proofs.md)
 - [resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md)
 - [resolve-deprecation-warnings-in-tests](resolve-deprecation-warnings-in-tests.md)
+- [fix-check-env-warnings-test](fix-check-env-warnings-test.md)
 - [ensure-pytest-bdd-plugin-available-for-tests](
   archive/ensure-pytest-bdd-plugin-available-for-tests.md)
 - [reduce-cache-backend-test-runtime](reduce-cache-backend-test-runtime.md)

--- a/issues/reduce-cache-backend-test-runtime.md
+++ b/issues/reduce-cache-backend-test-runtime.md
@@ -6,6 +6,9 @@ over 60 seconds and can appear stalled during `task verify`. Its variant
 `test_cache_is_backend_specific_without_embeddings` shows similar runtime.
 Interrupting either test raises `StorageError: Ontology reasoning interrupted`.
 
+On September 13, 2025, the test completed in about 0.22 seconds, but
+`rdflib_sqlalchemy` still emitted deprecation warnings.
+
 ## Dependencies
 None
 

--- a/issues/resolve-resource-tracker-errors-in-verify.md
+++ b/issues/resolve-resource-tracker-errors-in-verify.md
@@ -12,6 +12,11 @@ On September 12, 2025, `task verify` again emitted `KeyError: '/mp-...'` after
 `tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_initialize_schema_version`
 failed, leaving coverage incomplete.
 
+On September 13, 2025, the run failed in
+`tests/unit/test_check_env_warnings.py::test_missing_package_metadata_warns`
+and still produced a `KeyError` from the multiprocessing resource tracker after
+the unit suite finished.
+
 Auditing fixtures that spawn multiprocessing pools and queues shows they call
 `close()` and `join_thread()` to avoid leaking resources.
 


### PR DESCRIPTION
## Summary
- document failing check-env warning test and link it into release planning
- note recurring resource-tracker KeyError after unit tests
- record current cache test runtime and outstanding warning

## Testing
- `task check`
- `task verify` *(fails: test_missing_package_metadata_warns, resource tracker KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_68c59f5848688333b99c04890e9369a0