### PR TITLE
Validate API keys before reading bodies

### DIFF
--- a/docs/api_authentication.md
+++ b/docs/api_authentication.md
@@ -5,6 +5,14 @@ When either mechanism is configured, unauthenticated or invalid requests
 receive a `401` response with a `WWW-Authenticate` header indicating the
 required scheme.
 
+## Required keys and roles
+
+- Define keys with `api.api_key` or `api.api_keys`.
+- Map each key to a role and configure `api.role_permissions`.
+- Requests with missing or invalid credentials return **401 Unauthorized**.
+- Requests lacking required permissions return **403 Forbidden**.
+- Keys are validated and roles assigned before request bodies are read.
+
 ## API keys
 
 - Set `api.api_key` in your configuration to require a shared secret.
@@ -12,7 +20,6 @@ required scheme.
 - Missing or incorrect keys trigger `401` with `WWW-Authenticate: API-Key`.
 - Multiple keys with different roles can be defined via `api.api_keys`.
 - Each key maps to a role that grants permissions via `api.role_permissions`.
-- Keys are validated and roles assigned before request bodies are read.
 - If an `X-API-Key` header is present but invalid, the request is rejected
   even when a bearer token is supplied.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -51,6 +51,16 @@ Run a search from the command line:
 autoresearch search "What is quantum computing?"
 ```
 
+## API authentication
+
+To access the HTTP API, configure keys and roles:
+
+- Set `api.api_key` for a shared secret or define multiple keys via
+  `api.api_keys`.
+- Map each key to a role and grant permissions with `api.role_permissions`.
+- Missing or invalid credentials return **401 Unauthorized**.
+- Insufficient permissions return **403 Forbidden**.
+
 ## Local file and Git search
 
 Enable local search backends in `autoresearch.toml`:

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -13,6 +13,18 @@ Requests and responses use versioned schemas; the current
 `"1"`. Deprecated versions return **410 Gone** while unknown versions
 return **422 Unprocessable Entity**.
 
+## Authentication
+
+Clients must include a valid API key or bearer token.
+
+- ``X-API-Key`` headers map to roles defined in ``api.api_keys``.
+- ``Authorization: Bearer <token>`` headers are checked against
+  ``api.bearer_token``.
+- Each role's permissions come from ``api.role_permissions``.
+- Missing or invalid credentials return **401 Unauthorized**.
+- Insufficient permissions return **403 Forbidden**.
+- Credentials are validated before request bodies are read.
+
 ## Algorithms
 
 - Implement core behaviors described above.

--- a/src/autoresearch/api/auth_middleware.py
+++ b/src/autoresearch/api/auth_middleware.py
@@ -5,19 +5,24 @@ from __future__ import annotations
 import secrets
 from typing import cast
 
-from fastapi import Request
 from fastapi.responses import JSONResponse
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from ..config import ConfigLoader
 from .utils import verify_bearer_token
 
-security = HTTPBearer(auto_error=False)
 
-
-class AuthMiddleware(BaseHTTPMiddleware):
+class AuthMiddleware:
     """API key and token authentication middleware."""
+
+    def __init__(self, app: ASGIApp):
+        """Initialize the middleware.
+
+        Args:
+            app: Downstream ASGI application.
+        """
+
+        self.app = app
 
     @staticmethod
     def _unauthorized(detail: str, scheme: str) -> JSONResponse:
@@ -27,6 +32,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
             detail: Human readable error message.
             scheme: Authentication scheme for the ``WWW-Authenticate`` header
                 (e.g. ``"API-Key"`` or ``"Bearer"``).
+
+        Returns:
+            JSON response object representing the error.
         """
 
         return JSONResponse(
@@ -36,7 +44,15 @@ class AuthMiddleware(BaseHTTPMiddleware):
         )
 
     def _resolve_role(self, key: str | None, cfg) -> tuple[str, JSONResponse | None]:
-        """Return the role for ``key`` or an error response."""
+        """Return the role for ``key`` or an error response.
+
+        Args:
+            key: Provided API key or ``None``.
+            cfg: Loaded API configuration.
+
+        Returns:
+            A tuple containing the resolved role and an optional error response.
+        """
 
         if cfg.api_keys:
             if not key:
@@ -55,40 +71,55 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         return "anonymous", None
 
-    async def dispatch(self, request: Request, call_next):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Authenticate requests using API keys or bearer tokens."""
 
-        loader = cast(ConfigLoader, request.app.state.config_loader)
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        app_state = scope["app"].state  # type: ignore[index]
+        loader = cast(ConfigLoader, app_state.config_loader)
         loader._config = loader.load_config()
         cfg = loader._config.api
 
         auth_scheme = "API-Key" if (cfg.api_keys or cfg.api_key) else "Bearer"
 
-        api_key = request.headers.get("X-API-Key")
-        auth_header = request.headers.get("Authorization")
+        headers = {k.lower(): v for k, v in scope.get("headers", [])}
+        api_key = headers.get(b"x-api-key")
+        auth_header = headers.get(b"authorization")
 
         key_valid = False
         role = "anonymous"
         if api_key is not None:
-            role, key_error = self._resolve_role(api_key, cfg)
+            api_key_str = api_key.decode()
+            role, key_error = self._resolve_role(api_key_str, cfg)
             if key_error:
-                return key_error
+                await key_error(scope, receive, send)
+                return
             key_valid = True
 
-        token = None
         token_valid = False
         if (auth_header or not key_valid) and cfg.bearer_token:
-            credentials: HTTPAuthorizationCredentials | None = await security(request)
-            token = credentials.credentials if credentials else None
+            token = None
+            if auth_header:
+                auth_str = auth_header.decode()
+                if auth_str.lower().startswith("bearer "):
+                    token = auth_str.split(" ", 1)[1]
             token_valid = verify_bearer_token(token, cfg.bearer_token)
             if token and not token_valid:
-                return self._unauthorized("Invalid token", "Bearer")
+                resp = self._unauthorized("Invalid token", "Bearer")
+                await resp(scope, receive, send)
+                return
 
         auth_configured = bool(cfg.api_keys or cfg.api_key or cfg.bearer_token)
         if auth_configured and not (key_valid or token_valid):
             if cfg.bearer_token and not key_valid:
-                return self._unauthorized("Missing token", "Bearer")
-            return self._unauthorized("Missing API key", "API-Key")
+                resp = self._unauthorized("Missing token", "Bearer")
+            else:
+                resp = self._unauthorized("Missing API key", "API-Key")
+            await resp(scope, receive, send)
+            return
 
         if not key_valid and token_valid:
             role = "user"
@@ -98,11 +129,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
         else:
             auth_scheme = "Bearer" if cfg.bearer_token else "API-Key"
 
-        request.state.role = role
-        request.state.permissions = set(cfg.role_permissions.get(role, []))
-        request.state.www_authenticate = auth_scheme
+        state = scope.setdefault("state", {})
+        state["role"] = role
+        state["permissions"] = set(cfg.role_permissions.get(role, []))
+        state["www_authenticate"] = auth_scheme
 
-        return await call_next(request)
+        await self.app(scope, receive, send)
 
 
 __all__ = ["AuthMiddleware"]

--- a/tests/integration/test_api_auth_middleware.py
+++ b/tests/integration/test_api_auth_middleware.py
@@ -12,6 +12,19 @@ def test_auth_validated_before_body(monkeypatch, api_client):
     assert resp.json()["detail"] == "Missing API key"
 
 
+def test_invalid_key_before_body(monkeypatch, api_client):
+    cfg = _setup(monkeypatch)
+    cfg.api.api_key = "secret"
+
+    resp = api_client.post(
+        "/query",
+        data="not json",
+        headers={"Content-Type": "application/json", "X-API-Key": "bad"},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid API key"
+
+
 def test_webhook_auth(monkeypatch, api_client):
     cfg = _setup(monkeypatch)
     cfg.api.api_key = "secret"

--- a/tests/integration/test_api_auth_permissions.py
+++ b/tests/integration/test_api_auth_permissions.py
@@ -40,3 +40,12 @@ def test_permission_unauthenticated(monkeypatch, api_client):
     resp = api_client.get("/metrics")
     assert resp.status_code == 401
     assert resp.json()["detail"] == "Missing API key"
+
+
+def test_permission_invalid_key(monkeypatch, api_client):
+    cfg = _setup(monkeypatch)
+    cfg.api.api_keys = {"adm": "admin"}
+    cfg.api.role_permissions = {"admin": ["metrics"]}
+    resp = api_client.get("/metrics", headers={"X-API-Key": "bad"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid API key"

--- a/tests/integration/test_api_auth_streaming.py
+++ b/tests/integration/test_api_auth_streaming.py
@@ -44,6 +44,20 @@ def test_streaming_with_api_key(monkeypatch, api_client):
 
 
 @pytest.mark.slow
+def test_streaming_forbidden(monkeypatch, api_client):
+    cfg = _setup_stream(monkeypatch)
+    cfg.api.api_keys = {"usr": "user"}
+    cfg.api.role_permissions = {"user": []}
+    resp = api_client.post(
+        "/query?stream=true",
+        json={"query": "q"},
+        headers={"X-API-Key": "usr"},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Insufficient permissions"
+
+
+@pytest.mark.slow
 def test_streaming_with_bearer_token(monkeypatch, api_client):
     cfg = _setup_stream(monkeypatch)
     token = generate_bearer_token()


### PR DESCRIPTION
## Summary
- Refactor auth middleware to an ASGI implementation that checks API keys and tokens before reading request bodies.
- Add negative API auth tests for missing, invalid, and unauthorized roles across middleware, permissions, and streaming flows.
- Document required API keys, roles, and permission checks in API spec and user guides.

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run --extra test pytest` *(fails: AttributeError in unrelated tests)*
- `uv run --extra test pytest tests/integration/test_api_auth_middleware.py tests/integration/test_api_auth_permissions.py tests/integration/test_api_auth_streaming.py`


------
https://chatgpt.com/codex/tasks/task_e_68c792c71220833395fe7586d45acc00