### PR TITLE
Patch weasel config import and modernize tests

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -10,6 +10,11 @@ checks are required.
 ## September 16, 2025
 - `uv run task check` still fails because the Go Task CLI is absent in the
   container (`No such file or directory`).
+- Added a sitecustomize importer that rewrites `weasel.util.config` to use
+  `click.shell_completion.split_arg_string`, clearing Click deprecation warnings
+  and allowing newer Click releases.
+- Bumped the Typer minimum version to 0.17.4 so the CLI depends on a release
+  that no longer references deprecated Click helpers.
 - `uv run pytest tests/unit/test_config_validation_errors.py::
   test_weights_must_sum_to_one -q` now passes but emits
   `PytestConfigWarning: Unknown config option: bdd_features_base_dir` until the

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -17,8 +17,8 @@ groups or add `gpu` packages.
 
 - No deprecation warnings are expected when running `task verify`.
 - `sitecustomize.py` re-exports `click.shell_completion.split_arg_string`
-  for compatibility so Click no longer warns about the deprecated
-  `click.parser` module during tests.
+  and rewrites `weasel.util.config` to import it so Click no longer warns
+  about the deprecated `click.parser` module during tests.
 - `pytest.ini` keeps the default `.hypothesis` ignore entry so Hypothesis'
   plugin does not emit warnings when collecting tests.
 - Record any remaining unavoidable warnings here, along with a link to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.12,<4.0"
 packages = [{include = "autoresearch", from = "src"}]
 dependencies = [
     "a2a-sdk >=0.3.0",
-    "click >=8.2.1", # sitecustomize.py re-exports shell_completion.split_arg_string
+    "click >=8.2.1",  # Patched weasel.util.config to use shell_completion helpers
     "duckdb >=1.3.0",
     "fastapi >=0.116.1", # 0.116.1+ needed for Pydantic v2 and Starlette 0.41
     "fastmcp >=2.11.2",
@@ -41,7 +41,7 @@ dependencies = [
     "tabulate >=0.9.0",
     "tinydb >=4.8.2",
     "tomli-w >=1.2.0",
-    "typer >=0.16.0",
+    "typer >=0.17.4",
     "watchfiles >=1.1.0",
     "setuptools >=80.9.0,<81",
     "owlrl >=7.1.4",

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -3,8 +3,14 @@
 from typing import TYPE_CHECKING
 import warnings
 
+_WEASEL_CONFIG_PATCH_INSTALLED = False
+
 if not TYPE_CHECKING:  # pragma: no cover - runtime import
+    import contextlib
     import importlib
+    import importlib.abc
+    import importlib.machinery
+    import importlib.util
     import sys
     import types
 
@@ -36,8 +42,94 @@ if not TYPE_CHECKING:  # pragma: no cover - runtime import
         if "split_arg_string" not in click_parser.__dict__:
             click_parser.split_arg_string = split_arg_string
 
+    def _install_weasel_config_patch() -> None:
+        """Ensure ``weasel.util.config`` imports Click helpers without warnings."""
+
+        global _WEASEL_CONFIG_PATCH_INSTALLED
+
+        if _WEASEL_CONFIG_PATCH_INSTALLED:
+            return
+
+        target_module = "weasel.util.config"
+
+        class _WeaselConfigLoader(importlib.abc.Loader):
+            """Delegate loader that patches deprecated Click imports."""
+
+            def __init__(self, delegate: importlib.abc.Loader, origin: str | None) -> None:
+                self._delegate = delegate
+                self._origin = origin
+
+            def create_module(self, spec):  # type: ignore[override]
+                create = getattr(self._delegate, "create_module", None)
+                if create is None:
+                    return None
+                return create(spec)
+
+            def exec_module(self, module) -> None:  # type: ignore[override]
+                get_source = getattr(self._delegate, "get_source", None)
+                if get_source is None:
+                    self._delegate.exec_module(module)
+                    return
+
+                source = get_source(module.__name__)
+                if not source:
+                    self._delegate.exec_module(module)
+                    return
+
+                sentinel = "from click.parser import split_arg_string"
+                if sentinel not in source:
+                    self._delegate.exec_module(module)
+                    return
+
+                replacement = (
+                    "try:\n"
+                    "    from click.shell_completion import split_arg_string\n"
+                    "except ImportError:  # pragma: no cover - fallback for older Click\n"
+                    "    from click.parser import split_arg_string\n"
+                )
+                patched_source = source.replace(sentinel, replacement)
+
+                get_filename = getattr(self._delegate, "get_filename", None)
+                filename = None
+                if get_filename is not None:
+                    with contextlib.suppress(Exception):
+                        filename = get_filename(module.__name__)
+                if not filename:
+                    filename = getattr(module.__spec__, "origin", None)
+
+                module.__loader__ = self
+                module.__file__ = filename
+                exec(compile(patched_source, filename or module.__name__, "exec"), module.__dict__)
+
+        class _WeaselConfigFinder(importlib.abc.MetaPathFinder):
+            """Finder that injects the patched loader."""
+
+            def find_spec(self, fullname, path=None, target=None):  # type: ignore[override]
+                if fullname != target_module:
+                    return None
+
+                spec = importlib.machinery.PathFinder.find_spec(fullname, path)
+                if spec is None or spec.loader is None:
+                    return None
+
+                spec.loader = _WeaselConfigLoader(spec.loader, spec.origin)
+                return spec
+
+        sys.meta_path.insert(0, _WeaselConfigFinder())
+        _WEASEL_CONFIG_PATCH_INSTALLED = True
+
+        existing = sys.modules.pop(target_module, None)
+        if existing is not None:
+            with contextlib.suppress(Exception):
+                importlib.import_module(target_module)
+
     try:
         _ensure_click_split_arg_string()
+    except Exception:  # pragma: no cover - best effort
+        pass
+
+    try:
+        _install_weasel_config_patch()
     except Exception:  # pragma: no cover - best effort
         pass
 

--- a/tests/unit/search/test_ranking_convergence_simulation.py
+++ b/tests/unit/search/test_ranking_convergence_simulation.py
@@ -1,8 +1,8 @@
 import sys
-import pytest
-from importlib.machinery import SourceFileLoader
-from importlib.util import module_from_spec, spec_from_loader
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+
+import pytest
 
 pytestmark = pytest.mark.skip(
     reason="CollectorRegistry duplication in test environment"
@@ -12,13 +12,13 @@ pytestmark = pytest.mark.skip(
 def _load_module():
     root = Path(__file__).resolve().parents[3]
     path = root / "src/autoresearch/search/ranking_convergence.py"
-    name = "src.autoresearch.search.ranking_convergence"
-    loader = SourceFileLoader(name, str(path))
-    spec = spec_from_loader(name, loader)
+    name = "autoresearch.search.ranking_convergence"
+    spec = spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(name)
     module = module_from_spec(spec)
-    module.__package__ = "src.autoresearch.search"
     sys.modules[name] = module
-    loader.exec_module(module)
+    spec.loader.exec_module(module)
     return module
 
 

--- a/tests/unit/search/test_simulate_rate_limit.py
+++ b/tests/unit/search/test_simulate_rate_limit.py
@@ -1,20 +1,19 @@
 import sys
-import pytest
-from importlib.machinery import SourceFileLoader
-from importlib.util import module_from_spec, spec_from_loader
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
+import pytest
 
 def _load_module():
     root = Path(__file__).resolve().parents[3]
     path = root / "src/autoresearch/search/simulate_rate_limit.py"
-    name = "src.autoresearch.search.simulate_rate_limit"
-    loader = SourceFileLoader(name, str(path))
-    spec = spec_from_loader(name, loader)
+    name = "autoresearch.search.simulate_rate_limit"
+    spec = spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(name)
     module = module_from_spec(spec)
-    module.__package__ = "src.autoresearch.search"
     sys.modules[name] = module
-    loader.exec_module(module)
+    spec.loader.exec_module(module)
     return module
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -463,7 +463,7 @@ requires-dist = [
     { name = "tomli-w", marker = "extra == 'dev-minimal'", specifier = ">=1.2.0" },
     { name = "tomli-w", marker = "extra == 'test'", specifier = ">=1.2.0" },
     { name = "twine", marker = "extra == 'build'", specifier = ">=6.0.1" },
-    { name = "typer", specifier = ">=0.16.0" },
+    { name = "typer", specifier = ">=0.17.4" },
     { name = "typer", marker = "extra == 'dev'", specifier = ">=0.16.0" },
     { name = "types-networkx", marker = "python_full_version < '3.13' and extra == 'dev'", specifier = ">=3.4.0" },
     { name = "types-protobuf", marker = "python_full_version < '3.13' and extra == 'dev'", specifier = ">=6.30.2.20250516" },


### PR DESCRIPTION
## Summary
- add a meta path loader in `sitecustomize.py` that rewrites `weasel.util.config` to import `split_arg_string` from `click.shell_completion`, retaining a fallback for older Click releases and preventing the deprecated `click.parser` import
- raise the Typer minimum version, refresh the Click dependency comment, and document the new shim in STATUS and the testing guide
- update unit tests that load helper modules to rely on `importlib.util.spec_from_file_location` instead of legacy loader patterns

## Testing
- uv run task verify *(fails: `task` binary is unavailable in the container)*
- uv run pytest -W error::DeprecationWarning tests/unit/test_distributed_perf_compare.py -q
- uv run pytest -W error::DeprecationWarning tests/unit/search/test_simulate_rate_limit.py -q
- uv run pytest -W error::DeprecationWarning tests/unit/search/test_ranking_convergence_simulation.py -q
- uv run pytest -W error::DeprecationWarning tests/unit/test_scheduling_resource_benchmark.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c8d98f93508333982d767e08c33680