### PR TITLE
Update API documentation to reflect current middleware behavior

### DIFF
--- a/SPEC_COVERAGE.md
+++ b/SPEC_COVERAGE.md
@@ -50,32 +50,32 @@
 | `autoresearch/main` | [main.md](docs/specs/main.md) | [t75], [t76], [t77] | OK |
 | `autoresearch/mcp_interface.py` | [mcp-interface.md](docs/specs/mcp-interface.md) | [t78], [t79] | OK |
 | `autoresearch/models.py` | [models.md](docs/specs/models.md) | [p16], [t80] | OK |
-| `autoresearch/monitor` | [monitor.md](docs/specs/monitor.md) | [p17], [s12], [t81], [t82], [t83], [t84] | OK |
-| `autoresearch/monitor/cli.py` | [monitor.md](docs/specs/monitor.md) | [p17], [s12], [t81], [t82], [t83], [t84] | OK |
-| `autoresearch/monitor/metrics.py` | [monitor.md](docs/specs/monitor.md) | [p17], [s12], [t81], [t82], [t83], [t84] | OK |
-| `autoresearch/monitor/node_health.py` | [monitor.md](docs/specs/monitor.md) | [p17], [s12], [t81], [t82], [t83], [t84] | OK |
-| `autoresearch/monitor/system_monitor.py` | [monitor.md](docs/specs/monitor.md) | [p17], [s12], [t81], [t82], [t83], [t84] | OK |
-| `autoresearch/orchestration` | [orchestration.md](docs/specs/orchestration.md) | [p18], [s13], [t85], [t86], [t87], [t88], [t89] | OK |
-| `autoresearch/orchestration/metrics.py` | [metrics.md](docs/specs/metrics.md) | [p15], [s14], [t90], [t91] | OK |
-| `autoresearch/orchestrator_perf.py` | [orchestrator-perf.md](docs/specs/orchestrator-perf.md)<br>[orchestrator_scheduling.md](docs/specs/orchestrator_scheduling.md) | [s15], [t92], [t93], [t94] | OK |
-| `autoresearch/output_format.py` | [output-format.md](docs/specs/output-format.md) | [t95], [t96] | OK |
-| `autoresearch/resource_monitor.py` | [resource-monitor.md](docs/specs/resource-monitor.md) | [p19], [s16], [t81], [t84] | OK |
-| `autoresearch/scheduler_benchmark.py` | [scheduler-benchmark.md](docs/specs/scheduler-benchmark.md) | [t94] | OK |
-| `autoresearch/search` | [search.md](docs/specs/search.md) | [t97], [t98], [t99], [t100], [t101], [t41], [t102], [t103] | OK |
-| `autoresearch/search/ranking_convergence.py` | [search_ranking.md](docs/specs/search_ranking.md) | [t97], [t99], [t104] | OK |
-| `autoresearch/storage.py` | [storage.md](docs/specs/storage.md) | [p20], [s17], [s18], [s19], [s20], [t100], [t105], [t106], [t103], [t107], [t108], [t109], [t110], [t111] | OK |
-| `autoresearch/storage_backends.py` | [storage-backends.md](docs/specs/storage-backends.md) | [s21], [t106], [t65], [t66] | OK |
-| `autoresearch/storage_backup.py` | [storage-backup.md](docs/specs/storage-backup.md) | [t112] | OK |
-| `autoresearch/storage_utils.py` | [storage-utils.md](docs/specs/storage-utils.md) | [t113] | OK |
+| `autoresearch/monitor` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
+| `autoresearch/monitor/cli.py` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
+| `autoresearch/monitor/metrics.py` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
+| `autoresearch/monitor/node_health.py` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
+| `autoresearch/monitor/system_monitor.py` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
+| `autoresearch/orchestration` | [orchestration.md](docs/specs/orchestration.md) | [p17], [s13], [t87], [t88], [t89], [t90], [t91] | OK |
+| `autoresearch/orchestration/metrics.py` | [metrics.md](docs/specs/metrics.md) | [p15], [s14], [t92], [t93] | OK |
+| `autoresearch/orchestrator_perf.py` | [orchestrator-perf.md](docs/specs/orchestrator-perf.md)<br>[orchestrator_scheduling.md](docs/specs/orchestrator_scheduling.md) | [s15], [t94], [t95], [t96] | OK |
+| `autoresearch/output_format.py` | [output-format.md](docs/specs/output-format.md) | [t97], [t98] | OK |
+| `autoresearch/resource_monitor.py` | [resource-monitor.md](docs/specs/resource-monitor.md) | [p18], [s16], [t81], [t99] | OK |
+| `autoresearch/scheduler_benchmark.py` | [scheduler-benchmark.md](docs/specs/scheduler-benchmark.md) | [t96] | OK |
+| `autoresearch/search` | [search.md](docs/specs/search.md) | [t100], [t101], [t102], [t103], [t104], [t41], [t105], [t106] | OK |
+| `autoresearch/search/ranking_convergence.py` | [search_ranking.md](docs/specs/search_ranking.md) | [t100], [t102], [t107] | OK |
+| `autoresearch/storage.py` | [storage.md](docs/specs/storage.md) | [p19], [s17], [s18], [s19], [s20], [t103], [t108], [t109], [t106], [t110], [t111], [t112], [t113], [t114] | OK |
+| `autoresearch/storage_backends.py` | [storage-backends.md](docs/specs/storage-backends.md) | [s21], [t109], [t65], [t66] | OK |
+| `autoresearch/storage_backup.py` | [storage-backup.md](docs/specs/storage-backup.md) | [t115] | OK |
+| `autoresearch/storage_utils.py` | [storage-utils.md](docs/specs/storage-utils.md) | [t116] | OK |
 | `autoresearch/streamlit_app.py` | [streamlit-app.md](docs/specs/streamlit-app.md) | [t51] | OK |
-| `autoresearch/streamlit_ui.py` | [streamlit-ui.md](docs/specs/streamlit-ui.md) | [t114] | OK |
-| `autoresearch/synthesis.py` | [synthesis.md](docs/specs/synthesis.md) | [t115] | OK |
-| `autoresearch/test_tools.py` | [test-tools.md](docs/specs/test-tools.md) | [t116] | OK |
-| `autoresearch/token_budget.py` | [token-budget.md](docs/specs/token-budget.md) | [s14], [t90] | OK |
-| `autoresearch/tracing.py` | [tracing.md](docs/specs/tracing.md) | [t117] | OK |
-| `autoresearch/visualization.py` | [visualization.md](docs/specs/visualization.md) | [p21], [t118], [t119] | OK |
-| `git` | [git.md](docs/specs/git.md) | [t120], [t121] | OK |
-| `git/search.py` | [git-search.md](docs/specs/git-search.md) | [t121] | OK |
+| `autoresearch/streamlit_ui.py` | [streamlit-ui.md](docs/specs/streamlit-ui.md) | [t117] | OK |
+| `autoresearch/synthesis.py` | [synthesis.md](docs/specs/synthesis.md) | [t118] | OK |
+| `autoresearch/test_tools.py` | [test-tools.md](docs/specs/test-tools.md) | [t119] | OK |
+| `autoresearch/token_budget.py` | [token-budget.md](docs/specs/token-budget.md) | [s14], [t92] | OK |
+| `autoresearch/tracing.py` | [tracing.md](docs/specs/tracing.md) | [t120] | OK |
+| `autoresearch/visualization.py` | [visualization.md](docs/specs/visualization.md) | [p20], [t121], [t122] | OK |
+| `git` | [git.md](docs/specs/git.md) | [t123], [t124] | OK |
+| `git/search.py` | [git-search.md](docs/specs/git-search.md) | [t124] | OK |
 
 [t1]: tests/integration/test_a2a_interface.py
 [t2]: tests/unit/test_distributed.py
@@ -184,59 +184,61 @@
 [t79]: tests/unit/test_mcp_interface.py
 [p16]: docs/algorithms/models.md
 [t80]: tests/unit/test_models_docstrings.py
-[p17]: docs/algorithms/monitor_cli.md
 [s12]: scripts/monitor_cli_reliability.py
 [t81]: tests/integration/test_monitor_metrics.py
 [t82]: tests/unit/test_main_monitor_commands.py
 [t83]: tests/unit/test_monitor_cli.py
-[t84]: tests/unit/test_resource_monitor_gpu.py
-[p18]: docs/algorithms/orchestration.md
+[t84]: tests/unit/test_monitor_metrics_init.py
+[t85]: tests/unit/test_node_health_monitor_property.py
+[t86]: tests/unit/test_system_monitor.py
+[p17]: docs/algorithms/orchestration.md
 [s13]: scripts/orchestration_sim.py
-[t85]: tests/unit/orchestration/test_budgeting_algorithm.py
-[t86]: tests/unit/orchestration/test_circuit_breaker_determinism.py
-[t87]: tests/unit/orchestration/test_circuit_breaker_thresholds.py
-[t88]: tests/unit/orchestration/test_parallel_execute.py
-[t89]: tests/unit/orchestration/test_parallel_merge_invariant.py
+[t87]: tests/unit/orchestration/test_budgeting_algorithm.py
+[t88]: tests/unit/orchestration/test_circuit_breaker_determinism.py
+[t89]: tests/unit/orchestration/test_circuit_breaker_thresholds.py
+[t90]: tests/unit/orchestration/test_parallel_execute.py
+[t91]: tests/unit/orchestration/test_parallel_merge_invariant.py
 [s14]: scripts/token_budget_convergence.py
-[t90]: tests/unit/test_metrics_token_budget_spec.py
-[t91]: tests/unit/test_token_budget_convergence.py
+[t92]: tests/unit/test_metrics_token_budget_spec.py
+[t93]: tests/unit/test_token_budget_convergence.py
 [s15]: scripts/orchestrator_perf_sim.py
-[t92]: tests/integration/test_orchestrator_performance.py
-[t93]: tests/unit/test_orchestrator_perf_sim.py
-[t94]: tests/unit/test_scheduler_benchmark.py
-[t95]: tests/behavior/features/output_formatting.feature
-[t96]: tests/unit/test_output_format.py
-[p19]: docs/algorithms/resource_monitor.md
+[t94]: tests/integration/test_orchestrator_performance.py
+[t95]: tests/unit/test_orchestrator_perf_sim.py
+[t96]: tests/unit/test_scheduler_benchmark.py
+[t97]: tests/behavior/features/output_formatting.feature
+[t98]: tests/unit/test_output_format.py
+[p18]: docs/algorithms/resource_monitor.md
 [s16]: scripts/resource_monitor_bounds.py
-[t97]: tests/behavior/features/hybrid_search.feature
-[t98]: tests/behavior/features/local_sources.feature
-[t99]: tests/behavior/features/search_cli.feature
-[t100]: tests/behavior/features/storage_search_integration.feature
-[t101]: tests/behavior/features/vector_search_performance.feature
-[t102]: tests/integration/test_search_regression.py
-[t103]: tests/integration/test_search_storage.py
-[t104]: tests/benchmark/test_hybrid_ranking.py
-[p20]: docs/algorithms/storage.md
+[t99]: tests/unit/test_resource_monitor_gpu.py
+[t100]: tests/behavior/features/hybrid_search.feature
+[t101]: tests/behavior/features/local_sources.feature
+[t102]: tests/behavior/features/search_cli.feature
+[t103]: tests/behavior/features/storage_search_integration.feature
+[t104]: tests/behavior/features/vector_search_performance.feature
+[t105]: tests/integration/test_search_regression.py
+[t106]: tests/integration/test_search_storage.py
+[t107]: tests/benchmark/test_hybrid_ranking.py
+[p19]: docs/algorithms/storage.md
 [s17]: scripts/ram_budget_enforcement_sim.py
 [s18]: scripts/schema_idempotency_sim.py
 [s19]: scripts/storage_concurrency_sim.py
 [s20]: scripts/storage_eviction_sim.py
-[t105]: tests/integration/storage/test_simulation_benchmarks.py
-[t106]: tests/integration/test_rdf_persistence.py
-[t107]: tests/integration/test_storage_duckdb_fallback.py
-[t108]: tests/integration/test_storage_eviction.py
-[t109]: tests/targeted/test_storage_eviction.py
-[t110]: tests/unit/test_storage_eviction.py
-[t111]: tests/unit/test_storage_eviction_sim.py
+[t108]: tests/integration/storage/test_simulation_benchmarks.py
+[t109]: tests/integration/test_rdf_persistence.py
+[t110]: tests/integration/test_storage_duckdb_fallback.py
+[t111]: tests/integration/test_storage_eviction.py
+[t112]: tests/targeted/test_storage_eviction.py
+[t113]: tests/unit/test_storage_eviction.py
+[t114]: tests/unit/test_storage_eviction_sim.py
 [s21]: scripts/oxigraph_backend_sim.py
-[t112]: tests/unit/test_storage_backup.py
-[t113]: tests/integration/test_storage_schema.py
-[t114]: tests/unit/test_streamlit_ui_helpers.py
-[t115]: tests/behavior/features/synthesis.feature
-[t116]: tests/unit/test_test_tools.py
-[t117]: tests/behavior/features/tracing.feature
-[p21]: docs/algorithms/visualization.md
-[t118]: tests/behavior/features/visualization_cli.feature
-[t119]: tests/unit/test_visualization.py
-[t120]: tests/integration/test_local_git_backend.py
-[t121]: tests/targeted/test_git_search.py
+[t115]: tests/unit/test_storage_backup.py
+[t116]: tests/integration/test_storage_schema.py
+[t117]: tests/unit/test_streamlit_ui_helpers.py
+[t118]: tests/behavior/features/synthesis.feature
+[t119]: tests/unit/test_test_tools.py
+[t120]: tests/behavior/features/tracing.feature
+[p20]: docs/algorithms/visualization.md
+[t121]: tests/behavior/features/visualization_cli.feature
+[t122]: tests/unit/test_visualization.py
+[t123]: tests/integration/test_local_git_backend.py
+[t124]: tests/targeted/test_git_search.py

--- a/docs/algorithms/api-authentication.md
+++ b/docs/algorithms/api-authentication.md
@@ -6,9 +6,15 @@ length, preventing attackers from guessing characters by timing responses.
 
 ## Role Checks
 
-Authorization verifies that a user's role permits the requested operation. A
-permissions mapping assigns actions to each role and fails fast when a role is
-missing or lacks the required permission.
+Authorization verifies that a user's role permits the requested operation. On
+each request `AuthMiddleware` reloads configuration, resolves the caller's
+role, and stores `role`, `permissions`, and `www_authenticate` on
+`request.scope["state"]`. A permissions mapping assigns actions to each role
+and fails fast when a role is missing or lacks the required permission.
+
+`enforce_permission` consults that set, returning **401** with the recorded
+`WWW-Authenticate` challenge when credentials are missing. It yields **403**
+when the role lacks the required action.
 
 Permissions align with the [API spec](../specs/api.md), so query, config,
 metrics, docs, health, and capability endpoints stay isolated unless roles


### PR DESCRIPTION
## Summary
- align docs/specs/api.md with the current router, config watcher lifecycle, and rate limiting behaviour
- refresh API authentication algorithm docs to describe credential precedence, request state, and enforcement flow
- regenerate SPEC_COVERAGE.md via scripts/generate_spec_coverage.py

## Testing
- uv run python scripts/generate_spec_coverage.py --output SPEC_COVERAGE.md

------
https://chatgpt.com/codex/tasks/task_e_68c8ee2ada2c8333a9b8d3d4b8931520