### PR TITLE
chore: reopen release-blocking issues and refresh status

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,16 +11,15 @@ and recent changes. Installation and environment details are covered in the
 See [STATUS.md](STATUS.md) for current results and
 [CHANGELOG.md](CHANGELOG.md) for recent updates. 0.1.0a1 remains untagged and
 targets **September 15, 2026**, with **0.1.0** planned for **October 1, 2026**
-across project documentation. Go Task 3.44.1 is available—`task check` passes,
-but `task verify` exits with a multiprocessing resource tracker `KeyError`
-after unit tests, even though
-`tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::`
-`test_initialize_schema_version`
-now passes individually. `uv run --extra test pytest` previously reported a
-failing integration test, but a recent full run passes (`289 passed`,
-`10 skipped`). The tracking issue
-[`resolve-integration-test-regressions`](issues/archive/resolve-integration-test-regressions.md)
-is archived.
+across project documentation. The `task` command is currently unavailable and
+`uv run pytest` reports 43 failing integration tests covering API authentication,
+ranking, and storage. Reopened
+[fix-api-authentication-and-metrics-tests](issues/fix-api-authentication-and-metrics-tests.md),
+[fix-search-ranking-and-extension-tests](issues/fix-search-ranking-and-extension-tests.md),
+and
+[fix-storage-integration-test-failures](issues/fix-storage-integration-test-failures.md)
+track these regressions. Once `task` is restored, `task verify` still exits with
+a multiprocessing resource tracker `KeyError` after unit tests.
 Scheduler resource benchmarks
 (`scripts/scheduling_resource_benchmark.py`) offer utilization and memory
 estimates documented in `docs/orchestrator_perf.md`. Dependency pins:
@@ -43,7 +42,7 @@ before running tests.
 - 0.2.0 (2027-03-01, status: planned): API stabilization, configuration
   hot-reload and improved search backends.
   - [stabilize-api-and-improve-search](
-    issues/stabilize-api-and-improve-search.md)
+    issues/archive/stabilize-api-and-improve-search.md)
     - [streaming-webhook-refinements](
       issues/archive/streaming-webhook-refinements.md)
     - [configuration-hot-reload-tests](
@@ -78,12 +77,15 @@ release is re-targeted for **September 15, 2026**. Key activities include:
 
 - [x] Environment bootstrap documented and installation instructions
   consolidated.
-- [x] Task CLI availability restored
-  ([restore-task-cli-availability](issues/archive/restore-task-cli-availability.md)).
+- [ ] Task CLI availability restored
+  ([install-task-cli-system-level](issues/install-task-cli-system-level.md)).
 - [x] Packaging verification with DuckDB fallback.
 - [x] Improve DuckDB extension fallback
   ([improve-duckdb-extension-fallback](issues/archive/improve-duckdb-extension-fallback.md)).
-- [x] Integration tests stabilized.
+- [ ] Integration tests stabilized
+  ([fix-api-authentication-and-metrics-tests](issues/fix-api-authentication-and-metrics-tests.md),
+  [fix-search-ranking-and-extension-tests](issues/fix-search-ranking-and-extension-tests.md),
+  [fix-storage-integration-test-failures](issues/fix-storage-integration-test-failures.md)).
 - [ ] Coverage gates target **90%** total coverage once tests run
   ([add-test-coverage-for-optional-components](
   issues/archive/add-test-coverage-for-optional-components.md);

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,15 @@ Install Go Task with `scripts/setup.sh` or your package manager to enable
 Taskfile commands.
 
 ## September 13, 2025
+- `task` command remains unavailable after running setup scripts; opened
+  [install-task-cli-system-level](issues/install-task-cli-system-level.md).
+- `uv run pytest` reports 43 failing integration tests touching API
+  authentication, ranking formulas, and storage layers.
+- Reopened
+  [fix-api-authentication-and-metrics-tests](issues/fix-api-authentication-and-metrics-tests.md),
+  [fix-search-ranking-and-extension-tests](issues/fix-search-ranking-and-extension-tests.md),
+  and
+  [fix-storage-integration-test-failures](issues/fix-storage-integration-test-failures.md).
 
 - Updated `scripts/check_env.py` to flag unknown extras and Python versions
   outside 3.12–<4.0, and invoked it via the `check-env` task inside `task`
@@ -41,7 +50,7 @@ Taskfile commands.
 
 ## September 12, 2025
 
-- Ran `scripts/codex_setup.sh` to bootstrap the environment and append
+- Ran the setup script to bootstrap the environment and append
   `.venv/bin` to `PATH`.
 - `uv run python scripts/run_task.py check` fails with mypy:
   "type[StorageManager]" missing `update_claim`.
@@ -395,10 +404,10 @@ tracker `KeyError` before integration tests, leaving coverage reports
 incomplete.
 
 ## Open issues
-- [add-storage-initialization-proofs](issues/add-storage-initialization-proofs.md)
+- [install-task-cli-system-level](issues/install-task-cli-system-level.md)
+- [fix-api-authentication-and-metrics-tests](issues/fix-api-authentication-and-metrics-tests.md)
+- [fix-search-ranking-and-extension-tests](issues/fix-search-ranking-and-extension-tests.md)
+- [fix-storage-integration-test-failures](issues/fix-storage-integration-test-failures.md)
 - [resolve-resource-tracker-errors-in-verify](issues/resolve-resource-tracker-errors-in-verify.md)
 - [resolve-deprecation-warnings-in-tests](issues/resolve-deprecation-warnings-in-tests.md)
-- [fix-check-env-warnings-test](issues/fix-check-env-warnings-test.md)
-- [reduce-cache-backend-test-runtime](issues/reduce-cache-backend-test-runtime.md)
-- [stabilize-api-and-improve-search](issues/stabilize-api-and-improve-search.md)
 - [prepare-first-alpha-release](issues/prepare-first-alpha-release.md)

--- a/issues/fix-api-authentication-and-metrics-tests.md
+++ b/issues/fix-api-authentication-and-metrics-tests.md
@@ -17,4 +17,4 @@ None.
 - Documentation references authentication and metrics behavior.
 
 ## Status
-Archived
+Open

--- a/issues/fix-search-ranking-and-extension-tests.md
+++ b/issues/fix-search-ranking-and-extension-tests.md
@@ -19,4 +19,4 @@ None.
 - Docs reference extension loading and ranking formulae.
 
 ## Status
-Archived
+Open

--- a/issues/fix-storage-integration-test-failures.md
+++ b/issues/fix-storage-integration-test-failures.md
@@ -12,4 +12,4 @@ None.
 - Document fixes in the changelog.
 
 ## Status
-Archived
+Open

--- a/issues/install-task-cli-system-level.md
+++ b/issues/install-task-cli-system-level.md
@@ -1,7 +1,8 @@
 # Install Task CLI system level
 
 ## Context
-The evaluation environment requires the Task CLI available on the PATH so task commands can run.
+The evaluation environment still lacks the Task CLI; current setup scripts leave
+`task` unavailable on PATH.
 
 ## Dependencies
 None
@@ -12,4 +13,4 @@ None
 - `task verify` runs without missing-command errors
 
 ## Status
-Archived
+Open

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -7,22 +7,12 @@ finalize outstanding testing, documentation, and packaging tasks while keeping
 workflows dispatch-only.
 
 ## Dependencies
-- [add-a2a-concurrency-proofs-and-simulations](
-  archive/add-a2a-concurrency-proofs-and-simulations.md)
-- [stabilize-api-and-improve-search](stabilize-api-and-improve-search.md)
-- [resolve-integration-test-regressions](archive/resolve-integration-test-regressions.md)
-- [fix-duckdb-storage-schema-initialization](archive/fix-duckdb-storage-schema-initialization.md)
-- [resolve-storage-persistence-test-failure](archive/resolve-storage-persistence-test-failure.md)
-- [add-storage-initialization-proofs](add-storage-initialization-proofs.md)
+- [install-task-cli-system-level](install-task-cli-system-level.md)
+- [fix-api-authentication-and-metrics-tests](fix-api-authentication-and-metrics-tests.md)
+- [fix-search-ranking-and-extension-tests](fix-search-ranking-and-extension-tests.md)
+- [fix-storage-integration-test-failures](fix-storage-integration-test-failures.md)
 - [resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md)
 - [resolve-deprecation-warnings-in-tests](resolve-deprecation-warnings-in-tests.md)
-- [fix-check-env-warnings-test](fix-check-env-warnings-test.md)
-- [ensure-pytest-bdd-plugin-available-for-tests](
-  archive/ensure-pytest-bdd-plugin-available-for-tests.md)
-- [reduce-cache-backend-test-runtime](reduce-cache-backend-test-runtime.md)
-- [avoid-large-downloads-in-task-verify](archive/avoid-large-downloads-in-task-verify.md)
-- [add-test-coverage-for-optional-components](archive/add-test-coverage-for-optional-components.md)
-- [fix-task-verify-coverage-hang](archive/fix-task-verify-coverage-hang.md)
 
 ## Acceptance Criteria
 - All dependency issues are closed.


### PR DESCRIPTION
## Summary
- reopen issues for missing Task CLI and failing API, search, and storage tests
- streamline alpha release dependencies and update status log
- refresh roadmap to reflect current test failures and manual task requirements

## Testing
- `task check` *(fails: command not found)*
- `uv run pytest` *(fails: 43 failed, 1145 passed, 49 skipped, 125 deselected, 9 xfailed, 5 xpassed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ebe7eaa88333b2f7301ac5230635