### PR TITLE
Add dialectical and specialized agent specs

### DIFF
--- a/SPEC_COVERAGE.md
+++ b/SPEC_COVERAGE.md
@@ -4,6 +4,8 @@
 | `autoresearch/__main__.py` | [main-entrypoint.md](docs/specs/main-entrypoint.md) | [t3] | OK |
 | `autoresearch/a2a_interface.py` | [a2a-interface.md](docs/specs/a2a-interface.md) | [p1], [s1], [t4], [t1], [t5], [t6] | OK |
 | `autoresearch/agents` | [agents.md](docs/specs/agents.md) | [s2], [t7], [t8], [t9], [t10] | OK |
+| `autoresearch/agents/dialectical` | [agents-dialectical.md](docs/specs/agents-dialectical.md) | [p20], [s19], [t9], [t113], [t114], [t115] | OK |
+| `autoresearch/agents/specialized` | [agents-specialized.md](docs/specs/agents-specialized.md) | [t8], [t10] | OK |
 | `autoresearch/api` | [api.md](docs/specs/api.md) | [p2], [p3], [p4], [p5], [p6], [s3], [s4], [t11], [t12], [t13], [t14], [t15], [t16], [t17], [t18], [t19], [t20], [t21], [t22], [t23] | OK |
 | `autoresearch/api/middleware.py` | [api_rate_limiting.md](docs/specs/api_rate_limiting.md) | [p5], [t24] | OK |
 | `autoresearch/cache.py` | [cache.md](docs/specs/cache.md) | [t25] | OK |
@@ -202,3 +204,8 @@
 [t110]: tests/unit/test_visualization.py
 [t111]: tests/integration/test_local_git_backend.py
 [t112]: tests/targeted/test_git_search.py
+[p20]: docs/algorithms/dialectical_coordination.md
+[s19]: scripts/dialectical_coordination_demo.py
+[t113]: tests/unit/test_synthesizer_agent_modes.py
+[t114]: tests/unit/test_property_dialectical_coordination.py
+[t115]: tests/analysis/test_dialectical_cycle_property.py

--- a/docs/specs/agents-dialectical.md
+++ b/docs/specs/agents-dialectical.md
@@ -1,0 +1,124 @@
+# Dialectical Agents
+
+## Overview
+
+The dialectical agent family orchestrates thesis–antithesis–synthesis dialogue
+between the synthesizer, contrarian, and fact checker roles. The cycle follows
+the convergence guarantees derived in [Dialectical Agent Coordination][a1] and
+updates shared claims stored on the query state.[m1][m2][m3]
+
+## Algorithms
+
+### SynthesizerAgent
+
+1. Resolve the adapter and active model from configuration.[m1]
+2. If the reasoning mode is direct, prompt ``synthesizer.direct`` and emit a
+   synthesis claim with both ``final_answer`` and ``synthesis`` results.[m1]
+3. On the first dialectical cycle, prompt ``synthesizer.thesis`` to seed the
+   thesis claim and mark the phase as ``DialoguePhase.THESIS``.[m1]
+4. On later cycles, concatenate prior claim content, apply the
+   ``synthesizer.synthesis`` template, and record the combined answer under both
+   ``final_answer`` and ``synthesis`` keys.[m1]
+
+### ContrarianAgent
+
+1. Acquire the adapter and model, then search the state for the most recent
+   thesis claim.[m2]
+2. Fall back to the user query when no thesis exists, keeping the dialogue
+   grounded.[m2]
+3. Populate the ``contrarian.antithesis`` prompt with that text, generate the
+   antithesis, and wrap it as a claim tagged ``antithesis``.[m2]
+4. Return a result whose metadata identifies the antithesis phase and exposes
+   the generated rebuttal.[m2]
+
+### FactChecker
+
+1. Resolve the adapter and active model.[m3]
+2. Derive the maximum search fan-out from configuration (defaulting to five)
+   and call ``Search.external_lookup`` to gather supporting sources.[m3]
+3. Annotate each source with the claims examined and the agent name so that
+   downstream synthesizers can audit provenance.[m3]
+4. Feed the assembled claims into ``fact_checker.verification`` and emit a
+   verification claim alongside the structured sources and source counts.[m3]
+
+### Execution gating
+
+- ``SynthesizerAgent`` always executes when enabled.
+- ``ContrarianAgent`` and ``FactChecker`` require dialectical reasoning mode and
+  at least one existing claim (thesis for the contrarian, any claim for the fact
+  checker) before delegating to ``Agent.can_execute``.[m2][m3]
+
+## Invariants
+
+- Each agent returns at least one claim bearing the expected ``type`` value:
+  ``thesis`` or ``synthesis`` for the synthesizer, ``antithesis`` for the
+  contrarian, and ``verification`` for the fact checker.[m1][m2][m3]
+- ``metadata["phase"]`` reflects the dialogue stage asserted by the agent,
+  aligning with ``DialoguePhase`` enumerations.[m1][m2][m3]
+- Fact-checker sources always include ``checked_claims`` and ``agent`` fields so
+  later agents can attribute evidence.[m3]
+- Synthesizer synthesis results duplicate the final answer string to guarantee
+  downstream consumers can access the conclusion under consistent keys.[m1]
+
+## Edge Cases
+
+- Direct reasoning mode bypasses dialectical phases and returns a final answer
+  in a single execution.[m1]
+- The contrarian falls back to the query text if no thesis is present, but its
+  ``can_execute`` guard prevents execution until a thesis exists.[m2]
+- The fact checker short-circuits when the configuration disables dialectical
+  mode or no claims are available.[m3]
+- Empty search responses degrade gracefully to zero sources while keeping the
+  verification claim intact.[m3]
+
+## Complexity
+
+- Synthesizer work scales linearly with the number of existing claims because it
+  concatenates their text before a single generation call.[m1]
+- Contrarian and fact checker work is ``O(c + r)`` where ``c`` counts scanned
+  claims and ``r`` counts retrieved sources; they each perform one generation.
+
+## Proof Sketch
+
+Execution guards ensure each role runs in a context that satisfies its
+preconditions. Prompted generations rely on shared mixins, so results always
+follow the base agent schema. Property-based tests confirm that the dialectical
+update never increases error and that higher fact-checker weights improve the
+mean outcome.[t1][t2] Unit tests inject adapters to verify each agent emits the
+expected claim types, metadata, and sources.[t3][t4]
+
+## Simulation Expectations
+
+Running ``uv run scripts/dialectical_coordination_demo.py --loops 3 --trials 10``
+produces convergence statistics such as ``mean=0.976 stdev=0.333`` that match
+the linear update analysis.[a1][s1] The analysis harness samples random
+initializations and writes ``dialectical_metrics.json`` with comparable means
+and deviations, supplying reproducible evidence for the convergence claim.[s2]
+
+## Traceability
+
+- Modules
+  - [SynthesizerAgent][m1]
+  - [ContrarianAgent][m2]
+  - [FactChecker][m3]
+- Algorithms
+  - [Dialectical Agent Coordination][a1]
+- Scripts
+  - [dialectical_coordination_demo.py][s1]
+  - [dialectical_cycle_analysis.py][s2]
+- Tests
+  - [test_synthesizer_agent_modes.py][t3]
+  - [test_agents_llm.py][t4]
+  - [test_property_dialectical_coordination.py][t1]
+  - [test_dialectical_cycle_property.py][t2]
+
+[a1]: ../algorithms/dialectical_coordination.md
+[m1]: ../../src/autoresearch/agents/dialectical/synthesizer.py
+[m2]: ../../src/autoresearch/agents/dialectical/contrarian.py
+[m3]: ../../src/autoresearch/agents/dialectical/fact_checker.py
+[s1]: ../../scripts/dialectical_coordination_demo.py
+[s2]: ../../tests/analysis/dialectical_cycle_analysis.py
+[t1]: ../../tests/unit/test_property_dialectical_coordination.py
+[t2]: ../../tests/analysis/test_dialectical_cycle_property.py
+[t3]: ../../tests/unit/test_synthesizer_agent_modes.py
+[t4]: ../../tests/unit/test_agents_llm.py

--- a/docs/specs/agents-specialized.md
+++ b/docs/specs/agents-specialized.md
@@ -1,0 +1,140 @@
+# Specialized Agents
+
+## Overview
+
+Specialized agents extend the shared agent mixins to cover research planning,
+evidence gathering, critique, summarization, moderation, domain expertise, and
+user alignment. Each class tailors ``execute`` to its role while reusing the
+base claim and result helpers.[m1][m2][m3][m4][m5][m6][m7]
+
+## Algorithms
+
+### ResearcherAgent
+
+1. Resolve the adapter and model, then double the configured search fan-out to
+   collect expanded evidence.[m1]
+2. Convert external lookup results into structured sources tagged with the agent
+   name.[m1]
+3. Format the sources into a prompt for ``researcher.findings`` and generate a
+   ``research_findings`` claim with attached sources and ``source_count``
+   metadata.[m1]
+
+### DomainSpecialistAgent
+
+1. Determine the operating domain, inferring it from the query when none is
+   preset.[m5]
+2. Retrieve targeted context via ``Search.external_lookup`` and augment it with
+   heuristic fallbacks when the search layer fails.[m5]
+3. Filter claims whose content matches domain keywords, defaulting to recent
+   entries when nothing matches.[m5]
+4. Generate ``domain_analysis`` and ``domain_recommendations`` claims using
+   prompts that optionally incorporate peer feedback.[m5]
+
+### CriticAgent
+
+1. Gather thesis, synthesis, and research finding claims to evaluate, or fall
+   back to all claims when no targeted evidence exists.[m2]
+2. Feed the formatted claims into ``critic.evaluation`` to produce a
+   ``critique`` claim plus phase and evaluated-claim metadata.[m2]
+3. When feedback is enabled, send critique summaries to downstream agents via
+   coalition broadcasts or targeted feedback events.[m2]
+
+### SummarizerAgent
+
+1. Collect every claim from the state and serialize them into prompt context.[m3]
+2. Invoke ``summarizer.concise`` to create a ``summary`` claim and count the
+   summarized items for metadata.[m3]
+3. Broadcast availability when agent messaging is enabled.[m3]
+
+### PlannerAgent
+
+1. Execute early in the dialogue, preferring cycle zero or an empty claim
+   history.[m4]
+2. Generate a ``research_plan`` claim using the ``planner.research_plan``
+   template, optionally enriched with peer feedback.[m4]
+
+### ModeratorAgent
+
+1. Collect the most recent claims (up to ten) and detect conflict markers to
+   summarize disagreements.[m6]
+2. Produce ``moderation`` and ``guidance`` claims with associated metadata,
+   including conflict flags and analyzed claim identifiers.[m6]
+
+### UserAgent
+
+1. Load configurable user preferences and collect recent claims plus current
+   aggregated results.[m7]
+2. Generate ``user_feedback`` and ``user_requirements`` claims that reinforce
+   those preferences and share metadata for downstream alignment.[m7]
+3. Emit direct feedback to contributing agents when enabled.[m7]
+
+## Invariants
+
+- Every specialized agent emits claims with stable ``type`` identifiers that
+  match downstream expectations (for example ``research_findings``,
+  ``domain_analysis``, and ``user_feedback``).[m1][m5][m7]
+- Result payloads always mirror the claim content under matching keys so later
+  orchestration steps can merge outputs without string parsing.[m1][m2][m3][m4]
+- Metadata reports the active dialogue phase and supporting counts (such as
+  analyzed claims, conflict detection, and source totals).[m1][m2][m3][m4][m6]
+- Feedback hooks respect coalition routing and do not emit messages unless the
+  configuration enables them.[m1][m2][m3][m7]
+
+## Edge Cases
+
+- Domain inference defaults to ``general`` when no keyword matches occur and
+  falls back to preconfigured descriptions if search fails.[m5]
+- The critic and summarizer gracefully evaluate the full claim list when
+  targeted evidence is absent.[m2][m3]
+- Planner execution short-circuits after the first cycle, preventing redundant
+  plan regeneration.[m4]
+- User feedback waits until at least one cycle has elapsed and skips execution
+  when no claims exist to assess.[m7]
+
+## Complexity
+
+- Each agent performs a constant number of adapter generations, so runtime is
+  dominated by gathering context (claim scans or search queries).
+- Claim filtering and formatting are linear in the number of claims inspected
+  (bounded by ten for the moderator and five for user feedback).
+
+## Proof Sketch
+
+Unit tests stub adapters and search results to assert claim types, metadata, and
+feedback propagation for every specialized agent.[t1] Additional tests exercise
+moderation conflict detection, domain gating, and planner eligibility thresholds
+under varied states, demonstrating that guard clauses prevent mis-timed
+execution.[t2]
+
+## Simulation Expectations
+
+Running ``uv run pytest tests/unit/test_specialized_agents.py`` yields mocked
+LLM responses such as ``"Mock response from LLM"`` for each agent, confirming the
+prompt wiring and metadata schema.[t1] Executing
+``uv run pytest tests/unit/test_advanced_agents.py`` validates domain routing,
+moderation conflict detection, and user preference handling with deterministic
+fixtures.[t2]
+
+## Traceability
+
+- Modules
+  - [ResearcherAgent][m1]
+  - [CriticAgent][m2]
+  - [SummarizerAgent][m3]
+  - [PlannerAgent][m4]
+  - [DomainSpecialistAgent][m5]
+  - [ModeratorAgent][m6]
+  - [UserAgent][m7]
+- Tests
+  - [test_specialized_agents.py][t1]
+  - [test_advanced_agents.py][t2]
+
+[m1]: ../../src/autoresearch/agents/specialized/researcher.py
+[m2]: ../../src/autoresearch/agents/specialized/critic.py
+[m3]: ../../src/autoresearch/agents/specialized/summarizer.py
+[m4]: ../../src/autoresearch/agents/specialized/planner.py
+[m5]: ../../src/autoresearch/agents/specialized/domain_specialist.py
+[m6]: ../../src/autoresearch/agents/specialized/moderator.py
+[m7]: ../../src/autoresearch/agents/specialized/user_agent.py
+[t1]: ../../tests/unit/test_specialized_agents.py
+[t2]: ../../tests/unit/test_advanced_agents.py


### PR DESCRIPTION
## Summary
- add a dialectical agent specification detailing synthesizer, contrarian, and fact-checker behaviors with convergence evidence
- document specialized research, critique, planning, moderation, summarization, and user alignment agents
- register the new specs in SPEC_COVERAGE with links to algorithms, scripts, and verifying tests

## Testing
- uv run --extra docs mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68c851126c448333977fdef2d9632c50