### PR TITLE
feat: install task in system path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,21 +42,15 @@ reported missing, rerun `task install` or sync optional extras with
 ```bash
 ./scripts/setup.sh
 source .venv/bin/activate
-export PATH="$PATH:$(pwd)/.venv/bin"
 task --version
 task check
 ```
 
-`scripts/setup.sh` verifies the Python version, installs Go Task when needed,
-confirms `uv` is functional, and syncs the `dev-minimal` and `test` extras. It
-exits with an error if a tool is missing or the dependency sync fails.
-
-To install a system-wide Go Task binary instead, run:
-
-```bash
-curl -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
-# macOS: brew install go-task/tap/go-task
-```
+`scripts/setup.sh` verifies the Python version, installs Go Task into
+`/usr/local/bin` when needed, confirms `uv` is functional, and syncs the
+`dev-minimal` and `test` extras. It exits with an error if a tool is missing or
+the dependency sync fails. If installation fails, see `docs/installation.md`
+for manual steps or package manager commands.
 
 Optional extras provide features such as NLP, a UI, or distributed
 processing. Install them on demand with `uv sync --extra <name>`, `task

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,14 +19,13 @@ tasks:
     cmds:
       - |
           if ! command -v task >/dev/null 2>&1; then
-              echo "Go Task missing; installing into .venv/bin..."
-              mkdir -p .venv/bin
+              install_dir="${TASK_INSTALL_DIR:-/usr/local/bin}"
+              echo "Go Task missing; installing into $install_dir..."
               if ! curl -sSL https://taskfile.dev/install.sh \
-                  | sh -s -- -b .venv/bin; then
+                  | sh -s -- -b "$install_dir"; then
                   echo "Failed to install Go Task. Run scripts/setup.sh." >&2
                   exit 1
               fi
-              export PATH="$(pwd)/.venv/bin:$PATH"
           fi
       - |
           extras="dev-minimal test"
@@ -48,6 +47,7 @@ tasks:
     env:
       EXTRAS: "{{.EXTRAS}}"
     cmds:
+      - task --version
       - uv run python scripts/check_env.py
     desc: "Validate required tool versions"
   lint-specs:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,8 +11,8 @@ Autoresearch requires these binaries on your `PATH`:
 
 - Python 3.12 or newer
 - [uv](https://github.com/astral-sh/uv) 0.7.0 or newer
-- [Go Task](https://taskfile.dev/) for Taskfile commands. Install via
-  `./scripts/setup.sh` or your package manager.
+- [Go Task](https://taskfile.dev/) for Taskfile commands.
+  `scripts/setup.sh` installs it into `/usr/local/bin` when missing.
 
 Run `task install` immediately after installing these prerequisites. It
 syncs the `dev-minimal` and `test` extras so `task check` and `pytest` have
@@ -26,14 +26,14 @@ CLI:
 
 ```bash
 ./scripts/setup.sh
-export PATH="$PATH:$(pwd)/.venv/bin"
 task --version
 task check
 ```
 
-The script checks the Python version, installs Go Task when absent, verifies
-`uv` is functional, and syncs the `dev-minimal` and `test` extras. It exits with
-an error if a tool is missing or the dependency sync fails.
+The script checks the Python version, installs Go Task into `/usr/local/bin`
+when absent, verifies `uv` is functional, and syncs the `dev-minimal` and
+`test` extras. It exits with an error if a tool is missing or the dependency
+sync fails.
 
 Activate the virtual environment in new shells to restore the path:
 
@@ -41,15 +41,9 @@ Activate the virtual environment in new shells to restore the path:
 source .venv/bin/activate
 ```
 
-Run `./scripts/bootstrap.sh` directly to install Go Task without syncing extras.
-This is usually unnecessary because `scripts/setup.sh` invokes it automatically.
-It places the `task` binary in `.venv/bin`. For a system-wide binary, install
-manually and confirm the installation:
-
-```bash
-curl -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
-# macOS: brew install go-task/tap/go-task
-```
+Run `./scripts/bootstrap.sh` to install Go Task without syncing extras. This is
+usually unnecessary because `scripts/setup.sh` installs the binary into
+`/usr/local/bin`. Set `TASK_INSTALL_DIR` to change the location.
 
 Verify Go Task is installed:
 
@@ -57,7 +51,7 @@ Verify Go Task is installed:
 task --version
 ```
 
-`task install` also checks for Go Task and downloads it to `.venv/bin` when
+`task install` also checks for Go Task and installs it to `/usr/local/bin` when
 missing.
 
 ## Version checks and troubleshooting
@@ -213,8 +207,9 @@ role are configured through `AUTORESEARCH_API__ROLE_PERMISSIONS`.
 ### Go Task
 
 Autoresearch uses [Go Task](https://taskfile.dev/) to run Taskfile commands.
-`scripts/bootstrap.sh` downloads it to `.venv/bin` and adjusts activation
-scripts, but you can install it manually:
+`scripts/setup.sh` installs the binary into `/usr/local/bin`. Run
+`scripts/bootstrap.sh` to place it in `.venv/bin` without syncing extras, or
+install it manually:
 
 ```bash
 # macOS

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Usage: AR_EXTRAS="nlp parsers" ./scripts/setup.sh
+# Optionally set TASK_INSTALL_DIR to override the Go Task installation path.
 # Verify Python 3.12+, confirm Go Task and uv>=0.7.0 are installed, append
 # .venv/bin to PATH, and sync dependencies.
 
@@ -32,8 +33,12 @@ PY
 
 ensure_go_task() {
     if ! command -v task >/dev/null 2>&1; then
-        echo "Go Task not found; running scripts/bootstrap.sh..." >&2
-        "$SCRIPT_DIR/bootstrap.sh"
+        local install_dir="${TASK_INSTALL_DIR:-/usr/local/bin}"
+        echo "Go Task not found; installing into $install_dir..." >&2
+        if ! curl -sSL https://taskfile.dev/install.sh | sh -s -- -b "$install_dir"; then
+            echo "Failed to install Go Task. See docs/installation.md for manual steps." >&2
+            exit 1
+        fi
     fi
     if ! command -v task >/dev/null 2>&1; then
         echo "Go Task installation failed. See docs/installation.md for manual steps." >&2


### PR DESCRIPTION
## Summary
- install Go Task into `/usr/local/bin` when missing
- run `task --version` in `check-env`
- document system-wide Task installation path

## Testing
- `task check`
- `task verify` *(fails: ontology reasoner plugin not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f0846cdc8333b8b08fb0cae3f0ce