### PR TITLE
Handle offline DuckDB extension reuse safely

### DIFF
--- a/docs/duckdb_vss_fallback.md
+++ b/docs/duckdb_vss_fallback.md
@@ -25,10 +25,13 @@ The loader only raises :class:`StorageError` when
 - `download_duckdb_extensions.py` installs the VSS extension.
 - If `VECTOR_EXTENSION_PATH` is present in `.env.offline` the script copies
   that file into the requested output directory and updates the environment
-  variable to point at the copy.
+  variable to point at the copy. It compares the cached source and
+  destination with `os.path.samefile` and skips the copy when they already
+  point to the same file, avoiding a `SameFileError`.
 - When no path is provided it creates an empty file in `extensions/vss/`,
   sets `VECTOR_EXTENSION_PATH` to the stub and warns that the stub is in
-  use.
+  use. The stub is opened with ``open(path, "wb")`` so repeated runs
+  truncate the file back to zero bytes if earlier attempts wrote data.
 - `setup.sh` logs when the stub is selected and records its location for
   reuse.
 


### PR DESCRIPTION
## Summary
- avoid copying cached DuckDB extensions onto themselves during offline fallback
- ensure stub generation truncates to an empty binary file and add regression tests
- document the offline reuse behaviour and stub reset in the DuckDB VSS fallback guide

## Testing
- uv run --extra test pytest tests/unit/test_download_duckdb_extensions.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c868016144833399639d732df28c74