### PR TITLE
Align CLI helper spec with implementation details

### DIFF
--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -1,3 +1,12 @@
+import inspect
+import io
+from pathlib import Path
+
+import pytest
+import typer
+from fastapi import HTTPException
+from rich.console import Console
+
 from autoresearch.cli_helpers import (
     find_similar_commands,
     parse_agent_groups,
@@ -5,12 +14,6 @@ from autoresearch.cli_helpers import (
     report_missing_tables,
     require_api_key,
 )
-import io
-import pytest
-import typer
-from pathlib import Path
-from rich.console import Console
-from fastapi import HTTPException
 
 
 pytestmark = pytest.mark.usefixtures("dummy_storage")
@@ -20,6 +23,11 @@ def test_find_similar_commands_basic():
     cmds = ["search", "serve", "backup"]
     matches = find_similar_commands("serch", cmds)
     assert "search" in matches
+
+
+def test_find_similar_commands_default_threshold():
+    sig = inspect.signature(find_similar_commands)
+    assert sig.parameters["threshold"].default == 0.6
 
 
 def test_parse_agent_groups_parses_nested_lists():


### PR DESCRIPTION
## Summary
- document the CLI helper defaults, suggestion text, and console behavior in the CLI helpers spec
- add a regression test to lock the `find_similar_commands` default threshold used by the CLI

## Testing
- uv run --extra test pytest tests/unit/test_cli_helpers.py
- uv run python scripts/generate_spec_coverage.py

------
https://chatgpt.com/codex/tasks/task_e_68c8f2d8a8948333bf372da531d23028