### PR TITLE
Improve ranking weight handling and offline VSS stub tests

### DIFF
--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -15,8 +15,8 @@ from ..orchestration import ReasoningMode
 from .validators import (
     normalize_ranking_weights,
     validate_eviction_policy,
-    validate_reasoning_mode,
     validate_rdf_backend,
+    validate_reasoning_mode,
     validate_token_budget,
 )
 
@@ -64,9 +64,9 @@ class SearchConfig(BaseModel):
     )
     use_semantic_similarity: bool = Field(default=True)
     use_bm25: bool = Field(default=True)
-    semantic_similarity_weight: float = Field(default=0.5, ge=0.0, le=1.0)
-    bm25_weight: float = Field(default=0.3, ge=0.0, le=1.0)
-    source_credibility_weight: float = Field(default=0.2, ge=0.0, le=1.0)
+    semantic_similarity_weight: float = Field(default=0.5, ge=0.0)
+    bm25_weight: float = Field(default=0.3, ge=0.0)
+    source_credibility_weight: float = Field(default=0.2, ge=0.0)
     use_source_credibility: bool = Field(default=True)
     domain_authority_factor: float = Field(default=0.6, ge=0.0, le=1.0)
     citation_count_factor: float = Field(default=0.4, ge=0.0, le=1.0)

--- a/tests/integration/test_optional_extras.py
+++ b/tests/integration/test_optional_extras.py
@@ -16,9 +16,10 @@ to modules is:
 
 from __future__ import annotations
 
+import sys
+
 import duckdb
 import pytest
-import sys
 
 from autoresearch.config.loader import get_config, temporary_config
 from autoresearch.data_analysis import metrics_dataframe
@@ -53,9 +54,12 @@ def test_vss_extension_loader(monkeypatch) -> None:
     """The VSS extra enables DuckDB vector extension management."""
 
     monkeypatch.setenv("ENABLE_ONLINE_EXTENSION_INSTALL", "false")
+    monkeypatch.setattr(VSSExtensionLoader, "_load_from_package", staticmethod(lambda conn: False))
+    monkeypatch.setattr(VSSExtensionLoader, "_load_local_stub", staticmethod(lambda conn: False))
     conn = duckdb.connect(":memory:")
     loaded = VSSExtensionLoader.load_extension(conn)
-    assert loaded is VSSExtensionLoader.verify_extension(conn, verbose=False)
+    assert loaded is True
+    assert VSSExtensionLoader.verify_extension(conn, verbose=False) is True
 
 
 @pytest.mark.requires_git

--- a/tests/unit/search/test_property_ranking_monotonicity.py
+++ b/tests/unit/search/test_property_ranking_monotonicity.py
@@ -1,14 +1,15 @@
 from typing import List
 
 import pytest
-from hypothesis import HealthCheck, given, settings, strategies as st
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel, SearchConfig
 from autoresearch.search import Search
 
 
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(max_examples=50, suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(
     bm25_a=st.floats(min_value=0, max_value=1),
     bm25_b=st.floats(min_value=0, max_value=1),
@@ -16,9 +17,9 @@ from autoresearch.search import Search
     sem_b=st.floats(min_value=0, max_value=1),
     cred_a=st.floats(min_value=0, max_value=1),
     cred_b=st.floats(min_value=0, max_value=1),
-    weights=st.lists(
-        st.floats(min_value=0.01, max_value=1.0), min_size=3, max_size=3
-    ).map(lambda w: [x / sum(w) for x in w]),
+    weights=st.lists(st.floats(min_value=0.01, max_value=1.0), min_size=3, max_size=3).map(
+        lambda w: [x / sum(w) for x in w]
+    ),
 )
 def test_monotonic_ranking(
     bm25_a: float,


### PR DESCRIPTION
## Summary
- Normalize ranking weights and allow automatic fallbacks when weights sum to zero
- Adjust config validators and models to permit non-unit weights
- Ensure VSS extension loader test exercises offline stub path and speed up Hypothesis test generation

## Testing
- `uv run --extra test pytest tests/unit/search/test_ranking_formula.py tests/unit/search/test_property_ranking_monotonicity.py::test_monotonic_ranking tests/integration/test_optional_extras.py::test_vss_extension_loader`
- `task check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c783637da48333a385b07ec8f9eadd