### PR TITLE
Raise non-duckdb errors when loading VSS extension

### DIFF
--- a/tests/unit/test_vss_extension_loader.py
+++ b/tests/unit/test_vss_extension_loader.py
@@ -204,8 +204,10 @@ class TestVSSExtensionLoader:
         conn = MagicMock()
         conn.execute.side_effect = RuntimeError("boom")
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="boom"):
             VSSExtensionLoader.load_extension(conn)
+
+        assert conn.execute.call_count == 1
 
     @pytest.mark.real_vss
     @patch("autoresearch.extensions.ConfigLoader")


### PR DESCRIPTION
## Summary
- ensure `VSSExtensionLoader.load_extension` only falls back after DuckDB-specific errors
- document the propagated error path with an updated unit test

## Testing
- uv run --extra test pytest tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::test_load_extension_download_unhandled_exception
- task check *(fails: `task` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d17446e883338961178cc25b6af8