### PR TITLE
Fix Click split warnings and pin fastembed

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -19,8 +19,8 @@ by default. Use `EXTRAS="gpu"` to include the GPU packages or limit extras.
 - `sitecustomize.py` replaces `click.parser.split_arg_string` with
   `shlex.split` to avoid Click deprecation warnings during tests.
 - Some third-party packages still issue deprecation warnings.
-  `pkg_resources` messages are filtered, and `fastembed` may emit
-  notices until upstream fixes land.
+  `pkg_resources` messages are filtered.
+  Document any other unavoidable warnings.
 
 ## Multiprocessing cleanup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ analysis = [
 # CPU-friendly LLM dependencies
 llm = [
     "dspy-ai >=2.6.27",
-    "fastembed >=0.3.2,<0.8"
+    "fastembed >=0.7.3,<0.8"
 ]
 # Dependencies needed only for running tests
 test = [

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -40,7 +40,9 @@ BASE_REQUIREMENTS = {
     "uv": "0.7.0",
 }
 
-BASE_EXTRAS = ["dev-minimal", "test"]
+# Include LLM dependencies to verify packages like ``fastembed`` are
+# installed at compatible versions.
+BASE_EXTRAS = ["dev-minimal", "test", "llm"]
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -20,10 +20,13 @@ if not TYPE_CHECKING:  # pragma: no cover - runtime import
         spec = importlib.util.find_spec("weasel.util.config")
         if spec and spec.origin:
             src = Path(spec.origin).read_text()
+            # Replace deprecated Click API with ``shlex.split`` to silence
+            # deprecation warnings from the ``weasel`` dependency.
             src = src.replace(
                 "from click.parser import split_arg_string",
                 "import shlex\n\nsplit_arg_string = shlex.split",
             )
+            src = src.replace("click.parser.split_arg_string", "shlex.split")
             module = types.ModuleType("weasel.util.config")
             exec(compile(src, spec.origin, "exec"), module.__dict__)
             sys.modules["weasel.util.config"] = module

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ requires-dist = [
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.25.0" },
     { name = "fakeredis", marker = "extra == 'test'", specifier = ">=2.25.0" },
     { name = "fastapi", specifier = ">=0.115.12" },
-    { name = "fastembed", marker = "extra == 'llm'", specifier = ">=0.3.2,<0.8" },
+    { name = "fastembed", marker = "extra == 'llm'", specifier = ">=0.7.3,<0.8" },
     { name = "fastmcp", specifier = ">=2.11.2" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=7.2.0" },
     { name = "flake8", marker = "extra == 'dev-minimal'", specifier = ">=7.2.0" },


### PR DESCRIPTION
## Summary
- patch `weasel.util.config` at startup to replace deprecated `click.parser.split_arg_string`
- include llm extras in environment checks and pin fastembed to 0.7.3
- document handling of residual deprecation warnings

## Testing
- `PYTHONWARNINGS=error::DeprecationWarning uv run mkdocs build`
- `PYTHONWARNINGS=error::DeprecationWarning task verify` *(fails: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c65c03fad8833396f682e04ccb444f