### PR TITLE
test: add gpu extra smoke test

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -43,6 +43,8 @@ These instructions apply to files in the `tests/` directory.
 - Implement steps with existing fixtures such as `bdd_context` or `cli_runner`.
 - Register any new markers in `pytest.ini`.
 - Include extras corresponding to any other markers as needed.
+- Smoke tests for optional extras live under `tests/targeted/`.
+- Ensure cases for `gpu` and `parsers` extras exist.
 - Scenarios tagged `error_recovery` or `reasoning_modes` run with the base
   `.[test]` extra; add `[nlp]`, `[ui]`, or `[vss]` only when combining with
   their respective `requires_*` markers.

--- a/tests/targeted/test_extras_install.py
+++ b/tests/targeted/test_extras_install.py
@@ -85,6 +85,13 @@ def test_parsers_extra_imports(tmp_path) -> None:
     assert len(doc.paragraphs) == 0
 
 
+@pytest.mark.requires_gpu
+def test_gpu_extra_imports() -> None:
+    """Smoke test imports from the gpu extra."""
+    bertopic = pytest.importorskip("bertopic")
+    assert hasattr(bertopic, "__version__")
+
+
 @pytest.mark.slow
 def test_task_check_runs_after_setup() -> None:
     """Ensure task check runs from a fresh setup."""


### PR DESCRIPTION
## Summary
- add targeted smoke test exercising gpu extra via BERTopic import
- document optional extra smoke tests in tests/AGENTS

## Testing
- `EXTRAS="nlp ui vss git distributed analysis llm parsers gpu" ./bin/task check` *(fails: exit status 130 – large dependency download)*
- `EXTRAS="nlp ui vss git distributed analysis llm parsers gpu" ./bin/task coverage` *(fails: exit status 130 – large dependency download)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fc77ed4c8333aa1393781837411c