### PR TITLE
Add storage initialization proofs and extension failure tests

### DIFF
--- a/issues/archive/add-storage-initialization-proofs.md
+++ b/issues/archive/add-storage-initialization-proofs.md
@@ -6,8 +6,8 @@ initialization and teardown behavior, especially when DuckDB extensions are
 missing. Failing tests highlight gaps in documented invariants.
 
 ## Dependencies
-- [resolve-storage-persistence-test-failure](archive/resolve-storage-persistence-test-failure.md)
-- [fix-duckdb-storage-schema-initialization](archive/fix-duckdb-storage-schema-initialization.md)
+- [resolve-storage-persistence-test-failure](resolve-storage-persistence-test-failure.md)
+- [fix-duckdb-storage-schema-initialization](fix-duckdb-storage-schema-initialization.md)
 
 ## Acceptance Criteria
 - Storage initialization invariants are formally proven or justified.
@@ -15,4 +15,4 @@ missing. Failing tests highlight gaps in documented invariants.
 - Documentation links to the new proofs and corresponding tests.
 
 ## Status
-Open
+Archived

--- a/tests/unit/test_storage_persistence.py
+++ b/tests/unit/test_storage_persistence.py
@@ -5,7 +5,10 @@ See docs/algorithms/storage_initialization.md for the specification.
 
 from __future__ import annotations
 
+import duckdb
+
 from autoresearch import storage
+from autoresearch.extensions import VSSExtensionLoader
 
 
 def test_initialize_creates_tables_and_teardown_removes_file(tmp_path, monkeypatch):
@@ -38,3 +41,35 @@ def test_initialize_creates_tables_and_teardown_removes_file(tmp_path, monkeypat
 
     storage.teardown(remove_db=True, context=ctx)
     assert not db_file.exists()
+
+
+def test_initialize_handles_missing_extension(tmp_path, monkeypatch):
+    """Initialization proceeds when the vector extension cannot be loaded."""
+
+    db_file = tmp_path / "temp.duckdb"
+    called = {"count": 0}
+    orig_create = storage.DuckDBStorageBackend._create_tables
+
+    def wrapped_create(self, skip_migrations: bool = False) -> None:
+        called["count"] += 1
+        return orig_create(self, skip_migrations)
+
+    monkeypatch.setattr(storage.DuckDBStorageBackend, "_create_tables", wrapped_create)
+    monkeypatch.setattr(
+        storage.DuckDBStorageBackend, "_initialize_schema_version", lambda self: None
+    )
+    monkeypatch.setattr(storage.DuckDBStorageBackend, "_run_migrations", lambda self: None)
+    monkeypatch.setattr(storage.DuckDBStorageBackend, "create_hnsw_index", lambda self: None)
+    monkeypatch.setattr(
+        VSSExtensionLoader,
+        "load_extension",
+        lambda conn: (_ for _ in ()).throw(duckdb.Error("missing")),
+    )
+
+    storage.teardown(remove_db=True)
+    ctx = storage.initialize_storage(str(db_file))
+    assert db_file.exists()
+    assert ctx.db_backend.has_vss() is False
+    assert called["count"] >= 1
+    ctx.db_backend._conn.execute("SELECT 1 FROM nodes LIMIT 1")
+    storage.teardown(remove_db=True, context=ctx)


### PR DESCRIPTION
## Summary
- document explicit storage invariants, detailed proofs, and simulation pseudocode
- test DuckDB backend and storage initialization against missing VSS extension
- archive add-storage-initialization-proofs issue

## Testing
- `uv run --with mkdocs --with mkdocs-material --with mkdocstrings --with mkdocstrings-python mkdocs build`
- `uv run --extra test pytest tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_setup_missing_extension_continues tests/unit/test_storage_persistence.py::test_initialize_handles_missing_extension tests/unit/test_storage_persistence.py::test_initialize_creates_tables_and_teardown_removes_file`
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e83e21608333a59349971a5375df