### PR TITLE
docs: note extension test failure

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,6 +6,10 @@ Taskfile commands. Confirm the CLI is available with `task --version`.
 ## September 14, 2025
 - Verified Go Task 3.44.1 installation with `task --version`.
 - Updated README and STATUS with verification instructions.
+- `task check` succeeds after activating the development environment.
+- `task verify` fails at
+  `tests/unit/test_download_duckdb_extensions.py::test_download_extension_network_fallback`,
+  so coverage and resource tracker checks do not run.
 
 ## September 13, 2025
 - Installed Task CLI via setup script; archived

--- a/issues/fix-search-ranking-and-extension-tests.md
+++ b/issues/fix-search-ranking-and-extension-tests.md
@@ -8,6 +8,8 @@ returns `['B', 'A']` instead of `['A', 'B']`. Integration tests also fail:
 initialize the vector search extension and
 `tests/integration/test_ranking_formula_consistency.py::test_convex_combination_matches_docs`
 reports mismatched ranking values.
+Unit test `tests/unit/test_download_duckdb_extensions.py::test_download_extension_network_fallback`
+expects a stubbed extension file but returns a directory path.
 
 ## Dependencies
 None.


### PR DESCRIPTION
## Summary
- record failing DuckDB extension download test in issue tracker
- update status log with latest task check and task verify results

## Testing
- `task check`
- `task verify` *(fails: tests/unit/test_download_duckdb_extensions.py::test_download_extension_network_fallback)*

------
https://chatgpt.com/codex/tasks/task_e_68c651a6c60083339a1a431b881fc5df