### PR TITLE
Link proofs for unverified modules

### DIFF
--- a/SPEC_COVERAGE.md
+++ b/SPEC_COVERAGE.md
@@ -2,50 +2,50 @@
 | --- | --- | --- | --- |
 | `autoresearch` | [autoresearch.md](docs/specs/autoresearch.md) | [t3], [t4] | OK |
 | `autoresearch/__main__.py` | [main-entrypoint.md](docs/specs/main-entrypoint.md) | [t5] | OK |
-| `autoresearch/a2a_interface.py` | [a2a-interface.md](docs/specs/a2a-interface.md) |  | OK |
+| `autoresearch/a2a_interface.py` | [a2a-interface.md](docs/specs/a2a-interface.md) | [a2a_interface.md](docs/algorithms/a2a_interface.md) | OK |
 | `autoresearch/agents` | [agents.md](docs/specs/agents.md) | [agents.md](docs/algorithms/agents.md) | OK |
 | `autoresearch/api` | [api.md](docs/specs/api.md) | [p1], [p2], [s1] | OK |
 | `autoresearch/api/auth_middleware.py` | [api_authentication.md](docs/specs/api_authentication.md) | [s3], [s4], [t8], [t9] | OK |
 | `autoresearch/cache.py` | [cache.md](docs/specs/cache.md) | [cache.md](docs/algorithms/cache.md) | OK |
-| `autoresearch/cli_backup.py` | [cli-backup.md](docs/specs/cli-backup.md) |  | OK |
+| `autoresearch/cli_backup.py` | [cli-backup.md](docs/specs/cli-backup.md) | [cli_backup.md](docs/algorithms/cli_backup.md) | OK |
 | `autoresearch/cli_helpers.py` | [cli-helpers.md](docs/specs/cli-helpers.md) | [cli_helpers.md](docs/algorithms/cli_helpers.md) | OK |
-| `autoresearch/cli_utils.py` | [cli-utils.md](docs/specs/cli-utils.md) |  | OK |
+| `autoresearch/cli_utils.py` | [cli-utils.md](docs/specs/cli-utils.md) | [cli_utils.md](docs/algorithms/cli_utils.md) | OK |
 | `autoresearch/config` | [config.md](docs/specs/config.md) | [config.md](docs/algorithms/config.md) | OK |
-| `autoresearch/config_utils.py` | [config-utils.md](docs/specs/config-utils.md) |  | OK |
-| `autoresearch/data_analysis.py` | [data-analysis.md](docs/specs/data-analysis.md) |  | OK |
+| `autoresearch/config_utils.py` | [config-utils.md](docs/specs/config-utils.md) | [config_utils.md](docs/algorithms/config_utils.md) | OK |
+| `autoresearch/data_analysis.py` | [data-analysis.md](docs/specs/data-analysis.md) | [data_analysis.md](docs/algorithms/data_analysis.md) | OK |
 | `autoresearch/distributed` | [distributed.md](docs/specs/distributed.md) | [distributed.md](docs/algorithms/distributed.md) | OK |
-| `autoresearch/error_recovery.py` | [error-recovery.md](docs/specs/error-recovery.md) |  | OK |
-| `autoresearch/error_utils.py` | [error-utils.md](docs/specs/error-utils.md) |  | OK |
+| `autoresearch/error_recovery.py` | [error-recovery.md](docs/specs/error-recovery.md) | [error_recovery.md](docs/algorithms/error_recovery.md) | OK |
+| `autoresearch/error_utils.py` | [error-utils.md](docs/specs/error-utils.md) | [error_utils.md](docs/algorithms/error_utils.md) | OK |
 | `autoresearch/errors.py` | [errors.md](docs/specs/errors.md) | [errors.md](docs/algorithms/errors.md) | OK |
 | `autoresearch/examples` | [examples.md](docs/specs/examples.md) | [examples.md](docs/algorithms/examples.md) | OK |
 | `autoresearch/extensions.py` | [extensions.md](docs/specs/extensions.md) | [extensions.md](docs/algorithms/extensions.md) | OK |
 | `autoresearch/interfaces.py` | [interfaces.md](docs/specs/interfaces.md) | [interfaces.md](docs/algorithms/interfaces.md) | OK |
-| `autoresearch/kg_reasoning.py` | [kg-reasoning.md](docs/specs/kg-reasoning.md) |  | OK |
+| `autoresearch/kg_reasoning.py` | [kg-reasoning.md](docs/specs/kg-reasoning.md) | [kg_reasoning.md](docs/algorithms/kg_reasoning.md) | OK |
 | `autoresearch/llm` | [llm.md](docs/specs/llm.md) | [llm.md](docs/algorithms/llm.md) | OK |
-| `autoresearch/logging_utils.py` | [logging-utils.md](docs/specs/logging-utils.md) |  | OK |
+| `autoresearch/logging_utils.py` | [logging-utils.md](docs/specs/logging-utils.md) | [logging_utils.md](docs/algorithms/logging_utils.md) | OK |
 | `autoresearch/main` | [main.md](docs/specs/main.md) | [main.md](docs/algorithms/main.md) | OK |
-| `autoresearch/mcp_interface.py` | [mcp-interface.md](docs/specs/mcp-interface.md) |  | OK |
+| `autoresearch/mcp_interface.py` | [mcp-interface.md](docs/specs/mcp-interface.md) | [mcp_interface.md](docs/algorithms/mcp_interface.md) | OK |
 | `autoresearch/models.py` | [models.md](docs/specs/models.md) | [models.md](docs/algorithms/models.md) | OK |
 | `autoresearch/monitor` | [monitor.md](docs/specs/monitor.md) | [monitor.md](docs/algorithms/monitor.md) | OK |
 | `autoresearch/orchestration` | [orchestration.md](docs/specs/orchestration.md) | [orchestration.md](docs/algorithms/orchestration.md) | OK |
 | `autoresearch/orchestrator_perf.py` | [orchestrator-perf.md](docs/specs/orchestrator-perf.md) | [orchestrator_perf.md](docs/algorithms/orchestrator_perf.md) | OK |
-| `autoresearch/output_format.py` | [output-format.md](docs/specs/output-format.md) |  | OK |
-| `autoresearch/resource_monitor.py` | [resource-monitor.md](docs/specs/resource-monitor.md) |  | OK |
+| `autoresearch/output_format.py` | [output-format.md](docs/specs/output-format.md) | [output_format.md](docs/algorithms/output_format.md) | OK |
+| `autoresearch/resource_monitor.py` | [resource-monitor.md](docs/specs/resource-monitor.md) | [resource_monitor.md](docs/algorithms/resource_monitor.md) | OK |
 | `autoresearch/scheduler_benchmark.py` | [scheduler-benchmark.md](docs/specs/scheduler-benchmark.md) | [scheduler_benchmark.md](docs/algorithms/scheduler_benchmark.md) | OK |
 | `autoresearch/search` | [search.md](docs/specs/search.md) | [search.md](docs/algorithms/search.md) | OK |
 | `autoresearch/storage.py` | [storage.md](docs/specs/storage.md) | [storage.md](docs/algorithms/storage.md) | OK |
 | `autoresearch/storage_backends.py` | [storage-backends.md](docs/specs/storage-backends.md) | [p3], [s2] | OK |
-| `autoresearch/storage_backup.py` | [storage-backup.md](docs/specs/storage-backup.md) |  | OK |
-| `autoresearch/storage_utils.py` | [storage-utils.md](docs/specs/storage-utils.md) |  | OK |
-| `autoresearch/streamlit_app.py` | [streamlit-app.md](docs/specs/streamlit-app.md) |  | OK |
-| `autoresearch/streamlit_ui.py` | [streamlit-ui.md](docs/specs/streamlit-ui.md) |  | OK |
+| `autoresearch/storage_backup.py` | [storage-backup.md](docs/specs/storage-backup.md) | [storage_backup.md](docs/algorithms/storage_backup.md) | OK |
+| `autoresearch/storage_utils.py` | [storage-utils.md](docs/specs/storage-utils.md) | [storage_utils.md](docs/algorithms/storage_utils.md) | OK |
+| `autoresearch/streamlit_app.py` | [streamlit-app.md](docs/specs/streamlit-app.md) | [streamlit_app.md](docs/algorithms/streamlit_app.md) | OK |
+| `autoresearch/streamlit_ui.py` | [streamlit-ui.md](docs/specs/streamlit-ui.md) | [streamlit_ui.md](docs/algorithms/streamlit_ui.md) | OK |
 | `autoresearch/synthesis.py` | [synthesis.md](docs/specs/synthesis.md) | [synthesis.md](docs/algorithms/synthesis.md) | OK |
-| `autoresearch/test_tools.py` | [test-tools.md](docs/specs/test-tools.md) |  | OK |
-| `autoresearch/token_budget.py` | [token-budget.md](docs/specs/token-budget.md) |  | OK |
+| `autoresearch/test_tools.py` | [test-tools.md](docs/specs/test-tools.md) | [test_tools.md](docs/algorithms/test_tools.md) | OK |
+| `autoresearch/token_budget.py` | [token-budget.md](docs/specs/token-budget.md) | [token_budgeting.md](docs/algorithms/token_budgeting.md) | OK |
 | `autoresearch/tracing.py` | [tracing.md](docs/specs/tracing.md) | [tracing.md](docs/algorithms/tracing.md) | OK |
 | `autoresearch/visualization.py` | [visualization.md](docs/specs/visualization.md) | [visualization.md](docs/algorithms/visualization.md) | OK |
 | `git` | [git.md](docs/specs/git.md) | [t6], [t7] | OK |
-| `git/search.py` | [git-search.md](docs/specs/git-search.md) |  | OK |
+| `git/search.py` | [git-search.md](docs/specs/git-search.md) | [search.md](docs/algorithms/search.md) | OK |
 [p1]: docs/algorithms/api.md
 [p2]: docs/algorithms/api-authentication.md
 [p3]: docs/algorithms/oxigraph.md

--- a/docs/algorithms/README.md
+++ b/docs/algorithms/README.md
@@ -56,6 +56,7 @@
 - cli_utils – simulation covers CLI utilities.
 - config_hot_reload – simulation confirms live config reload.
 - config_utils – simulation verifies config helpers.
+- data_analysis – simulation exercises metrics aggregation.
 - distributed_workflows – simulation models workflow distribution.
 - error_utils – simulation checks error helpers.
 - errors – simulation explores error scenarios.

--- a/docs/algorithms/data_analysis.md
+++ b/docs/algorithms/data_analysis.md
@@ -1,9 +1,48 @@
 # Data analysis
 
-Metrics aggregation converts nested timing measurements into a tabular view.
-`metrics_dataframe` builds a table from agent timings, computing mean
-runtime and count per agent. The function relies on the optional
-[Polars](https://pola.rs) library. When enabled, it returns a
-`polars.DataFrame` with `agent`, `avg_time`, and `count`. If Polars is
-disabled or missing, a `RuntimeError` is raised. See the
-[specification](../specs/data-analysis.md) for full details.
+`metrics_dataframe` converts nested agent timings into a Polars data
+frame with `agent`, `avg_time`, and `count` columns. It evaluates
+`polars_enabled` from configuration and rejects execution when Polars is
+disabled so that callers never rely on a missing dependency.
+
+## Invariants
+
+- Every returned row aggregates one agent from the `agent_timings`
+  mapping.
+- Rows contain arithmetic means, not medians or sums, preserving the
+  interpretation of latency measurements.
+- Empty timing lists are ignored, ensuring the result reflects only
+  observed work.
+- When no agent reports timings the function returns an empty frame with
+  the expected schema, preventing downstream index errors.
+
+## Proof sketch
+
+For each agent key the implementation collects the count and arithmetic
+mean of its timing samples. Dividing by the length of the list enforces
+the invariant that
+
+\[
+\text{avg\_time} = \frac{\sum_{t \in T_a} t}{|T_a|}
+\]
+
+for timings `T_a`. Empty lists never enter the accumulator, so the
+denominator is non-zero. The constructor builds a Polars frame from the
+rows and thus maintains the schema `(agent: str, avg_time: float,
+count: int)`.
+
+## Simulation
+
+- `uv run scripts/avg_timing_simulation.py` fabricates agent timings,
+  runs `metrics_dataframe`, and confirms the averages `[1.5, 3.0]` for
+  two agents.
+- [`tests/unit/test_data_analysis.py`](../../tests/unit/test_data_analysis.py)
+  checks runtime errors when Polars is disabled and validates the empty
+  frame contract.
+- [`tests/unit/test_data_analysis_polars.py`](../../tests/unit/test_data_analysis_polars.py)
+  exercises successful paths with Polars enabled and verifies column
+  ordering.
+
+## Related Issues
+
+- [Add proofs for unverified modules](../../issues/archive/add-proofs-for-unverified-modules.md)

--- a/issues/archive/add-proofs-for-unverified-modules.md
+++ b/issues/archive/add-proofs-for-unverified-modules.md
@@ -30,4 +30,4 @@ None
 - `SPEC_COVERAGE.md` references these proofs.
 
 ## Status
-Open
+Archived


### PR DESCRIPTION
## Summary
- document the invariants and simulations for `data_analysis` metrics aggregation
- reference algorithm proof documents from `SPEC_COVERAGE.md`
- archive the "add-proofs-for-unverified-modules" planning issue after linking coverage

## Testing
- uv run mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68c83e54f7708333983a90abb3f2427b