### PR TITLE
Archive resolved LLM extras issue and track mypy blockers

### DIFF
--- a/issues/archive/document-llm-extras-for-task-check.md
+++ b/issues/archive/document-llm-extras-for-task-check.md
@@ -16,4 +16,4 @@ None
 - Documentation explains how to run `task check` with LLM extras.
 
 ## Status
-Open
+Archived

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -7,11 +7,11 @@ finalize outstanding testing, documentation, and packaging tasks while keeping
 workflows dispatch-only.
 
 ## Dependencies
+- [resolve-mypy-errors-in-orchestrator-perf-and-search-core](resolve-mypy-errors-in-orchestrator-perf-and-search-core.md)
 - [fix-search-ranking-and-extension-tests](fix-search-ranking-and-extension-tests.md)
 - [fix-benchmark-scheduler-scaling-test](fix-benchmark-scheduler-scaling-test.md)
 - [resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md)
 - [resolve-deprecation-warnings-in-tests](resolve-deprecation-warnings-in-tests.md)
-- [document-llm-extras-for-task-check](document-llm-extras-for-task-check.md)
 
 ## Acceptance Criteria
 - All dependency issues are closed.

--- a/issues/resolve-mypy-errors-in-orchestrator-perf-and-search-core.md
+++ b/issues/resolve-mypy-errors-in-orchestrator-perf-and-search-core.md
@@ -1,0 +1,15 @@
+# Resolve mypy errors in orchestrator perf and search core
+
+## Context
+`task check` and `task verify` currently fail due to mypy type errors in `src/autoresearch/orchestrator_perf.py` and `src/autoresearch/search/core.py`. These errors block the test suite from running, preventing verification of other issues.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- `src/autoresearch/orchestrator_perf.py` passes mypy without errors.
+- `src/autoresearch/search/core.py` passes mypy without errors.
+- `task check` and `task verify` advance past the type-checking stage.
+
+## Status
+Open

--- a/tests/unit/test_download_duckdb_extensions.py
+++ b/tests/unit/test_download_duckdb_extensions.py
@@ -6,7 +6,6 @@ import sys
 from pathlib import Path
 
 import duckdb
-import pytest
 
 spec = importlib.util.spec_from_file_location(
     "download_duckdb_extensions",


### PR DESCRIPTION
## Summary
- remove unused pytest import in DuckDB extension test
- archive resolved `document-llm-extras-for-task-check` issue
- add issue to resolve mypy errors blocking verification and update release dependencies

## Testing
- `task check` *(fails: Dict entry has incompatible type in orchestrator_perf.py)*
- `task verify` *(fails: Dict entry has incompatible type in orchestrator_perf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c6edfa4b788333a9a685a36ca11fb5