### PR TITLE
chore: align release planning with current issue status

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,12 +16,9 @@ passes with `llm` extras installed. `task verify` fails in
 `tests/unit/test_relevance_ranking.py::test_rank_results_with_disabled_features`
 (expected score `1.0`, got `0.0`), and earlier runs failed at
 `tests/unit/test_orchestrator_perf_sim.py::test_benchmark_scheduler_scales`,
-so integration tests and resource tracker diagnostics do not run. Reopened
-[fix-api-authentication-and-metrics-tests](issues/fix-api-authentication-and-metrics-tests.md),
-[fix-search-ranking-and-extension-tests](issues/fix-search-ranking-and-extension-tests.md),
-and
-[fix-storage-integration-test-failures](issues/fix-storage-integration-test-failures.md)
-still track earlier regressions.
+so integration tests and resource tracker diagnostics do not run. The open
+[fix-search-ranking-and-extension-tests](issues/fix-search-ranking-and-extension-tests.md)
+issue tracks remaining regressions.
 Scheduler resource benchmarks
 (`scripts/scheduling_resource_benchmark.py`) offer utilization and memory
 estimates documented in `docs/orchestrator_perf.md`. Dependency pins:
@@ -79,15 +76,13 @@ release is re-targeted for **September 15, 2026**. Key activities include:
 
 - [x] Environment bootstrap documented and installation instructions
   consolidated.
-- [ ] Task CLI availability restored
-  ([install-task-cli-system-level](issues/install-task-cli-system-level.md)).
+- [x] Task CLI availability restored
+  ([install-task-cli-system-level](issues/archive/install-task-cli-system-level.md)).
 - [x] Packaging verification with DuckDB fallback.
 - [x] Improve DuckDB extension fallback
   ([improve-duckdb-extension-fallback](issues/archive/improve-duckdb-extension-fallback.md)).
 - [ ] Integration tests stabilized
-  ([fix-api-authentication-and-metrics-tests](issues/fix-api-authentication-and-metrics-tests.md),
-  [fix-search-ranking-and-extension-tests](issues/fix-search-ranking-and-extension-tests.md),
-  [fix-storage-integration-test-failures](issues/fix-storage-integration-test-failures.md)).
+  ([fix-search-ranking-and-extension-tests](issues/fix-search-ranking-and-extension-tests.md)).
 - [ ] Coverage gates target **90%** total coverage once tests run
   ([add-test-coverage-for-optional-components](
   issues/archive/add-test-coverage-for-optional-components.md);

--- a/STATUS.md
+++ b/STATUS.md
@@ -13,6 +13,8 @@ Taskfile commands. Confirm the CLI is available with `task --version`.
   (expected score `1.0`, got `0.0`), so coverage and resource tracker checks do not
   run; earlier runs failed at
   `tests/unit/test_orchestrator_perf_sim.py::test_benchmark_scheduler_scales`.
+- A later `EXTRAS="llm" task verify` run was interrupted after 135 unit tests,
+  leaving integration tests unexecuted.
 
 - Enabled full integration suite by removing unconditional skips for
   `requires_ui`, `requires_vss`, and `requires_distributed` markers.

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -7,10 +7,7 @@ finalize outstanding testing, documentation, and packaging tasks while keeping
 workflows dispatch-only.
 
 ## Dependencies
-- [install-task-cli-system-level](archive/install-task-cli-system-level.md)
-- [fix-api-authentication-and-metrics-tests](fix-api-authentication-and-metrics-tests.md)
 - [fix-search-ranking-and-extension-tests](fix-search-ranking-and-extension-tests.md)
-- [fix-storage-integration-test-failures](fix-storage-integration-test-failures.md)
 - [fix-benchmark-scheduler-scaling-test](fix-benchmark-scheduler-scaling-test.md)
 - [resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md)
 - [resolve-deprecation-warnings-in-tests](resolve-deprecation-warnings-in-tests.md)


### PR DESCRIPTION
## Summary
- prune resolved dependencies from prepare-first-alpha-release issue
- sync roadmap with current tasks and archived links
- record interrupted verify run in status log

## Testing
- `EXTRAS="llm" task check`
- `EXTRAS="llm" task verify` *(interrupted after unit tests)*


------
https://chatgpt.com/codex/tasks/task_e_68c6e2d8e6e883339477a994d5539367