### PR TITLE
docs: document task verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install these binaries and ensure they are on your `PATH`:
 
 - Python 3.12+
 - [uv](https://github.com/astral-sh/uv) 0.7.0+
-- [Go Task](https://taskfile.dev/)
+- [Go Task](https://taskfile.dev/) 3.44.1+ (verify with `task --version`)
 
 After installing the prerequisites, run `task install` to sync the
 `dev-minimal` and `test` extras before executing any tests or `task`

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,11 @@
 # Status
 
 Install Go Task with `scripts/setup.sh` or your package manager to enable
-Taskfile commands.
+Taskfile commands. Confirm the CLI is available with `task --version`.
+
+## September 14, 2025
+- Verified Go Task 3.44.1 installation with `task --version`.
+- Updated README and STATUS with verification instructions.
 
 ## September 13, 2025
 - Installed Task CLI via setup script; archived


### PR DESCRIPTION
## Summary
- document how to confirm Go Task installation via `task --version`
- record verification in status log

## Testing
- `task --version`
- `task check`
- `task verify` *(fails: tests/unit/test_api_auth_middleware.py::test_resolve_role_missing_key)*

------
https://chatgpt.com/codex/tasks/task_e_68c6063135a48333acbc1e5308facdad