### PR TITLE
Add type annotations and adjust storage docstring

### DIFF
--- a/src/autoresearch/storage_backends.py
+++ b/src/autoresearch/storage_backends.py
@@ -566,14 +566,15 @@ class DuckDBStorageBackend:
     def update_claim(self, claim: Dict[str, Any], partial_update: bool = False) -> None:
         """Update an existing claim in the DuckDB database.
 
-        Parameters
-        ----------
-        claim:
-            The claim data with at least an ``id`` field. Other fields are
-            updated if provided.
-        partial_update:
-            If ``True`` only the supplied fields are updated, otherwise the
-            existing rows are fully replaced.
+        Args:
+            claim: The claim data with at least an ``id`` field. Other fields are
+                updated if provided.
+            partial_update: If ``True`` only the supplied fields are updated;
+                otherwise, existing rows are fully replaced.
+
+        Raises:
+            StorageError: If the DuckDB connection is not initialized or the
+                update fails.
         """
         if self._conn is None and self._pool is None:
             raise StorageError("DuckDB connection not initialized")


### PR DESCRIPTION
## Summary
- add ClassVar annotations and typed helpers in the agent registry/factory
- introduce reusable payload aliases for agent mixins and tighten config lookup types
- type the prompt registry configuration handling and normalize the DuckDB update docstring

## Testing
- uv run mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68c85119eb2c83338a50d9fb8cd8e51d