### PR TITLE
feat(api): add dispatch for auth middleware

### DIFF
--- a/SPEC_COVERAGE.md
+++ b/SPEC_COVERAGE.md
@@ -5,6 +5,7 @@
 | `autoresearch/a2a_interface.py` | [a2a-interface.md](docs/specs/a2a-interface.md) |  | OK |
 | `autoresearch/agents` | [agents.md](docs/specs/agents.md) | [agents.md](docs/algorithms/agents.md) | OK |
 | `autoresearch/api` | [api.md](docs/specs/api.md) | [p1], [p2], [s1] | OK |
+| `autoresearch/api/auth_middleware.py` | [api_authentication.md](docs/specs/api_authentication.md) |  | OK |
 | `autoresearch/cache.py` | [cache.md](docs/specs/cache.md) | [cache.md](docs/algorithms/cache.md) | OK |
 | `autoresearch/cli_backup.py` | [cli-backup.md](docs/specs/cli-backup.md) |  | OK |
 | `autoresearch/cli_helpers.py` | [cli-helpers.md](docs/specs/cli-helpers.md) | [cli_helpers.md](docs/algorithms/cli_helpers.md) | OK |

--- a/docs/specs/api_authentication.md
+++ b/docs/specs/api_authentication.md
@@ -3,12 +3,16 @@
 ## Overview
 
 API requests include an API key or bearer token. Credentials map to roles
-whose permissions gate access to features.
+whose permissions gate access to features. The `AuthMiddleware` dispatch
+method validates credentials and populates request state before passing
+control downstream.
 
 ## Algorithms
 
 - Compare presented credentials with `secrets.compare_digest`.
 - Resolve roles and verify required permissions.
+- Use `AuthMiddleware.dispatch` to emit `401` responses on missing or invalid
+  credentials.
 
 ## Invariants
 


### PR DESCRIPTION
## Summary
- extend AuthMiddleware with BaseHTTPMiddleware dispatch support
- test dispatch for both valid and invalid bearer tokens
- document middleware dispatch behavior and reference in spec coverage

## Testing
- `task check` *(fails: command not found)*
- `task verify` *(fails: command not found)*
- `uv run --extra test pytest tests/unit/test_api_auth_middleware.py`
- `uv run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68c82e9718408333904efb5a9559f40f