### PR TITLE
Fix Click split_arg_string deprecation handling

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -16,11 +16,13 @@ groups or add `gpu` packages.
 ## Deprecation warnings
 
 - No deprecation warnings are expected when running `task verify`.
-- `sitecustomize.py` replaces `click.parser.split_arg_string` with
-  `shlex.split` to avoid Click deprecation warnings during tests.
-- Some third-party packages still issue deprecation warnings.
-  `pkg_resources` messages are filtered.
-  Document any other unavoidable warnings.
+- `sitecustomize.py` re-exports `click.shell_completion.split_arg_string`
+  for compatibility so Click no longer warns about the deprecated
+  `click.parser` module during tests.
+- `pytest.ini` keeps the default `.hypothesis` ignore entry so Hypothesis'
+  plugin does not emit warnings when collecting tests.
+- Record any remaining unavoidable warnings here, along with a link to the
+  upstream tracker or mitigation plan.
 
 ## Multiprocessing cleanup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.12,<4.0"
 packages = [{include = "autoresearch", from = "src"}]
 dependencies = [
     "a2a-sdk >=0.3.0",
-    "click >=8.2.1", # sitecustomize.py shims split_arg_string removal
+    "click >=8.2.1", # sitecustomize.py re-exports shell_completion.split_arg_string
     "duckdb >=1.3.0",
     "fastapi >=0.116.1", # 0.116.1+ needed for Pydantic v2 and Starlette 0.41
     "fastmcp >=2.11.2",

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,14 @@ minversion = 6.0
 addopts = -m 'not slow and not pending'
 testpaths = tests/unit tests/integration tests/behavior tests/behavior/features
 bdd_features_base_dir = tests/behavior/features
-norecursedirs = tests/behavior/archive
+norecursedirs =
+    .git
+    .hypothesis
+    .mypy_cache
+    .venv
+    build
+    dist
+    tests/behavior/archive
 python_files = test_*.py *_steps.py
 markers =
     behavior: mark behavior (BDD) tests

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -5,7 +5,6 @@ import warnings
 
 if not TYPE_CHECKING:  # pragma: no cover - runtime import
     import importlib
-    import shlex
     import sys
     import types
 
@@ -14,18 +13,17 @@ if not TYPE_CHECKING:  # pragma: no cover - runtime import
         message=".*pkg_resources.*",
         category=DeprecationWarning,
     )
-    warnings.filterwarnings(
-        "ignore",
-        message=".*split_arg_string.*",
-        category=DeprecationWarning,
-    )
 
     def _ensure_click_split_arg_string() -> None:
         """Provide a ``click.parser.split_arg_string`` compat shim."""
 
         try:
-            importlib.import_module("click")
+            shell_completion = importlib.import_module("click.shell_completion")
         except Exception:  # pragma: no cover - optional dependency
+            return
+
+        split_arg_string = getattr(shell_completion, "split_arg_string", None)
+        if split_arg_string is None:
             return
 
         module_name = "click.parser"
@@ -35,8 +33,8 @@ if not TYPE_CHECKING:  # pragma: no cover - runtime import
             click_parser = types.ModuleType(module_name)
             sys.modules[module_name] = click_parser
 
-        if not hasattr(click_parser, "split_arg_string"):
-            click_parser.split_arg_string = shlex.split
+        if "split_arg_string" not in click_parser.__dict__:
+            click_parser.split_arg_string = split_arg_string
 
     try:
         _ensure_click_split_arg_string()


### PR DESCRIPTION
## Summary
- update the Click compatibility shim to bind `click.parser.split_arg_string` to the new `click.shell_completion` helper without triggering deprecation warnings
- extend the default `pytest.ini` ignore list so Hypothesis no longer emits `.hypothesis` collection warnings
- refresh the testing guidelines to note the new shim behaviour and how unavoidable warnings are tracked

## Testing
- `uv run --extra test pytest tests/unit/test_cli_help.py -W error::DeprecationWarning`
- `uv run --extra test pytest tests/unit -W error::DeprecationWarning --maxfail=1` *(fails: ConfigError in tests/unit/search/test_ranking_formula.py::test_rank_results_weighted_combination)*

------
https://chatgpt.com/codex/tasks/task_e_68c888fb07b88333b2d8b96985d6ae07