### PR TITLE
Replace deprecated click API usage to silence warnings

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -16,6 +16,11 @@ by default. Use `EXTRAS="gpu"` to include the GPU packages or limit extras.
 ## Deprecation warnings
 
 - No deprecation warnings are expected when running `task verify`.
+- `sitecustomize.py` replaces `click.parser.split_arg_string` with
+  `shlex.split` to avoid Click deprecation warnings during tests.
+- Some third-party packages still issue deprecation warnings.
+  `pkg_resources` messages are filtered, and `fastembed` may emit
+  notices until upstream fixes land.
 
 ## Multiprocessing cleanup
 

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -13,3 +13,19 @@ if not TYPE_CHECKING:  # pragma: no cover - runtime import
         import pydantic.root_model  # noqa: F401
     except Exception:  # pragma: no cover - best effort
         pass
+    try:
+        import importlib.util, sys, types
+        from pathlib import Path
+
+        spec = importlib.util.find_spec("weasel.util.config")
+        if spec and spec.origin:
+            src = Path(spec.origin).read_text()
+            src = src.replace(
+                "from click.parser import split_arg_string",
+                "import shlex\n\nsplit_arg_string = shlex.split",
+            )
+            module = types.ModuleType("weasel.util.config")
+            exec(compile(src, spec.origin, "exec"), module.__dict__)
+            sys.modules["weasel.util.config"] = module
+    except Exception:  # pragma: no cover - best effort
+        pass


### PR DESCRIPTION
## Summary
- dynamically patch `weasel.util.config` to use `shlex.split` instead of the deprecated `click.parser.split_arg_string`
- document current warning filters and remaining unavoidable deprecation notices

## Testing
- `uv run pre-commit run --files sitecustomize.py docs/testing_guidelines.md`

------
https://chatgpt.com/codex/tasks/task_e_68c6414113a4833382f6e9f09dc3eb4c