### PR TITLE
docs: cover uncovered modules

### DIFF
--- a/docs/algorithms/README.md
+++ b/docs/algorithms/README.md
@@ -27,6 +27,17 @@
 - [Search Cache](cache.md)
 - [CLI Helpers](cli_helpers.md)
 - [Interfaces](interfaces.md)
+- [Agents](agents.md)
+- [API](api.md)
+- [Configuration](config.md)
+- [Distributed](distributed.md)
+- [Examples](examples.md)
+- [LLM](llm.md)
+- [Main Entrypoints](main.md)
+- [Monitor](monitor.md)
+- [Orchestrator Performance](orchestrator_perf.md)
+- [Scheduler Benchmark](scheduler_benchmark.md)
+- [Storage Utilities](storage_utils.md)
 
 ## Proof and Simulation Coverage
 
@@ -62,6 +73,17 @@
 - test_tools – simulation exercises testing tools.
 - tracing – simulation traces execution.
 - visualization – simulation renders graphs.
+- agents – simulation verifies agent coordination.
+- api – simulation exercises HTTP endpoints.
+- config – simulation validates configuration loading.
+- distributed – simulation models node coordination.
+- examples – simulation imports example workflows.
+- llm – simulation checks model adapters.
+- main – simulation exercises CLI entrypoints.
+- monitor – simulation monitors resource metrics.
+- orchestrator_perf – simulation benchmarks worker queues.
+- scheduler_benchmark – simulation measures scheduler resources.
+- storage_utils – simulation initialises schema version.
 
 ### Pending
 - None

--- a/docs/algorithms/agents.md
+++ b/docs/algorithms/agents.md
@@ -1,0 +1,26 @@
+# Agents
+
+## Overview
+Agents encapsulate specialized behaviours and coordinate via the orchestrator.
+
+## Algorithm
+Each agent implements a `step` loop processing tasks from a queue and
+reporting results back to the orchestrator.
+
+## Proof sketch
+The agent's loop terminates because each step consumes one task and tasks
+are finite.
+
+## Simulation
+`tests/unit/test_advanced_agents.py` exercises agent registration and task
+handling.
+
+## References
+- [code](../../src/autoresearch/agents/)
+- [spec](../specs/agents.md)
+- [tests](../../tests/unit/test_advanced_agents.py)
+
+## Related Issues
+- [Test orchestrator with all agent combinations][issue]
+
+[issue]: ../../issues/archive/test-orchestrator-with-all-agent-combinations.md

--- a/docs/algorithms/api.md
+++ b/docs/algorithms/api.md
@@ -1,0 +1,26 @@
+# API
+
+## Overview
+The API package exposes HTTP endpoints for orchestrator actions.
+
+## Algorithm
+Endpoints validate requests, delegate to orchestrator services, and stream
+responses to clients.
+
+## Proof sketch
+Validation ensures well-formed data; the orchestrator confirms task
+completion, so each request yields a finite response.
+
+## Simulation
+`tests/unit/test_api.py` simulates calls to key routes and checks status
+codes.
+
+## References
+- [code](../../src/autoresearch/api/)
+- [spec](../specs/api.md)
+- [tests](../../tests/unit/test_api.py)
+
+## Related Issues
+- [Fix API authentication and metrics tests][issue]
+
+[issue]: ../../issues/fix-api-authentication-and-metrics-tests.md

--- a/docs/algorithms/config.md
+++ b/docs/algorithms/config.md
@@ -1,0 +1,26 @@
+# Configuration
+
+## Overview
+The config package loads settings from files and environment variables.
+
+## Algorithm
+`ConfigLoader` merges defaults with profile data, watching files for
+changes to support live reload.
+
+## Proof sketch
+Merging operates on ordered layers; each layer overrides the previous,
+ensuring deterministic results.
+
+## Simulation
+`tests/unit/test_config_loader_defaults.py` exercises merging and reload
+behaviour.
+
+## References
+- [code](../../src/autoresearch/config/)
+- [spec](../specs/config.md)
+- [tests](../../tests/unit/test_config_loader_defaults.py)
+
+## Related Issues
+- [Resolve deprecation warnings in tests][issue]
+
+[issue]: ../../issues/resolve-deprecation-warnings-in-tests.md

--- a/docs/algorithms/distributed.md
+++ b/docs/algorithms/distributed.md
@@ -1,0 +1,27 @@
+# Distributed
+
+## Overview
+The distributed package coordinates work across multiple nodes.
+
+## Algorithm
+A leader elects workers via heartbeats and assigns tasks while monitoring
+queue saturation.
+
+## Proof sketch
+Leader election uses timeouts so at most one leader exists; tasks are
+acknowledged, preventing loss.
+
+## Simulation
+`tests/unit/test_distributed.py` and `scripts/distributed_coordination_sim.py`
+model coordination and verify convergence.
+
+## References
+- [code](../../src/autoresearch/distributed/)
+- [spec](../specs/distributed.md)
+- [tests](../../tests/unit/test_distributed.py)
+- [simulation](../../scripts/distributed_coordination_sim.py)
+
+## Related Issues
+- [Fix distributed perf sim CLI failure][issue]
+
+[issue]: ../../issues/archive/fix-distributed-perf-sim-cli-failure.md

--- a/docs/algorithms/examples.md
+++ b/docs/algorithms/examples.md
@@ -1,0 +1,27 @@
+# Examples
+
+## Overview
+The examples package bundles runnable workflows demonstrating library
+features.
+
+## Algorithm
+Each example registers a CLI entry that constructs agents and executes a
+predefined scenario.
+
+## Proof sketch
+Examples rely on tested modules; running them composes proven components,
+so scenarios succeed when dependencies pass.
+
+## Simulation
+`tests/unit/test_examples_package.py` imports every example to confirm
+entrypoints resolve.
+
+## References
+- [code](../../src/autoresearch/examples/)
+- [spec](../specs/examples.md)
+- [tests](../../tests/unit/test_examples_package.py)
+
+## Related Issues
+- [Prepare first alpha release][issue]
+
+[issue]: ../../issues/prepare-first-alpha-release.md

--- a/docs/algorithms/llm.md
+++ b/docs/algorithms/llm.md
@@ -1,0 +1,26 @@
+# LLM
+
+## Overview
+The llm package adapts model providers and normalizes responses.
+
+## Algorithm
+Adapters map provider APIs to a common interface and enforce token limits
+through the token budget helper.
+
+## Proof sketch
+Each adapter validates content length before dispatch, so returned
+messages respect configured budgets.
+
+## Simulation
+`tests/unit/test_llm_adapter.py` exercises adapter logic and token
+accounting.
+
+## References
+- [code](../../src/autoresearch/llm/)
+- [spec](../specs/llm.md)
+- [tests](../../tests/unit/test_llm_adapter.py)
+
+## Related Issues
+- [Resolve LLM extra installation failure][issue]
+
+[issue]: ../../issues/archive/resolve-llm-extra-installation-failure.md

--- a/docs/algorithms/main.md
+++ b/docs/algorithms/main.md
@@ -1,0 +1,25 @@
+# Main Entrypoints
+
+## Overview
+The main package exposes CLI commands for running orchestration tasks.
+
+## Algorithm
+It routes subcommands to handlers, initialising configuration and the
+orchestrator before executing actions.
+
+## Proof sketch
+Argument parsing uses `argparse` which guarantees a finite parse tree, so
+command dispatch terminates.
+
+## Simulation
+`tests/unit/test_main_cli.py` runs key commands and checks exit statuses.
+
+## References
+- [code](../../src/autoresearch/main/)
+- [spec](../specs/main.md)
+- [tests](../../tests/unit/test_main_cli.py)
+
+## Related Issues
+- [Prepare first alpha release][issue]
+
+[issue]: ../../issues/prepare-first-alpha-release.md

--- a/docs/algorithms/monitor.md
+++ b/docs/algorithms/monitor.md
@@ -1,0 +1,26 @@
+# Monitor
+
+## Overview
+The monitor package collects runtime metrics and exposes a CLI.
+
+## Algorithm
+A background loop polls resource usage and writes metrics to a shared
+queue for reporting.
+
+## Proof sketch
+The loop sleeps between samples and drains the queue each cycle, so
+memory use remains bounded.
+
+## Simulation
+`tests/unit/test_monitor_cli.py` invokes the CLI and verifies metric
+outputs.
+
+## References
+- [code](../../src/autoresearch/monitor/)
+- [spec](../specs/monitor.md)
+- [tests](../../tests/unit/test_monitor_cli.py)
+
+## Related Issues
+- [Fix monitor CLI metrics failure][issue]
+
+[issue]: ../../issues/archive/fix-monitor-cli-metrics-failure.md

--- a/docs/algorithms/orchestrator_perf.md
+++ b/docs/algorithms/orchestrator_perf.md
@@ -1,0 +1,28 @@
+# Orchestrator Performance
+
+## Overview
+`orchestrator_perf` models queueing behaviour for the orchestrator worker
+pool.
+
+## Algorithm
+It applies M/M/c queue formulas to estimate wait times and worker
+utilisation.
+
+## Proof sketch
+The formulas derive from standard queueing theory, ensuring bounds on
+queue length and service time.
+
+## Simulation
+`scripts/orchestrator_perf_sim.py` samples synthetic workloads and the
+tests compare predictions to measured metrics.
+
+## References
+- [code](../../src/autoresearch/orchestrator_perf.py)
+- [spec](../specs/orchestrator_perf.md)
+- [tests](../../tests/unit/test_orchestrator_perf_sim.py)
+- [simulation](../../scripts/orchestrator_perf_sim.py)
+
+## Related Issues
+- [Simulate distributed orchestrator performance][issue]
+
+[issue]: ../../issues/archive/simulate-distributed-orchestrator-performance.md

--- a/docs/algorithms/scheduler_benchmark.md
+++ b/docs/algorithms/scheduler_benchmark.md
@@ -1,0 +1,26 @@
+# Scheduler Benchmark
+
+## Overview
+`scheduler_benchmark` measures resource usage of the task scheduler.
+
+## Algorithm
+It runs a timed loop, tracking CPU time and memory growth while enqueuing
+dummy tasks.
+
+## Proof sketch
+The benchmark's loop runs for a fixed duration; bounds on the queue size
+ensure resources remain within limits.
+
+## Simulation
+`tests/unit/test_scheduler_benchmark.py` validates timing growth and
+memory ceilings.
+
+## References
+- [code](../../src/autoresearch/scheduler_benchmark.py)
+- [spec](../specs/scheduler_benchmark.md)
+- [tests](../../tests/unit/test_scheduler_benchmark.py)
+
+## Related Issues
+- [Benchmark scheduler queue saturation][issue]
+
+[issue]: ../../issues/archive/benchmark-scheduler-queue-saturation.md

--- a/docs/algorithms/storage_utils.md
+++ b/docs/algorithms/storage_utils.md
@@ -1,0 +1,26 @@
+# Storage Utilities
+
+## Overview
+`storage_utils` provides helpers for storage backends.
+
+## Algorithm
+`initialize_schema_version_without_fetchone` reads the metadata table and
+inserts version `1` when absent, even on cursors lacking `fetchone`.
+
+## Proof sketch
+Every path either finds a value or performs a single insert, so the
+metadata contains at most one schema version row.
+
+## Simulation
+`tests/integration/test_storage_schema.py` exercises initialization on a
+mock connection without `fetchone`.
+
+## References
+- [code](../../src/autoresearch/storage_utils.py)
+- [spec](../specs/storage-utils.md)
+- [tests](../../tests/integration/test_storage_schema.py)
+
+## Related Issues
+- [Fix storage schema and eviction tests][issue]
+
+[issue]: ../../issues/archive/fix-storage-schema-and-eviction-tests.md

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -39,9 +39,12 @@ documented behaviour.
 | `src/autoresearch/mcp_interface.py` | [mcp-interface.md](mcp-interface.md) | `../../tests/unit/test_mcp_interface.py<br>../../tests/behavior/features/mcp_interface.feature` |
 | `src/autoresearch/models.py` | [models.md](models.md) | `../../tests/unit/test_models_docstrings.py` |
 | `src/autoresearch/monitor/` | [monitor.md](monitor.md) | `../../tests/unit/test_main_monitor_commands.py<br>../../tests/unit/test_monitor_cli.py<br>../../tests/unit/test_resource_monitor_gpu.py` |
+| `src/autoresearch/orchestrator_perf.py` | [orchestrator_perf.md](orchestrator_perf.md) | `../../tests/unit/test_orchestrator_perf_sim.py`<br>`../../tests/integration/test_orchestrator_performance.py` |
 | `src/autoresearch/resource_monitor.py` | [resource-monitor.md](resource-monitor.md) | `../../tests/unit/test_resource_monitor_gpu.py<br>../../tests/integration/test_monitor_metrics.py<br>../../scripts/resource_monitor_bounds.py` |
+| `src/autoresearch/scheduler_benchmark.py` | [scheduler_benchmark.md](scheduler_benchmark.md) | `../../tests/unit/test_scheduler_benchmark.py` |
 | `src/autoresearch/storage_backends.py` | [storage-backends.md](storage-backends.md) | `../../tests/unit/test_duckdb_storage_backend.py<br>../../tests/unit/test_duckdb_storage_backend_extended.py` |
 | `src/autoresearch/storage_backup.py` | [storage-backup.md](storage-backup.md) | `../../tests/unit/test_storage_backup.py` |
+| `src/autoresearch/storage_utils.py` | [storage-utils.md](storage-utils.md) | `../../tests/integration/test_storage_schema.py` |
 | `src/autoresearch/streamlit_app.py` | [streamlit-app.md](streamlit-app.md) | `../../tests/unit/test_streamlit_app_edgecases.py` |
 | `src/autoresearch/streamlit_ui.py` | [streamlit-ui.md](streamlit-ui.md) | `../../tests/unit/test_streamlit_ui_helpers.py` |
 | `src/autoresearch/test_tools.py` | [test-tools.md](test-tools.md) | `../../tests/unit/test_test_tools.py` |

--- a/docs/specs/storage-utils.md
+++ b/docs/specs/storage-utils.md
@@ -1,0 +1,27 @@
+# Storage Utilities
+
+## Overview
+Helpers for storage routines that ensure schema metadata exists.
+
+## Algorithms
+- `initialize_schema_version_without_fetchone` uses `fetchall` to read
+  metadata and inserts version `1` if missing.
+
+## Invariants
+- Metadata table contains a single `schema_version` row.
+
+## Proof Sketch
+The function inserts only when no row is returned, preserving uniqueness.
+
+## Simulation Expectations
+Integration tests simulate a DuckDB connection without `fetchone`.
+
+## Traceability
+
+- Modules
+  - [src/autoresearch/storage_utils.py][m1]
+- Tests
+  - [tests/integration/test_storage_schema.py][t1]
+
+[m1]: ../../src/autoresearch/storage_utils.py
+[t1]: ../../tests/integration/test_storage_schema.py


### PR DESCRIPTION
## Summary
- document algorithms for agents, API, config, distributed, examples, LLM, main entrypoints, monitor, orchestrator performance, scheduler benchmark, and storage utilities
- add storage utilities specification linked to integration tests
- expand algorithm and spec indexes for new modules

## Testing
- `uv run mkdocs build`
- `task verify` *(fails: tests/unit/test_download_duckdb_extensions.py::test_download_extension_network_fallback)*

------
https://chatgpt.com/codex/tasks/task_e_68c64fa1769c8333a1c9a0e52929e9cf