### PR TITLE
chore: update issues for failing tests

### DIFF
--- a/issues/fix-api-authentication-regressions.md
+++ b/issues/fix-api-authentication-regressions.md
@@ -1,0 +1,20 @@
+# Fix API authentication regressions
+
+## Context
+A `uv run pytest` on 2025-09-14 reported numerous authentication and
+permission failures. Requests without valid API keys returned `200` instead
+of `401` or `403`, affecting suites under `tests/integration/test_api_auth*`,
+`test_api_docs.py`, `test_api_streaming.py`, `test_cli_http.py`, and
+`test_monitor_metrics.py`.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- API endpoints enforce API keys and correct status codes.
+- Authentication middleware validates requests before reading the body.
+- Integration tests for auth, docs, streaming, CLI, and metrics pass.
+- Documentation explains required API keys and roles.
+
+## Status
+Open

--- a/issues/fix-oxigraph-backend-initialization.md
+++ b/issues/fix-oxigraph-backend-initialization.md
@@ -1,0 +1,18 @@
+# Fix OxiGraph backend initialization
+
+## Context
+`uv run pytest` on 2025-09-14 failed in
+`tests/integration/test_rdf_persistence.py::test_oxigraph_backend_initializes`.
+The backend returned `"Memory"` instead of `"OxiGraph"`, indicating the
+OxiGraph storage backend was not configured or imported correctly.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- OxiGraph backend initializes and reports the expected identifier.
+- Related RDF persistence tests pass.
+- Documentation covers enabling OxiGraph in environments and tests.
+
+## Status
+Open

--- a/issues/fix-search-ranking-and-extension-tests.md
+++ b/issues/fix-search-ranking-and-extension-tests.md
@@ -13,6 +13,10 @@ expects a stubbed extension file but returns a directory path.
 On September 14, 2025, `task verify` failed in
 `tests/unit/test_relevance_ranking.py::test_rank_results_with_disabled_features`
 when ranking returned `0.0` instead of `1.0` with disabled features.
+The same run reported failures in:
+- `test_cross_backend_ranking_consistency.py::test_cross_backend_ranking_consistent`
+- `tests/integration/test_relevance_ranking_integration.py::test_rank_results_invalid_weight_sum`
+- `tests/integration/test_optional_extras.py::test_fastembed_available`
 
 ## Dependencies
 None.
@@ -20,7 +24,9 @@ None.
 ## Acceptance Criteria
 - DuckDB VSS extension loads with fallback when network access is unavailable.
 - Ranking formula tests match documented values.
-- Integration tests for extension loading and ranking pass.
+- Integration tests for extension loading, ranking consistency, and invalid
+  weight detection pass.
+- Optional extras such as `fastembed` load in test environments.
 - Docs reference extension loading and ranking formulae.
 
 ## Status

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -7,13 +7,17 @@ finalize outstanding testing, documentation, and packaging tasks while keeping
 workflows dispatch-only.
 
 ## Dependencies
-- [resolve-mypy-errors-in-orchestrator-perf-and-search-core](resolve-mypy-errors-in-orchestrator-perf-and-search-core.md)
+ - [resolve mypy errors in orchestrator perf][resolve-mypy-errors]
 - [fix-search-ranking-and-extension-tests](fix-search-ranking-and-extension-tests.md)
 - [fix-benchmark-scheduler-scaling-test](fix-benchmark-scheduler-scaling-test.md)
 - [resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md)
 - [resolve-deprecation-warnings-in-tests](resolve-deprecation-warnings-in-tests.md)
 - [document-llm-extras-for-task-check](document-llm-extras-for-task-check.md)
 - [audit-spec-coverage-and-proofs](audit-spec-coverage-and-proofs.md)
+- [fix-api-authentication-regressions](fix-api-authentication-regressions.md)
+- [fix-oxigraph-backend-initialization](fix-oxigraph-backend-initialization.md)
+
+[resolve-mypy-errors]: resolve-mypy-errors-in-orchestrator-perf-and-search-core.md
 
 ## Acceptance Criteria
 - All dependency issues are closed.

--- a/issues/resolve-mypy-errors-in-orchestrator-perf-and-search-core.md
+++ b/issues/resolve-mypy-errors-in-orchestrator-perf-and-search-core.md
@@ -1,7 +1,13 @@
 # Resolve mypy errors in orchestrator perf and search core
 
 ## Context
-`task check` and `task verify` currently fail due to mypy type errors in `src/autoresearch/orchestrator_perf.py` and `src/autoresearch/search/core.py`. These errors block the test suite from running, preventing verification of other issues.
+`task check` and `task verify` currently fail due to mypy type errors in
+`src/autoresearch/orchestrator_perf.py` and `src/autoresearch/search/core.py`.
+The 2025-09-14 run reported `Dict entry 3 has incompatible type 'str': 'str';`
+expected `str: float` at line 137 of `orchestrator_perf.py` and an
+`Argument 4 to "combine_scores" has incompatible type` error at line 661 of
+`search/core.py`. These errors block the test suite from running, preventing
+verification of other issues.
 
 ## Dependencies
 None


### PR DESCRIPTION
## Summary
- track API authentication regressions and OxiGraph backend failures
- expand ranking test issue and release dependencies
- note specific mypy error locations

## Testing
- `task check` *(fails: mypy errors)*
- `task verify` *(fails: mypy errors)*
- `uv run pytest` *(fails: 42 tests, mostly auth and ranking)*

------
https://chatgpt.com/codex/tasks/task_e_68c6faef9d088333a76ed5fae9b8d5ca