### PR TITLE
Audit spec coverage and record gaps

### DIFF
--- a/SPEC_COVERAGE.md
+++ b/SPEC_COVERAGE.md
@@ -1,0 +1,47 @@
+| Module | Spec | Proof/Simulation | Status |
+| --- | --- | --- | --- |
+| `autoresearch` |  |  | Missing spec |
+| `autoresearch/__main__.py` |  |  | Missing spec |
+| `autoresearch/a2a_interface.py` | [a2a-interface.md](docs/specs/a2a-interface.md) |  | OK |
+| `autoresearch/agents` | [agents.md](docs/specs/agents.md) | [agents.md](docs/algorithms/agents.md) | OK |
+| `autoresearch/api` | [api.md](docs/specs/api.md) | [api.md](docs/algorithms/api.md) | Outdated spec |
+| `autoresearch/cache.py` | [cache.md](docs/specs/cache.md) | [cache.md](docs/algorithms/cache.md) | OK |
+| `autoresearch/cli_backup.py` | [cli-backup.md](docs/specs/cli-backup.md) |  | OK |
+| `autoresearch/cli_helpers.py` | [cli-helpers.md](docs/specs/cli-helpers.md) |  | Outdated spec |
+| `autoresearch/cli_utils.py` | [cli-utils.md](docs/specs/cli-utils.md) |  | OK |
+| `autoresearch/config` | [config.md](docs/specs/config.md) | [config.md](docs/algorithms/config.md) | Outdated spec |
+| `autoresearch/config_utils.py` | [config-utils.md](docs/specs/config-utils.md) |  | OK |
+| `autoresearch/data_analysis.py` | [data-analysis.md](docs/specs/data-analysis.md) |  | OK |
+| `autoresearch/distributed` | [distributed.md](docs/specs/distributed.md) | [distributed.md](docs/algorithms/distributed.md) | Outdated spec |
+| `autoresearch/error_recovery.py` | [error-recovery.md](docs/specs/error-recovery.md) |  | OK |
+| `autoresearch/error_utils.py` | [error-utils.md](docs/specs/error-utils.md) |  | OK |
+| `autoresearch/errors.py` | [errors.md](docs/specs/errors.md) | [errors.md](docs/algorithms/errors.md) | OK |
+| `autoresearch/examples` | [examples.md](docs/specs/examples.md) | [examples.md](docs/algorithms/examples.md) | OK |
+| `autoresearch/extensions.py` | [extensions.md](docs/specs/extensions.md) | [extensions.md](docs/algorithms/extensions.md) | Outdated spec |
+| `autoresearch/interfaces.py` | [interfaces.md](docs/specs/interfaces.md) | [interfaces.md](docs/algorithms/interfaces.md) | OK |
+| `autoresearch/kg_reasoning.py` | [kg-reasoning.md](docs/specs/kg-reasoning.md) |  | OK |
+| `autoresearch/llm` | [llm.md](docs/specs/llm.md) | [llm.md](docs/algorithms/llm.md) | OK |
+| `autoresearch/logging_utils.py` | [logging-utils.md](docs/specs/logging-utils.md) |  | OK |
+| `autoresearch/main` | [main.md](docs/specs/main.md) | [main.md](docs/algorithms/main.md) | OK |
+| `autoresearch/mcp_interface.py` | [mcp-interface.md](docs/specs/mcp-interface.md) |  | OK |
+| `autoresearch/models.py` | [models.md](docs/specs/models.md) | [models.md](docs/algorithms/models.md) | OK |
+| `autoresearch/monitor` | [monitor.md](docs/specs/monitor.md) | [monitor.md](docs/algorithms/monitor.md) | Outdated spec |
+| `autoresearch/orchestration` | [orchestration.md](docs/specs/orchestration.md) | [orchestration.md](docs/algorithms/orchestration.md) | OK |
+| `autoresearch/orchestrator_perf.py` |  |  | Missing spec |
+| `autoresearch/output_format.py` | [output-format.md](docs/specs/output-format.md) |  | OK |
+| `autoresearch/resource_monitor.py` | [resource-monitor.md](docs/specs/resource-monitor.md) |  | OK |
+| `autoresearch/scheduler_benchmark.py` |  |  | Missing spec |
+| `autoresearch/search` | [search.md](docs/specs/search.md) | [search.md](docs/algorithms/search.md) | OK |
+| `autoresearch/storage.py` | [storage.md](docs/specs/storage.md) | [storage.md](docs/algorithms/storage.md) | OK |
+| `autoresearch/storage_backends.py` | [storage-backends.md](docs/specs/storage-backends.md) |  | OK |
+| `autoresearch/storage_backup.py` | [storage-backup.md](docs/specs/storage-backup.md) |  | OK |
+| `autoresearch/storage_utils.py` | [storage-utils.md](docs/specs/storage-utils.md) |  | OK |
+| `autoresearch/streamlit_app.py` | [streamlit-app.md](docs/specs/streamlit-app.md) |  | OK |
+| `autoresearch/streamlit_ui.py` | [streamlit-ui.md](docs/specs/streamlit-ui.md) |  | OK |
+| `autoresearch/synthesis.py` | [synthesis.md](docs/specs/synthesis.md) | [synthesis.md](docs/algorithms/synthesis.md) | OK |
+| `autoresearch/test_tools.py` | [test-tools.md](docs/specs/test-tools.md) |  | OK |
+| `autoresearch/token_budget.py` | [token-budget.md](docs/specs/token-budget.md) |  | OK |
+| `autoresearch/tracing.py` | [tracing.md](docs/specs/tracing.md) | [tracing.md](docs/algorithms/tracing.md) | OK |
+| `autoresearch/visualization.py` | [visualization.md](docs/specs/visualization.md) | [visualization.md](docs/algorithms/visualization.md) | OK |
+| `git` |  |  | Missing spec |
+| `git/search.py` | [git-search.md](docs/specs/git-search.md) |  | OK |

--- a/STATUS.md
+++ b/STATUS.md
@@ -25,6 +25,7 @@ checks are required.
   to confirm every module has matching specifications and proofs.
 - Opened [add-oxigraph-backend-proofs](issues/add-oxigraph-backend-proofs.md) to
   provide formal validation for the OxiGraph storage backend.
+- Generated `SPEC_COVERAGE.md` linking modules to specs and proofs; opened issues for missing or outdated specs.
 
 - Added `task check EXTRAS="llm"` instructions to README and testing
   guidelines; archived

--- a/issues/add-autoresearch-package-spec.md
+++ b/issues/add-autoresearch-package-spec.md
@@ -1,0 +1,15 @@
+# Add autoresearch package spec
+
+## Context
+The root autoresearch package lacks a specification outlining its overall responsibilities.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Create docs/specs/autoresearch.md summarizing the package.
+- Reference associated proof or simulation if applicable.
+- Update SPEC_COVERAGE.md to link the new spec.
+
+## Status
+Open

--- a/issues/add-git-package-spec.md
+++ b/issues/add-git-package-spec.md
@@ -1,0 +1,15 @@
+# Add git package spec
+
+## Context
+The git package is missing a spec describing its search utilities.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Create docs/specs/git.md or similar for the package.
+- Reference proofs or simulations for git search if available.
+- Update SPEC_COVERAGE.md.
+
+## Status
+Open

--- a/issues/add-main-entrypoint-spec.md
+++ b/issues/add-main-entrypoint-spec.md
@@ -1,0 +1,15 @@
+# Add main entrypoint spec
+
+## Context
+The __main__ entrypoint has no specification describing CLI behavior.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Add docs/specs/main-entrypoint.md or equivalent describing the entrypoint.
+- Include proof or simulation if needed.
+- Update SPEC_COVERAGE.md.
+
+## Status
+Open

--- a/issues/add-orchestrator-perf-spec.md
+++ b/issues/add-orchestrator-perf-spec.md
@@ -1,0 +1,15 @@
+# Add orchestrator perf spec
+
+## Context
+orchestrator_perf.py implements performance benchmarking without an accompanying spec.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Create docs/specs/orchestrator-perf.md detailing benchmarks and invariants.
+- Provide proof or simulation demonstrating performance bounds.
+- Update SPEC_COVERAGE.md.
+
+## Status
+Open

--- a/issues/add-scheduler-benchmark-spec.md
+++ b/issues/add-scheduler-benchmark-spec.md
@@ -1,0 +1,15 @@
+# Add scheduler benchmark spec
+
+## Context
+scheduler_benchmark.py lacks a specification covering its metrics and methods.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Author docs/specs/scheduler-benchmark.md outlining benchmark logic.
+- Link to proofs or simulations validating results.
+- Update SPEC_COVERAGE.md.
+
+## Status
+Open

--- a/issues/update-api-spec.md
+++ b/issues/update-api-spec.md
@@ -1,0 +1,15 @@
+# Update API spec
+
+## Context
+docs/specs/api.md predates recent changes to the API package.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Revise the spec to reflect current endpoints and behavior.
+- Update associated proofs or simulations.
+- Mark SPEC_COVERAGE.md status as OK.
+
+## Status
+Open

--- a/issues/update-cli-helpers-spec.md
+++ b/issues/update-cli-helpers-spec.md
@@ -1,0 +1,15 @@
+# Update CLI helpers spec
+
+## Context
+docs/specs/cli-helpers.md is older than the implementation.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Refresh the spec to match current CLI helper functions.
+- Add or update proof/simulation references.
+- Update SPEC_COVERAGE.md status.
+
+## Status
+Open

--- a/issues/update-config-spec.md
+++ b/issues/update-config-spec.md
@@ -1,0 +1,15 @@
+# Update config spec
+
+## Context
+docs/specs/config.md is older than src/autoresearch/config.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Align the spec with current configuration logic.
+- Provide updated proofs or simulations.
+- Mark SPEC_COVERAGE.md as OK.
+
+## Status
+Open

--- a/issues/update-distributed-spec.md
+++ b/issues/update-distributed-spec.md
@@ -1,0 +1,15 @@
+# Update distributed spec
+
+## Context
+docs/specs/distributed.md lags behind the distributed package implementation.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Revise the spec for distributed workflows.
+- Update proofs or simulations.
+- Set SPEC_COVERAGE.md status to OK.
+
+## Status
+Open

--- a/issues/update-extensions-spec.md
+++ b/issues/update-extensions-spec.md
@@ -1,0 +1,15 @@
+# Update extensions spec
+
+## Context
+docs/specs/extensions.md predates recent changes.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Bring the spec up to date with extension loading logic.
+- Revise proofs or simulations if needed.
+- Update SPEC_COVERAGE.md.
+
+## Status
+Open

--- a/issues/update-monitor-spec.md
+++ b/issues/update-monitor-spec.md
@@ -1,0 +1,15 @@
+# Update monitor spec
+
+## Context
+docs/specs/monitor.md is older than monitor package changes.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Refresh the spec to describe current monitoring features.
+- Update related proofs or simulations.
+- Set SPEC_COVERAGE.md status to OK.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- Add SPEC_COVERAGE.md mapping modules to specs and proofs
- Open issues for modules missing specs or with stale documentation
- Note spec coverage results in STATUS

## Testing
- `uv run task check` *(fails: Failed to spawn: `task`)*
- `uv run task verify` *(fails: Failed to spawn: `task`)*

------
https://chatgpt.com/codex/tasks/task_e_68c726b4e53c8333afab3c19a0b92d18