### PR TITLE
chore: expand alpha release prerequisites

### DIFF
--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -4,7 +4,9 @@
 The project remains unreleased even though the codebase and documentation are
 publicly available. To tag version v0.1.0a1, we need a coordinated effort to
 finalize outstanding testing, documentation, and packaging tasks while keeping
-workflows dispatch-only.
+workflows dispatch-only. The 2025-09-14 runs of `task check` and `task verify`
+halt at the type-checking stage due to mypy errors, preventing the test suite
+from executing.
 
 ## Dependencies
 - [resolve mypy errors in orchestrator perf][resolve-mypy-errors]
@@ -15,6 +17,8 @@ workflows dispatch-only.
 - [audit-spec-coverage-and-proofs](audit-spec-coverage-and-proofs.md)
 - [fix-api-authentication-regressions](fix-api-authentication-regressions.md)
 - [fix-oxigraph-backend-initialization](fix-oxigraph-backend-initialization.md)
+- [fix-mkdocs-griffe-warnings](fix-mkdocs-griffe-warnings.md)
+- [add-api-authentication-proofs](add-api-authentication-proofs.md)
 
 [resolve-mypy-errors]: resolve-mypy-errors-in-orchestrator-perf-and-search-core.md
 


### PR DESCRIPTION
## Summary
- note that `task check` and `task verify` currently stop at mypy errors
- add `fix-mkdocs-griffe-warnings` and `add-api-authentication-proofs` to alpha release blockers

## Testing
- `task check` *(fails: Dict entry 3 has incompatible type "str": "str"; expected "str": "float")*
- `task verify` *(fails: Dict entry 3 has incompatible type "str": "str"; expected "str": "float")*

------
https://chatgpt.com/codex/tasks/task_e_68c7025384d48333af1931d2b71d69d1