### PR TITLE
docs: sync config spec with configuration modules

### DIFF
--- a/docs/algorithms/config.md
+++ b/docs/algorithms/config.md
@@ -1,28 +1,49 @@
 # Configuration
 
 ## Overview
-The config package loads settings from files and environment variables.
+
+`ConfigLoader` merges `ConfigModel` defaults with TOML configuration files and
+environment overrides. Profile overrides are applied last, and the loader
+returns a fully validated `ConfigModel` that includes nested sections for
+storage, search, API, distributed execution, and per agent overrides.
 
 ## Algorithm
-`ConfigLoader` merges defaults with environment variables and profile
-data, watching files for changes to support live reload. Successful
-parses atomically replace the active state while unknown fields preserve
-prior values.
+
+1. Load `.env` values (if present) and process environment variables whose
+   names are prefixed with `AUTORESEARCH_` or contain double underscores.
+2. Expand these keys into nested dictionaries and merge them into the parsed
+   `core` section from the first available config file.
+3. Assemble nested sections (`StorageConfig`, `APIConfig`, `DistributedConfig`,
+   `AnalysisConfig`) using `_safe_model`, which filters invalid fields while
+   preserving valid ones.
+4. Collect enabled agents, derive top level booleans such as `distributed`, and
+   attach per agent overrides in `agent_config`.
+5. Apply the selected profile, instantiate `ConfigModel.from_dict`, and cache
+   the resulting model for reuse until the configuration changes.
 
 ## Proof sketch
-Merging operates on ordered layers; each layer overrides the previous,
-ensuring deterministic results.
+
+Each layer overrides the previous one deterministically, so the final
+configuration depends only on the ordered sources. `ConfigModel.from_dict`
+ensures partially invalid settings degrade gracefully by retaining valid
+fields, while validators enforce ranking weights, token budgets, and eviction
+policies before returning control to callers.[p1]
 
 ## Simulation
-`tests/unit/test_config_loader_defaults.py` exercises merging and reload
-behaviour.
+
+- [Config weight and validator simulation][p1]
+- [tests/unit/test_config_loader_defaults.py][t]
 
 ## References
+
 - [code](../../src/autoresearch/config/)
 - [spec](../specs/config.md)
 - [tests](../../tests/unit/test_config_loader_defaults.py)
 
 ## Related Issues
+
 - [Resolve deprecation warnings in tests][issue]
 
 [issue]: ../../issues/resolve-deprecation-warnings-in-tests.md
+[p1]: ../algorithms/config_weight_sum_simulation.md
+[t]: ../../tests/unit/test_config_loader_defaults.py

--- a/docs/algorithms/config_hot_reload.md
+++ b/docs/algorithms/config_hot_reload.md
@@ -74,7 +74,8 @@ See [simulate_config_reload.py](../../scripts/simulate_config_reload.py).
 
 ## Simulation
 
-Automated tests confirm config hot reload behavior.
+Automated tests and collected metrics confirm config hot reload behavior.
 
 - [Spec](../specs/config.md)
+- [Metrics](../../tests/analysis/config_hot_reload_metrics.json)
 - [Tests](../../tests/integration/test_config_hot_reload_components.py)


### PR DESCRIPTION
## Summary
- expand the configuration spec to document current models, loader lifecycle, and validator behaviour
- update the configuration algorithm note to reflect layered merging and link to the validator simulation
- tie the hot-reload algorithm note to the collected metrics proof for watcher delivery

## Testing
- uv run python scripts/generate_spec_coverage.py --output SPEC_COVERAGE.md

------
https://chatgpt.com/codex/tasks/task_e_68c8f622cee0833381f1a90a8aec660a