### PR TITLE
Guard storage graph writes with lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ Reference issues by slugged filename (for example,
 ## [Unreleased]
 - Documented ranking formula test failure in
   [fix-search-ranking-and-extension-tests](issues/archive/fix-search-ranking-and-extension-tests.md).
-- Hardened storage concurrency and eviction logic with thread-safe locks and
-  added `initialize_schema_version_without_fetchone` helper to support DuckDB
+- Hardened storage concurrency and eviction logic with re-entrant locks
+  guarding NetworkX writes and added
+  `initialize_schema_version_without_fetchone` helper to support DuckDB
   connections lacking `fetchone`.
 - Fallback to in-memory RDF store when persistent backends cannot acquire a
   file lock, ensuring concurrent storage operations succeed.


### PR DESCRIPTION
## Summary
- prevent race conditions by guarding NetworkX graph and LRU updates with a re-entrant lock
- document storage concurrency and schema helpers, including fetchall-based schema initialization
- test schema initialization without `fetchone` and validate eviction and RAM-budget logic

## Testing
- `task check` *(fails: command not found)*
- `uv run --extra test pytest tests/integration/test_storage_schema.py::test_initialize_schema_version_without_fetchone tests/integration/test_storage_eviction_sim.py tests/integration/test_storage_duckdb_fallback.py`
- `task verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c65bfd2cb8833388c0a513d4e73aa3