### PR TITLE
Register Oxigraph RDF backend and expose identifier

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -133,6 +133,19 @@ Ensure the `oxrdflib` package is installed so RDFLib can load the Oxigraph
 store correctly. The parent directory is created automatically so DuckDB and
 the RDF store can initialize together without manual path setup.
 
+### Enabling Oxigraph
+
+Add the following to `autoresearch.toml` to persist RDF data with Oxigraph:
+
+```toml
+[storage]
+rdf_backend = "oxigraph"
+```
+
+Call `StorageManager.get_rdf_backend_identifier()` to verify that the
+"Oxigraph" backend is active. The function returns the name of the current RDF
+store, allowing tests to confirm the correct backend is in use.
+
 ## Troubleshooting
 
 ### HNSW Index Creation Error

--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -1476,6 +1476,20 @@ class StorageManager(metaclass=StorageManagerMeta):
             return StorageManager.context.rdf_store
 
     @staticmethod
+    def get_rdf_backend_identifier() -> str:
+        """Return the identifier of the configured RDF store.
+
+        Returns:
+            str: Name of the underlying RDF backend. Defaults to the store's
+            class name when no explicit identifier is present.
+
+        Raises:
+            NotFoundError: If the RDF store is not initialized.
+        """
+        store = StorageManager.get_rdf_store()
+        return getattr(store.store, "identifier", store.store.__class__.__name__)
+
+    @staticmethod
     def has_vss() -> bool:
         """Check if the VSS extension is available for vector search.
 

--- a/tests/integration/test_rdf_persistence.py
+++ b/tests/integration/test_rdf_persistence.py
@@ -85,8 +85,8 @@ def test_oxigraph_backend_initializes(tmp_path, monkeypatch):
     StorageManager.teardown(remove_db=True)
     StorageManager.setup()
 
-    store = StorageManager.get_rdf_store()
-    assert store.store.__class__.__name__ == "OxigraphStore"
+    StorageManager.get_rdf_store()
+    assert StorageManager.get_rdf_backend_identifier() == "Oxigraph"
 
 
 def test_oxrdflib_missing_plugin(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- ensure RDF init registers the Oxigraph plugin and records backend identifiers
- expose `StorageManager.get_rdf_backend_identifier` for backend introspection
- test Oxigraph initialization via backend identifier and document enabling the backend

## Testing
- `uv run pre-commit run --files src/autoresearch/storage_backends.py src/autoresearch/storage.py tests/integration/test_rdf_persistence.py docs/storage.md`
- `uv run pytest tests/integration/test_rdf_persistence.py::test_oxigraph_backend_initializes`


------
https://chatgpt.com/codex/tasks/task_e_68c71a41e9748333b1f6b7bd35cff5aa