### PR TITLE
doc: record property ranking test failure and setup gap

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -10,6 +10,8 @@ checks are required.
 ## September 14, 2025
 - Fresh environment lacked the Go Task CLI; `task check` returned
   "command not found".
+- Executing `scripts/codex_setup.sh` did not expose the `task` CLI; commands
+  run via `uv run task` instead.
 - `uv run --extra test pytest tests/unit/test_version.py -q` runs two tests in
   0.33s, demonstrating minimal coverage without Task.
 - Verified Go Task 3.44.1 installation with `task --version`.
@@ -45,6 +47,9 @@ checks are required.
 - A subsequent run on 2025-09-14 with the default extras downloaded over 80
   packages and was interrupted after the first unit test, so full coverage and
   integration results remain unavailable.
+- Another run on 2025-09-14 failed in
+  `tests/unit/search/test_property_ranking_monotonicity.py::test_monotonic_ranking`
+  with `hypothesis.errors.FailedHealthCheck` due to slow input generation.
 - Archived [resolve-mypy-errors-in-orchestrator-perf-and-search-core][resolve-mypy-errors-archive]
   after mypy passed in `task check`.
 

--- a/issues/expose-task-cli-after-codex-setup.md
+++ b/issues/expose-task-cli-after-codex-setup.md
@@ -1,0 +1,19 @@
+# Expose task CLI after codex setup
+
+## Context
+Running `scripts/codex_setup.sh` prints that `.venv/bin` was appended to `PATH`,
+but the parent shell does not retain the change. `task` remains unavailable
+unless commands are invoked as `uv run task` or the virtual environment is
+activated manually.
+
+## Dependencies
+None.
+
+## Acceptance Criteria
+- Running `scripts/codex_setup.sh` exposes `task` in the current shell or
+  documents activation steps.
+- `task --version` succeeds immediately after the script completes.
+- STATUS.md notes the updated setup instructions.
+
+## Status
+Open

--- a/issues/fix-search-ranking-and-extension-tests.md
+++ b/issues/fix-search-ranking-and-extension-tests.md
@@ -17,6 +17,10 @@ The same run reported failures in:
 - `test_cross_backend_ranking_consistency.py::test_cross_backend_ranking_consistent`
 - `tests/integration/test_relevance_ranking_integration.py::test_rank_results_invalid_weight_sum`
 - `tests/integration/test_optional_extras.py::test_fastembed_available`
+A later run on September 14, 2025, failed in
+`tests/unit/search/test_property_ranking_monotonicity.py::test_monotonic_ranking`
+with `hypothesis.errors.FailedHealthCheck` because input generation was too
+slow.
 
 ## Dependencies
 None.

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -11,6 +11,9 @@ blocking the release.
 An attempt on 2025-09-14 to run `task verify` with the default extras
 required downloading more than 80 packages and was interrupted after the first
 test, so full results are still pending.
+A later run on September 14, 2025, failed in
+`tests/unit/search/test_property_ranking_monotonicity.py::test_monotonic_ranking`
+with a `hypothesis.errors.FailedHealthCheck` due to slow input generation.
 
 ## Dependencies
 - [fix-search-ranking-and-extension-tests](fix-search-ranking-and-extension-tests.md)


### PR DESCRIPTION
## Summary
- note Hypothesis health check failure in `test_property_ranking_monotonicity`
- update release status to reflect verify failure and missing Task CLI
- add issue to expose Task CLI after `codex_setup.sh`

## Testing
- `uv run task check`
- `uv run task verify` *(fails: `tests/unit/search/test_property_ranking_monotonicity.py::test_monotonic_ranking`)*

------
https://chatgpt.com/codex/tasks/task_e_68c74261e190833386cbd32caa624b34