### PR TITLE
Ensure Codex setup adds Task to PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ immediately after cloning to bootstrap the required `dev-minimal` and `test`
 extras; skipping this step often yields missing plugin errors when running
 `task check` or any tests.
 
+Run `scripts/codex_setup.sh` in the Codex evaluation environment to bootstrap
+dependencies. The script appends `.venv/bin` to `PATH`, so the shell exposes
+`task` immediately after it finishes.
+
 For orchestrator state transitions and API contracts see
 [docs/orchestrator_state.md](docs/orchestrator_state.md).
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,6 +7,10 @@ Run `task check` for linting and smoke tests, then `task verify` before
 committing. Include `EXTRAS="llm"` only when LLM features or dependency
 checks are required.
 
+## September 15, 2025
+- Running `scripts/codex_setup.sh` exports `.venv/bin` to `PATH`,
+  giving the shell immediate access to `task`.
+
 ## September 14, 2025
 - Fresh environment lacked the Go Task CLI; `task check` returned
   "command not found".

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -63,4 +63,5 @@ uv run python -c "import owlrl" \
 
 ensure_venv_bin_on_path "$PWD/.venv/bin"
 echo ".venv/bin appended to PATH for this session"
+export PATH="$(pwd)/.venv/bin:$PATH"
 


### PR DESCRIPTION
## Summary
- export `.venv/bin` in `scripts/codex_setup.sh` so the Codex setup shell immediately exposes `task`
- document Task availability after `codex_setup.sh` in README and STATUS

## Testing
- `./scripts/codex_setup.sh`
- `task --version`
- `task check`
- `task verify` *(fails: test_vss_extension_loader::test_verify_extension_failure)*

------
https://chatgpt.com/codex/tasks/task_e_68c7780f8ad48333a125960c40119a59