### PR TITLE
docs: analyze token budgeting

### DIFF
--- a/docs/specs/llm.md
+++ b/docs/specs/llm.md
@@ -35,6 +35,44 @@ per-agent spikes. The budget is enforced by [`compress_prompt`][m3], which
 truncates the middle of an over-long prompt or delegates to a summarizer. See
 also [token budgeting algorithm][a2].
 
+### Formal reasoning
+
+#### Adapter selection
+
+Let ``A`` be the ordered list of adapter names. The procedure performs a
+linear scan over ``A`` and invokes ``validate_model`` on each candidate. If a
+candidate succeeds the search stops, yielding the first compatible adapter.
+Should every candidate fail, the algorithm falls back to ``DummyAdapter``. The
+strategy is therefore complete, deterministic, and runs in ``O(|A|)`` time.
+
+#### Token budgeting
+
+Define ``C = {latest, avg_used, max_agent_delta, max_agent_avg}`` and margin
+``m >= 0``. The update computes ``b = max(round(max(C) * (1 + m)), 1)``. Each
+element of ``C`` upper-bounds recent usage, so ``b`` always covers the largest
+observed load. Flooring at one prevents the orchestrator from stalling when
+usage temporarily drops to zero.
+
+### Mathematical analysis
+
+#### Budget convergence
+
+Let usage stabilize at ``u`` tokens per cycle. With margin ``m`` the fixed
+point is ``b* = ceil(u * (1 + m))``. Any pre-spike value ``U`` persists in the
+averages for at most ten cycles. As history fills with ``u`` the maximum
+candidate decreases monotonically to ``u`` and the update yields ``b*``. Thus
+convergence occurs within ten steady cycles. See [token budgeting
+algorithm][a2] for the derivation.
+
+#### Worst-case prompt compression
+
+Assume a prompt with ``n`` tokens and budget ``b >= 3``. Without a summarizer,
+``compress_prompt`` keeps ``h = floor((b - 1) / 2)`` tokens from each end and
+inserts an ellipsis, producing at most ``2h + 1 <= b`` tokens. When a
+summarizer is provided its output must already respect ``b``; otherwise the
+fallback truncation applies. Budgets below three require a summarizer to remain
+within bounds.
+
 ## Invariants
 
 - Preserve documented state across operations.

--- a/scripts/llm_budget_sim.py
+++ b/scripts/llm_budget_sim.py
@@ -1,0 +1,92 @@
+"""Simulate token budget adaptation with random workloads.
+
+Usage:
+    uv run scripts/llm_budget_sim.py --steps 50 --agents 3 --margin 0.1
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+
+from autoresearch.orchestration.metrics import (
+    OrchestrationMetrics,
+    _mean_last,
+    _mean_last_nonzero,
+)
+from autoresearch.token_budget import round_with_margin
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify token budget bounds with random usage patterns."
+    )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=20,
+        help="number of cycles to simulate",
+    )
+    parser.add_argument(
+        "--agents",
+        type=int,
+        default=2,
+        help="number of agents to simulate",
+    )
+    parser.add_argument(
+        "--margin",
+        type=float,
+        default=0.1,
+        help="non-negative budget margin",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="random seed",
+    )
+    return parser.parse_args()
+
+
+def _validate(args: argparse.Namespace) -> None:
+    if args.steps <= 0 or args.agents <= 0:
+        raise SystemExit("steps and agents must be positive")
+    if args.margin < 0:
+        raise SystemExit("margin must be non-negative")
+
+
+def main() -> None:
+    args = _parse_args()
+    _validate(args)
+
+    rng = random.Random(args.seed)
+    metrics = OrchestrationMetrics()
+    budget = 10
+    for step in range(1, args.steps + 1):
+        for i in range(args.agents):
+            tokens = rng.randint(0, 50)
+            if tokens:
+                metrics.record_tokens(f"A{i}", tokens, 0)
+        suggested = metrics.suggest_token_budget(budget, margin=args.margin)
+
+        latest = metrics.token_usage_history[-1]
+        avg_used = _mean_last_nonzero(metrics.token_usage_history)
+        max_agent_delta = max(
+            (hist[-1] for hist in metrics.agent_usage_history.values()), default=0
+        )
+        max_agent_avg = max(
+            (_mean_last(hist) for hist in metrics.agent_usage_history.values()),
+            default=0.0,
+        )
+        expected = round_with_margin(
+            max(latest, avg_used, max_agent_delta, max_agent_avg), args.margin
+        )
+        expected = max(expected, 1)
+        assert suggested == expected, f"bound violated at step {step}"
+        budget = suggested
+        print(f"step {step}: usage={latest} budget={budget}")
+    print(f"final budget: {budget}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_token_usage.py
+++ b/tests/unit/test_token_usage.py
@@ -105,6 +105,31 @@ def test_compress_prompt_with_summarizer():
     assert "p" in called
 
 
+def test_summarizer_skipped_when_within_budget():
+    """Summarizer is ignored when the prompt already fits the budget."""
+
+    called = {}
+
+    def summarizer(prompt: str, budget: int) -> str:  # pragma: no cover - should not run
+        called["p"] = prompt
+        return "unused"
+
+    result = compress_prompt("one two", 3, summarizer)
+    assert result == "one two"
+    assert called == {}
+
+
+def test_summarizer_fallback_to_truncation():
+    """If the summary is too long an ellipsis-based truncation is used."""
+
+    def long_summary(prompt: str, budget: int) -> str:
+        return "this summary exceeds the budget"
+
+    result = compress_prompt("one two three four five", 3, long_summary)
+    assert result.split()[1] == "..."
+    assert len(result.split()) == 3
+
+
 def test_budget_considers_agent_history():
     """Token budget suggestion accounts for per-agent history."""
 


### PR DESCRIPTION
## Summary
- detail LLM adapter selection reasoning and token budgeting math
- simulate random workloads to verify token budget bounds
- add tests for summarizer edge cases

## Testing
- `./bin/task check`
- `./bin/task verify` *(fails: test_api_auth_middleware.py::test_resolve_role_missing_key)*
- `uv run mkdocs build` *(fails: Command not found)*
- `uv run flake8 scripts/llm_budget_sim.py tests/unit/test_token_usage.py`
- `uv run pytest tests/unit/test_token_usage.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5fc6a37388333b8cc582d8c831c3d