### PR TITLE
Track missing spec coverage and proofs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,11 @@ checks are required.
   `test_weights_must_sum_to_one` but emits no deprecation warnings.
 - Pinned Click `<9` because `weasel.util.config` still imports the removed
   `split_arg_string` helper.
+- Cross-checked modules against `SPEC_COVERAGE.md`; agent subpackages were absent
+  and prompted [add-specs-for-agent-subpackages](issues/add-specs-for-agent-subpackages.md).
+- Found 19 modules with specs but no proofs; opened
+  [add-proofs-for-unverified-modules](issues/add-proofs-for-unverified-modules.md)
+  to track verification work.
 
 ## September 14, 2025
 - Fresh environment lacked the Go Task CLI; `task check` returned

--- a/issues/add-proofs-for-unverified-modules.md
+++ b/issues/add-proofs-for-unverified-modules.md
@@ -1,0 +1,33 @@
+# Add proofs for unverified modules
+
+## Context
+Several modules in `SPEC_COVERAGE.md` have specifications but no proofs or simulations:
+- `autoresearch/a2a_interface.py`
+- `autoresearch/cli_backup.py`
+- `autoresearch/cli_utils.py`
+- `autoresearch/config_utils.py`
+- `autoresearch/data_analysis.py`
+- `autoresearch/error_recovery.py`
+- `autoresearch/error_utils.py`
+- `autoresearch/kg_reasoning.py`
+- `autoresearch/logging_utils.py`
+- `autoresearch/mcp_interface.py`
+- `autoresearch/output_format.py`
+- `autoresearch/resource_monitor.py`
+- `autoresearch/storage_backup.py`
+- `autoresearch/storage_utils.py`
+- `autoresearch/streamlit_app.py`
+- `autoresearch/streamlit_ui.py`
+- `autoresearch/test_tools.py`
+- `autoresearch/token_budget.py`
+- `git/search.py`
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- Each listed module has an associated proof or simulation.
+- `SPEC_COVERAGE.md` references these proofs.
+
+## Status
+Open

--- a/issues/add-specs-for-agent-subpackages.md
+++ b/issues/add-specs-for-agent-subpackages.md
@@ -1,0 +1,15 @@
+# Add specs for agent subpackages
+
+## Context
+Packages `agents/dialectical` and `agents/specialized` are absent from `SPEC_COVERAGE.md`,
+suggesting their specifications are undocumented.
+
+## Dependencies
+None
+
+## Acceptance Criteria
+- `SPEC_COVERAGE.md` lists `autoresearch/agents/dialectical` and `autoresearch/agents/specialized`.
+- Each entry links to a specification document.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- audit SPEC_COVERAGE for gaps in agent subpackages
- record modules lacking proofs and open tracking issues
- summarize spec coverage audit in STATUS

## Testing
- `task check`
- `task verify` *(fails: AttributeError: 'AuthMiddleware' object has no attribute 'dispatch')*

------
https://chatgpt.com/codex/tasks/task_e_68c8251ff704833391b7c50c152df04d