### PR TITLE
Defer API key absence to dispatcher

### DIFF
--- a/docs/api_authentication.md
+++ b/docs/api_authentication.md
@@ -32,5 +32,10 @@ WWW-Authenticate: API-Key
 - Set `api.bearer_token` to enable bearer authentication.
 - Clients send `Authorization: Bearer <token>` headers.
 
+- When both API keys and bearer tokens are configured, a valid bearer token
+  suffices even if no API key is supplied. Requests missing both credentials
+  return `401` with `WWW-Authenticate: API-Key` and a `Missing API key or token`
+  message.
+
 See [api.md](api.md) for a complete overview of available endpoints.
 


### PR DESCRIPTION
## Summary
- adjust AuthMiddleware to defer missing API key handling to dispatch and keep invalid-key checks
- document interaction between API keys and bearer tokens

## Testing
- `uv run --extra test pytest tests/unit/test_api_auth_middleware.py::test_resolve_role_missing_key -q`
- `uv run --extra test pytest tests/integration/test_api_streaming.py::test_stream_requires_api_key -q`
- `uv run --extra test pytest tests/integration/test_cli_http.py::test_http_api_key -q`
- `uv run --extra test pytest tests/integration/test_monitor_metrics.py::test_system_monitor_metrics_exposed -q`
- `uv run --extra test pytest tests/integration/test_api_docs.py::test_query_endpoint -q`
- `uv run ruff check src/autoresearch/api/auth_middleware.py tests/unit/test_api_auth_middleware.py`
- `uv run mypy src/autoresearch/api/auth_middleware.py`
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c60aae7e5c8333a20a9dce7688b19e