### PR TITLE
docs: refresh api and subsystem specs

### DIFF
--- a/docs/algorithms/api_streaming.md
+++ b/docs/algorithms/api_streaming.md
@@ -12,6 +12,8 @@ state to the client, then posts the final response to any configured webhooks.
 - The queue is unbounded; the orchestrator never blocks when adding items. If a
   client stops reading, results accumulate in memory. Consumers should read from
   the stream to apply back-pressure and avoid unbounded growth.
+- When the queue is idle for 15 seconds the generator yields a blank newline as
+  a heartbeat to keep intermediaries from closing the connection.
 
 ## Queue growth model
 

--- a/docs/algorithms/monitor_cli.md
+++ b/docs/algorithms/monitor_cli.md
@@ -1,43 +1,57 @@
 # Monitor CLI
 
-The `autoresearch monitor` commands stream system metrics and resource usage.
+The `autoresearch monitor` subcommands surface runtime metrics, resource
+sampling, knowledge graph inspection, interactive orchestration, and health
+checks.
 
 ## Flow
 
-1. `monitor` prints a single snapshot of CPU, memory, and token counts.
-2. `monitor -w` refreshes the snapshot every second.
-3. `monitor resources` collects samples for a duration and reports
-   aggregates.
-4. `monitor start --prometheus` launches a Prometheus metrics endpoint.
-5. `monitor serve` runs a node health server and exits 0 when stopped.
+1. `monitor metrics` prints a single snapshot of CPU, memory, GPU, and token
+   counters collected by `_collect_system_metrics`.
+2. `monitor metrics --watch` refreshes the snapshot every second using Rich
+   `Live` updates without mutating counters.
+3. `monitor resources` records samples for a configurable duration and renders a
+   summary table of the collected points.
+4. `monitor graph` queries the in-memory knowledge graph and prints either a
+   table of edges or a Rich tree when `--tree`/`--tui` are supplied.
+5. `monitor run` prompts for queries, runs the orchestrator with live cycle
+   metrics, gathers optional feedback, and exits when the user types `q`.
+6. `monitor start` launches `ResourceMonitor` and `SystemMonitor`, optionally
+   exposing Prometheus metrics, and runs until interrupted.
+7. `monitor serve` starts `NodeHealthMonitor`, exposes Prometheus gauges for
+   Redis and Ray checks, and stops cleanly on Ctrl+C.
 
 ## Interrupt Handling
 
-- `monitor serve` catches `KeyboardInterrupt` and shuts down cleanly.
+- `monitor start` and `monitor serve` wrap long-running loops in `try`/`finally`
+  blocks so monitors stop and global state resets when interrupted.
 
 ## Error Handling
 
-- If metrics collection fails, a friendly message is printed and exit code 1
-  is returned.
-- When the endpoint fails to start, the command stops gracefully without
-  leaving background threads.
+- Failures while collecting metrics log warnings but still produce best-effort
+  output, allowing commands to complete without raising exceptions.
+- Health check failures set gauges to zero, keeping Prometheus output consistent
+  even when dependencies are unreachable.
 
-## Reliability analysis
+## Reliability Analysis
 
-A Monte Carlo model estimates how often metrics collection fails and the
-latency of successful samples. Run the simulation to explore different
-failure rates and observe average latency:
+A Monte Carlo model estimates how often metrics collection fails and the latency
+of successful samples:
 
 ```bash
 uv run scripts/monitor_cli_reliability.py --runs 1000 --fail-rate 0.05
 ```
 
-This informs retry budgets and helps tune sampling intervals.
+The simulation informs retry budgets and sampling intervals.
 
 ## References
 
 - [src/autoresearch/monitor/](../../src/autoresearch/monitor/)
 - [scripts/monitor_cli_reliability.py](../../scripts/monitor_cli_reliability.py)
 - [tests/unit/test_monitor_cli.py](../../tests/unit/test_monitor_cli.py)
-- [tests/integration/test_monitor_metrics.py](../../tests/integration/test_monitor_metrics.py)
-- [tests/behavior/steps/monitor_cli_steps.py](../../tests/behavior/steps/monitor_cli_steps.py)
+- [tests/unit/test_main_monitor_commands.py](../../tests/unit/
+  test_main_monitor_commands.py)
+- [tests/integration/test_monitor_metrics.py](../../tests/integration/
+  test_monitor_metrics.py)
+- [tests/unit/test_resource_monitor_gpu.py](../../tests/unit/
+  test_resource_monitor_gpu.py)

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2,70 +2,148 @@
 
 ## Overview
 
-FastAPI app aggregator for Autoresearch. See these algorithm references:
+The Autoresearch API assembles a FastAPI application that exposes query,
+configuration, documentation, and monitoring endpoints. `routing.create_app`
+initialises shared state, installs authentication and rate limiting
+middleware, and registers versioned routes built around
+`QueryRequestV1`/`QueryResponseV1`. The package draws configuration from
+`ConfigLoader`, uses `RequestLogger` to track per-client usage, and streams
+results while posting webhook callbacks. Related derivations live in:
+
 - [API authentication](../algorithms/api_authentication.md)
-- [Constant-time auth proof](../algorithms/api-authentication.md)
-- [Error paths](../algorithms/api_auth_error_paths.md)
+- [Authentication proof sketch](../algorithms/api-authentication.md)
+- [Auth error paths](../algorithms/api_auth_error_paths.md)
 - [API rate limiting](../algorithms/api_rate_limiting.md)
 - [API streaming](../algorithms/api_streaming.md)
 
-Requests and responses use versioned schemas. The current
-`QueryRequestV1` and `QueryResponseV1` models require a `version` field of
-`"1"`. Deprecated versions return **410 Gone** while unknown versions
-return **422 Unprocessable Entity**.
+## Schemas and Versioning
 
-## Authentication
+- `VersionedModel` exposes a `version` field while deferring validation so
+  routers can reject deprecated or unknown schemas with precise HTTP codes.
+- `SUPPORTED_VERSIONS` is `{ "1" }`; `DEPRECATED_VERSIONS` is empty.
+- `validate_version` raises **410 Gone** for deprecated versions and
+  **422 Unprocessable Entity** for unsupported values.
 
-Clients must include a valid API key or bearer token.
+## Authentication and Permissions
 
-- ``X-API-Key`` headers map to roles defined in ``api.api_keys``.
-- ``Authorization: Bearer <token>`` headers are checked against
-  ``api.bearer_token``.
-- Each role's permissions come from ``api.role_permissions``.
-- Missing or invalid credentials return **401 Unauthorized**.
-- Insufficient permissions return **403 Forbidden**.
-- Credentials are validated before request bodies are read.
+- `AuthMiddleware` reloads API configuration on each request, then checks
+  `api.api_keys`, `api.api_key`, or `api.bearer_token` for credentials.
+- API keys map to roles and leverage `secrets.compare_digest` to avoid timing
+  leaks; bearer tokens reuse `verify_bearer_token` for constant-time checks.
+- The resolved role's permissions populate `request.state.permissions`.
+- `require_permission` injects dependencies that call `enforce_permission`,
+  returning **401 Unauthorized** with `WWW-Authenticate` headers when missing
+  and **403 Forbidden** when insufficient.
+
+## Routing and Endpoints
+
+- `/query` validates request versions, runs synchronous queries, forwards
+  responses to configured webhooks, and normalises errors via
+  `format_error_for_api`.
+- `/query/stream` delegates to `query_stream_endpoint` to stream JSON lines,
+  emitting blank-line heartbeats every 15 seconds until a final payload
+  arrives.
+- `/query/batch` paginates batched requests and executes each query
+  concurrently with `asyncio.TaskGroup`.
+- `/query/async`, `/query/{id}`, and `DELETE /query/{id}` manage background
+  tasks stored in `app.state.async_tasks`.
+- `/config` (GET, PUT, POST, DELETE) surfaces live configuration, applies
+  validated updates via `ConfigModel`, and notifies observers.
+- `/capabilities` summarises reasoning modes, LLM backends, agent metadata,
+  and storage/search capabilities from `StorageManager`.
+- `/metrics` is available only when monitoring is enabled in configuration;
+  otherwise `routes.router` omits the path.
+- `/docs` and `/openapi.json` render customised documentation guarded by the
+  `docs` permission.
+
+## Rate Limiting and Logging
+
+- `Limiter` defaults to SlowAPI's implementation when available and falls back
+  to a stub that reuses `RequestLogger` counts per client IP.
+- `dynamic_limit` reads `api.rate_limit` to derive SlowAPI-compatible strings.
+- `RateLimitMiddleware` injects limit headers when SlowAPI is present;
+  `FallbackRateLimitMiddleware` enforces simple thresholds otherwise.
 
 ## Algorithms
 
-- Implement core behaviors described above.
+1. **Version validation:** `validate_version` rejects deprecated or unknown
+   schema versions before any orchestration work begins.
+2. **Authentication:** `AuthMiddleware.dispatch` loads configuration, extracts
+   headers, resolves roles, stores permissions, and short-circuits with
+   `WWW-Authenticate` errors when credentials are missing or invalid.
+3. **Query execution:** `query_endpoint` runs orchestrator queries inside a
+   tracing span, formats errors, and mirrors responses to per-request or
+   global webhooks with retry backoff settings.
+4. **Streaming:** `query_stream_endpoint` spawns a background executor that
+   pushes cycle updates into an `asyncio.Queue`; the generator drains the
+   queue, yields newline-delimited JSON, and emits blank lines as keepalives.
+5. **Async management:** `/query/async` stores futures in
+   `app.state.async_tasks`, `/query/{id}` polls completion, and `DELETE` cancels
+   and removes outstanding work.
+6. **Configuration updates:** PUT/POST merge incoming data into `ConfigModel`
+   instances, notify observers, and preserve atomic swaps; DELETE reloads from
+   disk to discard runtime edits.
 
 ## Invariants
 
-- Streamed responses emit chunks in request order.
-- Heartbeats occur at least once per connection.
-- The ``END`` sentinel terminates the stream.
-- Webhook callbacks retry failed deliveries with exponential backoff.
+- Every request populates `request.state.permissions`, `role`, and
+  `www_authenticate` before reaching route handlers.
+- Versioned routes call `validate_version` exactly once, ensuring **410** or
+  **422** responses for deprecated or unsupported schemas.
+- Streaming responses preserve enqueue order, interleave keepalive heartbeats,
+  and end with a newline-terminated JSON object.
+- Async query identifiers remain in `app.state.async_tasks` until completion or
+  cancellation to avoid dangling futures.
+- `/metrics` is registered only when `api.monitoring_enabled` is true, so
+  deployments without monitoring expose no Prometheus endpoint.
+- Rate limiting never increments counters when disabled and always injects
+  limit headers when SlowAPI is active.
 
 ## Edge Cases
 
-- Zero chunks send only the ``END`` sentinel.
-- Deprecated versions return **410 Gone** and unknown versions return
-  **422 Unprocessable Entity**.
+- Missing credentials with authentication enabled return **401 Unauthorized**
+  and specify the required scheme.
+- Clients lacking required permissions receive **403 Forbidden** regardless of
+  credential type.
+- Unknown async identifiers return **404** without mutating stored futures.
+- Invalid pagination parameters in `/query/batch` raise **400 Bad Request**.
 
 ## Complexity
 
-Streaming ``n`` chunks performs ``O(n)`` work and uses ``O(1)`` extra memory.
+- Streaming `n` payloads performs `O(n)` work with `O(1)` additional memory.
+- Batch pagination slices requests in `O(page_size)` time per call.
+- Async status checks run in `O(1)` time per lookup.
 
 ## Proof Sketch
 
-Streaming a finite chunk list while recording data and heartbeats shows the
-ordering and liveness invariants hold. Tests cover nominal and error paths,
-and the simulation in [api_stream_order_sim.py][s1] confirms ordered
-delivery, heartbeat counts, and linear operations. The
-[api-authentication](../algorithms/api-authentication.md) proof outlines
-constant-time credential checks, and [api_auth_credentials_sim.py][s2]
-exercises valid and invalid tokens and roles.
+Authentication relies on constant-time comparisons and explicit permission
+checks proven in [API authentication](../algorithms/api_authentication.md) and
+[API authentication proof](../algorithms/api-authentication.md). Error
+responses follow [auth error paths](../algorithms/api_auth_error_paths.md) and
+rate limiting obeys [API rate limiting](../algorithms/api_rate_limiting.md).
+Streaming order and liveness are justified by
+[API streaming](../algorithms/api_streaming.md), while unit, integration, and
+analysis tests cover version handling, async orchestration, webhook retries,
+and documentation rendering.
 
 ## Simulation Expectations
 
-Streaming simulations send three chunks and record metrics such as
-``{"ordered": true, "heartbeats": 3, "operations": 7}``.
+- [api_auth_credentials_sim.py][s2] exercises valid, missing, and invalid
+  credentials across roles.
+- [api_stream_order_sim.py][s1] records streaming order, heartbeat cadence,
+  and queue lengths, expecting metrics such as
+  `{ "ordered": true, "heartbeats": 3, "operations": 7 }` for three-chunk
+  runs.
 
 ## Traceability
 
 - Modules
-  - [src/autoresearch/api/][m1]
+  - [src/autoresearch/api/__init__.py][m1]
+  - [src/autoresearch/api/auth_middleware.py][m2]
+  - [src/autoresearch/api/middleware.py][m3]
+  - [src/autoresearch/api/routing.py][m4]
+  - [src/autoresearch/api/streaming.py][m5]
+  - [src/autoresearch/api/utils.py][m6]
 - Scripts
   - [scripts/api_stream_order_sim.py][s1]
   - [scripts/api_auth_credentials_sim.py][s2]
@@ -75,16 +153,26 @@ Streaming simulations send three chunks and record metrics such as
   - [tests/unit/test_api_imports.py][t3]
   - [tests/unit/test_api_auth_middleware.py][t4]
   - [tests/unit/test_api_auth_deps.py][t5]
+  - [tests/unit/test_webhooks_logging.py][t12]
+  - [tests/integration/test_api.py][t14]
+  - [tests/integration/test_api_additional.py][t15]
   - [tests/integration/test_api_auth.py][t6]
   - [tests/integration/test_api_auth_middleware.py][t7]
+  - [tests/integration/test_api_auth_permissions.py][t16]
+  - [tests/integration/test_api_docs.py][t9]
   - [tests/integration/test_api_streaming.py][t8]
   - [tests/integration/test_api_streaming_webhook.py][t10]
-  - [tests/integration/test_api_docs.py][t9]
+  - [tests/integration/test_api_versioning.py][t17]
+  - [tests/integration/test_api_hot_reload.py][t18]
   - [tests/analysis/test_api_streaming_sim.py][t11]
-  - [tests/unit/test_webhooks_logging.py][t12]
   - [tests/analysis/test_api_stream_order_sim.py][t13]
 
-[m1]: ../../src/autoresearch/api/
+[m1]: ../../src/autoresearch/api/__init__.py
+[m2]: ../../src/autoresearch/api/auth_middleware.py
+[m3]: ../../src/autoresearch/api/middleware.py
+[m4]: ../../src/autoresearch/api/routing.py
+[m5]: ../../src/autoresearch/api/streaming.py
+[m6]: ../../src/autoresearch/api/utils.py
 [t1]: ../../tests/unit/test_api.py
 [t2]: ../../tests/unit/test_api_error_handling.py
 [t3]: ../../tests/unit/test_api_imports.py
@@ -93,11 +181,15 @@ Streaming simulations send three chunks and record metrics such as
 [t6]: ../../tests/integration/test_api_auth.py
 [t7]: ../../tests/integration/test_api_auth_middleware.py
 [t8]: ../../tests/integration/test_api_streaming.py
-[t10]: ../../tests/integration/test_api_streaming_webhook.py
 [t9]: ../../tests/integration/test_api_docs.py
+[t10]: ../../tests/integration/test_api_streaming_webhook.py
 [t11]: ../../tests/analysis/test_api_streaming_sim.py
 [t12]: ../../tests/unit/test_webhooks_logging.py
-[r1]: ../../tests/analysis/api_streaming_metrics.json
+[t13]: ../../tests/analysis/test_api_stream_order_sim.py
+[t14]: ../../tests/integration/test_api.py
+[t15]: ../../tests/integration/test_api_additional.py
+[t16]: ../../tests/integration/test_api_auth_permissions.py
+[t17]: ../../tests/integration/test_api_versioning.py
+[t18]: ../../tests/integration/test_api_hot_reload.py
 [s1]: ../../scripts/api_stream_order_sim.py
 [s2]: ../../scripts/api_auth_credentials_sim.py
-[t13]: ../../tests/analysis/test_api_stream_order_sim.py

--- a/docs/specs/cli-helpers.md
+++ b/docs/specs/cli-helpers.md
@@ -2,64 +2,81 @@
 
 ## Overview
 
-Small helper utilities used by the CLI for error handling and command
-parsing.
+Utility helpers shared by CLI entry points. They provide fuzzy matching for
+commands, parse agent group arguments, enforce API headers, and surface storage
+state warnings with consistent Rich output.
 
 ## Algorithms
 
 ### find_similar_commands
-1. Uses `difflib.get_close_matches` to compare the input command against a
-   sequence of valid commands.
-2. Returns up to three commands whose similarity ratio is above the
-   threshold.
+
+1. Call `difflib.get_close_matches` with a maximum of three suggestions and a
+   configurable cutoff.
+2. Return the matches as a list to keep the API stable for tests.
 
 ### parse_agent_groups
-1. Split each group string on commas.
-2. Trim whitespace from names and discard empty results.
-3. Collect non-empty lists in input order.
+
+1. Split each string on commas.
+2. Strip whitespace and discard empty agent names.
+3. Append only non-empty groups to preserve input ordering.
+
+### require_api_key
+
+1. Check for an `X-API-Key` header in the provided mapping.
+2. Raise `HTTPException(status_code=401)` with a `WWW-Authenticate: API-Key`
+   header when missing.
+3. Return `None` when the header is present.
 
 ### report_missing_tables
-1. If the list is empty, exit early.
-2. Sort table names and join with commas.
-3. Print an error or send output to a provided console.
+
+1. Exit immediately when the input sequence is empty.
+2. Sort table names, join them with commas, and render either to the provided
+   `Console` or through `print_error` with a suggestion.
 
 ### handle_command_not_found
-1. Emit an error noting the unknown command.
-2. Gather available commands from the Click/Typer context.
-3. Suggest similar commands using `find_similar_commands`.
-4. Exit with code 1.
+
+1. Emit a formatted error for the unknown command.
+2. Collect subcommand names from the active Click/Typer context.
+3. Suggest similar commands via `find_similar_commands` and show examples.
+4. Raise `typer.Exit(code=1)` to stop execution.
 
 ## Invariants
 
-- `find_similar_commands` returns at most three entries and obeys the
-  threshold.
-- `parse_agent_groups` yields groups of non-empty, trimmed names in input
-  order.
-- `report_missing_tables` sorts table names and never emits output when none
-  are missing.
-- `handle_command_not_found` always raises `typer.Exit` and lists suggestions
-  only when candidates exist.
+- `find_similar_commands` never returns more than three suggestions and respects
+  the cutoff threshold.
+- `parse_agent_groups` returns only non-empty, trimmed agent names and preserves
+  original ordering.
+- `require_api_key` always raises `HTTPException` with a `WWW-Authenticate`
+  header when the key is missing.
+- `report_missing_tables` sorts table names consistently and never emits output
+  when the input is empty.
+- `handle_command_not_found` always raises `typer.Exit` after printing
+  suggestions (when any).
 
 ## Complexity
 
-- `find_similar_commands`: `O(n × m)` for `n` commands of length `m`.
-- `parse_agent_groups`: `O(k)` for `k` characters across groups.
+- `find_similar_commands`: `O(n × m)` for `n` command strings of length `m`.
+- `parse_agent_groups`: `O(k)` for `k` characters across the inputs.
+- `require_api_key`: `O(1)` key lookup.
 
 ## Proof Sketch
 
-- `find_similar_commands` delegates to Python's standard `difflib`, which
-  bounds results and filters by similarity score.
-- `parse_agent_groups` only appends lists that contain at least one name,
-  ensuring no empty groups.
-- `report_missing_tables` checks for falsy input and sorts names before
-  formatting, guaranteeing stable output.
-- `handle_command_not_found` raises `typer.Exit` after printing, so the CLI
-  cannot continue in an invalid state.
+- Python's `difflib` enforces the upper bound on matches, guaranteeing the
+  invariant for `find_similar_commands`.
+- `parse_agent_groups` filters falsy values before appending, so empty groups
+  are impossible.
+- `require_api_key` checks a single dictionary key and raises immediately,
+  ensuring no downstream code executes without credentials.
+- `report_missing_tables` shares the same branch regardless of whether a
+  `Console` is supplied, keeping messages deterministic.
+- `handle_command_not_found` finishes by raising `typer.Exit`, preventing the
+  CLI from continuing in an invalid state.
 
 ## Simulation Expectations
 
-Unit tests exercise threshold handling, empty group parsing, sorted table
-reporting, and the single-execution contract for command dispatch errors.
+Unit tests cover threshold handling, group parsing edge cases, missing header
+errors, sorted table reporting, and friendly suggestions for mistyped
+commands.
 
 ## Traceability
 

--- a/docs/specs/config.md
+++ b/docs/specs/config.md
@@ -2,54 +2,122 @@
 
 ## Overview
 
-Configuration loader for Autoresearch. It merges defaults, environment
-variables, and profile files. See
-[config hot reload algorithm](../algorithms/config_hot_reload.md) for reload
-behavior.
+Configuration loading and hot-reload utilities for Autoresearch. `ConfigLoader`
+locates configuration files, merges environment overrides (including `.env`
+values), instantiates `ConfigModel`, and optionally watches files for changes.
+Helper APIs expose the active configuration, temporary overrides, and profile
+management. See [config hot reload](../algorithms/config_hot_reload.md) for the
+underlying watcher model.
 
 ## Algorithms
 
-1. Read defaults and overlay environment variables and profile data.
-2. Parse the active file into structured state.
-3. Watch the file and atomically swap ``state.active`` on valid changes.
+### load_config
+
+1. Collect variables from `.env`, OS environment, and prefixed keys such as
+   `AUTORESEARCH_*` or `section__nested` pairs.
+2. Search `autoresearch.toml`, `config/autoresearch.toml`, or supplied paths
+   for the first existing configuration file.
+3. Parse TOML content, logging errors via `ConfigError`.
+4. Merge environment overrides into the parsed structure, expanding storage,
+   API, distributed, analysis, and agent sections.
+5. Instantiate `AgentConfig` entries, collecting valid values even when some
+   fields fail validation.
+6. Apply active profile overrides when `profiles.<name>` exists in the file or
+   was previously selected with `set_active_profile`.
+7. Create and return a `ConfigModel`; on validation failure, log the error and
+   fall back to defaults.
+
+### watch_changes / watching
+
+1. Determine which configuration and `.env` paths exist and monitor their parent
+   directories with `watchfiles.watch`.
+2. Spawn a daemon thread that reloads the configuration when a watched file
+   changes.
+3. Update `self._config` with the fresh `ConfigModel` and notify registered
+   observers.
+4. Stop the watcher when the context manager exits or `stop_watching` is
+   invoked.
+
+### register_observer / notify_observers
+
+1. Maintain a set of callables registered by clients.
+2. On reload, call each observer with the new `ConfigModel` and surface
+   exceptions as `ConfigError` to avoid silent failures.
+
+### set_active_profile
+
+1. Ensure profiles are loaded (calling `load_config` if necessary).
+2. Validate that the requested profile exists; raise `ConfigError` with
+   suggestions when unknown.
+3. Record the active profile, invalidate cached configuration, and notify
+   observers with the new `ConfigModel`.
+
+### temporary_config / get_config
+
+1. Use a `contextvars.ContextVar` to store a temporary configuration override.
+2. `temporary_config` sets the variable for the duration of the context manager
+   and restores the previous state on exit.
+3. `get_config` returns the context override when present, otherwise defers to
+   the singleton `ConfigLoader().config`.
 
 ## Invariants
 
-- ``state.active`` equals the last successfully parsed config file.
-- Reloads are atomic; readers never observe partially written state.
-- Unknown or malformed fields leave prior values unchanged.
+- `ConfigLoader` behaves as a process-wide singleton unless `new_for_tests` or
+  `temporary_instance` is used, ensuring consistent state during normal
+  operation.
+- Environment variables override file values without mutating the original
+  parsed dictionary.
+- Observer notifications always receive validated `ConfigModel` instances.
+- Watch threads stop cleanly and clear `app.state.watch_ctx` during shutdown.
+- Active profiles inherit base settings and only override declared keys.
 
 ## Proof Sketch
 
-Reloading a modified file updates ``state.active`` atomically while preserving
-unchanged fields. Tests exercise reload paths, and the simulation
-increments a value from 1 to 2, recording metrics in
-[config_hot_reload_metrics.json][r1] to verify success and fallback
-behavior when files disappear.
+`ConfigLoader` adheres to the atomic reload guarantees outlined in
+[config hot reload](../algorithms/config_hot_reload.md). Parsing occurs before
+state swaps, observers run after validation, and context overrides ensure
+callers within `temporary_config` observe a consistent snapshot. Tests cover
+error handling, defaults, environment overrides, and watcher cleanup, providing
+empirical confirmation of the invariants.
 
 ## Simulation Expectations
 
-The hot-reload simulation updates a value from 1 to 2 and records metrics in
-[config_hot_reload_metrics.json][r1].
+Hot-reload simulations toggle configuration values and record transitions from 1
+to 2 in [config_hot_reload_metrics.json][r1], verifying that observers receive
+updated state exactly once per change. Analysis tests exercise watcher threads
+and ensure missing files fall back to defaults without crashing the process.
 
 ## Traceability
 
-
 - Modules
-  - [src/autoresearch/config/][m1]
+  - [src/autoresearch/config/__init__.py][m1]
+  - [src/autoresearch/config/loader.py][m2]
+  - [src/autoresearch/config/models.py][m3]
+  - [src/autoresearch/config/validators.py][m4]
 - Tests
   - [tests/unit/test_config_env_file.py][t1]
   - [tests/unit/test_config_errors.py][t2]
   - [tests/unit/test_config_loader_defaults.py][t3]
-  - [tests/behavior/features/configuration_hot_reload.feature][t4]
-  - [tests/integration/test_config_hot_reload_components.py][t5]
-  - [tests/analysis/test_config_hot_reload_sim.py][t6]
+  - [tests/unit/test_config_profiles.py][t4]
+  - [tests/unit/test_config_reload.py][t5]
+  - [tests/unit/test_config_validation_errors.py][t6]
+  - [tests/unit/test_config_watcher_cleanup.py][t7]
+  - [tests/behavior/features/configuration_hot_reload.feature][t8]
+  - [tests/integration/test_config_hot_reload_components.py][t9]
+  - [tests/analysis/test_config_hot_reload_sim.py][t10]
 
-[m1]: ../../src/autoresearch/config/
+[m1]: ../../src/autoresearch/config/__init__.py
+[m2]: ../../src/autoresearch/config/loader.py
+[m3]: ../../src/autoresearch/config/models.py
+[m4]: ../../src/autoresearch/config/validators.py
 [t1]: ../../tests/unit/test_config_env_file.py
 [t2]: ../../tests/unit/test_config_errors.py
 [t3]: ../../tests/unit/test_config_loader_defaults.py
-[t4]: ../../tests/behavior/features/configuration_hot_reload.feature
-[t5]: ../../tests/integration/test_config_hot_reload_components.py
-[t6]: ../../tests/analysis/test_config_hot_reload_sim.py
+[t4]: ../../tests/unit/test_config_profiles.py
+[t5]: ../../tests/unit/test_config_reload.py
+[t6]: ../../tests/unit/test_config_validation_errors.py
+[t7]: ../../tests/unit/test_config_watcher_cleanup.py
+[t8]: ../../tests/behavior/features/configuration_hot_reload.feature
+[t9]: ../../tests/integration/test_config_hot_reload_components.py
+[t10]: ../../tests/analysis/test_config_hot_reload_sim.py
 [r1]: ../../tests/analysis/config_hot_reload_metrics.json

--- a/docs/specs/monitor.md
+++ b/docs/specs/monitor.md
@@ -2,66 +2,107 @@
 
 ## Overview
 
-Interactive monitoring commands for Autoresearch. See
-[monitor CLI algorithm](../algorithms/monitor_cli.md) for command flow and
-error handling. The metrics command reports system statistics without changing
-the `autoresearch_queries_total` counter. Monitor commands skip storage
-initialization so metrics can run without a configured database.
+Monitoring commands and helpers for Autoresearch. The Typer application exposes
+metrics snapshots, resource recordings, knowledge graph inspection, interactive
+query loops, background monitors, and a node health server. All commands call
+`orch_metrics.ensure_counters_initialized` before execution. Algorithms and
+reliability analysis appear in [monitor CLI](../algorithms/monitor_cli.md).
 
 ## Algorithms
 
-### Command Flow
+### metrics
 
-#### metrics
+1. Collect system metrics via `_collect_system_metrics`, aggregating CPU,
+   memory, GPU, and orchestration counters.
+2. Render a Rich table (`_render_metrics`).
+3. When `--watch` is provided, refresh the table every second using `Live`
+   without mutating counters.
 
-1. Initialize orchestration counters.
-2. Collect CPU, memory, and GPU data with ``_collect_system_metrics``.
-3. Render a table to the console.
-   - Invariant: ``queries_total_after = queries_total_before``.
+### resources
 
-#### run
+1. Instantiate `OrchestrationMetrics` to record system resource samples for the
+   requested duration.
+2. Loop until the timer expires, recording CPU, memory, and GPU values once per
+   second and updating a progress bar.
+3. Print a summary table when sampling completes.
 
-1. Prompt for queries until ``""`` or ``"q"`` is entered.
-2. For each query:
-   - Execute ``Orchestrator.run_query`` for ``loops`` cycles.
-   - After each cycle, display system metrics and cycle metrics.
-   - Abort if feedback ``"q"`` forces ``error_count`` to ``max_errors``.
-   - Invariant: storage layers remain uninitialized.
+### graph
+
+1. Read the in-memory knowledge graph via `StorageManager.get_graph()` when
+   available.
+2. Render a table of edges or a Rich `Tree` when `--tree` or `--tui` is set.
+
+### run
+
+1. Prompt for queries until the user enters `""` or `"q"`.
+2. Execute `Orchestrator.run_query` with an `on_cycle_end` callback that prints
+   cycle metrics, system metrics, and token budget usage.
+3. Collect optional feedback; on `"q"`, set `state.error_count` to force exit
+   via the configured `max_errors` threshold.
+4. Format the final result using `OutputFormatter` without initialising storage.
+
+### start
+
+1. Determine the sampling interval from CLI options or configuration.
+2. Start `ResourceMonitor` (with optional Prometheus export) and
+   `SystemMonitor`, storing the latter globally for reuse by `metrics`.
+3. Loop until interrupted, then stop both monitors and clear global state.
+
+### serve
+
+1. Instantiate `NodeHealthMonitor` with optional Redis URL, Ray address, port,
+   and interval.
+2. Start the Prometheus HTTP server and background check thread.
+3. Sleep until interrupted, then stop the monitor and exit with status 0.
 
 ## Invariants
 
-- ``monitor metrics`` never mutates ``autoresearch_queries_total``.
-- Monitor commands do not initialize ``StorageManager`` before use.
-
-## Complexity
-
-- ``metrics``: time ``Θ(1)``, space ``Θ(1)``.
-- ``run``: time ``Θ(loops × C_orchestrator)`` per query, space ``Θ(1)``.
+- `metrics` reads orchestration counters but never increments them.
+- `_system_monitor` is started only once and stopped when `start` exits, keeping
+  metrics consistent for subsequent commands.
+- `NodeHealthMonitor` gauges reset to zero before each health check, ensuring
+  stale values do not persist.
+- `run` does not initialise storage directly; it relies on orchestrator
+  callbacks so monitors can operate without database configuration.
+- `serve` always stops the monitor thread before exiting, preventing orphaned
+  background work.
 
 ## Proof Sketch
 
-Correctness follows from command flow constraints and invariant checks.
+`monitor` commands are thin wrappers around the primitives documented in
+[monitor CLI](../algorithms/monitor_cli.md). Each command prints deterministic
+Rich output and guards cleanup paths with `try`/`finally` blocks so monitors
+stop reliably. Unit tests exercise CLI entry points, metrics collection,
+feedback loops, and GPU/resource integration, providing empirical evidence
+that the invariants hold.
 
 ## Simulation Expectations
 
-Monte Carlo analysis lives in
-[`monitor_cli_reliability.py`](../../scripts/monitor_cli_reliability.py), which
-estimates latency and failure rate. Unit tests cover nominal and edge cases for
-these routines.
+[monitor_cli_reliability.py][s1] runs Monte Carlo analyses of sampling latency
+and failure rates, while GPU/resource tests simulate environments with and
+without GPU metrics to confirm graceful degradation.
 
 ## Traceability
 
 - Modules
-  - [src/autoresearch/monitor/][m1]
-- Scripts
-  - [monitor_cli_reliability.py][s1]
+  - [src/autoresearch/monitor/__init__.py][m1]
+  - [src/autoresearch/monitor/cli.py][m2]
+  - [src/autoresearch/monitor/metrics.py][m3]
+  - [src/autoresearch/monitor/node_health.py][m4]
+  - [src/autoresearch/monitor/system_monitor.py][m5]
 - Tests
-  - [test_main_monitor_commands.py][t1]
-  - [test_monitor_cli.py][t2]
-  - [test_resource_monitor_gpu.py][t3]
+  - [tests/unit/test_main_monitor_commands.py][t1]
+  - [tests/unit/test_monitor_cli.py][t2]
+  - [tests/unit/test_resource_monitor_gpu.py][t3]
+  - [tests/integration/test_monitor_metrics.py][t4]
 
-[m1]: ../../src/autoresearch/monitor/
-[s1]: ../../scripts/monitor_cli_reliability.py
+[m1]: ../../src/autoresearch/monitor/__init__.py
+[m2]: ../../src/autoresearch/monitor/cli.py
+[m3]: ../../src/autoresearch/monitor/metrics.py
+[m4]: ../../src/autoresearch/monitor/node_health.py
+[m5]: ../../src/autoresearch/monitor/system_monitor.py
 [t1]: ../../tests/unit/test_main_monitor_commands.py
 [t2]: ../../tests/unit/test_monitor_cli.py
 [t3]: ../../tests/unit/test_resource_monitor_gpu.py
+[t4]: ../../tests/integration/test_monitor_metrics.py
+[s1]: ../../scripts/monitor_cli_reliability.py


### PR DESCRIPTION
## Summary
- expand the API specification with current routing, authentication, streaming, and configuration behaviours
- align CLI helper, configuration, distributed, extensions, and monitor specs with their implementations
- refresh related algorithm references for authentication error paths, streaming heartbeats, and monitor CLI flows

## Testing
- uv run mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68c8576e9e7c8333b4c684357124258d