### PR TITLE
Update release status after targeted tests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,27 +11,23 @@ and recent changes. Installation and environment details are covered in the
 See [STATUS.md](STATUS.md) for current results and
 [CHANGELOG.md](CHANGELOG.md) for recent updates. 0.1.0a1 remains untagged and
 targets **September 15, 2026**, with **0.1.0** planned for **October 1, 2026**
-across project documentation. The evaluation container no longer includes the
-Go Task CLI by default, so install it manually or run automation via
-`uv run task ...`. After syncing the `dev-minimal`, `test`, and `docs` extras,
-`uv run --extra test pytest
-tests/unit/test_config_validation_errors.py::test_weights_must_sum_to_one -q`
-still fails because the validation helper never raises `ConfigError`, and
-`uv run --extra test pytest tests/unit/test_download_duckdb_extensions.py -q`
-continues to fail its offline fallback scenarios with `SameFileError` and
-non-zero stub sizes. The unit test
+across project documentation. The evaluation container still lacks the Go Task
+CLI on first boot, so `uv run task check` fails until `scripts/setup.sh` or a
+manual install provides the binary. Targeted unit tests on **September 16,
+2025** show the ranking weight regression and DuckDB offline fallback suite now
+pass, while
 `tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::
-test_verify_extension_failure` also fails because the loader executes a second
-verification query. Running the unit suite without extras logs
-`PytestConfigWarning: Unknown config option: bdd_features_base_dir`; install
-the `[test]` extras so `pytest-bdd` registers the option. `uv run --extra docs
-mkdocs build` succeeds but reports more than forty pages missing from `nav` and
-broken links such as `specs/api_authentication.md`. The open
+test_load_extension_download_unhandled_exception` fails because
+`VSSExtensionLoader.load_extension` suppresses unexpected runtime errors.
+Running `pytest` without the `[test]` extras continues to trigger
+`PytestConfigWarning: Unknown config option: bdd_features_base_dir` until
+`pytest-bdd` is installed, and documentation builds require syncing the docs
+extras because `mkdocs` is not yet available. The open
 [fix-search-ranking-and-extension-tests](issues/fix-search-ranking-and-extension-tests.md),
-[fix-config-weight-sum-validation](issues/fix-config-weight-sum-validation.md),
+[resolve-resource-tracker-errors-in-verify](issues/resolve-resource-tracker-errors-in-verify.md),
 and
-[fix-duckdb-extension-offline-fallback](issues/fix-duckdb-extension-offline-fallback.md)
-issues track the remaining regressions. Scheduler resource benchmarks
+[resolve-deprecation-warnings-in-tests](issues/resolve-deprecation-warnings-in-tests.md)
+issues track the remaining release blockers. Scheduler resource benchmarks
 (`scripts/scheduling_resource_benchmark.py`) offer utilization and memory
 estimates documented in `docs/orchestrator_perf.md`. Dependency pins:
 `fastapi>=0.115.12` and `slowapi==0.1.9`. Use Python 3.12+ with:

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,6 +7,31 @@ Run `task check` for linting and smoke tests, then `task verify` before
 committing. Include `EXTRAS="llm"` only when LLM features or dependency
 checks are required.
 
+## September 16, 2025
+- `uv run task check` still fails because the Go Task CLI is absent in the
+  container (`No such file or directory`).
+- `uv run pytest tests/unit/test_config_validation_errors.py::
+  test_weights_must_sum_to_one -q` now passes but emits
+  `PytestConfigWarning: Unknown config option: bdd_features_base_dir` until the
+  `[test]` extras install `pytest-bdd`.
+- `uv run pytest tests/unit/test_download_duckdb_extensions.py -q` passes with
+  the same missing-plugin warning, confirming the offline fallback stubs now
+  satisfy the tests.
+- `uv run pytest tests/unit/test_vss_extension_loader.py -q` fails in
+  `TestVSSExtensionLoader.test_load_extension_download_unhandled_exception`
+  because `VSSExtensionLoader.load_extension` suppresses unexpected runtime
+  errors instead of re-raising them, so the expected `RuntimeError` is not
+  propagated.
+- `uv run pytest tests/unit/test_api_auth_middleware.py::
+  test_dispatch_invalid_token -q` succeeds, indicating the earlier
+  `AuthMiddleware` regression has been resolved.
+- `uv run python -c "import pkgutil; ..."` confirms `pytest-bdd` is missing in
+  the unsynced environment; run `uv sync --extra test` or `scripts/setup.sh`
+  before executing tests to avoid warnings.
+- `uv run mkdocs build` fails with `No such file or directory` because docs
+  extras are not installed yet; sync them (e.g. `uv sync --extra docs`) before
+  building the documentation.
+
 ## September 15, 2025
 - The evaluation container does not ship with the Go Task CLI;
   `task --version` reports `command not found`. Use `scripts/setup.sh` or

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,27 +1,24 @@
 # Autoresearch Project - Task Progress
 
 This document tracks the progress of tasks for the Autoresearch project,
-organized by phases from the code complete plan. As of **September 15, 2025** the
-evaluation container does not include the Go Task CLI by default—`task
---version` reports `command not found`. Running `uv sync --extra dev-minimal
---extra test --extra docs` prepares the virtual environment, after which
-`uv run --extra test pytest
-tests/unit/test_config_validation_errors.py::test_weights_must_sum_to_one -q`
-still fails because the validation helper does not raise `ConfigError`. The
-DuckDB extension suite (`uv run --extra test pytest
-tests/unit/test_download_duckdb_extensions.py -q`) continues to trigger
-`SameFileError` and leaves non-zero stub files, and the VSS loader still
-executes an extra verification query in
+organized by phases from the code complete plan. As of **September 16, 2025**
+the evaluation container still lacks the Go Task CLI by default, so
+`uv run task check` fails until `scripts/setup.sh` installs the binary.
+Targeted unit tests now confirm that
+`tests/unit/test_config_validation_errors.py::test_weights_must_sum_to_one`
+and the DuckDB offline fallback suite both pass, but
 `tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::
-test_verify_extension_failure`. Running the tests without the `[test]` extras
-emits `PytestConfigWarning: Unknown config option: bdd_features_base_dir`; sync
-the extras before local runs. Unit coverage and `task verify` remain blocked
-until these regressions are resolved.
+test_load_extension_download_unhandled_exception` fails because
+`VSSExtensionLoader.load_extension` suppresses unexpected runtime errors. The
+API authentication middleware test succeeds. Running `pytest` without the
+`[test]` extras still triggers `PytestConfigWarning: Unknown config option:
+bdd_features_base_dir` because `pytest-bdd` is not yet installed, and
+`uv run mkdocs build` fails until the docs extras sync `mkdocs` onto the PATH.
+Unit coverage and `task verify` remain blocked while these regressions persist.
 See [docs/release_plan.md](docs/release_plan.md) for current test and coverage
-status, including the `uv run --extra docs mkdocs build` warnings about missing
-navigation entries and stale links. An **0.1.0-alpha.1** preview is
-re-targeted for **September 15, 2026**, with the final **0.1.0** release
-targeted for **October 1, 2026**.
+status and the alpha release checklist. An **0.1.0-alpha.1** preview remains
+targeted for **September 15, 2026**, with the final **0.1.0** release targeted
+for **October 1, 2026**.
 
 ## Phase 1: Core System Completion (Weeks 1-2)
 

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -9,7 +9,7 @@ The publishing workflow follows the steps in
 ROADMAP.md for high-level milestones.
 
 The project kicked off in **May 2025** (see the initial commit dated
-`2025-05-18`). This schedule was last updated on **September 15, 2025** and
+`2025-05-18`). This schedule was last updated on **September 16, 2025** and
 reflects that the codebase currently sits at the **unreleased 0.1.0a1** version
 defined in `autoresearch.__version__`. The project targets **0.1.0a1** for
 **September 15, 2026** and **0.1.0** for **October 1, 2026**. See
@@ -20,25 +20,21 @@ STATUS.md, ROADMAP.md, and CHANGELOG.md for aligned progress. Phase 3
 
 The dependency pins for `fastapi` (>=0.115.12) and `slowapi` (==0.1.9) remain
 confirmed in `pyproject.toml` and [installation.md](installation.md), but the
-evaluation environment no longer includes the Go Task CLI by default.
-`task --version` fails unless contributors install Task manually or run
-commands via `uv run task ...`. After `uv sync --extra dev-minimal --extra test
---extra docs`, `uv run --extra test pytest
-tests/unit/test_config_validation_errors.py::test_weights_must_sum_to_one -q`
-still reports that the validation path never raises `ConfigError`. The DuckDB
-extension helper suite (`uv run --extra test pytest
-tests/unit/test_download_duckdb_extensions.py -q`) continues to raise
-`SameFileError` during network fallbacks and leaves four-byte stub files, and
-the VSS loader still performs a second verification query in
+evaluation environment still omits the Go Task CLI. `uv run task check` fails
+with `No such file or directory` until `scripts/setup.sh` installs the binary.
+Targeted unit runs on **September 16, 2025** show that
+`tests/unit/test_config_validation_errors.py::test_weights_must_sum_to_one` and
+the DuckDB offline fallback suite now pass, while
 `tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::
-test_verify_extension_failure`. Running the unit suite without extras emits
-`PytestConfigWarning: Unknown config option: bdd_features_base_dir`; install
-the `[test]` extras so `pytest-bdd` registers that option. `uv run --extra docs
-mkdocs build` succeeds but lists more than forty pages missing from the
-navigation alongside broken links such as `specs/api_authentication.md`.
-`task verify` has not been rerun because the missing CLI blocks the workflow,
-and coverage numbers are currently unavailable. These regressions are tracked
-in the open issues referenced by STATUS.md.
+test_load_extension_download_unhandled_exception` fails because
+`VSSExtensionLoader.load_extension` suppresses unexpected runtime errors. The
+API authentication middleware test passes. Running the unit suite without the
+`[test]` extras continues to emit `PytestConfigWarning: Unknown config option:
+bdd_features_base_dir` because `pytest-bdd` is not installed, and
+`uv run mkdocs build` fails until the docs extras add `mkdocs` to the PATH.
+`task verify` remains blocked by the missing CLI and the outstanding extension
+regression, so coverage numbers are still unavailable. These items are tracked
+in [STATUS.md](../STATUS.md) and the open issues listed there.
 ## Milestones
 
 - **0.1.0a1** (2026-09-15, status: in progress): Alpha preview to collect

--- a/issues/archive/fix-config-weight-sum-validation.md
+++ b/issues/archive/fix-config-weight-sum-validation.md
@@ -17,4 +17,4 @@ None
 - Update release notes or specs if validation rules changed.
 
 ## Status
-Open
+Archived

--- a/issues/archive/fix-duckdb-extension-offline-fallback.md
+++ b/issues/archive/fix-duckdb-extension-offline-fallback.md
@@ -20,4 +20,4 @@ None
   corrected offline flow.
 
 ## Status
-Open
+Archived

--- a/issues/fix-search-ranking-and-extension-tests.md
+++ b/issues/fix-search-ranking-and-extension-tests.md
@@ -10,22 +10,23 @@ and the integration scenarios in
 documented in the specs. Optional extras also load successfully during
 `tests/integration/test_optional_extras.py`.
 
-Remaining regressions focus on extension bootstrapping. The unit test
-`tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::
-test_verify_extension_failure` still fails because
-`VSSExtensionLoader.verify_extension` executes an extra fallback query, so the
-mocked cursor records two calls instead of one—the expected
-`duckdb_extensions()` probe followed by a stub verification query. The DuckDB
-download helpers also mis-handle offline fallbacks and create non-empty stub
-files; track those failures separately in
-`fix-duckdb-extension-offline-fallback`.
+Remaining regressions focus on extension bootstrapping. Running
+`uv run pytest tests/unit/test_vss_extension_loader.py -q` on
+2025-09-16 fails in
+`TestVSSExtensionLoader.test_load_extension_download_unhandled_exception`
+because `VSSExtensionLoader.load_extension` now catches unexpected runtime
+errors, logs them, and falls back to stub creation instead of re-raising. The
+double `duckdb_extensions()` verification call no longer reproduces, and the
+DuckDB download helper suite passes after the offline fallback fixes (see
+`issues/archive/fix-duckdb-extension-offline-fallback.md`).
 
 ## Dependencies
 None.
 
 ## Acceptance Criteria
-- DuckDB VSS extension loader unit tests pass; offline download fallbacks are
-  handled in `fix-duckdb-extension-offline-fallback`.
+- DuckDB VSS extension loader unit tests pass, including
+  `test_load_extension_download_unhandled_exception` propagating
+  non-DuckDB errors.
 - Ranking formula tests match documented values.
 - Integration tests for extension loading, ranking consistency, and invalid
   weight detection pass.

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -4,29 +4,24 @@
 The project remains unreleased even though the codebase and documentation are
 public. To tag v0.1.0a1 we still need a coordinated push across testing,
 documentation, and packaging while keeping workflows dispatch-only. As of
-2025-09-15 the Go Task CLI is absent in a fresh environment, so contributors
-must rely on `uv run task ...` or install Task manually before running
-automation. After syncing the `dev-minimal`, `test`, and `docs` extras,
-`uv run --extra test pytest
-tests/unit/test_config_validation_errors.py::test_weights_must_sum_to_one -q`
-still fails because overweight ranking vectors no longer raise `ConfigError`,
-`uv run --extra test pytest tests/unit/test_download_duckdb_extensions.py -q`
-continues to surface `SameFileError` and non-zero offline stubs, and the VSS
-extension loader mock expectations still fail due to a second verification
-query. Running the unit entry point without extras logs
-`PytestConfigWarning: Unknown config option: bdd_features_base_dir`, and
-`uv run --extra docs mkdocs build` lists more than forty pages missing from
-`nav` alongside broken relative links. These regressions block the release
-checklist and require targeted fixes before we can draft reliable release
-notes.
+2025-09-16 the Go Task CLI is still absent in a fresh environment, so running
+`uv run task check` fails until contributors install Task manually. Targeted
+unit tests now show that the config weight regression and DuckDB offline
+fallback suite have been resolved, but
+`tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::
+test_load_extension_download_unhandled_exception` fails because
+`VSSExtensionLoader.load_extension` swallows unexpected runtime errors. API
+authentication middleware tests pass, yet running `pytest` without the `[test]`
+extra still triggers `PytestConfigWarning: Unknown config option:
+bdd_features_base_dir` because `pytest-bdd` is not present. Documentation
+tooling also remains unprovisioned; `uv run mkdocs build` cannot start until
+the docs extras are synced. These regressions block the release checklist and
+require targeted fixes before we can draft reliable release notes.
 
 ## Dependencies
 - [fix-search-ranking-and-extension-tests](fix-search-ranking-and-extension-tests.md)
-- [fix-config-weight-sum-validation](fix-config-weight-sum-validation.md)
-- [fix-duckdb-extension-offline-fallback](fix-duckdb-extension-offline-fallback.md)
 - [resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md)
 - [resolve-deprecation-warnings-in-tests](resolve-deprecation-warnings-in-tests.md)
-- [fix-mkdocs-griffe-warnings](fix-mkdocs-griffe-warnings.md)
 
 ## Acceptance Criteria
 - All dependency issues are closed.


### PR DESCRIPTION
## Summary
- refresh STATUS.md, ROADMAP.md, TASK_PROGRESS.md, and docs/release_plan.md with the September 16, 2025 test results and current environment gaps
- archive the resolved config weight and DuckDB offline fallback tickets while updating the alpha-release and extension test issues to reflect the remaining blocker
- document the outstanding VSSExtensionLoader failure so the release plan points at the active issues

## Testing
- `uv run pytest tests/unit/test_config_validation_errors.py::test_weights_must_sum_to_one -q`
- `uv run pytest tests/unit/test_download_duckdb_extensions.py -q`
- `uv run pytest tests/unit/test_vss_extension_loader.py -q`
- `uv run pytest tests/unit/test_api_auth_middleware.py::test_dispatch_invalid_token -q`
- `uv run task check`
- `uv run mkdocs build`
- `uv run python -c "import pkgutil; import sys; print('pytest-bdd' in {m.name for m in pkgutil.iter_modules()})"`


------
https://chatgpt.com/codex/tasks/task_e_68c8cd5834a0833385c6c55265898450