### PR TITLE
Configure OxiGraph backend and update tests

### DIFF
--- a/docs/specs/storage-backends.md
+++ b/docs/specs/storage-backends.md
@@ -35,6 +35,12 @@ Unit tests cover nominal and edge cases for these routines.
 Run [scripts/oxigraph_backend_sim.py][s1] to exercise repeated setup and
 teardown.
 
+### Setup
+
+- Install `oxrdflib` to enable the OxiGraph RDF store.
+- Set `storage.rdf_backend` to `oxigraph` and provide `storage.rdf_path`.
+- Confirm the backend with `StorageManager.get_rdf_backend_identifier()`.
+
 ## Traceability
 
 

--- a/tests/integration/test_rdf_persistence.py
+++ b/tests/integration/test_rdf_persistence.py
@@ -76,7 +76,7 @@ def test_rdf_persistence(storage_manager, tmp_path, monkeypatch):
 
 
 def test_oxigraph_backend_initializes(tmp_path, monkeypatch):
-    """RDF store should use Oxigraph backend when configured."""
+    """RDF store should use OxiGraph backend when configured."""
     cfg = ConfigModel(
         storage=StorageConfig(
             rdf_backend="oxigraph",
@@ -90,7 +90,7 @@ def test_oxigraph_backend_initializes(tmp_path, monkeypatch):
     StorageManager.setup()
 
     StorageManager.get_rdf_store()
-    assert StorageManager.get_rdf_backend_identifier() == "Oxigraph"
+    assert StorageManager.get_rdf_backend_identifier() == "OxiGraph"
 
 
 def test_oxrdflib_missing_plugin(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- configure OxiGraph RDF backend and register plugin
- align integration test with new OxiGraph identifier
- document OxiGraph backend setup instructions

## Testing
- `task install` *(fails: command not found)*
- `uv run pre-commit run --files src/autoresearch/storage_backends.py tests/integration/test_rdf_persistence.py docs/specs/storage-backends.md`
- `uv run black --check src/autoresearch/storage_backends.py tests/integration/test_rdf_persistence.py`
- `uv run isort --check-only src/autoresearch/storage_backends.py tests/integration/test_rdf_persistence.py`
- `uv run flake8 src/autoresearch/storage_backends.py tests/integration/test_rdf_persistence.py`
- `task verify` *(fails: command not found)*
- `uv run pytest` *(fails: missing optional dependencies, 43 errors during collection)*
- `uv run pytest tests/integration/test_rdf_persistence.py::test_oxigraph_backend_initializes`


------
https://chatgpt.com/codex/tasks/task_e_68c795b39434833384866f3ad1dd8b81