### PR TITLE
Refine coverage targeted runs by extra

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -243,17 +243,27 @@ tasks:
       - |
           uv run pytest -vv --maxfail=1 --durations=10 -x tests/integration -m 'not slow' \
             --cov=src --cov-report=term-missing --cov-append
-      - echo "[coverage] running targeted tests"
+      - echo "[coverage] running targeted tests per extra"
       - |
-          {{if .EXTRAS}}
-          uv run pytest -vv --maxfail=1 --durations=10 -x tests/targeted \
-            -m 'not slow{{.EXTRA_MARKERS}}' \
-            --noconftest --cov=autoresearch.search --cov=autoresearch.storage \
-            --cov=autoresearch.orchestration --cov-report=term-missing \
-            --cov-report=xml --cov-append
-          {{else}}
-          echo "[coverage] skipping targeted tests; no extras provided"
-          {{end}}
+          set -eu
+          extras_requested="{{.EXTRAS}}"
+          if [ -z "$extras_requested" ]; then
+            echo "[coverage][targeted] skipping; no extras requested"
+          else
+            for extra in {{.ALL_EXTRAS}}; do
+              if ! printf ' %s ' "$extras_requested" | grep -q " ${extra} "; then
+                echo "[coverage][targeted][${extra}] skipping; extra not requested"
+                continue
+              fi
+              echo "[coverage][targeted][${extra}] starting"
+              uv run pytest -vv --maxfail=1 --durations=10 -x tests/targeted \
+                -m "requires_${extra} and not slow" \
+                --noconftest --cov=autoresearch.search --cov=autoresearch.storage \
+                --cov=autoresearch.orchestration --cov-report=term-missing \
+                --cov-report=xml --cov-append
+              echo "[coverage][targeted][${extra}] passed"
+            done
+          fi
       - echo "[coverage] running behavior tests"
       - |
           uv run pytest -vv --maxfail=1 --durations=10 -x tests/behavior -m 'not slow' \

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -82,6 +82,11 @@ Tests are organized into four categories:
    Run them manually and migrate to unit or integration suites once
    validated.
 
+During `task coverage`, targeted smoke tests execute once per optional extra.
+The task iterates over `ALL_EXTRAS` and runs `pytest tests/targeted -m
+"requires_<extra> and not slow" --noconftest` so CI logs show which marker
+passes. Extras omitted from the `EXTRAS` variable are logged as skipped.
+
 ## Running tests
 
 Two installation strategies support different workflows:


### PR DESCRIPTION
## Summary
- iterate through each optional extra during the coverage task and run its targeted pytest marker with detailed logging
- document the per-extra targeted coverage runs in the testing guidelines so contributors know what to expect

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9c4e9b4d88333b667a082bbb99f7a