### PR TITLE
Add versioned API schemas and refine search ranking

### DIFF
--- a/docs/algorithms/search_ranking.md
+++ b/docs/algorithms/search_ranking.md
@@ -6,7 +6,9 @@ combination of multiple signals. The formula is
 
 - \(b(d)\) is the [BM25](bm25.md) keyword score.
 - \(m(d)\) is the [semantic similarity](semantic_similarity.md) score.
-- \(v(d)\) is the DuckDB vector similarity when available.
+- \(v(d)\) is the DuckDB vector similarity when available. When semantic
+  similarity is disabled the normalized DuckDB score is used directly as the
+  semantic component so weighting remains consistent.
 - \(c(d)\) is the [domain authority](source_credibility.md) score.
 
 The weights \(w_b\), \(w_s\), and \(w_c\) are non-negative and must sum to

--- a/docs/api_reference/query.md
+++ b/docs/api_reference/query.md
@@ -51,9 +51,34 @@ The batch endpoint wraps individual responses with pagination metadata:
   "page": 1,
   "page_size": 2,
   "results": [
-    {"version": "1", "answer": "a", "citations": [], "reasoning": [], "metrics": {}},
-    {"version": "1", "answer": "b", "citations": [], "reasoning": [], "metrics": {}}
+    {
+      "version": "1",
+      "answer": "a",
+      "citations": [],
+      "reasoning": [],
+      "metrics": {}
+    },
+    {
+      "version": "1",
+      "answer": "b",
+      "citations": [],
+      "reasoning": [],
+      "metrics": {}
+    }
   ]
+}
+```
+
+## Async Response
+
+::: autoresearch.api.models.AsyncQueryResponseV1
+
+Async queries acknowledge receipt and provide a tracking identifier:
+
+```json
+{
+  "version": "1",
+  "query_id": "123"
 }
 ```
 

--- a/issues/archive/stabilize-api-and-improve-search.md
+++ b/issues/archive/stabilize-api-and-improve-search.md
@@ -12,4 +12,4 @@ Finalize public API behavior and upgrade search backends for consistent, high qu
 - Documentation reflects updated API and search contracts.
 
 ## Status
-Open
+Archived

--- a/src/autoresearch/api/models.py
+++ b/src/autoresearch/api/models.py
@@ -78,6 +78,7 @@ class AsyncQueryResponseV1(VersionedModel):
 
 
 __all__ = [
+    "VersionedModel",
     "ReasoningMode",
     "QueryRequestV1",
     "QueryResponseV1",

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,0 +1,30 @@
+"""Integration tests for versioned query endpoint."""
+
+from autoresearch.api.models import QueryResponseV1
+from autoresearch.config import APIConfig, ConfigModel
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.orchestration.orchestrator import Orchestrator
+
+
+def _setup(monkeypatch) -> None:
+    cfg = ConfigModel(api=APIConfig())
+    ConfigLoader.reset_instance()
+    cfg.api.role_permissions["anonymous"] = ["query"]
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+
+
+def test_query_returns_version(monkeypatch, api_client) -> None:
+    """The standard query endpoint returns a versioned response."""
+    _setup(monkeypatch)
+    monkeypatch.setattr(
+        Orchestrator,
+        "run_query",
+        lambda self, q, c, callbacks=None, **k: QueryResponseV1(
+            answer=q, citations=[], reasoning=[], metrics={}
+        ),
+    )
+    resp = api_client.post("/query", json={"query": "hello"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] == "1"
+    assert body["answer"] == "hello"

--- a/tests/unit/search/test_ranking_formula.py
+++ b/tests/unit/search/test_ranking_formula.py
@@ -1,6 +1,10 @@
 import pytest
 
 from autoresearch.search.ranking import combine_scores
+from autoresearch.search.core import Search
+from autoresearch.config import ConfigModel
+from autoresearch.config.models import SearchConfig
+from autoresearch.config.loader import ConfigLoader
 
 
 def test_combine_scores_weighted_sum() -> None:
@@ -18,3 +22,18 @@ def test_combine_scores_invalid_weights() -> None:
     """Invalid weight sums raise ValueError."""
     with pytest.raises(ValueError):
         combine_scores([1.0], [1.0], [1.0], (0.6, 0.3, 0.2))
+
+
+def test_duckdb_scores_used_without_semantic(monkeypatch) -> None:
+    """DuckDB similarities act as semantic component when semantic search is off."""
+    cfg = ConfigModel(search=SearchConfig(use_semantic_similarity=False))
+    ConfigLoader.reset_instance()
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setattr(Search, "calculate_bm25_scores", staticmethod(lambda q, r: [0.0, 0.0]))
+    monkeypatch.setattr(Search, "assess_source_credibility", lambda self, r: [0.0, 0.0])
+    docs = [
+        {"title": "a", "similarity": 0.2},
+        {"title": "b", "similarity": 0.8},
+    ]
+    ranked = Search.rank_results("q", docs)
+    assert [d["title"] for d in ranked] == ["b", "a"]


### PR DESCRIPTION
## Summary
- Export `VersionedModel` alongside versioned query schemas and document async responses
- Normalize DuckDB scores as the semantic component when embeddings are unavailable for consistent ranking
- Add API integration and ranking formula unit tests and archive completed issue

## Testing
- `task check`
- `uv run mkdocs build`
- `task verify` *(fails: exit status 139, segmentation fault)*
- `uv run pytest tests/integration/test_api.py -q`
- `uv run pytest tests/unit/test_relevance_ranking.py::test_rank_results_with_unavailable_libraries -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5e845ebc4833398866e079c7dc7e3