### PR TITLE
Use dataclass for benchmark metrics and fix search weight typing

### DIFF
--- a/src/autoresearch/orchestrator_perf.py
+++ b/src/autoresearch/orchestrator_perf.py
@@ -13,6 +13,7 @@ import pstats
 import resource
 import time
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from typing import Dict
 
 
@@ -71,12 +72,29 @@ def simulate(
     return metrics
 
 
+@dataclass
+class BenchmarkResult:
+    """Performance metrics from a scheduling benchmark.
+
+    Attributes:
+        throughput: Observed throughput in tasks per second.
+        cpu_time: User CPU time consumed in seconds.
+        mem_kb: Resident memory usage in kilobytes.
+        profile: Aggregated profiler statistics.
+    """
+
+    throughput: float
+    cpu_time: float
+    mem_kb: float
+    profile: str = ""
+
+
 def benchmark_scheduler(
     workers: int,
     tasks: int,
     mem_per_task: float = 0.0,
     profile: bool = False,
-) -> Dict[str, float]:
+) -> BenchmarkResult:
     """Measure scheduling throughput and resource usage.
 
     Each task allocates memory and sleeps briefly to mimic an I/O-bound
@@ -90,7 +108,7 @@ def benchmark_scheduler(
         profile: Whether to return cProfile statistics for the run.
 
     Returns:
-        Dictionary with observed throughput in tasks/s, CPU time, memory usage
+        BenchmarkResult containing throughput in tasks/s, CPU time, memory usage
         in kilobytes, and optional profiler output.
 
     Raises:
@@ -130,9 +148,9 @@ def benchmark_scheduler(
     throughput = tasks / elapsed if elapsed > 0 else float("inf")
     cpu_time = end_res.ru_utime - start_res.ru_utime
     mem_kb = end_res.ru_maxrss - start_res.ru_maxrss
-    return {
-        "throughput": throughput,
-        "cpu_time": cpu_time,
-        "mem_kb": mem_kb,
-        "profile": profile_output,
-    }
+    return BenchmarkResult(
+        throughput=throughput,
+        cpu_time=cpu_time,
+        mem_kb=mem_kb,
+        profile=profile_output,
+    )

--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -627,7 +627,11 @@ class Search:
                 weights=weights,
                 suggestion="Enable a component or increase its weight",
             )
-        normalized_weights = tuple(value / weights_sum for value in weights.values())
+        normalized_weights: tuple[float, float, float] = (
+            weights["bm25_weight"] / weights_sum,
+            weights["semantic_similarity_weight"] / weights_sum,
+            weights["source_credibility_weight"] / weights_sum,
+        )
 
         # Calculate scores using different algorithms
         bm25_scores = (


### PR DESCRIPTION
## Summary
- Return structured `BenchmarkResult` from `benchmark_scheduler` instead of raw dict
- Normalize ranking weights to an explicit three-float tuple before `combine_scores`

## Testing
- `task check` *(fails: command not found)*
- `uv run mypy src/autoresearch`
- `uv run black src/autoresearch/orchestrator_perf.py src/autoresearch/search/core.py`
- `uv run flake8 src/autoresearch/orchestrator_perf.py src/autoresearch/search/core.py`

------
https://chatgpt.com/codex/tasks/task_e_68c70cf05530833395f790c935cc330e