### PR TITLE
Organize documentation nav and archive mkdocs warning ticket

### DIFF
--- a/docs/api_authentication.md
+++ b/docs/api_authentication.md
@@ -59,6 +59,6 @@ See [api.md](api.md) for a complete overview of available endpoints.
 
 ## Further reading
 
-- [API authentication spec](specs/api_authentication.md)
-- [Authentication simulation](../scripts/api_auth_sim.py)
+- Module specification: see `docs/specs/api_authentication.md`.
+- Authentication simulation script: see `scripts/api_auth_sim.py`.
 

--- a/docs/domain_model.md
+++ b/docs/domain_model.md
@@ -8,7 +8,7 @@ relationships.
 Agents drive the dialectical reasoning cycle. Each agent implements the base
 interface and uses prompts and models defined in `AgentConfig`.
 
-- Spec: see the [agents specification](specs/agents.md)
+- Spec: documented in `docs/specs/agents.md`
 - Code: `src/autoresearch/agents/base.py`
 
 ## Queries
@@ -16,7 +16,7 @@ interface and uses prompts and models defined in `AgentConfig`.
 Queries define user intent and orchestrator responses. `QueryRequest` captures
 incoming parameters, while `QueryResponse` records final answers.
 
-- Spec: see the [models specification](specs/models.md)
+- Spec: documented in `docs/specs/models.md`
 - Code: `src/autoresearch/models.py`
 
 ## Storage
@@ -24,7 +24,7 @@ incoming parameters, while `QueryResponse` records final answers.
 Storage persists claims and supports graph and vector retrieval via a unified
 `StorageManager` over NetworkX, DuckDB, and RDFLib backends.
 
-- Spec: see the [storage specification](specs/storage.md)
+- Spec: documented in `docs/specs/storage.md`
 - Code: `src/autoresearch/storage.py`
 
 ## Search
@@ -32,7 +32,7 @@ Storage persists claims and supports graph and vector retrieval via a unified
 Search generates query variants and federates lookups across registered
 backends, caching results and ranking sources.
 
-- Spec: see the [search specification](specs/search.md)
+- Spec: documented in `docs/specs/search.md`
 - Code: `src/autoresearch/search/core.py`
 
 ## Relationships

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -38,7 +38,7 @@ mkdocs build` succeeds but lists more than forty pages missing from the
 navigation alongside broken links such as `specs/api_authentication.md`.
 `task verify` has not been rerun because the missing CLI blocks the workflow,
 and coverage numbers are currently unavailable. These regressions are tracked
-in the open issues referenced by [STATUS.md](../STATUS.md).
+in the open issues referenced by STATUS.md.
 ## Milestones
 
 - **0.1.0a1** (2026-09-15, status: in progress): Alpha preview to collect

--- a/issues/archive/fix-mkdocs-griffe-warnings.md
+++ b/issues/archive/fix-mkdocs-griffe-warnings.md
@@ -21,5 +21,13 @@ None
 - The docstring in `storage_backends.py` uses consistent indentation.
 - `uv run mkdocs build` completes without warnings.
 
+## Build Log
+```
+2025-09-15: uv run mkdocs build
+INFO    -  Cleaning site directory
+INFO    -  Building documentation to directory: /workspace/autoresearch/site
+INFO    -  Documentation built in 5.91 seconds
+```
+
 ## Status
-Open
+Archived

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,18 +1,72 @@
 site_name: Autoresearch
 nav:
-  - Getting Started: getting_started.md
-  - Configuration: configuration.md
-  - Agents: agents_overview.md
-  - Agent Communication: agent_communication.md
-  - Storage: storage.md
-  - Orchestration: orchestration.md
-  - API Usage: api.md
-  - Advanced Usage: advanced_usage.md
-  - Deployment: deployment.md
-  - FAQ: faq.md
-  - Agent System: agent_system.md
-  - Component Interactions: component_interactions.md
-  - Message Brokers: message_brokers.md
+  - Overview:
+    - Getting Started: getting_started.md
+    - Quickstart Guides: quickstart_guides.md
+    - FAQ: faq.md
+    - User Flows: user_flows.md
+  - Concepts:
+    - Agents: agents_overview.md
+    - Agent Communication: agent_communication.md
+    - Agent System: agent_system.md
+    - Component Interactions: component_interactions.md
+    - Domain Model: domain_model.md
+    - Orchestration: orchestration.md
+    - Orchestrator State: orchestrator_state.md
+    - Orchestrator State Spec: orchestrator_state_spec.md
+    - Message Brokers: message_brokers.md
+    - Storage: storage.md
+    - Search Backends: search_backends.md
+    - Search Specification: search_spec.md
+    - API Usage: api.md
+    - API Authentication: api_authentication.md
+    - A2A MCP Integration: a2a_mcp_integration.md
+  - Setup & Configuration:
+    - Installation: installation.md
+    - Setup Checklist: setup.md
+    - Configuration Overview: configuration.md
+    - Config Reference: config.md
+    - Advanced Usage: advanced_usage.md
+    - Custom UI Extensions: custom_ui_extensions.md
+    - Container Usage: container_usage.md
+    - CLI Helpers: cli_helpers.md
+    - Caching: caching.md
+    - Output Formats: output_formats.md
+  - Operations:
+    - Deployment Overview: deployment.md
+    - Deploy Validation: deploy_validation.md
+    - Distributed Execution: distributed.md
+    - Monitoring Overview: monitoring.md
+    - Monitor CLI: monitor.md
+    - Orchestrator Performance: orchestrator_perf.md
+    - Scheduler Benchmark: scheduler_benchmark.md
+    - Ranking Benchmark: ranking_benchmark.md
+    - Performance Overview: performance.md
+    - Performance Tuning: performance_tuning.md
+    - DuckDB Compatibility: duckdb_compatibility.md
+    - DuckDB VSS Fallback: duckdb_vss_fallback.md
+  - Development Workflow:
+    - Development Overview: development.md
+    - Developer Guide: developer_guide.md
+    - Spec-Driven Development: spec_driven_development.md
+    - Spec Template: spec_template.md
+    - Review Guidelines: review_guidelines.md
+    - Testing Guidelines: testing_guidelines.md
+    - UI Testing Procedures: ui_testing_procedures.md
+    - Contributing: contributing.md
+    - Releasing Workflow: releasing.md
+    - Release Plan: release_plan.md
+    - Release Notes:
+        - Overview: release_notes.md
+        - Version 0.1.0a1: release_notes/v0.1.0a1.md
+    - Requirements: requirements.md
+    - Requirements Traceability Matrix: requirements_traceability_matrix.md
+  - Planning & Design:
+    - Plan: plan.md
+    - Pseudocode: pseudocode.md
+    - Specification Overview: specification.md
+    - Diagrams:
+        - UX Architecture: diagrams/ux_architecture.md
   - API Reference:
     - Overview: api_reference/index.md
     - Agents: api_reference/agents.md
@@ -21,15 +75,12 @@ nav:
     - LLM: api_reference/llm.md
     - Search: api_reference/search.md
     - Config: api_reference/config.md
-  - Contributing: contributing.md
-  - Requirements: requirements.md
-  - Specification: specification.md
-  - Plan: plan.md
-  - Pseudocode: pseudocode.md
-  - Requirements Traceability Matrix: requirements_traceability_matrix.md
-  - Testing Guidelines: testing_guidelines.md
+    - Query: api_reference/query.md
+    - Distributed: api_reference/distributed.md
   - Troubleshooting:
     - Multiprocessing Resource Tracker: multiprocessing_resource_tracker.md
+  - Appendices:
+    - Documentation Guide: AGENTS.md
 markdown_extensions:
   - toc
   - admonition


### PR DESCRIPTION
## Summary
- group the MkDocs navigation into thematic sections and add the previously missing documentation pages
- reference module specifications as repository paths so the API authentication and domain model docs no longer point to excluded files, and clean the release plan note about STATUS.md
- move the "fix mkdocs griffe warnings" issue to the archive with the successful build log included

## Testing
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c881c058b483338f67fa0f2993bcff