### PR TITLE
Improve storage eviction locks and schema init fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Reference issues by slugged filename (for example,
 ## [Unreleased]
 - Documented ranking formula test failure in
   [fix-search-ranking-and-extension-tests](issues/archive/fix-search-ranking-and-extension-tests.md).
+- Hardened storage concurrency and eviction logic with thread-safe locks and
+  added `initialize_schema_version_without_fetchone` helper to support DuckDB
+  connections lacking `fetchone`.
 
 ## [0.1.0a1] - Unreleased
 - Local-first orchestrator coordinating multiple agents for research


### PR DESCRIPTION
## Summary
- guard LRU and eviction routines with thread-safe locks
- add `initialize_schema_version_without_fetchone` to handle DuckDB connections lacking `fetchone`
- document storage concurrency improvements

## Testing
- `uv run task check` *(failed: No such file or directory)*
- `uv run python scripts/storage_concurrency_sim.py --threads 2 --items 3`
- `uv run python scripts/storage_eviction_sim.py --threads 2 --items 3 --policy lru`
- `uv run --extra test pytest tests/integration/test_storage_*` *(failures: StorageError during RDF store setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f7e9bf6c8333bdc092e0484f53d2