### PR TITLE
Ensure OxiGraph backend initializes correctly

### DIFF
--- a/docs/specs/storage-backends.md
+++ b/docs/specs/storage-backends.md
@@ -37,9 +37,13 @@ teardown.
 
 ### Setup
 
-- Install `oxrdflib` to enable the OxiGraph RDF store.
+- Install `oxrdflib` with `uv pip install oxrdflib` to enable the OxiGraph
+  RDF store.
+- Verify the driver is discoverable with
+  `uv run python -c "import oxrdflib"`.
 - Set `storage.rdf_backend` to `oxigraph` and provide `storage.rdf_path`.
-- Confirm the backend with `StorageManager.get_rdf_backend_identifier()`.
+- Initialize storage and confirm the backend with
+  `StorageManager.get_rdf_backend_identifier()`; it should report `OxiGraph`.
 
 ## Traceability
 

--- a/src/autoresearch/storage_backends.py
+++ b/src/autoresearch/storage_backends.py
@@ -15,15 +15,11 @@ from queue import Queue
 from threading import Lock
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
 
+import importlib.util
 import duckdb
 import rdflib
 from dotenv import dotenv_values
 from rdflib.plugin import Store, register
-
-try:  # pragma: no cover - optional dependency
-    from oxrdflib import OxigraphStore as OxiGraphBackend
-except Exception:  # pragma: no cover - optional dependency
-    OxiGraphBackend = None
 
 from .config import ConfigLoader
 from .errors import NotFoundError, StorageError
@@ -74,7 +70,7 @@ def init_rdf_store(backend: str, path: str) -> rdflib.Graph:
         store_name = "OxiGraph"
         rdf_path = path
         os.makedirs(rdf_path, exist_ok=True)
-        if OxiGraphBackend is None:
+        if importlib.util.find_spec("oxrdflib") is None:
             raise StorageError(
                 "OxiGraph driver not installed",
                 suggestion="Install oxrdflib to use the OxiGraph RDF backend",


### PR DESCRIPTION
## Summary
- add explicit `importlib` check before registering the OxiGraph RDF backend
- document OxiGraph setup and verification steps in storage-backends spec

## Testing
- `task check`
- `task verify` *(fails: AttributeError: 'AuthMiddleware' object has no attribute 'dispatch')*
- `uv run pytest tests/integration/test_rdf_persistence.py::test_oxigraph_backend_initializes -q`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c82eaffd9c83338ffff7db3cccb318