### PR TITLE
Add OxiGraph backend simulation and docs

### DIFF
--- a/docs/specs/storage-backends.md
+++ b/docs/specs/storage-backends.md
@@ -20,15 +20,35 @@ Core routines enforce invariants by validating inputs and state.
 
 Unit tests cover nominal and edge cases for these routines.
 
+## OxiGraph Backend
+
+### Proof Sketch
+
+- Setup opens an ``OxigraphStore`` at the requested path. When the directory
+  exists, ``rdflib.Graph.open`` reuses it; otherwise ``create=True`` initializes
+  a new store.
+- Teardown removes the directory with ``shutil.rmtree(..., ignore_errors=True)``
+  so repeated calls leave no residue.
+
+### Simulation
+
+Run [scripts/oxigraph_backend_sim.py][s1] to exercise repeated setup and
+teardown.
+
 ## Traceability
 
 
 - Modules
   - [src/autoresearch/storage_backends.py][m1]
+- Scripts
+  - [scripts/oxigraph_backend_sim.py][s1]
 - Tests
   - [tests/unit/test_duckdb_storage_backend.py][t1]
   - [tests/unit/test_duckdb_storage_backend_extended.py][t2]
+  - [tests/integration/test_rdf_persistence.py][t3]
 
 [m1]: ../../src/autoresearch/storage_backends.py
+[s1]: ../../scripts/oxigraph_backend_sim.py
 [t1]: ../../tests/unit/test_duckdb_storage_backend.py
 [t2]: ../../tests/unit/test_duckdb_storage_backend_extended.py
+[t3]: ../../tests/integration/test_rdf_persistence.py

--- a/scripts/oxigraph_backend_sim.py
+++ b/scripts/oxigraph_backend_sim.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Simulate idempotent OxiGraph setup and teardown.
+
+Usage:
+    uv run python scripts/oxigraph_backend_sim.py --path /tmp/rdf_store
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+import rdflib
+from oxrdflib import OxigraphStore
+
+
+def setup_store(path: Path) -> None:
+    """Create the store at ``path`` if needed and close it immediately."""
+    store = OxigraphStore()
+    graph = rdflib.Graph(store=store)
+    cfg = str(path)
+    if path.exists():
+        graph.open(configuration=cfg)
+    else:
+        graph.open(configuration=cfg, create=True)
+    graph.close()
+
+
+def teardown_store(path: Path) -> None:
+    """Remove the store directory if it exists."""
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def main(path: Path) -> None:
+    setup_store(path)
+    setup_store(path)
+    teardown_store(path)
+    teardown_store(path)
+    print("completed")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path("rdf_store"),
+        help="Directory for the OxiGraph store",
+    )
+    args = parser.parse_args()
+    main(args.path)

--- a/tests/integration/test_rdf_persistence.py
+++ b/tests/integration/test_rdf_persistence.py
@@ -1,7 +1,11 @@
 """Tests for RDF persistence functionality.
 
-This module contains tests for the RDF persistence functionality of the storage system,
-verifying that claims are properly stored in the RDF store and can be retrieved.
+This module contains tests for the RDF persistence functionality of the storage
+system, verifying that claims are properly stored in the RDF store and can be
+retrieved.
+
+For a standalone demo of idempotent setup and teardown, see
+``scripts/oxigraph_backend_sim.py``.
 """
 
 import importlib


### PR DESCRIPTION
## Summary
- document OxiGraph backend invariants and simulation expectations
- add `oxigraph_backend_sim.py` to demo idempotent setup and teardown
- mention simulation in RDF persistence tests

## Testing
- `task check` *(fails: command not found)*
- `uv run mkdocs build` *(fails: no such file or directory: mkdocs)*
- `uv run python scripts/oxigraph_backend_sim.py --path /tmp/rdf_store_sim`
- `uv run pytest tests/integration/test_rdf_persistence.py`


------
https://chatgpt.com/codex/tasks/task_e_68c71c5026308333b4c2cbb0d2c57363