### PR TITLE
Refine VSS verification flow

### DIFF
--- a/docs/specs/extensions.md
+++ b/docs/specs/extensions.md
@@ -45,8 +45,10 @@ Strict mode raises `StorageError` when no strategy succeeds.
 ### verify_extension
 
 1. Query `duckdb_extensions()` for the `vss` extension.
-2. If unavailable, check for the `vss_stub` marker table.
-3. Log informative messages and return `True` only when either check succeeds.
+2. When the extension is absent, log the result and return `False` immediately
+   without probing stub markers.
+3. If the probe raises, log the exception and fall back to checking the
+   `vss_stub` marker table before reporting success.
 
 ## Invariants
 

--- a/src/autoresearch/extensions.py
+++ b/src/autoresearch/extensions.py
@@ -227,19 +227,22 @@ class VSSExtensionLoader:
             result = conn.execute(
                 "SELECT * FROM duckdb_extensions() WHERE extension_name = 'vss'"
             ).fetchall()
+        except Exception as err:  # pragma: no cover - defensive
+            if verbose:
+                log.warning("VSS extension verification failed: %s", err)
+        else:
             if result and len(result) > 0:
                 if verbose:
                     log.info("VSS extension is loaded")
                 return True
-            else:
-                if verbose:
-                    log.warning("VSS extension is not loaded")
-        except Exception as e:  # pragma: no cover - defensive
             if verbose:
-                log.warning(f"VSS extension verification failed: {e}")
+                log.warning("VSS extension is not loaded")
+            return False
 
         try:
-            conn.execute("SELECT 1 FROM information_schema.tables WHERE table_name='vss_stub'")
+            conn.execute(
+                "SELECT 1 FROM information_schema.tables WHERE table_name='vss_stub'"
+            )
             if verbose:
                 log.info("VSS stub marker present")
             return True

--- a/tests/unit/test_vss_extension_loader.py
+++ b/tests/unit/test_vss_extension_loader.py
@@ -29,9 +29,11 @@ class TestVSSExtensionLoader:
     @pytest.mark.real_vss
     def test_verify_extension_failure(self):
         """Test that verify_extension returns False when the extension is not loaded."""
-        # Create a mock connection that raises a DuckDB error when executing the verification query
+        # Create a mock connection that reports an empty extension list
         conn = MagicMock()
-        conn.execute.side_effect = duckdb.Error("Extension not loaded")
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        conn.execute.return_value = mock_result
 
         # Verify that the extension is reported as not loaded
         assert VSSExtensionLoader.verify_extension(conn) is False


### PR DESCRIPTION
## Summary
- ensure `verify_extension` returns immediately when VSS is absent
- update failure test and docs to reflect the streamlined probe behavior

## Testing
- `uv run pytest tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::test_verify_extension_failure -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8680d2ac4833387335bda320ec9fb