### PR TITLE
docs: add OxiGraph durability proof

### DIFF
--- a/SPEC_COVERAGE.md
+++ b/SPEC_COVERAGE.md
@@ -34,7 +34,7 @@
 | `autoresearch/scheduler_benchmark.py` | [scheduler-benchmark.md](docs/specs/scheduler-benchmark.md) | [scheduler_benchmark.md](docs/algorithms/scheduler_benchmark.md) | OK |
 | `autoresearch/search` | [search.md](docs/specs/search.md) | [search.md](docs/algorithms/search.md) | OK |
 | `autoresearch/storage.py` | [storage.md](docs/specs/storage.md) | [storage.md](docs/algorithms/storage.md) | OK |
-| `autoresearch/storage_backends.py` | [storage-backends.md](docs/specs/storage-backends.md) | [oxigraph.md](docs/algorithms/oxigraph.md), [s2] | OK |
+| `autoresearch/storage_backends.py` | [storage-backends.md](docs/specs/storage-backends.md) | [p3], [s2] | OK |
 | `autoresearch/storage_backup.py` | [storage-backup.md](docs/specs/storage-backup.md) |  | OK |
 | `autoresearch/storage_utils.py` | [storage-utils.md](docs/specs/storage-utils.md) |  | OK |
 | `autoresearch/streamlit_app.py` | [streamlit-app.md](docs/specs/streamlit-app.md) |  | OK |
@@ -48,6 +48,7 @@
 | `git/search.py` | [git-search.md](docs/specs/git-search.md) |  | OK |
 [p1]: docs/algorithms/api.md
 [p2]: docs/algorithms/api-authentication.md
+[p3]: docs/algorithms/oxigraph.md
 [s1]: scripts/api_auth_credentials_sim.py
 [s2]: scripts/oxigraph_persistence_sim.py
 [t3]: tests/integration/test_a2a_interface.py

--- a/docs/algorithms/oxigraph.md
+++ b/docs/algorithms/oxigraph.md
@@ -1,7 +1,17 @@
-# OxiGraph Schema Idempotency and Persistence
+# OxiGraph Schema Idempotency and Durability
 
 Repeated initialization of the OxiGraph backend leaves the schema unchanged and
 keeps data across restarts until the store is explicitly removed.
+
+## Proof
+
+OxiGraph uses file backed storage. The `open` call accepts a `create` flag. When
+a new path is provided with `create=True`, the schema is written to disk once.
+Later openings omit the flag, so the call reuses the existing files without
+altering the schema. A sentinel triple inserted in the first run persists across
+restarts, showing that no second initialization occurs and that data remains on
+disk until the directory is deleted. Therefore schema creation is idempotent and
+the store is durable.
 
 ## Simulation
 
@@ -15,12 +25,4 @@ Run:
 
 The command prints `completed 3 cycles` and leaves no residual directory,
 demonstrating deterministic creation and teardown.
-
-## Proof
-
-OxiGraph uses file backed storage. When the store path exists, opening the store
-without the create flag reuses the prior schema. Because each cycle observes the
-sentinel triple, schema creation is idempotent and persistence holds until the
-directory is removed. See [OxiGraph](https://github.com/oxigraph/oxigraph) for
-backend details.
 

--- a/scripts/oxigraph_persistence_sim.py
+++ b/scripts/oxigraph_persistence_sim.py
@@ -20,6 +20,7 @@ SENTINEL = (
     rdflib.URIRef("urn:p"),
     rdflib.Literal("v"),
 )
+# Fixed triple used to detect whether state survives between runs.
 
 
 def init_store(path: Path) -> rdflib.Graph:
@@ -29,8 +30,10 @@ def init_store(path: Path) -> rdflib.Graph:
     graph = rdflib.Graph(store=store)
     cfg = str(path)
     if path.exists():
+        # Reuse existing store without the create flag.
         graph.open(configuration=cfg)
     else:
+        # First initialization writes schema and data to disk.
         graph.open(configuration=cfg, create=True)
     return graph
 
@@ -43,8 +46,10 @@ def cycle(path: Path, runs: int) -> None:
     for i in range(runs):
         graph = init_store(path)
         if i == 0:
+            # Insert the sentinel once; later cycles verify persistence.
             graph.add(SENTINEL)
         else:
+            # Reopening the store should retain the sentinel triple.
             assert SENTINEL in graph
         graph.close()
 


### PR DESCRIPTION
## Summary
- formalize OxiGraph storage idempotency and durability note
- annotate persistence simulation script
- link proof and simulation in spec coverage table

## Testing
- `task check` *(fails: src/autoresearch/api/auth_middleware.py:12:1: F401 'starlette.types.Receive' imported but unused)*
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c83197c5188333972a0f6d6a64602f