### PR TITLE
Document mypy failures and schedule spec audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Reference issues by slugged filename (for example,
 ## [Unreleased]
 - Documented ranking formula test failure in
   [fix-search-ranking-and-extension-tests](issues/archive/fix-search-ranking-and-extension-tests.md).
+- Tracked specification coverage gaps in
+  [audit-spec-coverage-and-proofs](issues/audit-spec-coverage-and-proofs.md).
 - Hardened storage concurrency and eviction logic with re-entrant locks
   guarding NetworkX writes and added
   `initialize_schema_version_without_fetchone` helper to support DuckDB

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,14 +11,14 @@ and recent changes. Installation and environment details are covered in the
 See [STATUS.md](STATUS.md) for current results and
 [CHANGELOG.md](CHANGELOG.md) for recent updates. 0.1.0a1 remains untagged and
 targets **September 15, 2026**, with **0.1.0** planned for **October 1, 2026**
-across project documentation. Go Task 3.44.1 is available and `task check`
-passes with `llm` extras installed. `task verify` fails in
-`tests/unit/test_relevance_ranking.py::test_rank_results_with_disabled_features`
-(expected score `1.0`, got `0.0`), and earlier runs failed at
-`tests/unit/test_orchestrator_perf_sim.py::test_benchmark_scheduler_scales`,
-so integration tests and resource tracker diagnostics do not run. The open
+across project documentation. Go Task 3.44.1 is available, but `task check` and
+`task verify` fail due to mypy errors in
+`src/autoresearch/orchestrator_perf.py` and
+`src/autoresearch/search/core.py`, preventing tests from running. The open
+[resolve-mypy-errors-in-orchestrator-perf-and-search-core](issues/resolve-mypy-errors-in-orchestrator-perf-and-search-core.md)
+and
 [fix-search-ranking-and-extension-tests](issues/fix-search-ranking-and-extension-tests.md)
-issue tracks remaining regressions.
+issues track the type-check failures and downstream test regressions.
 Scheduler resource benchmarks
 (`scripts/scheduling_resource_benchmark.py`) offer utilization and memory
 estimates documented in `docs/orchestrator_perf.md`. Dependency pins:

--- a/STATUS.md
+++ b/STATUS.md
@@ -15,14 +15,12 @@ checks are required.
 - Verified Go Task 3.44.1 installation with `task --version`.
 - Updated README and STATUS with verification instructions.
 - Running `task check` without extras reports missing `dspy-ai` and `fastembed`.
-- `EXTRAS="llm" task check` succeeds.
-- `EXTRAS="llm" task verify` fails in
-  `tests/unit/test_relevance_ranking.py::test_rank_results_with_disabled_features`
-  (expected score `1.0`, got `0.0`), so coverage and resource tracker checks do not
-  run; earlier runs failed at
-  `tests/unit/test_orchestrator_perf_sim.py::test_benchmark_scheduler_scales`.
-- A later `EXTRAS="llm" task verify` run was interrupted after 135 unit tests,
-  leaving integration tests unexecuted.
+- Running `task check` fails due to mypy errors in
+  `src/autoresearch/orchestrator_perf.py` and
+  `src/autoresearch/search/core.py`. `task verify` stops at the same stage, so
+  tests and coverage do not run.
+- Opened [audit-spec-coverage-and-proofs](issues/audit-spec-coverage-and-proofs.md)
+  to confirm every module has matching specifications and proofs.
 
 - Enabled full integration suite by removing unconditional skips for
   `requires_ui`, `requires_vss`, and `requires_distributed` markers.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,11 +1,11 @@
 # Autoresearch Project - Task Progress
 
 This document tracks the progress of tasks for the Autoresearch project,
-organized by phases from the code complete plan. As of **September 13, 2025**, 
-running `scripts/setup.sh` installs Task 3.44.1 and required extras.
-`task check` succeeds. `task verify` installs optional extras and currently
-fails at `tests/unit/test_api_auth_middleware.py::test_resolve_role_missing_key`,
-so integration tests and coverage reports are skipped.
+organized by phases from the code complete plan. As of **September 14, 2025**, running
+`scripts/setup.sh` installs Task 3.44.1 and required extras. `task check` fails due to
+mypy errors in `src/autoresearch/orchestrator_perf.py` and
+`src/autoresearch/search/core.py`. `task verify` stops at the same stage, so
+integration tests and coverage reports are skipped.
 See [docs/release_plan.md](docs/release_plan.md) for current test and coverage 
 status. An **0.1.0-alpha.1** preview is re-targeted for **September 15, 2026**, 
 with the final **0.1.0** release targeted for **October 1, 2026**.

--- a/issues/audit-spec-coverage-and-proofs.md
+++ b/issues/audit-spec-coverage-and-proofs.md
@@ -1,0 +1,17 @@
+# Audit spec coverage and proofs
+
+## Context
+Spec documents exist for most modules, but coverage may be incomplete or
+outdated. A thorough audit is needed to confirm every component has a
+corresponding specification, proof, simulation, or formula where appropriate.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Inventory maps each module to its spec, algorithm, and proof documents.
+- Missing or stale sections are documented with follow-up issues.
+- STATUS.md notes audit results.
+
+## Status
+Open

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -13,6 +13,7 @@ workflows dispatch-only.
 - [resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md)
 - [resolve-deprecation-warnings-in-tests](resolve-deprecation-warnings-in-tests.md)
 - [document-llm-extras-for-task-check](document-llm-extras-for-task-check.md)
+- [audit-spec-coverage-and-proofs](audit-spec-coverage-and-proofs.md)
 
 ## Acceptance Criteria
 - All dependency issues are closed.


### PR DESCRIPTION
## Summary
- Note current `task check` and `task verify` mypy errors in project status and roadmap
- Add `audit-spec-coverage-and-proofs` issue and include it in alpha release dependencies

## Testing
- `task check` *(fails: mypy errors in orchestrator_perf.py and search/core.py)*
- `task verify` *(fails: mypy errors in orchestrator_perf.py and search/core.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f5c3dd24833397b55e2f2b1bab0d