### PR TITLE
Sync API spec with routing updates

### DIFF
--- a/SPEC_COVERAGE.md
+++ b/SPEC_COVERAGE.md
@@ -6,7 +6,7 @@
 | `autoresearch/agents` | [agents.md](docs/specs/agents.md) | [s2], [t7], [t8], [t9], [t10] | OK |
 | `autoresearch/agents/dialectical` | [agents-dialectical.md](docs/specs/agents-dialectical.md) | [p20], [s19], [t9], [t113], [t114], [t115] | OK |
 | `autoresearch/agents/specialized` | [agents-specialized.md](docs/specs/agents-specialized.md) | [t8], [t10] | OK |
-| `autoresearch/api` | [api.md](docs/specs/api.md) | [p2], [p3], [p4], [p5], [p6], [s3], [s4], [t11], [t12], [t13], [t14], [t15], [t16], [t17], [t18], [t19], [t20], [t21], [t22], [t23] | OK |
+| `autoresearch/api` | [api.md](docs/specs/api.md) | [p2], [p3], [p4], [p5], [p6], [p21], [s3], [s4], [t11], [t12], [t13], [t14], [t15], [t16], [t17], [t18], [t19], [t20], [t21], [t22], [t23] | OK |
 | `autoresearch/api/middleware.py` | [api_rate_limiting.md](docs/specs/api_rate_limiting.md) | [p5], [t24] | OK |
 | `autoresearch/cache.py` | [cache.md](docs/specs/cache.md) | [t25] | OK |
 | `autoresearch/cli_backup.py` | [cli-backup.md](docs/specs/cli-backup.md) | [t26] | OK |
@@ -73,6 +73,7 @@
 [p4]: docs/algorithms/api_authentication.md
 [p5]: docs/algorithms/api_rate_limiting.md
 [p6]: docs/algorithms/api_streaming.md
+[p21]: docs/algorithms/api.md
 [s3]: scripts/api_auth_credentials_sim.py
 [s4]: scripts/api_stream_order_sim.py
 [t11]: tests/analysis/test_api_stream_order_sim.py

--- a/docs/algorithms/api-authentication.md
+++ b/docs/algorithms/api-authentication.md
@@ -10,6 +10,10 @@ Authorization verifies that a user's role permits the requested operation. A
 permissions mapping assigns actions to each role and fails fast when a role is
 missing or lacks the required permission.
 
+Permissions align with the [API spec](../specs/api.md), so query, config,
+metrics, docs, health, and capability endpoints stay isolated unless roles
+explicitly list the corresponding action.
+
 ## Constant-Time Comparison
 
 Traditional equality may exit on the first mismatched character, leaking timing

--- a/docs/algorithms/api.md
+++ b/docs/algorithms/api.md
@@ -1,27 +1,76 @@
 # API
 
 ## Overview
-The API package exposes HTTP endpoints for orchestrator actions.
+The API package wires FastAPI routers, authentication middleware, request
+logging, and configuration hot reloading. `routing.create_app` loads the
+configuration, starts storage, installs rate limiting, and registers
+versioned routes for queries, streaming, configuration management, and
+documentation.
 
 ## Algorithm
-Endpoints validate versioned schemas, authenticate API keys or bearer
-tokens, delegate to orchestrator services, and stream chunked responses with
-heartbeats and an ``END`` sentinel.
+1. `AuthMiddleware` loads the latest `ConfigModel`, extracts credentials, and
+   stores `request.state.permissions`.
+2. `require_permission` halts requests without the requisite capability,
+   returning **401** or **403** where appropriate.
+3. Route handlers call `validate_version` for versioned models before invoking
+   the orchestrator or configuration helpers.
+4. Query handlers optionally clone the configuration with request overrides,
+   run orchestrator queries inside tracing spans, and deliver webhook
+   notifications with retries.
+5. Streaming endpoints create an `asyncio.Queue`, stream newline-delimited
+   JSON, and emit blank heartbeat lines on idle cycles.
+6. Async endpoints manage futures in `app.state.async_tasks`, returning status
+   JSON until results resolve or cancellation succeeds.
+7. Configuration routes use `ConfigLoader` to merge, replace, or reload
+   models, surfacing `HTTPException` errors when validation fails.
+
+## Route Coverage
+- **POST /query** (`query`): Synchronous queries or `?stream=true` streaming.
+- **POST /query/stream** (`query`): Dedicated streaming endpoint.
+- **POST /query/batch** (`query`): Paginated batches with `asyncio.TaskGroup`.
+- **POST /query/async** (`query`): Background queries with task identifiers.
+- **GET /query/{query_id}** (`query`): Async status or final payload.
+- **DELETE /query/{query_id}** (`query`): Cancels async tasks and prunes state.
+- **GET /health** (`health`): Reports readiness after startup.
+- **GET /capabilities** (`capabilities`): Exposes modes, storage, search, and
+  agent descriptors.
+- **GET /config** (`config`): Returns current configuration.
+- **PUT /config** (`config`): Merges updates and notifies observers.
+- **POST /config** (`config`): Replaces configuration after validation.
+- **DELETE /config** (`config`): Reloads configuration from disk.
+- **GET /metrics** (`metrics`): Prometheus endpoint when monitoring is
+  enabled.
+- **GET /docs** (`docs`): Swagger UI behind docs permission.
+- **GET /openapi.json** (`docs`): OpenAPI schema and descriptive metadata.
 
 ## Proof sketch
-Validation ensures well-formed data; the orchestrator confirms task
-completion, so each request yields a finite response.
+- Authentication: constant-time comparisons and permission enforcement ensure
+  only authorised clients reach handlers.
+- Version handling: `validate_version` rejects unsupported schemas before
+  orchestration begins.
+- Async management: futures remain in `app.state.async_tasks` until retrieval
+  or cancellation, preventing leaks.
+- Configuration safety: `ConfigLoader` validation guarantees only well-formed
+  models reach observers, preserving runtime stability.
 
 ## Simulation
-`tests/unit/test_api.py` simulates calls to key routes and checks status
-codes.
+- [scripts/api_auth_credentials_sim.py][sim-credentials] exercises credential
+  success and failure cases.
+- [scripts/api_stream_order_sim.py][sim-stream-order] verifies streaming order
+  and heartbeat cadence.
 
 ## References
-- [code](../../src/autoresearch/api/)
-- [spec](../specs/api.md)
-- [tests](../../tests/unit/test_api.py)
+- [Code](../../src/autoresearch/api/)
+- [Spec](../specs/api.md)
+- Tests:
+  - [tests/unit/test_api.py][test-api-unit]
+  - [tests/unit/test_api_auth_middleware.py][test-api-auth-mw]
+  - [tests/integration/test_api_docs.py][test-api-docs]
+  - [tests/integration/test_api_streaming.py][test-api-streaming]
 
-## Related Issues
-- [Fix API authentication and metrics tests][issue]
-
-[issue]: ../../issues/fix-api-authentication-and-metrics-tests.md
+[sim-credentials]: ../../scripts/api_auth_credentials_sim.py
+[sim-stream-order]: ../../scripts/api_stream_order_sim.py
+[test-api-unit]: ../../tests/unit/test_api.py
+[test-api-auth-mw]: ../../tests/unit/test_api_auth_middleware.py
+[test-api-docs]: ../../tests/integration/test_api_docs.py
+[test-api-streaming]: ../../tests/integration/test_api_streaming.py

--- a/docs/algorithms/api_auth_error_paths.md
+++ b/docs/algorithms/api_auth_error_paths.md
@@ -18,7 +18,9 @@ Enumerates failure responses for API credential verification.
 
 - Authenticated clients lacking a required permission trigger
   `enforce_permission`, which raises **403 Forbidden** with
-  `detail="Insufficient permissions"`.
+  `detail="Insufficient permissions"`. Examples include roles that can run
+  queries but lack the `docs` permission for `/docs` or the `metrics`
+  permission for `/metrics`.
 
 ## Rate Limit Exceeded
 

--- a/docs/algorithms/api_authentication.md
+++ b/docs/algorithms/api_authentication.md
@@ -28,6 +28,22 @@ Credentials are defined in `autoresearch.toml` under `[api]`:
 Roles gain capabilities via `[api.role_permissions]` with entries such as
 `query` or `docs`.
 
+## Permission coverage
+
+Each route declares a required permission with `require_permission`:
+
+- `query`: `POST /query`, `POST /query/stream`, `POST /query/batch`,
+  `POST /query/async`, `GET /query/{query_id}`, and
+  `DELETE /query/{query_id}`.
+- `health`: `GET /health`.
+- `capabilities`: `GET /capabilities`.
+- `config`: `GET/PUT/POST/DELETE /config`.
+- `metrics`: `GET /metrics` (available only when monitoring is enabled).
+- `docs`: `GET /docs` and `GET /openapi.json`.
+
+Roles missing the relevant permission reach `enforce_permission`, which raises
+**403 Forbidden** even when authentication succeeds.
+
 ## Threat model
 
 - Adversaries may sniff traffic, replay requests, or attempt token guessing.

--- a/docs/algorithms/api_rate_limiting.md
+++ b/docs/algorithms/api_rate_limiting.md
@@ -48,12 +48,18 @@ usage is linear in the number of tracked clients.
 - Buckets must expire for idle clients to avoid unbounded memory use.
 - Bursty traffic may need jitter or leaky bucket smoothing.
 
+## Implementation Notes
+
+When SlowAPI is installed, `RateLimitMiddleware` injects limit headers and
+delegates enforcement to SlowAPI's limiter. When it is absent the
+`FallbackRateLimitMiddleware` reuses `RequestLogger` counters to track per-IP
+usage. Both modes share the same `Limiter` interface, matching the behaviour
+documented in the [API spec](../specs/api.md).
+
 ## Verification
 
-Property-based tests
-[tests/unit/test_property_api_rate_limit_bounds.py](../../tests/unit/test_property_api_rate_limit_bounds.py)
-generate random request patterns to confirm that a client never exceeds its
-configured bound.
+Property-based tests [test_rate_limit_bounds][test-rate-limit] generate random
+request patterns to confirm that a client never exceeds its configured bound.
 
 ## Convergence
 
@@ -66,13 +72,14 @@ b(t) = \min(C, b_0 + R t)
 
 where ``b_0`` is the starting token count. The state monotonically increases
 until `b(t) = C`, proving convergence. Property-based tests
-([`test_property_api_rate_limit_bounds.py`]
-(../../tests/unit/test_property_api_rate_limit_bounds.py)) simulate random
-request bursts and confirm that the bucket never grows beyond its limit.
+([`test_rate_limit_bounds`][test-rate-limit]) simulate random request bursts and
+confirm that the bucket never grows beyond its limit.
 
 ## Simulation
 
 Automated tests confirm api rate limiting behavior.
 
 - [Spec](../specs/api_rate_limiting.md)
-- [Tests](../../tests/unit/test_property_api_rate_limit_bounds.py)
+- [Tests][test-rate-limit]
+
+[test-rate-limit]: ../../tests/unit/test_property_api_rate_limit_bounds.py

--- a/docs/algorithms/api_streaming.md
+++ b/docs/algorithms/api_streaming.md
@@ -1,8 +1,10 @@
 # API Streaming
 
 The streaming endpoint delivers intermediate query results over an HTTP
-connection. It runs the query in a background thread and forwards each cycle's
-state to the client, then posts the final response to any configured webhooks.
+connection. `POST /query/stream` and `POST /query?stream=true` both route into
+the same generator. The handler runs the query in a background thread and
+forwards each cycle's state to the client, then posts the final response to any
+configured webhooks.
 
 ## Back-pressure
 

--- a/docs/specs/api_authentication.md
+++ b/docs/specs/api_authentication.md
@@ -19,7 +19,7 @@ control downstream.
 - Credential checks use constant-time comparisons.
 - Roles grant access only to permitted actions.
 
-## Proof
+## Proof Sketch
 
 ### Assumptions
 
@@ -64,7 +64,7 @@ are equivalent to set membership, and Lemma 3 demonstrates that alternative
 designs reintroduce timing or authorization risks. Therefore credential checks
 are constant-time and permission resolution is sound.
 
-## Simulation Evidence
+## Simulation Expectations
 
 Two simulations substantiate the proof:
 


### PR DESCRIPTION
## Summary
- align `docs/specs/api.md` with the current FastAPI routes, parameters, and permission notes
- refresh the API algorithm and authentication documentation with updated route coverage, permission mapping, and rate-limiting/streaming details
- record the API spec coverage entry and fix the authentication spec headings required by the specs linter

## Testing
- uv run task lint-specs
- uv run --extra docs mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68c88e0321cc83339a30d603eb70e2af