### PR TITLE
Suppress Hypothesis too-slow health check for ranking property test

### DIFF
--- a/tests/unit/search/test_property_ranking_monotonicity.py
+++ b/tests/unit/search/test_property_ranking_monotonicity.py
@@ -9,7 +9,15 @@ from autoresearch.config.models import ConfigModel, SearchConfig
 from autoresearch.search import Search
 
 
-@settings(max_examples=50, suppress_health_check=[HealthCheck.function_scoped_fixture])
+# Allow the slower combinations of mocks and Hypothesis scheduling without
+# lowering the number of generated examples.
+@settings(
+    max_examples=50,
+    suppress_health_check=[
+        HealthCheck.function_scoped_fixture,
+        HealthCheck.too_slow,
+    ],
+)
 @given(
     bm25_a=st.floats(min_value=0, max_value=1),
     bm25_b=st.floats(min_value=0, max_value=1),


### PR DESCRIPTION
## Summary
- add Hypothesis's too-slow health check to the suppressed list for the ranking monotonicity property test while keeping 50 examples
- explain the suppressed check to future maintainers

## Testing
- uv run --extra test pytest tests/unit/search/test_property_ranking_monotonicity.py -k monotonic -q

------
https://chatgpt.com/codex/tasks/task_e_68c9ad663f848333b4e516545c85cf8b