### PR TITLE
chore: align release planning

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,6 +91,8 @@ release is re-targeted for **September 15, 2026**. Key activities include:
 - [x] Algorithm validation for ranking and coordination
   ([add-ranking-algorithm-proofs-and-simulations](
   issues/archive/add-ranking-algorithm-proofs-and-simulations.md)).
+- [ ] Add formal validation for the OxiGraph backend
+  ([add-oxigraph-backend-proofs](issues/add-oxigraph-backend-proofs.md)).
 
 These steps proceed in sequence: environment bootstrap → packaging
 verification → integration tests → coverage gates → algorithm validation.

--- a/STATUS.md
+++ b/STATUS.md
@@ -15,10 +15,12 @@ checks are required.
 - Verified Go Task 3.44.1 installation with `task --version`.
 - Updated README and STATUS with verification instructions.
 - Running `task check` without extras reports missing `dspy-ai` and `fastembed`.
-- Running `task check` fails due to mypy errors in
-  `src/autoresearch/orchestrator_perf.py` and
-  `src/autoresearch/search/core.py`. `task verify` stops at the same stage, so
-  tests and coverage do not run.
+- Running `task check` fails with mypy: `Dict entry 3 has incompatible type
+  'str': 'str'; expected 'str': 'float'` at
+  `src/autoresearch/orchestrator_perf.py:137` and `Argument 4 to
+  "combine_scores" has incompatible type 'tuple[float, ...]'; expected
+  'tuple[float, float, float]'` at `src/autoresearch/search/core.py:661`.
+  `task verify` stops at the same stage, so tests and coverage do not run.
 - Opened [audit-spec-coverage-and-proofs](issues/audit-spec-coverage-and-proofs.md)
   to confirm every module has matching specifications and proofs.
 - Opened [add-oxigraph-backend-proofs](issues/add-oxigraph-backend-proofs.md) to

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -19,6 +19,7 @@ from executing.
 - [fix-oxigraph-backend-initialization](fix-oxigraph-backend-initialization.md)
 - [fix-mkdocs-griffe-warnings](fix-mkdocs-griffe-warnings.md)
 - [add-api-authentication-proofs](add-api-authentication-proofs.md)
+- [add-oxigraph-backend-proofs](add-oxigraph-backend-proofs.md)
 
 [resolve-mypy-errors]: resolve-mypy-errors-in-orchestrator-perf-and-search-core.md
 


### PR DESCRIPTION
## Summary
- record specific mypy errors blocking `task check` and `task verify`
- link OxiGraph backend proofs to the alpha release dependency chain
- note OxiGraph backend validation in the roadmap

## Testing
- `task check` *(fails: Dict entry 3 has incompatible type 'str': 'str'; expected 'str': 'float')*
- `task verify` *(fails: Dict entry 3 has incompatible type 'str': 'str'; expected 'str': 'float')*

------
https://chatgpt.com/codex/tasks/task_e_68c70a4bea608333b57d5ce4c103a01d