### PR TITLE
Add API auth proof and simulation

### DIFF
--- a/SPEC_COVERAGE.md
+++ b/SPEC_COVERAGE.md
@@ -4,7 +4,7 @@
 | `autoresearch/__main__.py` |  |  | Missing spec |
 | `autoresearch/a2a_interface.py` | [a2a-interface.md](docs/specs/a2a-interface.md) |  | OK |
 | `autoresearch/agents` | [agents.md](docs/specs/agents.md) | [agents.md](docs/algorithms/agents.md) | OK |
-| `autoresearch/api` | [api.md](docs/specs/api.md) | [api.md](docs/algorithms/api.md) | Outdated spec |
+| `autoresearch/api` | [api.md](docs/specs/api.md) | [p1], [p2], [s1] | OK |
 | `autoresearch/cache.py` | [cache.md](docs/specs/cache.md) | [cache.md](docs/algorithms/cache.md) | OK |
 | `autoresearch/cli_backup.py` | [cli-backup.md](docs/specs/cli-backup.md) |  | OK |
 | `autoresearch/cli_helpers.py` | [cli-helpers.md](docs/specs/cli-helpers.md) |  | Outdated spec |
@@ -45,3 +45,6 @@
 | `autoresearch/visualization.py` | [visualization.md](docs/specs/visualization.md) | [visualization.md](docs/algorithms/visualization.md) | OK |
 | `git` |  |  | Missing spec |
 | `git/search.py` | [git-search.md](docs/specs/git-search.md) |  | OK |
+[p1]: docs/algorithms/api.md
+[p2]: docs/algorithms/api-authentication.md
+[s1]: scripts/api_auth_credentials_sim.py

--- a/docs/algorithms/api-authentication.md
+++ b/docs/algorithms/api-authentication.md
@@ -1,0 +1,20 @@
+# API Authentication Proof
+
+Constant-time comparisons hide timing signals that could reveal secret tokens.
+The `secrets.compare_digest` function runs in time dependent only on input
+length, preventing attackers from guessing characters by timing responses.
+
+## Role Checks
+
+Authorization verifies that a user's role permits the requested operation. A
+permissions mapping assigns actions to each role and fails fast when a role is
+missing or lacks the required permission.
+
+## Constant-Time Comparison
+
+Traditional equality may exit on the first mismatched character, leaking timing
+data. Constant-time comparison evaluates every byte before returning a result,
+ensuring uniform execution.
+
+[Python secrets module]:
+  https://docs.python.org/3/library/secrets.html#secrets.compare_digest

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -4,6 +4,7 @@
 
 FastAPI app aggregator for Autoresearch. See these algorithm references:
 - [API authentication](../algorithms/api_authentication.md)
+- [Constant-time auth proof](../algorithms/api-authentication.md)
 - [Error paths](../algorithms/api_auth_error_paths.md)
 - [API rate limiting](../algorithms/api_rate_limiting.md)
 - [API streaming](../algorithms/api_streaming.md)
@@ -52,6 +53,9 @@ Streaming a finite chunk list while recording data and heartbeats shows the
 ordering and liveness invariants hold. Tests cover nominal and error paths, and
 the simulation in [api_stream_order_sim.py][s1] confirms ordered delivery,
 heartbeat counts, and linear operations.
+The [api-authentication](../algorithms/api-authentication.md) proof outlines
+constant-time credential checks, and [api_auth_credentials_sim.py][s2]
+exercises valid and invalid tokens and roles.
 
 ## Simulation Expectations
 
@@ -64,6 +68,7 @@ Streaming simulations send three chunks and record metrics such as
   - [src/autoresearch/api/][m1]
 - Scripts
   - [scripts/api_stream_order_sim.py][s1]
+  - [scripts/api_auth_credentials_sim.py][s2]
 - Tests
   - [tests/unit/test_api.py][t1]
   - [tests/unit/test_api_error_handling.py][t2]
@@ -94,4 +99,5 @@ Streaming simulations send three chunks and record metrics such as
 [t12]: ../../tests/unit/test_webhooks_logging.py
 [r1]: ../../tests/analysis/api_streaming_metrics.json
 [s1]: ../../scripts/api_stream_order_sim.py
+[s2]: ../../scripts/api_auth_credentials_sim.py
 [t13]: ../../tests/analysis/test_api_stream_order_sim.py

--- a/scripts/api_auth_credentials_sim.py
+++ b/scripts/api_auth_credentials_sim.py
@@ -1,0 +1,33 @@
+"""Simulate credential checks for API auth.
+
+Usage:
+    uv run scripts/api_auth_credentials_sim.py
+"""
+
+from __future__ import annotations
+
+from secrets import compare_digest
+
+EXPECTED_TOKEN = "secret-token"
+PERMISSIONS = {"admin": {"read", "write"}, "reader": {"read"}}
+
+
+def authenticate(token: str, role: str, action: str) -> bool:
+    """Return True when the token and role authorize the action."""
+    return compare_digest(token, EXPECTED_TOKEN) and action in PERMISSIONS.get(role, set())
+
+
+def main() -> None:  # pragma: no cover - CLI usage
+    scenarios = [
+        ("secret-token", "admin", "write"),
+        ("bad-token", "admin", "write"),
+        ("secret-token", "reader", "write"),
+    ]
+    for tok, role, action in scenarios:
+        allowed = authenticate(tok, role, action)
+        status = "allowed" if allowed else "denied"
+        print(f"{role} using {tok!r} for {action}: {status}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Document constant-time comparison and role checks for API authentication
- Provide a script simulating credential verification scenarios
- Cross-reference proof and simulation from API spec and update coverage table

## Testing
- `task check`
- `uv run mkdocs build` *(fails: mkdocstrings handler configuration issue)*
- `task verify` *(fails: AuthMiddleware missing dispatch attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68c795b028a0833397249956d586f84c