### PR TITLE
docs: update monitor spec and coverage

### DIFF
--- a/SPEC_COVERAGE.md
+++ b/SPEC_COVERAGE.md
@@ -30,40 +30,40 @@
 | `autoresearch/config/validators.py` | [config.md](docs/specs/config.md) | [p8], [p9], [t38], [t39], [t40], [t41], [t42], [t43], [t44], [t45], [t46], [t47], [t48] | OK |
 | `autoresearch/config_utils.py` | [config-utils.md](docs/specs/config-utils.md) | [p10], [t42], [t43], [t44], [t45], [t46], [t49], [t47], [t50], [t48], [t51], [t52] | OK |
 | `autoresearch/data_analysis.py` | [data-analysis.md](docs/specs/data-analysis.md) | [t53], [t54], [t55] | OK |
-| `autoresearch/distributed` | [distributed.md](docs/specs/distributed.md) | [p11], [p12], [p21], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
-| `autoresearch/distributed/broker.py` | [distributed.md](docs/specs/distributed.md) | [p11], [p12], [p21], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
-| `autoresearch/distributed/coordinator.py` | [distributed.md](docs/specs/distributed.md) | [p11], [p12], [p21], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
-| `autoresearch/distributed/executors.py` | [distributed.md](docs/specs/distributed.md) | [p11], [p12], [p21], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
-| `autoresearch/error_recovery.py` | [error-recovery.md](docs/specs/error-recovery.md) | [p13], [t61] | OK |
+| `autoresearch/distributed` | [distributed.md](docs/specs/distributed.md) | [p11], [p12], [p13], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
+| `autoresearch/distributed/broker.py` | [distributed.md](docs/specs/distributed.md) | [p11], [p12], [p13], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
+| `autoresearch/distributed/coordinator.py` | [distributed.md](docs/specs/distributed.md) | [p11], [p12], [p13], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
+| `autoresearch/distributed/executors.py` | [distributed.md](docs/specs/distributed.md) | [p11], [p12], [p13], [s6], [s7], [s8], [s9], [t56], [t57], [t58], [t59], [t2], [t60] | OK |
+| `autoresearch/error_recovery.py` | [error-recovery.md](docs/specs/error-recovery.md) | [p14], [t61] | OK |
 | `autoresearch/error_utils.py` | [error-utils.md](docs/specs/error-utils.md) | [t62] | OK |
 | `autoresearch/errors.py` | [errors.md](docs/specs/errors.md) | [t43], [t47], [t63] | OK |
 | `autoresearch/examples` | [examples.md](docs/specs/examples.md) | [t64] | OK |
-| `autoresearch/extensions.py` | [extensions.md](docs/specs/extensions.md) | [t65], [t66], [t67] (fallback ladder)<br>[s10], [s11] (offline cache) | OK |
+| `autoresearch/extensions.py` | [extensions.md](docs/specs/extensions.md) | [s10], [s11], [t65], [t66], [t67] | OK |
 | `autoresearch/interfaces.py` | [interfaces.md](docs/specs/interfaces.md) | [t68] | OK |
 | `autoresearch/kg_reasoning.py` | [kg-reasoning.md](docs/specs/kg-reasoning.md) | [t69] | OK |
-| `autoresearch/llm` | [llm.md](docs/specs/llm.md) | [p14], [p15], [t9], [t70], [t71], [t72] | OK |
-| `autoresearch/llm/adapters.py` | [llm.md](docs/specs/llm.md) | [p14], [p15], [t9], [t70], [t71], [t72] | OK |
-| `autoresearch/llm/capabilities.py` | [llm.md](docs/specs/llm.md) | [p14], [p15], [t9], [t70], [t71], [t72] | OK |
-| `autoresearch/llm/registry.py` | [llm.md](docs/specs/llm.md) | [p14], [p15], [t9], [t70], [t71], [t72] | OK |
-| `autoresearch/llm/token_counting.py` | [llm.md](docs/specs/llm.md) | [p14], [p15], [t9], [t70], [t71], [t72] | OK |
+| `autoresearch/llm` | [llm.md](docs/specs/llm.md) | [p15], [p16], [t9], [t70], [t71], [t72] | OK |
+| `autoresearch/llm/adapters.py` | [llm.md](docs/specs/llm.md) | [p15], [p16], [t9], [t70], [t71], [t72] | OK |
+| `autoresearch/llm/capabilities.py` | [llm.md](docs/specs/llm.md) | [p15], [p16], [t9], [t70], [t71], [t72] | OK |
+| `autoresearch/llm/registry.py` | [llm.md](docs/specs/llm.md) | [p15], [p16], [t9], [t70], [t71], [t72] | OK |
+| `autoresearch/llm/token_counting.py` | [llm.md](docs/specs/llm.md) | [p15], [p16], [t9], [t70], [t71], [t72] | OK |
 | `autoresearch/logging_utils.py` | [logging-utils.md](docs/specs/logging-utils.md) | [t73], [t74] | OK |
 | `autoresearch/main` | [main.md](docs/specs/main.md) | [t75], [t76], [t77] | OK |
 | `autoresearch/mcp_interface.py` | [mcp-interface.md](docs/specs/mcp-interface.md) | [t78], [t79] | OK |
-| `autoresearch/models.py` | [models.md](docs/specs/models.md) | [p16], [t80] | OK |
+| `autoresearch/models.py` | [models.md](docs/specs/models.md) | [p17], [t80] | OK |
 | `autoresearch/monitor` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
 | `autoresearch/monitor/cli.py` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
 | `autoresearch/monitor/metrics.py` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
 | `autoresearch/monitor/node_health.py` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
 | `autoresearch/monitor/system_monitor.py` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
-| `autoresearch/orchestration` | [orchestration.md](docs/specs/orchestration.md) | [p17], [s13], [t87], [t88], [t89], [t90], [t91] | OK |
-| `autoresearch/orchestration/metrics.py` | [metrics.md](docs/specs/metrics.md) | [p15], [s14], [t92], [t93] | OK |
+| `autoresearch/orchestration` | [orchestration.md](docs/specs/orchestration.md) | [p18], [s13], [t87], [t88], [t89], [t90], [t91] | OK |
+| `autoresearch/orchestration/metrics.py` | [metrics.md](docs/specs/metrics.md) | [p16], [s14], [t92], [t93] | OK |
 | `autoresearch/orchestrator_perf.py` | [orchestrator-perf.md](docs/specs/orchestrator-perf.md)<br>[orchestrator_scheduling.md](docs/specs/orchestrator_scheduling.md) | [s15], [t94], [t95], [t96] | OK |
 | `autoresearch/output_format.py` | [output-format.md](docs/specs/output-format.md) | [t97], [t98] | OK |
-| `autoresearch/resource_monitor.py` | [resource-monitor.md](docs/specs/resource-monitor.md) | [p18], [s16], [t81], [t99] | OK |
+| `autoresearch/resource_monitor.py` | [monitor.md](docs/specs/monitor.md)<br>[resource-monitor.md](docs/specs/resource-monitor.md) | [p19], [s12], [s16], [t81], [t82], [t83], [t84], [t85], [t99], [t86] | OK |
 | `autoresearch/scheduler_benchmark.py` | [scheduler-benchmark.md](docs/specs/scheduler-benchmark.md) | [t96] | OK |
 | `autoresearch/search` | [search.md](docs/specs/search.md) | [t100], [t101], [t102], [t103], [t104], [t41], [t105], [t106] | OK |
 | `autoresearch/search/ranking_convergence.py` | [search_ranking.md](docs/specs/search_ranking.md) | [t100], [t102], [t107] | OK |
-| `autoresearch/storage.py` | [storage.md](docs/specs/storage.md) | [p19], [s17], [s18], [s19], [s20], [t103], [t108], [t109], [t106], [t110], [t111], [t112], [t113], [t114] | OK |
+| `autoresearch/storage.py` | [storage.md](docs/specs/storage.md) | [p20], [s17], [s18], [s19], [s20], [t103], [t108], [t109], [t106], [t110], [t111], [t112], [t113], [t114] | OK |
 | `autoresearch/storage_backends.py` | [storage-backends.md](docs/specs/storage-backends.md) | [s21], [t109], [t65], [t66] | OK |
 | `autoresearch/storage_backup.py` | [storage-backup.md](docs/specs/storage-backup.md) | [t115] | OK |
 | `autoresearch/storage_utils.py` | [storage-utils.md](docs/specs/storage-utils.md) | [t116] | OK |
@@ -73,7 +73,7 @@
 | `autoresearch/test_tools.py` | [test-tools.md](docs/specs/test-tools.md) | [t119] | OK |
 | `autoresearch/token_budget.py` | [token-budget.md](docs/specs/token-budget.md) | [s14], [t92] | OK |
 | `autoresearch/tracing.py` | [tracing.md](docs/specs/tracing.md) | [t120] | OK |
-| `autoresearch/visualization.py` | [visualization.md](docs/specs/visualization.md) | [p20], [t121], [t122] | OK |
+| `autoresearch/visualization.py` | [visualization.md](docs/specs/visualization.md) | [p21], [t121], [t122] | OK |
 | `git` | [git.md](docs/specs/git.md) | [t123], [t124] | OK |
 | `git/search.py` | [git-search.md](docs/specs/git-search.md) | [t124] | OK |
 
@@ -149,6 +149,7 @@
 [t55]: tests/unit/test_kuzu_polars.py
 [p11]: docs/algorithms/distributed_coordination.md
 [p12]: docs/algorithms/distributed_overhead.md
+[p13]: docs/algorithms/distributed_perf.md
 [s6]: scripts/distributed_coordination_formulas.py
 [s7]: scripts/distributed_coordination_sim.py
 [s8]: scripts/distributed_recovery_benchmark.py
@@ -158,7 +159,7 @@
 [t58]: tests/integration/test_distributed_agent_storage.py
 [t59]: tests/unit/distributed/test_coordination_properties.py
 [t60]: tests/unit/test_distributed_extra.py
-[p13]: docs/algorithms/error_recovery.md
+[p14]: docs/algorithms/error_recovery.md
 [t61]: tests/unit/test_error_recovery.py
 [t62]: tests/unit/test_error_utils_additional.py
 [t63]: tests/unit/test_errors.py
@@ -170,8 +171,8 @@
 [t67]: tests/unit/test_vss_extension_loader.py
 [t68]: tests/unit/test_interfaces.py
 [t69]: tests/unit/test_kg_reasoning.py
-[p14]: docs/algorithms/llm_adapter.md
-[p15]: docs/algorithms/token_budgeting.md
+[p15]: docs/algorithms/llm_adapter.md
+[p16]: docs/algorithms/token_budgeting.md
 [t70]: tests/unit/test_llm_adapter.py
 [t71]: tests/unit/test_llm_capabilities.py
 [t72]: tests/unit/test_token_usage.py
@@ -182,7 +183,7 @@
 [t77]: tests/unit/test_main_config_commands.py
 [t78]: tests/behavior/features/mcp_interface.feature
 [t79]: tests/unit/test_mcp_interface.py
-[p16]: docs/algorithms/models.md
+[p17]: docs/algorithms/models.md
 [t80]: tests/unit/test_models_docstrings.py
 [s12]: scripts/monitor_cli_reliability.py
 [t81]: tests/integration/test_monitor_metrics.py
@@ -191,7 +192,7 @@
 [t84]: tests/unit/test_monitor_metrics_init.py
 [t85]: tests/unit/test_node_health_monitor_property.py
 [t86]: tests/unit/test_system_monitor.py
-[p17]: docs/algorithms/orchestration.md
+[p18]: docs/algorithms/orchestration.md
 [s13]: scripts/orchestration_sim.py
 [t87]: tests/unit/orchestration/test_budgeting_algorithm.py
 [t88]: tests/unit/orchestration/test_circuit_breaker_determinism.py
@@ -207,7 +208,7 @@
 [t96]: tests/unit/test_scheduler_benchmark.py
 [t97]: tests/behavior/features/output_formatting.feature
 [t98]: tests/unit/test_output_format.py
-[p18]: docs/algorithms/resource_monitor.md
+[p19]: docs/algorithms/resource_monitor.md
 [s16]: scripts/resource_monitor_bounds.py
 [t99]: tests/unit/test_resource_monitor_gpu.py
 [t100]: tests/behavior/features/hybrid_search.feature
@@ -218,7 +219,7 @@
 [t105]: tests/integration/test_search_regression.py
 [t106]: tests/integration/test_search_storage.py
 [t107]: tests/benchmark/test_hybrid_ranking.py
-[p19]: docs/algorithms/storage.md
+[p20]: docs/algorithms/storage.md
 [s17]: scripts/ram_budget_enforcement_sim.py
 [s18]: scripts/schema_idempotency_sim.py
 [s19]: scripts/storage_concurrency_sim.py
@@ -237,8 +238,7 @@
 [t118]: tests/behavior/features/synthesis.feature
 [t119]: tests/unit/test_test_tools.py
 [t120]: tests/behavior/features/tracing.feature
-[p20]: docs/algorithms/visualization.md
-[p21]: docs/algorithms/distributed_perf.md
+[p21]: docs/algorithms/visualization.md
 [t121]: tests/behavior/features/visualization_cli.feature
 [t122]: tests/unit/test_visualization.py
 [t123]: tests/integration/test_local_git_backend.py

--- a/docs/algorithms/monitor.md
+++ b/docs/algorithms/monitor.md
@@ -1,30 +1,96 @@
 # Monitor
 
 ## Overview
-The monitor package collects runtime metrics and exposes a CLI.
+
+The monitor package hosts the Typer application registered as
+`autoresearch monitor`. Its commands display live system metrics, stream
+resource usage, inspect the knowledge graph, run an interactive orchestrator,
+and supervise background monitors. CLI output is aligned with the Prometheus
+gauges exposed by `ResourceMonitor`, `SystemMonitor`, and `NodeHealthMonitor`.
+
+## Components
+
+### CLI commands
+
+- `monitor metrics` prints CPU, memory, GPU, and counter totals, optionally
+  refreshing once per second with `--watch`.
+- `monitor resources` records one sample per second and renders a table of CPU
+  percent, memory MB, GPU percent, and GPU memory MB.
+- `monitor graph` shows the knowledge graph as a table, tree, or TUI panel
+  depending on the options supplied.
+- `monitor run` prompts for queries, drives `Orchestrator.run_query()` with a
+  progress bar, prints cycle metrics plus current system metrics, and collects
+  optional feedback.
+- `monitor start` launches `ResourceMonitor` and `SystemMonitor`, optionally
+  exposing Prometheus gauges on the configured port, and stops both monitors on
+  interrupt.
+- `monitor serve` wraps `NodeHealthMonitor` to publish Redis and Ray health
+  gauges before exiting cleanly on Ctrl+C.
+
+### Background monitors
+
+- `SystemMonitor` records CPU and memory percentages in a daemon thread and
+  stores the latest snapshot for CLI reuse.
+- `ResourceMonitor` logs process and GPU usage, snapshots token counters, and
+  serves Prometheus gauges when requested.
+- `NodeHealthMonitor` probes Redis and Ray, updating gauges that report service
+  availability and overall node health.
 
 ## Algorithm
-`monitor metrics` initializes counters, gathers CPU, memory, and GPU data,
-and prints a table without mutating ``autoresearch_queries_total``.
-`monitor run` prompts for queries, executes them for a number of cycles,
-and displays metrics after each cycle while skipping storage
-initialization. Both commands rely on a background loop that polls system
-resources and pushes samples to a shared queue.
+
+1. A Typer callback invokes `orch_metrics.ensure_counters_initialized()` before
+   any command executes.
+2. `_collect_system_metrics` merges `_system_monitor.metrics` when a background
+   sampler is active; otherwise it calls `SystemMonitor.collect()` and augments
+   the snapshot with psutil and GPU data.
+3. All counter totals are read via `_value.get()` to avoid mutating metrics.
+4. `monitor run` drives `Orchestrator.run_query()` with an `on_cycle_end`
+   callback that prints execution metrics, renders system metrics, and applies
+   the configured token budget.
+5. `monitor start` and `monitor serve` wrap long-running loops in
+   `try`/`finally` so both monitors stop and module state resets after
+   interrupts.
+6. `metrics_endpoint` returns `generate_latest()` and `CONTENT_TYPE_LATEST` so
+   Prometheus scrapers and the CLI share the same data.
 
 ## Proof sketch
-The loop sleeps between samples and drains the queue each cycle, so
-memory use remains bounded.
+
+- `tests/unit/test_monitor_metrics_init.py` confirms the Typer callback
+  initialises counters.
+- `tests/unit/test_monitor_cli.py` checks metric output, ensures counters do not
+  change during snapshots, and verifies interactive flow handling.
+- `tests/unit/test_main_monitor_commands.py` validates CLI wiring plus clean
+  shutdown for `monitor start` and `monitor serve`.
+- `tests/unit/test_system_monitor.py` verifies background sampling updates CPU
+  and memory gauges.
+- `tests/unit/test_node_health_monitor_property.py` covers gauge updates for
+  Redis and Ray availability.
+- `tests/integration/test_monitor_metrics.py` exercises Prometheus exposure,
+  resource sampling tables, and query counter increments.
 
 ## Simulation
-`tests/unit/test_monitor_cli.py` invokes the CLI and verifies metric
-outputs.
+
+`scripts/monitor_cli_reliability.py` simulates metrics collection latency and
+failure rates. Running
+
+```
+uv run scripts/monitor_cli_reliability.py --runs 1000 --fail-rate 0.05
+```
+
+provides `average_latency_ms` and `success_rate` estimates that inform retry
+budgets. Integration tests also cover GPU-present and GPU-absent scenarios so
+resource sampling remains robust.
 
 ## References
-- [code](../../src/autoresearch/monitor/)
+
 - [spec](../specs/monitor.md)
+- [code](../../src/autoresearch/monitor/)
 - [tests](../../tests/unit/test_monitor_cli.py)
+- [tests/integration/test_monitor_metrics.py](../../tests/integration/
+  test_monitor_metrics.py)
 
 ## Related Issues
+
 - [Fix monitor CLI metrics failure][issue]
 
 [issue]: ../../issues/archive/fix-monitor-cli-metrics-failure.md

--- a/docs/algorithms/monitor_cli.md
+++ b/docs/algorithms/monitor_cli.md
@@ -1,48 +1,47 @@
 # Monitor CLI
 
-The `autoresearch monitor` subcommands surface runtime metrics, resource
-sampling, knowledge graph inspection, interactive orchestration, and health
-checks.
+The `autoresearch monitor` subcommands expose runtime metrics, streaming
+resource samples, knowledge graph inspection, interactive orchestration, and
+health checks.
 
 ## Flow
 
-1. `monitor metrics` prints a single snapshot of CPU, memory, GPU, and token
-   counters collected by `_collect_system_metrics`.
-2. `monitor metrics --watch` refreshes the snapshot every second using Rich
-   `Live` updates without mutating counters.
-3. `monitor resources` records samples for a configurable duration and renders a
-   summary table of the collected points.
-4. `monitor graph` queries the in-memory knowledge graph and prints either a
-   table of edges or a Rich tree when `--tree`/`--tui` are supplied.
-5. `monitor run` prompts for queries, runs the orchestrator with live cycle
-   metrics, gathers optional feedback, and exits when the user types `q`.
+1. `monitor metrics` collects CPU percent, memory percent, memory MB, process
+   RSS, and GPU metrics via `_collect_system_metrics`, then prints a Rich table
+   or refreshes via `Live` when `--watch`.
+2. When `_system_monitor` is active, the command merges its cached `metrics`
+   into the snapshot so background samplers and CLI output stay consistent.
+3. `monitor resources` records one sample per second via
+   `OrchestrationMetrics.record_system_resources()` and prints CPU percent,
+   memory MB, GPU percent, and GPU memory MB with timestamps.
+4. `monitor graph` loads the in-memory knowledge graph and renders either a
+   table or Rich tree/Panel depending on `--tree` or `--tui`.
+5. `monitor run` prompts for queries, runs each through `Orchestrator.run_query`
+   while updating progress, prints execution metrics and live system metrics,
+   and collects optional feedback before continuing.
 6. `monitor start` launches `ResourceMonitor` and `SystemMonitor`, optionally
-   exposing Prometheus metrics, and runs until interrupted.
-7. `monitor serve` starts `NodeHealthMonitor`, exposes Prometheus gauges for
-   Redis and Ray checks, and stops cleanly on Ctrl+C.
-
-## Interrupt Handling
-
-- `monitor start` and `monitor serve` wrap long-running loops in `try`/`finally`
-  blocks so monitors stop and global state resets when interrupted.
+   exposing Prometheus gauges on the requested port, and stops both monitors on
+   Ctrl+C.
+7. `monitor serve` wraps `NodeHealthMonitor`, publishing Redis and Ray health
+   gauges and exiting cleanly when interrupted.
 
 ## Error Handling
 
-- Failures while collecting metrics log warnings but still produce best-effort
-  output, allowing commands to complete without raising exceptions.
-- Health check failures set gauges to zero, keeping Prometheus output consistent
-  even when dependencies are unreachable.
+- Metric collection failures log warnings and reuse the last known values so the
+  CLI still prints a table.
+- Redis or Ray probe failures set the corresponding gauges to zero, keeping
+  Prometheus output consistent even when dependencies are unreachable.
 
 ## Reliability Analysis
 
-A Monte Carlo model estimates how often metrics collection fails and the latency
-of successful samples:
+A Monte Carlo model estimates latency and failure rates for the metrics flow:
 
-```bash
+```
 uv run scripts/monitor_cli_reliability.py --runs 1000 --fail-rate 0.05
 ```
 
-The simulation informs retry budgets and sampling intervals.
+The simulation informs retry budgets and sampling intervals. Integration tests
+exercise GPU-present and GPU-absent scenarios to ensure graceful degradation.
 
 ## References
 
@@ -55,3 +54,4 @@ The simulation informs retry budgets and sampling intervals.
   test_monitor_metrics.py)
 - [tests/unit/test_resource_monitor_gpu.py](../../tests/unit/
   test_resource_monitor_gpu.py)
+- [tests/unit/test_system_monitor.py](../../tests/unit/test_system_monitor.py)

--- a/docs/specs/monitor.md
+++ b/docs/specs/monitor.md
@@ -2,138 +2,156 @@
 
 ## Overview
 
-The monitor package hosts the Typer application registered as
-`autoresearch monitor`. Its commands stream live system metrics, sample
-resource usage, inspect the knowledge graph, run an interactive
-orchestrator loop, and supervise background monitors. The package also
-exposes the async `metrics_endpoint` for FastAPI routers so HTTP clients
-can scrape Prometheus metrics alongside the CLI utilities.
-
-A Typer callback calls `orch_metrics.ensure_counters_initialized()`
-before every command. `ConfigLoader` supplies CPU and memory thresholds
-that drive the health indicator and provides the default sampling
-interval when `--interval` is omitted. Background sampling reuses
-`ResourceMonitor` and `SystemMonitor`, letting CLI commands and HTTP
-scrapers observe the same gauges.
+The monitor package binds a Typer application under `autoresearch monitor`
+to surface orchestration metrics, explore the knowledge graph, and manage
+background health samplers. CLI commands share the `ResourceMonitor` and
+`SystemMonitor` samplers with the HTTP server so terminal snapshots and
+Prometheus scrapers observe the same gauges. The package also exposes an
+async `metrics_endpoint` for FastAPI routers and a `monitor serve` command
+that wraps `NodeHealthMonitor` for Redis and Ray health reporting.
 
 ## Algorithms
 
 ### metrics
 
-1. `_collect_system_metrics` merges values from `_system_monitor` when a
-   background sampler is running; otherwise it calls
-   `SystemMonitor.collect()` for a fresh psutil snapshot.
-2. psutil adds process RSS and total memory usage, GPU utilisation comes
-   from `resource_monitor._get_gpu_stats()`, and orchestration counters
-   are read via `._value.get()` without incrementing them.
-3. `_calculate_health` compares CPU and memory readings against
-   configuration thresholds to add a `health` field, and
-   `_render_metrics` colour-codes the row in a Rich table.
-4. With `--watch`, `Live` refreshes the table every second until
-   interrupted; otherwise the console prints a single snapshot.
+1. `_collect_system_metrics` reuses `_system_monitor.metrics` when a background
+   sampler is running; otherwise it calls `SystemMonitor.collect()` for a fresh
+   snapshot.
+2. psutil adds CPU percent, virtual memory percent, total memory usage in MB,
+   and process RSS in MB. GPU utilisation and memory in MB come from
+   `resource_monitor._get_gpu_stats()`, and missing values default to zero.
+3. Counter totals come from `orch_metrics.*._value.get()`, and
+   `_calculate_health` classifies CPU and memory load using warning and
+   critical thresholds from `ConfigLoader`.
+4. `_render_metrics` prints a Rich table; with `--watch` the command refreshes
+   the table once per second via `Live`, otherwise it emits a single snapshot.
 
 ### resources
 
 1. Instantiate `OrchestrationMetrics` and compute the end time from the
    requested `--duration`.
-2. Loop once per second, calling `record_system_resources()` and
-   advancing a Rich progress bar until the timer expires.
-3. Query `tracker.get_summary()["resource_usage"]` and render a table
-   with timestamps plus CPU, memory, GPU, and GPU-memory columns.
+2. Sleep in one second increments, calling `record_system_resources()` each
+   loop while advancing a Rich progress bar.
+3. Render a table that includes timestamps plus CPU percent, memory MB, GPU
+   percent, and GPU memory MB for every recorded sample.
 
 ### graph
 
-1. `_collect_graph_data` tries `StorageManager.get_graph()` and builds a
-   dictionary of node -> edges, falling back to `{}` when storage is not
+1. `_collect_graph_data` attempts `StorageManager.get_graph()` to build a map of
+   node IDs to outgoing edges, falling back to `{}` when storage is not
    configured.
-2. When `--tui` is provided the command wraps a `Tree` view in a Rich
-   `Panel`; otherwise it renders a `Tree` when `--tree` is set or a table
-   by default.
+2. With `--tui` the command wraps a `Tree` in a `Panel`; otherwise `--tree`
+   prints a `Tree` and the default formatting renders a table.
 
 ### run
 
-1. Load the active configuration and prompt for queries until the user
-   submits an empty string or `q`.
+1. Load the active configuration, prompt for queries, and exit when the user
+   enters an empty string or `q`.
 2. For each query create a progress bar sized to `config.loops` and call
-   `Orchestrator.run_query` with an `on_cycle_end` callback that advances
-   progress and captures each `QueryState`.
-3. The callback prints a table of `execution_metrics`, appends the
-   current system metrics table, and, when `token_budget` is configured,
-   shows a `Budget` versus `Used` table.
-4. Feedback collected with `Prompt.ask` appends structured claims; the
-   input `q` sets `state.error_count` to `config.max_errors` (default 3)
-   and flips an `abort_flag` so the outer loop terminates after the
-   current run.
-5. Results are formatted via `OutputFormatter.format` using
-   `config.output_format` or falling back to JSON when stdout is not a
-   TTY; exceptions are reported without stopping the monitor entirely.
+   `Orchestrator.run_query()` with an `on_cycle_end` callback that advances the
+   bar.
+3. The callback prints a table of `execution_metrics`, appends the current
+   system metrics table, and, when `token_budget` is configured, shows a
+   `Budget` versus `Used` table.
+4. Feedback collected via `Prompt.ask` attaches structured claims. Entering `q`
+   sets `state.error_count` to `config.max_errors` (default 3) and toggles an
+   abort flag so the outer loop terminates after the current run.
+5. Results flow through `OutputFormatter.format()` using `config.output_format`
+   or `json` when stdout is not a TTY. Exceptions are reported without aborting
+   the CLI.
 
 ### start
 
-1. Derive the sampling interval from `--interval` or
-   `config.monitor_interval`.
-2. Instantiate `ResourceMonitor` and assign a new `_system_monitor`
-   pointing to `SystemMonitor(interval=interval)`.
-3. Start `ResourceMonitor`, passing `prometheus_port=port` when
-   `--prometheus` is supplied, and call `_system_monitor.start()`.
-4. Print a status banner, sleep until interrupted, then stop both
-   monitors inside a `finally` block and clear `_system_monitor`.
+1. Derive the sampling interval from `--interval` or `config.monitor_interval`.
+2. Instantiate `ResourceMonitor` and set the module level `_system_monitor` to a
+   matching `SystemMonitor`.
+3. Start both monitors, exposing Prometheus metrics on the requested port when
+   `--prometheus` is provided, and print a status banner.
+4. Sleep until interrupted, then stop both monitors inside `finally` and clear
+   `_system_monitor` so future calls return fresh snapshots.
 
 ### serve
 
-1. Build `NodeHealthMonitor` with the provided Redis URL, Ray address,
-   port, and interval.
-2. Print startup messages, invoke `monitor.start()` (which launches the
-   HTTP server and background thread), and sleep in a loop.
-3. On `KeyboardInterrupt` or `SystemExit`, log shutdown, invoke
-   `monitor.stop()` inside `finally`, and exit with `typer.Exit(0)`.
+1. Build `NodeHealthMonitor` with the provided Redis URL, Ray address, port, and
+   interval.
+2. Print startup messages, invoke `monitor.start()` (launching the HTTP server
+   and background thread), and sleep until interrupted.
+3. On `KeyboardInterrupt` or `SystemExit`, log shutdown, call `monitor.stop()`
+   inside `finally`, and exit with `typer.Exit(0)`.
 
 ### metrics_endpoint
 
 1. `metrics_endpoint` returns a `PlainTextResponse` containing
-   `generate_latest()` output and `CONTENT_TYPE_LATEST`, giving HTTP
-   clients Prometheus-formatted metrics with status code 200.
+   `generate_latest()` output and `CONTENT_TYPE_LATEST`, so HTTP clients receive
+   Prometheus-formatted metrics with a `200` status code.
+
+### system_monitor
+
+1. `_gauge` obtains gauges from a Prometheus registry, resetting reused gauges
+   to zero to avoid stale samples.
+2. `SystemMonitor.start()` spawns a daemon thread that repeatedly calls
+   `collect()`, updates `self.metrics`, and synchronises CPU and memory gauges.
+3. `collect()` delegates to psutil to read CPU and memory percentages without
+   blocking.
+4. `stop()` signals the thread to halt and joins it, leaving `self.metrics`
+   populated with the latest snapshot.
+
+### node_health
+
+1. `NodeHealthMonitor` registers gauges for Redis, Ray, and overall node health,
+   zeroing reused gauges through `_gauge`.
+2. `start()` optionally launches a Prometheus server, spawns a daemon thread,
+   and repeatedly calls `check_once()` until stopped.
+3. `check_once()` runs Redis and Ray probes, writing `1` for healthy endpoints
+   and `0` otherwise while updating the composite health gauge.
+4. `stop()` joins the thread and leaves gauges in their latest state.
 
 ## Invariants
 
 - The Typer callback always initialises orchestration counters before any
   command executes.
-- `_collect_system_metrics` reuses cached snapshots when possible and
-  only reads orchestration counters, so CLI commands never mutate totals.
-- `_system_monitor` is created once per `start` invocation and cleared in
-  the `finally` block, keeping future `metrics` calls consistent.
-- `_gauge` zeroes reused Prometheus gauges and `NodeHealthMonitor.check_once`
-  overwrites every gauge each interval, preventing stale readings.
-- `ResourceMonitor.start()` and `SystemMonitor.start()` guard against
-  duplicate threads, making repeated `start` invocations idempotent.
-- `serve` always executes `monitor.stop()` through its `finally` block,
-  so the background health thread halts even after interrupts.
+- `_collect_system_metrics` reuses cached snapshots when available and only
+  reads orchestration counters, so CLI commands never mutate totals.
+- Health classifications use configuration thresholds with safe defaults when
+  values are missing.
+- `_system_monitor` is created once per `start` invocation and cleared in the
+  `finally` block, keeping subsequent `metrics` commands consistent.
+- `_gauge` zeroes Prometheus gauges before reuse and both monitors overwrite
+  gauge values each interval, preventing stale readings.
+- `ResourceMonitor.start()` and `SystemMonitor.start()` guard against duplicate
+  threads, making repeated `start` invocations idempotent.
+- `serve` always executes `monitor.stop()` through its `finally` block, so the
+  background health thread halts even after interrupts.
 
 ## Proof Sketch
 
 - `tests/unit/test_monitor_metrics_init.py` confirms the Typer callback
   initialises counters before commands run.
-- `tests/unit/test_monitor_cli.py` verifies the `metrics` command prints
-  CPU, memory, GPU, and counter data while `run` routes callbacks and
-  honours feedback.
+- `tests/unit/test_monitor_cli.py` verifies the `metrics` command prints CPU,
+  memory, GPU, and counter data, and that `run` routes callbacks and honours
+  feedback.
 - `tests/unit/test_main_monitor_commands.py` exercises the CLI wiring and
-  ensures `monitor serve` stops its monitor on exit.
-- `tests/unit/test_node_health_monitor_property.py` uses property tests
-  to show gauge updates match Redis/Ray health outcomes.
-- `tests/unit/test_system_monitor.py` confirms `SystemMonitor` captures
-  CPU and memory percentages and exposes them through gauges.
+  ensures `monitor start` and `monitor serve` shut down their monitors on exit.
+- `tests/unit/test_system_monitor.py` confirms `SystemMonitor` captures CPU and
+  memory percentages and exposes them through gauges.
+- `tests/unit/test_node_health_monitor_property.py` shows gauge updates match
+  Redis and Ray health outcomes.
 - `tests/integration/test_monitor_metrics.py` covers Prometheus scraping,
-  resource sampling tables, and counter increments across the CLI and
-  HTTP surfaces.
+  resource sampling tables, and counter increments across the CLI and HTTP
+  surfaces.
 
 ## Simulation Evidence
 
 `scripts/monitor_cli_reliability.py` performs a Monte Carlo simulation of
 metrics collection latency and failure probability. Run
-`uv run scripts/monitor_cli_reliability.py --runs 1000 --fail-rate 0.05`
-to obtain `average_latency_ms` and `success_rate` estimates. Integration
-tests also simulate GPU present/absent scenarios so resource sampling and
-counter snapshots degrade gracefully when GPU metrics are unavailable.
+
+```
+uv run scripts/monitor_cli_reliability.py --runs 1000 --fail-rate 0.05
+```
+
+to obtain `average_latency_ms` and `success_rate` estimates. Integration tests
+also exercise GPU present and absent scenarios so resource sampling and counter
+snapshots degrade gracefully when GPU metrics are unavailable.
 
 ## Traceability
 
@@ -143,6 +161,7 @@ counter snapshots degrade gracefully when GPU metrics are unavailable.
   - [src/autoresearch/monitor/metrics.py][m3]
   - [src/autoresearch/monitor/node_health.py][m4]
   - [src/autoresearch/monitor/system_monitor.py][m5]
+  - [src/autoresearch/resource_monitor.py][m6]
 - Scripts
   - [scripts/monitor_cli_reliability.py][s1]
 - Tests
@@ -158,6 +177,7 @@ counter snapshots degrade gracefully when GPU metrics are unavailable.
 [m3]: ../../src/autoresearch/monitor/metrics.py
 [m4]: ../../src/autoresearch/monitor/node_health.py
 [m5]: ../../src/autoresearch/monitor/system_monitor.py
+[m6]: ../../src/autoresearch/resource_monitor.py
 [s1]: ../../scripts/monitor_cli_reliability.py
 [t1]: ../../tests/unit/test_main_monitor_commands.py
 [t2]: ../../tests/unit/test_monitor_cli.py


### PR DESCRIPTION
## Summary
- expand the monitor specification to describe current CLI metrics, background samplers, invariants, and supporting evidence
- align the monitor algorithm notes with the refreshed CLI behaviour and health-monitor integration
- regenerate SPEC_COVERAGE.md so autoresearch/monitor/* modules reference the updated spec

## Testing
- uv run python scripts/generate_spec_coverage.py

------
https://chatgpt.com/codex/tasks/task_e_68c98059782083338f37e8f1327de33f