### PR TITLE
docs: record task CLI install failure and pytest run

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -10,10 +10,14 @@ checks are required.
 ## September 14, 2025
 - Fresh environment lacked the Go Task CLI; `task check` returned
   "command not found".
+- Attempting `apt-get install -y task` returned "Unable to locate package task".
 - Executing `scripts/codex_setup.sh` did not expose the `task` CLI; commands
   run via `uv run task` instead.
 - `uv run --extra test pytest tests/unit/test_version.py -q` runs two tests in
   0.33s, demonstrating minimal coverage without Task.
+- `uvx pre-commit run --all-files` succeeds.
+- Installed `pytest-bdd`, `hypothesis`, and `freezegun`; `uv run pytest -q`
+  reached 28% before manual interruption.
 - Verified Go Task 3.44.1 installation with `task --version`.
 - Updated README and STATUS with verification instructions.
 - Running `task check` without extras reports missing `dspy-ai` and `fastembed`.

--- a/issues/expose-task-cli-after-codex-setup.md
+++ b/issues/expose-task-cli-after-codex-setup.md
@@ -4,7 +4,8 @@
 Running `scripts/codex_setup.sh` prints that `.venv/bin` was appended to `PATH`,
 but the parent shell does not retain the change. `task` remains unavailable
 unless commands are invoked as `uv run task` or the virtual environment is
-activated manually.
+activated manually. Attempting to install the CLI with `apt-get install -y task`
+fails with "Unable to locate package task".
 
 ## Dependencies
 None.


### PR DESCRIPTION
## Summary
- note `apt-get install -y task` failing to find the Task CLI
- log pre-commit run and partial pytest progress in `STATUS.md`

## Testing
- `uvx pre-commit run --files STATUS.md issues/expose-task-cli-after-codex-setup.md`
- `uv run pytest tests/unit/test_version.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c743c450948333870e013cb33527c0