### PR TITLE
Document release blockers and add docs build issue

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,18 +13,23 @@ See [STATUS.md](STATUS.md) for current results and
 targets **September 15, 2026**, with **0.1.0** planned for **October 1, 2026**
 across project documentation. The evaluation container still lacks the Go Task
 CLI on first boot, so `uv run task check` fails until `scripts/setup.sh` or a
-manual install provides the binary. Targeted tests on **September 17, 2025**
-show the DuckDB extension loader suite and
-`tests/unit/search/test_ranking_formula.py::`
+manual install provides the binary. Running `uv sync --extra dev-minimal --extra
+test` followed by `uv run python scripts/check_env.py` leaves only the missing
+Go Task CLI warning in this environment. 【024fb5†L1-L13】【f56f62†L1-L24】
+Targeted tests on **September 17, 2025** show the DuckDB extension loader suite
+and `tests/unit/search/test_ranking_formula.py::`
 `test_rank_results_weighted_combination` now pass with the documented convex
-weights. However, `uv run --extra test pytest tests/unit -q` fails during
-collection because `scripts/distributed_coordination_sim.py` no longer exports
-`elect_leader` or `process_messages`, so the distributed property tests cannot
-import their reference helpers. Integration scenarios for ranking consistency
-and optional extras still pass with the `[test]` extras installed, and CLI
-helper plus data analysis suites run with
-`PYTHONWARNINGS=error::DeprecationWarning` without warnings. `uv run mkdocs`
-build still fails until docs extras install `mkdocs`. Release blockers remain
+weights. 【af6378†L1-L2】【75e1fd†L1-L2】 However, `uv run --extra test pytest`
+`tests/unit -q` fails during collection because
+`scripts/distributed_coordination_sim.py` no longer exports `elect_leader` or
+`process_messages`, so the distributed property tests cannot import their
+reference helpers. 【b4944c†L1-L23】 Integration scenarios for ranking
+consistency and optional extras still pass with the `[test]` extras installed,
+and CLI helper plus data analysis suites run with
+`PYTHONWARNINGS=error::DeprecationWarning` without warnings.
+【50b44e†L1-L2】【7a8f55†L1-L2】
+`uv run mkdocs build` still fails until docs extras install `mkdocs`.
+【6bcbaa†L1-L3】 Release blockers remain
 in [restore-distributed-coordination-simulation-exports](
 issues/restore-distributed-coordination-simulation-exports.md),
 [resolve-resource-tracker-errors-in-verify](

--- a/STATUS.md
+++ b/STATUS.md
@@ -8,33 +8,39 @@ committing. Include `EXTRAS="llm"` only when LLM features or dependency
 checks are required.
 
 ## September 17, 2025
+- `uv sync --extra dev-minimal --extra test` installs the linting and coverage
+  extras so `uv run python scripts/check_env.py` reports only the missing Go
+  Task CLI in this environment. 【024fb5†L1-L13】【f56f62†L1-L24】
 - `task --version` still reports `command not found`, so install Task with
   `scripts/setup.sh` before using the Taskfile.
 - `uv run --extra test pytest`
   `tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::`
   `test_load_extension_download_unhandled_exception -q` passes and keeps
-  propagating non-DuckDB errors.
+  propagating non-DuckDB errors. 【af6378†L1-L2】
 - `uv run --extra test pytest`
   `tests/unit/search/test_ranking_formula.py::test_rank_results_weighted_combination -q`
   now passes with the documented convex weights, confirming the validator
-  and ranking formula stay in sync.
+  and ranking formula stay in sync. 【75e1fd†L1-L2】
 - `uv run --extra test pytest tests/unit -q` fails during collection because
   `scripts/distributed_coordination_sim.py` no longer exports `elect_leader`
   or `process_messages`, so the distributed coordination property tests
-  cannot import their reference helpers.
+  cannot import their reference helpers. 【b4944c†L1-L23】
 - Integration coverage for ranking and optional extras is stable once
   weights are legal:
   `tests/integration/test_ranking_formula_consistency.py -q` and
   `tests/integration/test_optional_extras.py -q` both pass with the `[test]`
-  extras.
+  extras. 【50b44e†L1-L2】【7a8f55†L1-L2】
 - `uv run pytest tests/unit/test_config_validation_errors.py::`
   `test_weights_must_sum_to_one -q` passes after the validator fix, and
   targeted DuckDB storage plus orchestrator perf tests complete without
-  resource tracker errors.
+  resource tracker errors. 【127cf4†L1-L3】
 - CLI helper and data analysis suites run with
   `PYTHONWARNINGS=error::DeprecationWarning` and report no warnings.
 - `uv run mkdocs build` still fails with `No such file or directory` because
-  docs extras are not installed.
+  docs extras are not installed. 【6bcbaa†L1-L3】
+- Regenerated `SPEC_COVERAGE.md` with
+  `uv run python scripts/generate_spec_coverage.py --output SPEC_COVERAGE.md`
+  to confirm every module retains spec and proof references. 【a99f8d†L1-L2】
 - Reviewed the API, CLI helpers, config, distributed, extensions, and monitor
   specs; the documents match the implementation, so the update tickets were
   archived.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -4,19 +4,24 @@ This document tracks the progress of tasks for the Autoresearch project,
 organized by phases from the code complete plan. As of **September 17, 2025**
 the evaluation container still lacks the Go Task CLI by default, so
 `uv run task check` fails until `scripts/setup.sh` installs the binary.
-Targeted unit tests confirm that
-`tests/unit/test_config_validation_errors.py::test_weights_must_sum_to_one`,
+Running `uv sync --extra dev-minimal --extra test` followed by
+`uv run python scripts/check_env.py` leaves only the missing Go Task warning in
+this environment. 【024fb5†L1-L13】【f56f62†L1-L24】 Targeted unit tests confirm
+that `tests/unit/test_config_validation_errors.py::test_weights_must_sum_to_one`,
 the DuckDB offline fallback suite,
 `tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::
 test_load_extension_download_unhandled_exception`, and
 `tests/unit/search/test_ranking_formula.py::test_rank_results_weighted_combination`
-all pass after the ranking weights were updated. However,
-`uv run --extra test pytest tests/unit -q` now aborts during collection because
-`scripts/distributed_coordination_sim.py` no longer exports `elect_leader` or
-`process_messages`, so the distributed property tests cannot import their
-reference helpers. `uv run mkdocs build` still fails until the docs extras sync
-`mkdocs` onto the PATH. Unit coverage and `task verify` remain blocked while
-the Task CLI is missing and the distributed regression persists.
+all pass after the ranking weights were updated.
+【127cf4†L1-L3】【af6378†L1-L2】【75e1fd†L1-L2】 Integration scenarios for ranking
+consistency and optional extras also succeed with the `[test]` extras installed.
+【50b44e†L1-L2】【7a8f55†L1-L2】 However, `uv run --extra test pytest tests/unit -q`
+still aborts during collection because `scripts/distributed_coordination_sim.py`
+no longer exports `elect_leader` or `process_messages`, so the distributed
+property tests cannot import their reference helpers. 【b4944c†L1-L23】
+`uv run mkdocs build` still fails until the docs extras sync `mkdocs` onto the
+PATH. 【6bcbaa†L1-L3】 Unit coverage and `task verify` remain blocked while the
+Task CLI is missing and the distributed regression persists.
 See [docs/release_plan.md](docs/release_plan.md) for current test and coverage
 status and the alpha release checklist. An **0.1.0-alpha.1** preview remains
 targeted for **September 15, 2026**, with the final **0.1.0** release targeted

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -22,20 +22,24 @@ The dependency pins for `fastapi` (>=0.115.12) and `slowapi` (==0.1.9) remain
 confirmed in `pyproject.toml` and [installation.md](installation.md), but the
 evaluation environment still omits the Go Task CLI. `uv run task check` fails
 with `No such file or directory` until `scripts/setup.sh` installs the binary.
-Targeted unit runs on **September 17, 2025** show that the DuckDB offline
-fallback, extension loader suite, and
+Running `uv sync --extra dev-minimal --extra test` followed by
+`uv run python scripts/check_env.py` leaves only the missing Go Task warning in
+this setup. 【024fb5†L1-L13】【f56f62†L1-L24】 Targeted unit runs on **September 17,
+2025** show that the DuckDB offline fallback, extension loader suite, and
 `tests/unit/search/test_ranking_formula.py::`
 `test_rank_results_weighted_combination` now pass with the documented convex
-weights. However, `uv run --extra test pytest tests/unit -q` fails during
-collection because `scripts/distributed_coordination_sim.py` no longer exports
-`elect_leader` or `process_messages`, so the distributed property tests cannot
-import their reference helpers. Integration ranking checks and optional extras
-still pass with the `[test]` extras installed, and CLI helper plus data
+weights. 【127cf4†L1-L3】【af6378†L1-L2】【75e1fd†L1-L2】 However,
+`uv run --extra test pytest tests/unit -q` fails during collection because
+`scripts/distributed_coordination_sim.py` no longer exports `elect_leader` or
+`process_messages`, so the distributed property tests cannot import their
+reference helpers. 【b4944c†L1-L23】 Integration ranking checks and optional
+extras still pass with the `[test]` extras installed, and CLI helper plus data
 analysis suites run with `PYTHONWARNINGS=error::DeprecationWarning` without
-warnings. `uv run mkdocs` build still fails until the docs extras add `mkdocs`
-to the PATH. `task verify` remains blocked by the missing CLI and the
-distributed regression, so coverage numbers are still unavailable. These items
-are tracked in [STATUS.md](../STATUS.md) and the open issues listed there.
+warnings. 【50b44e†L1-L2】【7a8f55†L1-L2】 `uv run mkdocs build` still fails until
+the docs extras add `mkdocs` to the PATH. 【6bcbaa†L1-L3】 `task verify` remains
+blocked by the missing CLI and the distributed regression, so coverage numbers
+are still unavailable. These items are tracked in
+[STATUS.md](../STATUS.md) and the open issues listed there.
 ## Milestones
 
 - **0.1.0a1** (2026-09-15, status: in progress): Alpha preview to collect

--- a/issues/document-docs-build-prerequisites.md
+++ b/issues/document-docs-build-prerequisites.md
@@ -1,0 +1,25 @@
+# Document docs build prerequisites
+
+## Context
+Running `uv run mkdocs build` in the evaluation container still fails with
+`No such file or directory` because the docs extras are not installed by
+default. 【6bcbaa†L1-L3】 Contributors currently have to remember to sync the
+docs dependencies manually, even though the Taskfile exposes a `docs` target
+that installs the extras on demand. 【132116†L22-L32】 We need to document the
+expected workflow so release instructions consistently recommend either
+`task docs` or `uv run --extra docs mkdocs build` before verifying the site.
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- Update release documentation (e.g. README or `docs/release_plan.md`) to
+  instruct contributors to run `task docs` or `uv run --extra docs mkdocs build`
+  before building the site.
+- Confirm the updated guidance matches the Taskfile `docs` task and avoids
+  suggesting `uv run mkdocs build` without extras.
+- Note the change in STATUS.md or other status tracking so the release issue
+  reflects the clarified workflow.
+
+## Status
+Open

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -22,6 +22,23 @@ fails because docs extras are not present, and the missing Task CLI prevents
 release checklist and require targeted fixes before we can draft reliable
 release notes.
 
+Running `uv sync --extra dev-minimal --extra test` followed by
+`uv run python scripts/check_env.py` now reports only the missing Go Task CLI
+in the evaluation container. 【024fb5†L1-L13】【f56f62†L1-L24】 Targeted unit and
+integration checks continue to pass where helpers exist:
+`tests/unit/test_config_validation_errors.py::test_weights_must_sum_to_one`,
+`tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::
+test_load_extension_download_unhandled_exception`,
+`tests/unit/search/test_ranking_formula.py::test_rank_results_weighted_combination`,
+`tests/integration/test_ranking_formula_consistency.py`, and
+`tests/integration/test_optional_extras.py` all succeed with the `[test]`
+extras installed. 【127cf4†L1-L3】【af6378†L1-L2】【75e1fd†L1-L2】【50b44e†L1-L2】
+【7a8f55†L1-L2】 Full unit collection still aborts with ImportError until the
+distributed simulation exports return, and `uv run mkdocs build` continues to
+fail because `mkdocs` is not on the PATH in a minimal environment.
+【b4944c†L1-L23】【6bcbaa†L1-L3】 These regressions remain the final blockers
+before we can draft changelog entries and cut the first alpha tag.
+
 ## Dependencies
 - [restore-distributed-coordination-simulation-exports](
   restore-distributed-coordination-simulation-exports.md)
@@ -29,6 +46,7 @@ release notes.
   resolve-resource-tracker-errors-in-verify.md)
 - [resolve-deprecation-warnings-in-tests](
   resolve-deprecation-warnings-in-tests.md)
+- [document-docs-build-prerequisites](document-docs-build-prerequisites.md)
 
 ## Acceptance Criteria
 - All dependency issues are closed.

--- a/issues/restore-distributed-coordination-simulation-exports.md
+++ b/issues/restore-distributed-coordination-simulation-exports.md
@@ -10,6 +10,9 @@ validate the leader election and message ordering proofs documented in
 `docs/algorithms/distributed_coordination.md`. The specification still cites
 this script as the reference implementation, so the missing exports break the
 Doc/spec/test alignment and prevent `task verify` from running to completion.
+Pytest now raises `ImportError: cannot import name 'elect_leader'` for both
+distributed property suites, confirming the helpers must be reinstated before
+`tests/unit` can collect. 【b4944c†L1-L23】
 
 ## Dependencies
 None.


### PR DESCRIPTION
## Summary
- refresh STATUS, ROADMAP, TASK_PROGRESS, and docs/release_plan.md with the latest environment checks, targeted test results, and outstanding release blockers
- expand the 0.1.0a1 planning issue with current diagnostics, add an explicit dependency for documenting docs build prerequisites, and record the ImportError seen from the distributed coordination tests
- add a new issue to track documenting the required docs extras workflow before running `mkdocs`

## Testing
- `uv sync --extra dev-minimal --extra test`
- `uv run python scripts/check_env.py`
- `uv run --extra test pytest tests/unit -q`
- `uv run pytest tests/unit/test_vss_extension_loader.py::TestVSSExtensionLoader::test_load_extension_download_unhandled_exception -q`
- `uv run pytest tests/unit/test_config_validation_errors.py::test_weights_must_sum_to_one -q`
- `uv run pytest tests/unit/search/test_ranking_formula.py::test_rank_results_weighted_combination -q`
- `uv run pytest tests/integration/test_optional_extras.py -q`
- `uv run pytest tests/integration/test_ranking_formula_consistency.py -q`
- `uv run mkdocs build`
- `uv run python scripts/generate_spec_coverage.py --output SPEC_COVERAGE.md`


------
https://chatgpt.com/codex/tasks/task_e_68ca45aa2758833387b0cd0b23291e63