### PR TITLE
docs: note verify run status and add lighter verify issue

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -42,6 +42,9 @@ checks are required.
   `ImportError` explicitly.
 - Running `task verify` now fails in
   `tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::test_verify_extension_failure`.
+- A subsequent run on 2025-09-14 with the default extras downloaded over 80
+  packages and was interrupted after the first unit test, so full coverage and
+  integration results remain unavailable.
 - Archived [resolve-mypy-errors-in-orchestrator-perf-and-search-core][resolve-mypy-errors-archive]
   after mypy passed in `task check`.
 

--- a/issues/limit-verify-extras-for-local-runs.md
+++ b/issues/limit-verify-extras-for-local-runs.md
@@ -1,0 +1,17 @@
+# Limit verify extras for local runs
+
+## Context
+Running `task verify` with default settings pulls every optional extra,
+triggering over 80 package downloads. Local contributors need a way to run a
+lighter verify for quick iterations.
+
+## Dependencies
+- [resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md)
+
+## Acceptance Criteria
+- Verify task accepts an option or documented workflow to run with minimal extras.
+- README and testing guidelines mention how to run verify with reduced downloads.
+- STATUS.md notes the reduced download approach.
+
+## Status
+Open

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -8,6 +8,9 @@ workflows dispatch-only. `task check` now passes after resolving earlier mypy
 errors, but `task verify` fails in
 `tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::test_verify_extension_failure`,
 blocking the release.
+An attempt on 2025-09-14 to run `task verify` with the default extras
+required downloading more than 80 packages and was interrupted after the first
+test, so full results are still pending.
 
 ## Dependencies
 - [fix-search-ranking-and-extension-tests](fix-search-ranking-and-extension-tests.md)


### PR DESCRIPTION
## Summary
- note heavy package download when running `task verify`
- record attempt in STATUS and prepare-first-alpha-release issue
- add issue for running `task verify` with fewer extras

## Testing
- `task check`
- `task verify` *(fails: KeyboardInterrupt during unit tests after heavy downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68c73b6ef9488333b2a2f5948fe4829a