### PR TITLE
Document storage teardown regression and refresh planning docs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,17 +19,22 @@ Go Task CLI warning in this environment. 【12a21c†L1-L9】【0525bf†L1-L26�
 Targeted tests on **September 17, 2025** show the config validator, DuckDB
 extension fallback, VSS loader, ranking consistency, and optional extras suites
 now pass with the `[test]` extras installed. 【4567c0†L1-L2】【3108ac†L1-L2】
-【abaaf2†L1-L2】【897640†L1-L3】【d26393†L1-L2】 However, `uv run --extra test
-pytest tests/unit -q` fails during collection because
-`scripts/distributed_coordination_sim.py` no longer exports `elect_leader` or
-`process_messages`, so the distributed property tests cannot import their
-reference helpers. 【382418†L1-L23】 CLI helper and data analysis suites run with
-`PYTHONWARNINGS=error::DeprecationWarning` without warnings. `uv run mkdocs build`
-still fails until docs extras install `mkdocs`, so run `task docs` (or `uv run
---extra docs mkdocs build`) to pull the dependencies automatically.
-【9f25fa†L1-L3】 Release blockers remain
+【abaaf2†L1-L2】【897640†L1-L3】【d26393†L1-L2】 However, `uv run pytest
+tests/unit -q` now fails in teardown because monitor CLI metrics tests patch
+`ConfigLoader.load_config` to return `type("C", (), {})()`. The autouse
+`cleanup_storage` fixture raises `AttributeError: 'C' object has no attribute
+'storage'`, so the suite stops before distributed scenarios run.
+`uv run pytest tests/unit -k "storage" -q --maxfail=1` reproduces the
+failure at `tests/unit/test_monitor_cli.py::test_metrics_skips_storage`.
+【d541c6†L1-L58】【35a0a9†L63-L73】 CLI helper and data analysis suites run with
+`PYTHONWARNINGS=error::DeprecationWarning` without warnings. `uv run mkdocs
+build` still fails until docs extras install `mkdocs`, so run `task docs` (or
+`uv run --extra docs mkdocs build`) to pull the dependencies automatically.
+【fef027†L1-L3】 Release blockers remain
 in [restore-distributed-coordination-simulation-exports](
 issues/restore-distributed-coordination-simulation-exports.md),
+[handle-config-loader-patches-in-storage-teardown](
+issues/handle-config-loader-patches-in-storage-teardown.md),
 [resolve-resource-tracker-errors-in-verify](
 issues/resolve-resource-tracker-errors-in-verify.md),
 [resolve-deprecation-warnings-in-tests](

--- a/STATUS.md
+++ b/STATUS.md
@@ -20,15 +20,18 @@ checks are required.
   weights are legal: `tests/integration/test_ranking_formula_consistency.py -q`
   and `tests/integration/test_optional_extras.py -q` both pass.
   【897640†L1-L3】【d26393†L1-L2】
-- `uv run --extra test pytest tests/unit -q` fails during collection because
-  `scripts/distributed_coordination_sim.py` no longer exports `elect_leader`
-  or `process_messages`, so the distributed coordination property tests
-  cannot import their reference helpers. 【382418†L1-L23】
+- `uv run pytest tests/unit -q` fails in teardown because monitor CLI metrics
+  tests patch `ConfigLoader.load_config` to return `type("C", (), {})()`. The
+  autouse `cleanup_storage` fixture raises `AttributeError: 'C' object has no
+  attribute 'storage'`, so the suite stops before the remaining modules run.
+  `uv run pytest tests/unit -k "storage" -q --maxfail=1` reproduces the
+  failure at `tests/unit/test_monitor_cli.py::test_metrics_skips_storage`.
+  【d541c6†L1-L58】【35a0a9†L63-L73】
 - CLI helper and data analysis suites run with
   `PYTHONWARNINGS=error::DeprecationWarning` and report no warnings.
 - `uv run mkdocs build` still fails with `No such file or directory` because
   docs extras are not installed; run `task docs` (or `uv run --extra docs
-  mkdocs build`) to pull them automatically. 【9f25fa†L1-L3】
+  mkdocs build`) to pull them automatically. 【fef027†L1-L3】
 - Contributor docs and the release checklist now direct maintainers to run
   `task docs` or `uv run --extra docs mkdocs build` before building the site,
   keeping the workflow aligned with the Taskfile.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -11,14 +11,18 @@ that the config validator, DuckDB offline fallback, and VSS extension loader
 all pass with the `[test]` extras installed. 【4567c0†L1-L2】【3108ac†L1-L2】
 【abaaf2†L1-L2】 Integration scenarios for ranking consistency and optional extras
 also succeed with the `[test]` extras installed. 【897640†L1-L3】【d26393†L1-L2】
-However, `uv run --extra test pytest tests/unit -q` still aborts during
-collection because `scripts/distributed_coordination_sim.py` no longer exports
-`elect_leader` or `process_messages`, so the distributed property tests cannot
-import their reference helpers. 【382418†L1-L23】 `uv run mkdocs build` still fails
-until the docs extras sync `mkdocs` onto the PATH, so run `task docs` (or `uv
-run --extra docs mkdocs build`) to install them automatically. 【9f25fa†L1-L3】
-Unit coverage and `task verify` remain blocked while the
-Task CLI is missing and the distributed regression persists.
+However, `uv run pytest tests/unit -q` now fails in teardown because
+monitor CLI metrics tests patch `ConfigLoader.load_config` to return
+`type("C", (), {})()`. The autouse `cleanup_storage` fixture raises
+`AttributeError: 'C' object has no attribute 'storage'`, so the suite stops
+before the remaining modules run. `uv run pytest tests/unit -k "storage" -q
+--maxfail=1` reproduces the failure at
+`tests/unit/test_monitor_cli.py::test_metrics_skips_storage`.
+【d541c6†L1-L58】【35a0a9†L63-L73】 `uv run mkdocs build` still fails until the
+docs extras install `mkdocs`, so run `task docs` (or `uv run --extra docs
+mkdocs build`) to pull the dependencies automatically. 【fef027†L1-L3】 Unit
+coverage and `task verify` remain blocked while the Task CLI is missing and
+the storage teardown regression persists.
 See [docs/release_plan.md](docs/release_plan.md) for current test and coverage
 status and the alpha release checklist. An **0.1.0-alpha.1** preview remains
 targeted for **September 15, 2026**, with the final **0.1.0** release targeted

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -29,14 +29,17 @@ this setup. 【12a21c†L1-L9】【0525bf†L1-L26】 Targeted unit runs on **Se
 extension loader now pass with the `[test]` extras installed. 【4567c0†L1-L2】
 【3108ac†L1-L2】【abaaf2†L1-L2】 Integration ranking checks and optional extras
 still pass with the `[test]` extras installed. 【897640†L1-L3】【d26393†L1-L2】
-However, `uv run --extra test pytest tests/unit -q` fails during collection
-because `scripts/distributed_coordination_sim.py` no longer exports
-`elect_leader` or `process_messages`, so the distributed property tests cannot
-import their reference helpers.
-【382418†L1-L23】 `uv run mkdocs build` still fails until the docs extras add
-`mkdocs` to the PATH, so run `task docs` (or `uv run
---extra docs mkdocs build`) to install them automatically. 【9f25fa†L1-L3】
-`task verify` remains blocked by the missing CLI and the distributed
+However, `uv run pytest tests/unit -q` now fails in teardown because
+monitor CLI metrics tests patch `ConfigLoader.load_config` to return
+`type("C", (), {})()`. The autouse `cleanup_storage` fixture raises
+`AttributeError: 'C' object has no attribute 'storage'`, so the suite stops
+before distributed scenarios run. `uv run pytest tests/unit -k "storage" -q
+--maxfail=1` reproduces the failure at
+`tests/unit/test_monitor_cli.py::test_metrics_skips_storage`.
+【d541c6†L1-L58】【35a0a9†L63-L73】 `uv run mkdocs build` still fails until the
+docs extras add `mkdocs` to the PATH, so run `task docs` (or `uv run
+--extra docs mkdocs build`) to install them automatically. 【fef027†L1-L3】
+`task verify` remains blocked by the missing CLI and the storage teardown
 regression, so coverage numbers are still unavailable. These items are tracked
 in
 [STATUS.md](../STATUS.md) and the open issues listed there.

--- a/issues/archive/document-docs-build-prerequisites.md
+++ b/issues/archive/document-docs-build-prerequisites.md
@@ -23,4 +23,4 @@ site.
   reflects the clarified workflow.
 
 ## Status
-Open
+Archived

--- a/issues/handle-config-loader-patches-in-storage-teardown.md
+++ b/issues/handle-config-loader-patches-in-storage-teardown.md
@@ -1,0 +1,28 @@
+# Handle config loader patches in storage teardown
+
+## Context
+Tests that patch `ConfigLoader.load_config` to bare objects without a
+`storage` attribute now cause the autouse `cleanup_storage` fixture to fail
+during teardown. `test_metrics_skips_storage` in
+`tests/unit/test_monitor_cli.py` replaces the loader with `type("C", (), {})()`
+and the fixture subsequently raises `AttributeError: 'C' object has no
+attribute 'storage'` when `storage.teardown(remove_db=True)` runs.
+`uv run pytest tests/unit -k "storage" -q --maxfail=1` stops at that failure,
+so `uv run pytest tests/unit -q` never reaches the remaining suites.
+【F:tests/unit/test_monitor_cli.py†L41-L85】【d541c6†L1-L58】【35a0a9†L63-L73】
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- Ensure storage cleanup tolerates tests that patch `ConfigLoader.load_config`
+  or adjust those tests so teardown always receives a config with a
+  `storage` attribute.
+- `uv run pytest tests/unit -k "storage" -q --maxfail=1` completes without
+  errors in a fresh environment with the `[test]` extras installed.
+- `uv run pytest tests/unit -q` progresses beyond the monitor metrics tests
+  without triggering `AttributeError: 'C' object has no attribute 'storage'`.
+- Document the change in STATUS.md or TASK_PROGRESS.md.
+
+## Status
+Open

--- a/issues/resolve-deprecation-warnings-in-tests.md
+++ b/issues/resolve-deprecation-warnings-in-tests.md
@@ -16,10 +16,11 @@ comparison test. The `sitecustomize.py` shim that rewrites
 `weasel.util.config` appears to be working, and the Click bump to 8.2.1 removed
 the original warning. We still need an end-to-end `task verify` run with Go
 Task installed to confirm the absence of warnings across the full suite, but
-`uv run --extra test pytest tests/unit -q` currently fails because
-`scripts/distributed_coordination_sim.py` no longer exports the helpers that
-the distributed property tests import. 【382418†L1-L23】 Once those exports
-return we can rerun the warnings sweep under Task.
+`uv run pytest tests/unit -q` now fails in teardown when monitor CLI metrics
+tests patch `ConfigLoader.load_config` to return `type("C", (), {})()`. The
+autouse `cleanup_storage` fixture raises `AttributeError: 'C' object has no
+attribute 'storage'`, so the suite aborts before we can rerun the warnings
+sweep under Task. 【d541c6†L1-L58】【35a0a9†L63-L73】
 
 ## Dependencies
 None

--- a/issues/resolve-resource-tracker-errors-in-verify.md
+++ b/issues/resolve-resource-tracker-errors-in-verify.md
@@ -12,14 +12,15 @@ that Go Task is the remaining prerequisite. 【12a21c†L1-L9】【0525bf†L1-L
 Targeted retries of the DuckDB extension fallback, ranking consistency, and
 optional extras suites complete without resource tracker errors, suggesting the
 fixture cleanup helpers remain effective when the suite reaches teardown.
-【3108ac†L1-L2】【897640†L1-L3】【d26393†L1-L2】 However, running
-`uv run --extra test pytest tests/unit -q` still aborts during collection
-because `scripts/distributed_coordination_sim.py` no longer exports
-`elect_leader` or `process_messages`. 【382418†L1-L23】 Until the distributed
-properties import their reference helpers and Go Task is installed, we cannot
-exercise the full unit suite under coverage to confirm the resource tracker fix.
-We still need a full `task verify` execution (with Task installed) once the
-distributed regression is resolved.
+【3108ac†L1-L2】【897640†L1-L3】【d26393†L1-L2】 However, `uv run pytest tests/unit -q`
+now fails in teardown because the monitor metrics tests patch
+`ConfigLoader.load_config` to return `type("C", (), {})()`. The autouse
+`cleanup_storage` fixture calls `storage.teardown(remove_db=True)` during
+teardown and raises `AttributeError: 'C' object has no attribute 'storage'`,
+so the suite aborts before coverage can run. 【d541c6†L1-L58】【35a0a9†L63-L73】 Until
+the storage teardown regression is fixed and the Go Task CLI is available, we
+still cannot exercise the full unit suite under coverage to confirm the
+resource tracker fix.
 
 ## Dependencies
 - [fix-duckdb-storage-schema-initialization](

--- a/issues/restore-distributed-coordination-simulation-exports.md
+++ b/issues/restore-distributed-coordination-simulation-exports.md
@@ -1,18 +1,18 @@
 # Restore distributed coordination simulation exports
 
 ## Context
-Running `uv run --extra test pytest tests/unit -q` on September 17, 2025
-fails during collection because `scripts/distributed_coordination_sim.py`
-no longer exports `elect_leader` or `process_messages`. Property-based tests
-(`tests/unit/distributed/test_coordination_properties.py` and
-`tests/unit/test_distributed_coordination_props.py`) import those helpers to
-validate the leader election and message ordering proofs documented in
-`docs/algorithms/distributed_coordination.md`. The specification still cites
-this script as the reference implementation, so the missing exports break the
-Doc/spec/test alignment and prevent `task verify` from running to completion.
-Pytest now raises `ImportError: cannot import name 'elect_leader'` for both
-distributed property suites, confirming the helpers must be reinstated before
-`tests/unit` can collect. 【382418†L1-L23】【F:scripts/distributed_coordination_sim.py†L67-L200】【F:docs/algorithms/distributed_coordination.md†L66-L90】
+`scripts/distributed_coordination_sim.py` now exports `elect_leader` and
+`process_messages`, and direct imports confirm the helpers follow the proof in
+`docs/algorithms/distributed_coordination.md`.
+【F:scripts/distributed_coordination_sim.py†L1-L200】【049a40†L1-L3】 The unit
+suite still fails before the property tests run because monitor CLI metrics
+tests patch `ConfigLoader.load_config` to return `type("C", (), {})()`. The
+autouse `cleanup_storage` fixture invokes `storage.teardown(remove_db=True)`
+during teardown and raises `AttributeError: 'C' object has no attribute
+'storage'`, so `uv run pytest tests/unit -q` aborts early and never reaches the
+distributed scenarios. 【d541c6†L1-L58】【35a0a9†L63-L73】 We must keep this ticket
+open until the storage teardown regression is resolved and the property suites
+can execute again.
 
 ## Dependencies
 None.


### PR DESCRIPTION
## Summary
- archive the resolved documentation prerequisites ticket and add a new issue tracking the storage teardown regression triggered by monitor metrics tests
- refresh STATUS, TASK_PROGRESS, ROADMAP, and release plan narratives to describe the current pytest failure mode and updated mkdocs guidance
- update the first-alpha release tracker to depend on the new issue and to reflect the latest blocking conditions

## Testing
- `uv run pytest tests/unit -q` *(fails: storage teardown raises AttributeError when ConfigLoader is patched to type("C", (), {})())*
- `uv run pytest tests/unit -k "storage" -q --maxfail=1` *(fails: reproduces the same storage teardown regression)*

------
https://chatgpt.com/codex/tasks/task_e_68cacfd36cec833398f931012dbdd501