### PR TITLE
docs: reference archived duckdb fix

### DIFF
--- a/issues/resolve-resource-tracker-errors-in-verify.md
+++ b/issues/resolve-resource-tracker-errors-in-verify.md
@@ -34,7 +34,7 @@ Another run on the same day fails in
 still preventing reproduction of the KeyError.
 
 ## Dependencies
-- [fix-duckdb-storage-schema-initialization](fix-duckdb-storage-schema-initialization.md)
+- [fix-duckdb-storage-schema-initialization](../archive/fix-duckdb-storage-schema-initialization.md)
 
 ## Acceptance Criteria
 - `task verify` completes without resource tracker errors.


### PR DESCRIPTION
## Summary
- reference `fix-duckdb-storage-schema-initialization` from resource tracker issue

## Testing
- `npx markdown-link-check issues/resolve-resource-tracker-errors-in-verify.md` *(fails: [✖] ../archive/fix-duckdb-storage-schema-initialization.md)*
- `task check` *(fails: mypy errors in orchestrator_perf and search/core)*
- `task verify` *(fails: flake8 F401 in tests/unit/test_download_duckdb_extensions.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e9f4f01c8333bc2c7552e2278612