### PR TITLE
Document config models and invariants

### DIFF
--- a/SPEC_COVERAGE.md
+++ b/SPEC_COVERAGE.md
@@ -24,46 +24,46 @@
 | `autoresearch/cli_backup.py` | [cli-backup.md](docs/specs/cli-backup.md) | [t35] | OK |
 | `autoresearch/cli_helpers.py` | [cli-helpers.md](docs/specs/cli-helpers.md) | [t36] | OK |
 | `autoresearch/cli_utils.py` | [cli-utils.md](docs/specs/cli-utils.md) | [t37] | OK |
-| `autoresearch/config` | [config.md](docs/specs/config.md) | [p8], [t38], [t39], [t40], [t41], [t42], [t43], [t44], [t45], [t46], [t47], [t48] | OK |
-| `autoresearch/config/loader.py` | [config.md](docs/specs/config.md) | [p8], [t38], [t39], [t40], [t41], [t42], [t43], [t44], [t45], [t46], [t47], [t48] | OK |
-| `autoresearch/config/models.py` | [config.md](docs/specs/config.md) | [p8], [t38], [t39], [t40], [t41], [t42], [t43], [t44], [t45], [t46], [t47], [t48] | OK |
-| `autoresearch/config/validators.py` | [config.md](docs/specs/config.md) | [p8], [t38], [t39], [t40], [t41], [t42], [t43], [t44], [t45], [t46], [t47], [t48] | OK |
-| `autoresearch/config_utils.py` | [config-utils.md](docs/specs/config-utils.md) | [p9], [t42], [t43], [t44], [t45], [t46], [t49], [t47], [t50], [t48], [t51], [t52] | OK |
+| `autoresearch/config` | [config.md](docs/specs/config.md) | [p8], [p9], [t38], [t39], [t40], [t41], [t42], [t43], [t44], [t45], [t46], [t47], [t48] | OK |
+| `autoresearch/config/loader.py` | [config.md](docs/specs/config.md) | [p8], [p9], [t38], [t39], [t40], [t41], [t42], [t43], [t44], [t45], [t46], [t47], [t48] | OK |
+| `autoresearch/config/models.py` | [config.md](docs/specs/config.md) | [p8], [p9], [t38], [t39], [t40], [t41], [t42], [t43], [t44], [t45], [t46], [t47], [t48] | OK |
+| `autoresearch/config/validators.py` | [config.md](docs/specs/config.md) | [p8], [p9], [t38], [t39], [t40], [t41], [t42], [t43], [t44], [t45], [t46], [t47], [t48] | OK |
+| `autoresearch/config_utils.py` | [config-utils.md](docs/specs/config-utils.md) | [p10], [t42], [t43], [t44], [t45], [t46], [t49], [t47], [t50], [t48], [t51], [t52] | OK |
 | `autoresearch/data_analysis.py` | [data-analysis.md](docs/specs/data-analysis.md) | [t53], [t54], [t55] | OK |
-| `autoresearch/distributed` | [distributed.md](docs/specs/distributed.md) | [p10], [p11], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
-| `autoresearch/distributed/broker.py` | [distributed.md](docs/specs/distributed.md) | [p10], [p11], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
-| `autoresearch/distributed/coordinator.py` | [distributed.md](docs/specs/distributed.md) | [p10], [p11], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
-| `autoresearch/distributed/executors.py` | [distributed.md](docs/specs/distributed.md) | [p10], [p11], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
-| `autoresearch/error_recovery.py` | [error-recovery.md](docs/specs/error-recovery.md) | [p12], [t61] | OK |
+| `autoresearch/distributed` | [distributed.md](docs/specs/distributed.md) | [p11], [p12], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
+| `autoresearch/distributed/broker.py` | [distributed.md](docs/specs/distributed.md) | [p11], [p12], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
+| `autoresearch/distributed/coordinator.py` | [distributed.md](docs/specs/distributed.md) | [p11], [p12], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
+| `autoresearch/distributed/executors.py` | [distributed.md](docs/specs/distributed.md) | [p11], [p12], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
+| `autoresearch/error_recovery.py` | [error-recovery.md](docs/specs/error-recovery.md) | [p13], [t61] | OK |
 | `autoresearch/error_utils.py` | [error-utils.md](docs/specs/error-utils.md) | [t62] | OK |
 | `autoresearch/errors.py` | [errors.md](docs/specs/errors.md) | [t43], [t47], [t63] | OK |
 | `autoresearch/examples` | [examples.md](docs/specs/examples.md) | [t64] | OK |
 | `autoresearch/extensions.py` | [extensions.md](docs/specs/extensions.md) | [t65], [t66], [t67] | OK |
 | `autoresearch/interfaces.py` | [interfaces.md](docs/specs/interfaces.md) | [t68] | OK |
 | `autoresearch/kg_reasoning.py` | [kg-reasoning.md](docs/specs/kg-reasoning.md) | [t69] | OK |
-| `autoresearch/llm` | [llm.md](docs/specs/llm.md) | [p13], [p14], [t9], [t70], [t71], [t72] | OK |
-| `autoresearch/llm/adapters.py` | [llm.md](docs/specs/llm.md) | [p13], [p14], [t9], [t70], [t71], [t72] | OK |
-| `autoresearch/llm/capabilities.py` | [llm.md](docs/specs/llm.md) | [p13], [p14], [t9], [t70], [t71], [t72] | OK |
-| `autoresearch/llm/registry.py` | [llm.md](docs/specs/llm.md) | [p13], [p14], [t9], [t70], [t71], [t72] | OK |
-| `autoresearch/llm/token_counting.py` | [llm.md](docs/specs/llm.md) | [p13], [p14], [t9], [t70], [t71], [t72] | OK |
+| `autoresearch/llm` | [llm.md](docs/specs/llm.md) | [p14], [p15], [t9], [t70], [t71], [t72] | OK |
+| `autoresearch/llm/adapters.py` | [llm.md](docs/specs/llm.md) | [p14], [p15], [t9], [t70], [t71], [t72] | OK |
+| `autoresearch/llm/capabilities.py` | [llm.md](docs/specs/llm.md) | [p14], [p15], [t9], [t70], [t71], [t72] | OK |
+| `autoresearch/llm/registry.py` | [llm.md](docs/specs/llm.md) | [p14], [p15], [t9], [t70], [t71], [t72] | OK |
+| `autoresearch/llm/token_counting.py` | [llm.md](docs/specs/llm.md) | [p14], [p15], [t9], [t70], [t71], [t72] | OK |
 | `autoresearch/logging_utils.py` | [logging-utils.md](docs/specs/logging-utils.md) | [t73], [t74] | OK |
 | `autoresearch/main` | [main.md](docs/specs/main.md) | [t75], [t76], [t77] | OK |
 | `autoresearch/mcp_interface.py` | [mcp-interface.md](docs/specs/mcp-interface.md) | [t78], [t79] | OK |
-| `autoresearch/models.py` | [models.md](docs/specs/models.md) | [p15], [t80] | OK |
-| `autoresearch/monitor` | [monitor.md](docs/specs/monitor.md) | [p16], [s10], [t81], [t82], [t83], [t84] | OK |
-| `autoresearch/monitor/cli.py` | [monitor.md](docs/specs/monitor.md) | [p16], [s10], [t81], [t82], [t83], [t84] | OK |
-| `autoresearch/monitor/metrics.py` | [monitor.md](docs/specs/monitor.md) | [p16], [s10], [t81], [t82], [t83], [t84] | OK |
-| `autoresearch/monitor/node_health.py` | [monitor.md](docs/specs/monitor.md) | [p16], [s10], [t81], [t82], [t83], [t84] | OK |
-| `autoresearch/monitor/system_monitor.py` | [monitor.md](docs/specs/monitor.md) | [p16], [s10], [t81], [t82], [t83], [t84] | OK |
-| `autoresearch/orchestration` | [orchestration.md](docs/specs/orchestration.md) | [p17], [s11], [t85], [t86], [t87], [t88], [t89] | OK |
-| `autoresearch/orchestration/metrics.py` | [metrics.md](docs/specs/metrics.md) | [p14], [s12], [t90], [t91] | OK |
+| `autoresearch/models.py` | [models.md](docs/specs/models.md) | [p16], [t80] | OK |
+| `autoresearch/monitor` | [monitor.md](docs/specs/monitor.md) | [p17], [s10], [t81], [t82], [t83], [t84] | OK |
+| `autoresearch/monitor/cli.py` | [monitor.md](docs/specs/monitor.md) | [p17], [s10], [t81], [t82], [t83], [t84] | OK |
+| `autoresearch/monitor/metrics.py` | [monitor.md](docs/specs/monitor.md) | [p17], [s10], [t81], [t82], [t83], [t84] | OK |
+| `autoresearch/monitor/node_health.py` | [monitor.md](docs/specs/monitor.md) | [p17], [s10], [t81], [t82], [t83], [t84] | OK |
+| `autoresearch/monitor/system_monitor.py` | [monitor.md](docs/specs/monitor.md) | [p17], [s10], [t81], [t82], [t83], [t84] | OK |
+| `autoresearch/orchestration` | [orchestration.md](docs/specs/orchestration.md) | [p18], [s11], [t85], [t86], [t87], [t88], [t89] | OK |
+| `autoresearch/orchestration/metrics.py` | [metrics.md](docs/specs/metrics.md) | [p15], [s12], [t90], [t91] | OK |
 | `autoresearch/orchestrator_perf.py` | [orchestrator-perf.md](docs/specs/orchestrator-perf.md)<br>[orchestrator_scheduling.md](docs/specs/orchestrator_scheduling.md) | [s13], [t92], [t93], [t94] | OK |
 | `autoresearch/output_format.py` | [output-format.md](docs/specs/output-format.md) | [t95], [t96] | OK |
-| `autoresearch/resource_monitor.py` | [resource-monitor.md](docs/specs/resource-monitor.md) | [p18], [s14], [t81], [t84] | OK |
+| `autoresearch/resource_monitor.py` | [resource-monitor.md](docs/specs/resource-monitor.md) | [p19], [s14], [t81], [t84] | OK |
 | `autoresearch/scheduler_benchmark.py` | [scheduler-benchmark.md](docs/specs/scheduler-benchmark.md) | [t94] | OK |
 | `autoresearch/search` | [search.md](docs/specs/search.md) | [t97], [t98], [t99], [t100], [t101], [t41], [t102], [t103] | OK |
 | `autoresearch/search/ranking_convergence.py` | [search_ranking.md](docs/specs/search_ranking.md) | [t97], [t99], [t104] | OK |
-| `autoresearch/storage.py` | [storage.md](docs/specs/storage.md) | [p19], [s15], [s16], [s17], [s18], [t100], [t105], [t106], [t103], [t107], [t108], [t109], [t110], [t111] | OK |
+| `autoresearch/storage.py` | [storage.md](docs/specs/storage.md) | [p20], [s15], [s16], [s17], [s18], [t100], [t105], [t106], [t103], [t107], [t108], [t109], [t110], [t111] | OK |
 | `autoresearch/storage_backends.py` | [storage-backends.md](docs/specs/storage-backends.md) | [s19], [t106], [t65], [t66] | OK |
 | `autoresearch/storage_backup.py` | [storage-backup.md](docs/specs/storage-backup.md) | [t112] | OK |
 | `autoresearch/storage_utils.py` | [storage-utils.md](docs/specs/storage-utils.md) | [t113] | OK |
@@ -73,7 +73,7 @@
 | `autoresearch/test_tools.py` | [test-tools.md](docs/specs/test-tools.md) | [t116] | OK |
 | `autoresearch/token_budget.py` | [token-budget.md](docs/specs/token-budget.md) | [s12], [t90] | OK |
 | `autoresearch/tracing.py` | [tracing.md](docs/specs/tracing.md) | [t117] | OK |
-| `autoresearch/visualization.py` | [visualization.md](docs/specs/visualization.md) | [p20], [t118], [t119] | OK |
+| `autoresearch/visualization.py` | [visualization.md](docs/specs/visualization.md) | [p21], [t118], [t119] | OK |
 | `git` | [git.md](docs/specs/git.md) | [t120], [t121] | OK |
 | `git/search.py` | [git-search.md](docs/specs/git-search.md) | [t121] | OK |
 
@@ -127,6 +127,7 @@
 [t36]: tests/unit/test_cli_helpers.py
 [t37]: tests/unit/test_cli_utils_extra.py
 [p8]: docs/algorithms/config_hot_reload.md
+[p9]: docs/algorithms/config_weight_sum_simulation.md
 [t38]: tests/analysis/config_hot_reload_metrics.json
 [t39]: tests/analysis/test_config_hot_reload_sim.py
 [t40]: tests/behavior/features/configuration_hot_reload.feature
@@ -138,7 +139,7 @@
 [t46]: tests/unit/test_config_reload.py
 [t47]: tests/unit/test_config_validation_errors.py
 [t48]: tests/unit/test_config_watcher_cleanup.py
-[p9]: docs/algorithms/config_utils.md
+[p10]: docs/algorithms/config_utils.md
 [t49]: tests/unit/test_config_utils.py
 [t50]: tests/unit/test_config_validators_additional.py
 [t51]: tests/unit/test_streamlit_app_edgecases.py
@@ -146,8 +147,8 @@
 [t53]: tests/behavior/features/data_analysis.feature
 [t54]: tests/unit/test_data_analysis.py
 [t55]: tests/unit/test_kuzu_polars.py
-[p10]: docs/algorithms/distributed_coordination.md
-[p11]: docs/algorithms/distributed_overhead.md
+[p11]: docs/algorithms/distributed_coordination.md
+[p12]: docs/algorithms/distributed_overhead.md
 [s6]: scripts/distributed_coordination_formulas.py
 [s7]: scripts/distributed_coordination_sim.py
 [s8]: scripts/distributed_recovery_benchmark.py
@@ -157,7 +158,7 @@
 [t58]: tests/integration/test_distributed_agent_storage.py
 [t59]: tests/unit/distributed/test_coordination_properties.py
 [t60]: tests/unit/test_distributed_extra.py
-[p12]: docs/algorithms/error_recovery.md
+[p13]: docs/algorithms/error_recovery.md
 [t61]: tests/unit/test_error_recovery.py
 [t62]: tests/unit/test_error_utils_additional.py
 [t63]: tests/unit/test_errors.py
@@ -167,8 +168,8 @@
 [t67]: tests/unit/test_vss_extension_loader.py
 [t68]: tests/unit/test_interfaces.py
 [t69]: tests/unit/test_kg_reasoning.py
-[p13]: docs/algorithms/llm_adapter.md
-[p14]: docs/algorithms/token_budgeting.md
+[p14]: docs/algorithms/llm_adapter.md
+[p15]: docs/algorithms/token_budgeting.md
 [t70]: tests/unit/test_llm_adapter.py
 [t71]: tests/unit/test_llm_capabilities.py
 [t72]: tests/unit/test_token_usage.py
@@ -179,15 +180,15 @@
 [t77]: tests/unit/test_main_config_commands.py
 [t78]: tests/behavior/features/mcp_interface.feature
 [t79]: tests/unit/test_mcp_interface.py
-[p15]: docs/algorithms/models.md
+[p16]: docs/algorithms/models.md
 [t80]: tests/unit/test_models_docstrings.py
-[p16]: docs/algorithms/monitor_cli.md
+[p17]: docs/algorithms/monitor_cli.md
 [s10]: scripts/monitor_cli_reliability.py
 [t81]: tests/integration/test_monitor_metrics.py
 [t82]: tests/unit/test_main_monitor_commands.py
 [t83]: tests/unit/test_monitor_cli.py
 [t84]: tests/unit/test_resource_monitor_gpu.py
-[p17]: docs/algorithms/orchestration.md
+[p18]: docs/algorithms/orchestration.md
 [s11]: scripts/orchestration_sim.py
 [t85]: tests/unit/orchestration/test_budgeting_algorithm.py
 [t86]: tests/unit/orchestration/test_circuit_breaker_determinism.py
@@ -203,7 +204,7 @@
 [t94]: tests/unit/test_scheduler_benchmark.py
 [t95]: tests/behavior/features/output_formatting.feature
 [t96]: tests/unit/test_output_format.py
-[p18]: docs/algorithms/resource_monitor.md
+[p19]: docs/algorithms/resource_monitor.md
 [s14]: scripts/resource_monitor_bounds.py
 [t97]: tests/behavior/features/hybrid_search.feature
 [t98]: tests/behavior/features/local_sources.feature
@@ -213,7 +214,7 @@
 [t102]: tests/integration/test_search_regression.py
 [t103]: tests/integration/test_search_storage.py
 [t104]: tests/benchmark/test_hybrid_ranking.py
-[p19]: docs/algorithms/storage.md
+[p20]: docs/algorithms/storage.md
 [s15]: scripts/ram_budget_enforcement_sim.py
 [s16]: scripts/schema_idempotency_sim.py
 [s17]: scripts/storage_concurrency_sim.py
@@ -232,7 +233,7 @@
 [t115]: tests/behavior/features/synthesis.feature
 [t116]: tests/unit/test_test_tools.py
 [t117]: tests/behavior/features/tracing.feature
-[p20]: docs/algorithms/visualization.md
+[p21]: docs/algorithms/visualization.md
 [t118]: tests/behavior/features/visualization_cli.feature
 [t119]: tests/unit/test_visualization.py
 [t120]: tests/integration/test_local_git_backend.py

--- a/docs/algorithms/config_weight_sum_simulation.md
+++ b/docs/algorithms/config_weight_sum_simulation.md
@@ -1,0 +1,166 @@
+# Config Weight Sum Simulation
+
+## Purpose
+
+This note documents a reproducible simulation verifying the invariants cited by
+[config specification](../specs/config.md).
+
+## Method
+
+We executed `uv run python` with the script below to instantiate `SearchConfig`
+and `ConfigModel` variants. The script inspects ranking weight normalization,
+token budget validation, and eviction policy canonicalisation.
+
+### Script
+
+```python
+from __future__ import annotations
+
+import json
+
+from autoresearch.config.models import ConfigModel, SearchConfig
+from autoresearch.errors import ConfigError
+
+weights: dict[str, object] = {}
+default = SearchConfig()
+weights["default"] = {
+    "sum": round(
+        default.semantic_similarity_weight
+        + default.bm25_weight
+        + default.source_credibility_weight,
+        6,
+    ),
+    "weights": {
+        "semantic": default.semantic_similarity_weight,
+        "bm25": default.bm25_weight,
+        "source": default.source_credibility_weight,
+    },
+}
+partial = SearchConfig(semantic_similarity_weight=0.6, bm25_weight=0.2)
+weights["partial_override"] = {
+    "sum": round(
+        partial.semantic_similarity_weight
+        + partial.bm25_weight
+        + partial.source_credibility_weight,
+        6,
+    ),
+    "weights": {
+        "semantic": partial.semantic_similarity_weight,
+        "bm25": partial.bm25_weight,
+        "source": partial.source_credibility_weight,
+    },
+}
+try:
+    SearchConfig(semantic_similarity_weight=0.9, bm25_weight=0.3)
+except ConfigError:
+    weights["overweight_guard"] = "ConfigError raised"
+else:
+    weights["overweight_guard"] = "missing error"
+zeros = SearchConfig(
+    semantic_similarity_weight=0.0,
+    bm25_weight=0.0,
+    source_credibility_weight=0.0,
+)
+weights["zero_rebalanced"] = {
+    "sum": round(
+        zeros.semantic_similarity_weight
+        + zeros.bm25_weight
+        + zeros.source_credibility_weight,
+        6,
+    ),
+    "weights": {
+        "semantic": zeros.semantic_similarity_weight,
+        "bm25": zeros.bm25_weight,
+        "source": zeros.source_credibility_weight,
+    },
+}
+
+budgets: dict[str, object] = {}
+model = ConfigModel(token_budget=1024)
+budgets["positive_int"] = model.token_budget
+model = ConfigModel(token_budget="2048")
+budgets["numeric_string"] = model.token_budget
+for value in [0, -1, "-16"]:
+    try:
+        ConfigModel(token_budget=value)
+    except ConfigError:
+        budgets[f"invalid_{value}"] = "ConfigError raised"
+    else:
+        budgets[f"invalid_{value}"] = "missing error"
+
+policies = {
+    "score_normalized": ConfigModel(
+        graph_eviction_policy="score",
+    ).graph_eviction_policy,
+    "lru_casefold": ConfigModel(
+        graph_eviction_policy="lRu",
+    ).graph_eviction_policy,
+}
+
+print(
+    json.dumps(
+        {
+            "ranking_weights": weights,
+            "token_budget": budgets,
+            "eviction_policy": policies,
+        },
+        indent=2,
+        sort_keys=True,
+    )
+)
+```
+
+### Output
+
+```json
+{
+  "eviction_policy": {
+    "lru_casefold": "LRU",
+    "score_normalized": "score"
+  },
+  "ranking_weights": {
+    "default": {
+      "sum": 1.0,
+      "weights": {
+        "bm25": 0.3,
+        "semantic": 0.5,
+        "source": 0.2
+      }
+    },
+    "overweight_guard": "ConfigError raised",
+    "partial_override": {
+      "sum": 1.0,
+      "weights": {
+        "bm25": 0.2,
+        "semantic": 0.6,
+        "source": 0.19999999999999996
+      }
+    },
+    "zero_rebalanced": {
+      "sum": 1.0,
+      "weights": {
+        "bm25": 0.3333333333333333,
+        "semantic": 0.3333333333333333,
+        "source": 0.3333333333333333
+      }
+    }
+  },
+  "token_budget": {
+    "invalid_-1": "ConfigError raised",
+    "invalid_-16": "ConfigError raised",
+    "invalid_0": "ConfigError raised",
+    "numeric_string": 2048,
+    "positive_int": 1024
+  }
+}
+```
+
+## Findings
+
+- Default and partially overridden ranking weights normalise to a sum of `1.0`.
+- Overweight inputs raise `ConfigError`, preventing silent renormalisation.
+- Zero weights rebalance evenly so hybrid search remains deterministic.
+- Token budgets accept positive integers (or numeric strings) and reject
+  non-positive entries.
+- Graph eviction policies normalise case, providing canonical identifiers to
+  downstream consumers.

--- a/docs/specs/config.md
+++ b/docs/specs/config.md
@@ -9,6 +9,55 @@ Helper APIs expose the active configuration, temporary overrides, and profile
 management. See [config hot reload](../algorithms/config_hot_reload.md) for the
 underlying watcher model.
 
+## Models
+
+### ConfigModel
+
+- Pydantic container for runtime switches such as `backend`, `llm_backend`,
+  token budgeting, tracing flags, and agent orchestration parameters.
+- Wraps nested models (`StorageConfig`, `SearchConfig`, `APIConfig`,
+  `DistributedConfig`, `AnalysisConfig`) and per-agent overrides via
+  `agent_config`.
+- Applies validators that canonicalise `graph_eviction_policy`, enforce
+  positive `token_budget` values, and convert string reasoning modes before
+  instances are exposed to callers.
+- Stores observer hooks, profile selection, and monitoring thresholds while
+  ignoring extra keys through `SettingsConfigDict(extra="ignore")`.
+
+### SearchConfig
+
+- Chooses backends, embedding providers, result limits, and concurrency
+  controls for retrieval.
+- Coordinates hybrid ranking via `semantic_similarity_weight`,
+  `bm25_weight`, and `source_credibility_weight`. Missing weights inherit
+  defaults, and `_normalize_ranking_weights` ensures they remain positive and
+  sum to `1.0`, raising `ConfigError` when user supplied totals exceed one.
+- Provides toggles for user feedback, search history, and context awareness.
+  `ContextAwareSearchConfig` tunes expansion, entity recognition, and topic
+  modelling weights while respecting per-field bounds.
+- `LocalFileConfig` and `LocalGitConfig` capture connector specific paths,
+  extensions, and history depth.
+
+### StorageConfig
+
+- Describes DuckDB index options, vector extension availability, RDF store
+  settings, and ontology reasoning limits.
+- `validate_rdf_backend` constrains `rdf_backend` to supported engines and
+  surfaces actionable errors when misconfigured.
+
+### AgentConfig and APIConfig
+
+- `AgentConfig` records enablement and per-agent model overrides.
+- `APIConfig` manages webhook addresses, authentication, rate limits, and role
+  permissions for HTTP exposure.
+
+### DistributedConfig and AnalysisConfig
+
+- `DistributedConfig` toggles Ray based execution, broker selection, and worker
+  counts for distributed runs.
+- `AnalysisConfig` currently advertises whether Polars based pipelines are
+  enabled.
+
 ## Algorithms
 
 ### load_config
@@ -20,8 +69,8 @@ underlying watcher model.
 3. Parse TOML content, logging errors via `ConfigError`.
 4. Merge environment overrides into the parsed structure, expanding storage,
    API, distributed, analysis, and agent sections.
-5. Instantiate `AgentConfig` entries, collecting valid values even when some
-   fields fail validation.
+5. Instantiate nested models and validators, collecting valid values even when
+   some fields fail validation.
 6. Apply active profile overrides when `profiles.<name>` exists in the file or
    was previously selected with `set_active_profile`.
 7. Create and return a `ConfigModel`; on validation failure, log the error and
@@ -60,6 +109,18 @@ underlying watcher model.
 3. `get_config` returns the context override when present, otherwise defers to
    the singleton `ConfigLoader().config`.
 
+## Validators
+
+- `normalize_ranking_weights` renormalises ranking weights, fills unspecified
+  fields in proportion to defaults, and rejects totals above `1.0`.
+- `validate_rdf_backend` restricts storage engines to known RDF backends.
+- `validate_reasoning_mode` lowercases or casts inputs into `ReasoningMode`
+  enumerations, reporting invalid strings.
+- `validate_token_budget` coerces numeric strings, rejects non-integer values,
+  and raises when non-positive limits are supplied.
+- `validate_eviction_policy` accepts friendly names, normalises case, and maps
+  them to canonical graph eviction policy tokens.
+
 ## Invariants
 
 - `ConfigLoader` behaves as a process-wide singleton unless `new_for_tests` or
@@ -67,9 +128,14 @@ underlying watcher model.
   operation.
 - Environment variables override file values without mutating the original
   parsed dictionary.
-- Relevance ranking weights must not exceed a combined value of 1.0; a
-  `ConfigError` is raised when overweight vectors are provided instead of
-  silently renormalising them.
+- Search ranking weights always sum to `1.0`, missing entries inherit defaults,
+  and totals above `1.0` raise `ConfigError` before normalization.[p1]
+- Zeroed ranking weights rebalance to equal shares so hybrid search remains
+  deterministic.[p1]
+- Token budgets must be positive integers or omitted; non-positive or malformed
+  values surface `ConfigError` instead of clipping silently.[p1]
+- Graph eviction policies are validated and case-normalised so downstream
+  components receive canonical identifiers.[p1]
 - Observer notifications always receive validated `ConfigModel` instances.
 - Watch threads stop cleanly and clear `app.state.watch_ctx` during shutdown.
 - Active profiles inherit base settings and only override declared keys.
@@ -79,16 +145,18 @@ underlying watcher model.
 `ConfigLoader` adheres to the atomic reload guarantees outlined in
 [config hot reload](../algorithms/config_hot_reload.md). Parsing occurs before
 state swaps, observers run after validation, and context overrides ensure
-callers within `temporary_config` observe a consistent snapshot. Tests cover
-error handling, defaults, environment overrides, and watcher cleanup, providing
-empirical confirmation of the invariants.
+callers within `temporary_config` observe a consistent snapshot. Validators on
+`ConfigModel` and `SearchConfig` enforce canonical states prior to publishing
+updates, preventing downstream drift.
 
 ## Simulation Expectations
 
-Hot-reload simulations toggle configuration values and record transitions from 1
-to 2 in [config_hot_reload_metrics.json][r1], verifying that observers receive
-updated state exactly once per change. Analysis tests exercise watcher threads
-and ensure missing files fall back to defaults without crashing the process.
+- [Config weight and validator simulation][p1] demonstrates ranking weight,
+  eviction policy, and token budget invariants remain enforced across
+  configuration reloads.
+- Hot-reload simulations toggle configuration values and record transitions in
+  [config_hot_reload_metrics.json][r1], verifying that observers receive updated
+  state exactly once per change.
 
 ## Traceability
 
@@ -108,6 +176,9 @@ and ensure missing files fall back to defaults without crashing the process.
   - [tests/behavior/features/configuration_hot_reload.feature][t8]
   - [tests/integration/test_config_hot_reload_components.py][t9]
   - [tests/analysis/test_config_hot_reload_sim.py][t10]
+- Proofs and simulations
+  - [tests/analysis/config_hot_reload_metrics.json][r1]
+  - [docs/algorithms/config_weight_sum_simulation.md][p1]
 
 [m1]: ../../src/autoresearch/config/__init__.py
 [m2]: ../../src/autoresearch/config/loader.py
@@ -124,3 +195,4 @@ and ensure missing files fall back to defaults without crashing the process.
 [t9]: ../../tests/integration/test_config_hot_reload_components.py
 [t10]: ../../tests/analysis/test_config_hot_reload_sim.py
 [r1]: ../../tests/analysis/config_hot_reload_metrics.json
+[p1]: ../algorithms/config_weight_sum_simulation.md


### PR DESCRIPTION
## Summary
- expand the configuration specification with detailed model and validator descriptions, including the ranking weight constraints
- add a reproducible simulation note that exercises ranking, token budget, and eviction policy invariants and reference it from the spec
- regenerate SPEC_COVERAGE.md so the new proof document is indexed alongside existing tests

## Testing
- `uv run task lint-specs`


------
https://chatgpt.com/codex/tasks/task_e_68c8a91ca7e08333be79273e30dfeba4