### PR TITLE
chore: improve type hints and docstring formatting

### DIFF
--- a/src/autoresearch/agents/mixins.py
+++ b/src/autoresearch/agents/mixins.py
@@ -63,7 +63,7 @@ class ClaimGeneratorMixin:
         Returns:
             A dictionary representing the claim.
         """
-        claim = {
+        claim: Dict[str, Any] = {
             "id": str(uuid4()),
             "type": claim_type,
             "content": content,
@@ -94,7 +94,7 @@ class ResultGeneratorMixin:
         Returns:
             A dictionary representing the result.
         """
-        result = {
+        result: Dict[str, Any] = {
             "claims": claims,
             "metadata": metadata,
             "results": results,

--- a/src/autoresearch/agents/prompts.py
+++ b/src/autoresearch/agents/prompts.py
@@ -16,7 +16,7 @@ defined in configuration files or registered programmatically.
 """
 
 import string
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field
 
@@ -42,7 +42,7 @@ class PromptTemplate(BaseModel):
     description: Optional[str] = None
     variables: Dict[str, str] = Field(default_factory=dict)
 
-    def render(self, **kwargs) -> str:
+    def render(self, **kwargs: Any) -> str:
         """Render the template with the given variables.
 
         This method renders the template by substituting variables into the template text.
@@ -69,7 +69,7 @@ class PromptTemplate(BaseModel):
                      and a list of available variables.
         """
         # Combine default variables with provided kwargs
-        variables = {**self.variables, **kwargs}
+        variables: Dict[str, Any] = {**self.variables, **kwargs}
 
         # Use string.Template for variable substitution
         template = string.Template(self.template)
@@ -545,18 +545,14 @@ Your verification should be objective, balanced, and focused on factual accuracy
         Raises:
             ConfigError: If the prompt templates configuration is invalid.
         """
-        prompt_config = (
-            config.prompt_templates if hasattr(config, "prompt_templates") else {}
-        )
+        prompt_config = config.prompt_templates if hasattr(config, "prompt_templates") else {}
 
         for name, template_config in prompt_config.items():
             try:
                 template = PromptTemplate(**template_config)
                 cls.register(name, template)
             except Exception as e:
-                raise ConfigError(
-                    f"Invalid prompt template configuration for '{name}': {str(e)}"
-                )
+                raise ConfigError(f"Invalid prompt template configuration for '{name}': {str(e)}")
 
     @classmethod
     def reset(cls) -> None:
@@ -579,7 +575,7 @@ def get_prompt_template(name: str) -> PromptTemplate:
     return PromptTemplateRegistry.get(name)
 
 
-def render_prompt(name: str, **kwargs) -> str:
+def render_prompt(name: str, **kwargs: Any) -> str:
     """Render a prompt template with the given variables.
 
     Args:
@@ -592,5 +588,5 @@ def render_prompt(name: str, **kwargs) -> str:
     Raises:
         KeyError: If the template is not found or a required variable is missing.
     """
-    template = get_prompt_template(name)
+    template: PromptTemplate = get_prompt_template(name)
     return template.render(**kwargs)

--- a/src/autoresearch/agents/registry.py
+++ b/src/autoresearch/agents/registry.py
@@ -9,7 +9,7 @@ import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
 from threading import Lock
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, Iterator, List, Type
 
 from ..llm.adapters import LLMAdapter
 from .base import Agent
@@ -81,10 +81,10 @@ class AgentRegistry:
 
     @classmethod
     @contextmanager
-    def temporary_state(cls):
+    def temporary_state(cls) -> Iterator[type["AgentRegistry"]]:
         """Isolate registry state within a context."""
-        registry = dict(cls._registry)
-        coalitions = dict(cls._coalitions)
+        registry: Dict[str, Type[Agent]] = dict(cls._registry)
+        coalitions: Dict[str, Coalition] = dict(cls._coalitions)
         try:
             yield cls
         finally:
@@ -243,11 +243,11 @@ class AgentFactory:
 
     @classmethod
     @contextmanager
-    def temporary_state(cls):
+    def temporary_state(cls) -> Iterator[type["AgentFactory"]]:
         """Provide a context with isolated factory state."""
-        registry = dict(cls._registry)
-        instances = dict(cls._instances)
-        delegate = cls._delegate
+        registry: Dict[str, Type[Agent]] = dict(cls._registry)
+        instances: Dict[str, Agent] = dict(cls._instances)
+        delegate: type["AgentFactory"] | None = cls._delegate
         try:
             yield cls
         finally:

--- a/src/autoresearch/storage_backends.py
+++ b/src/autoresearch/storage_backends.py
@@ -139,6 +139,7 @@ class DuckDBStorageBackend:
         Args:
             db_path: Optional path to the DuckDB database file. If not provided,
                 the path is determined with the following precedence:
+
                 1. config.storage.duckdb.path
                 2. DUCKDB_PATH environment variable
                 3. Default to "kg.duckdb".
@@ -245,6 +246,7 @@ class DuckDBStorageBackend:
         """Create the required tables in the DuckDB database.
 
         This method creates the following tables if they don't exist:
+
         - nodes: Stores claim nodes with ID, type, content, confidence, and timestamp
         - edges: Stores relationships between nodes
         - embeddings: Stores vector embeddings for nodes


### PR DESCRIPTION
## Summary
- refine registry temporary-state handling with explicit types
- annotate mixin helpers and prompt rendering
- adjust storage backend docstrings for clearer indentation

## Testing
- `task install` *(fails: command not found)*
- `uv run flake8 src/autoresearch/agents/registry.py src/autoresearch/agents/mixins.py src/autoresearch/agents/prompts.py src/autoresearch/storage_backends.py`
- `uv run pyright src/autoresearch/agents/registry.py src/autoresearch/agents/mixins.py src/autoresearch/agents/prompts.py src/autoresearch/storage_backends.py` *(fails: missing imports and unbound variables)*
- `uv run pytest` *(fails: missing plugin pytest_bdd)*
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c7a065090c8333ac5ef7877cc94396