### PR TITLE
docs: note cache test runtime and rdflib warnings

### DIFF
--- a/issues/reduce-cache-backend-test-runtime.md
+++ b/issues/reduce-cache-backend-test-runtime.md
@@ -9,6 +9,12 @@ Interrupting either test raises `StorageError: Ontology reasoning interrupted`.
 On September 13, 2025, the test completed in about 0.22 seconds, but
 `rdflib_sqlalchemy` still emitted deprecation warnings.
 
+On the latest run on September 13, 2025, `task verify` reported
+`test_cache_is_backend_specific` completing in roughly 0.26 seconds and its
+variant finishing in about 0.21 seconds. Performance is now acceptable, yet
+`rdflib_sqlalchemy` continues to emit deprecation warnings that clutter test
+output.
+
 ## Dependencies
 None
 

--- a/issues/resolve-deprecation-warnings-in-tests.md
+++ b/issues/resolve-deprecation-warnings-in-tests.md
@@ -5,6 +5,10 @@ Recent test runs emit numerous deprecation warnings from packages such as
 RDFlib SQLAlchemy, Click, and fastembed. These warnings may become errors in
 future releases and obscure test output.
 
+The September 13, 2025 `task verify` run surfaced `RemovedIn20Warning` messages
+from `rdflib_sqlalchemy` during cache tests, underscoring the need to update or
+pin dependencies to supported versions.
+
 ## Dependencies
 None
 


### PR DESCRIPTION
## Summary
- record current runtime for cache backend tests
- capture rdflib_sqlalchemy warnings observed during verify

## Testing
- `task check`
- `task verify` *(fails: tests/unit/test_check_env_warnings.py::test_missing_package_metadata_warns, multiprocessing resource_tracker KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a0b8268c833390cd4fef9748a05f