### PR TITLE
Refresh release planning docs with current test evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,22 +15,22 @@ across project documentation. The evaluation container still lacks the Go Task
 CLI on first boot, so `uv run task check` fails until `scripts/setup.sh` or a
 manual install provides the binary. Running `uv sync --extra dev-minimal --extra
 test` followed by `uv run python scripts/check_env.py` leaves only the missing
-Go Task CLI warning in this environment. 【12a21c†L1-L9】【0525bf†L1-L26】
+Go Task CLI warning in this environment. 【8e4fc3†L1-L27】【37a1fe†L1-L26】
 Targeted tests on **September 17, 2025** show the config validator, DuckDB
 extension fallback, VSS loader, ranking consistency, and optional extras suites
-now pass with the `[test]` extras installed. 【4567c0†L1-L2】【3108ac†L1-L2】
-【abaaf2†L1-L2】【897640†L1-L3】【d26393†L1-L2】 However, `uv run pytest
+now pass with the `[test]` extras installed. 【5b737c†L1-L3】【a7a5ea†L1-L2】
+【93e5f9†L1-L2】【9a935a†L1-L2】【ee8c19†L1-L2】 However, `uv run pytest
 tests/unit -q` now fails in teardown because monitor CLI metrics tests patch
 `ConfigLoader.load_config` to return `type("C", (), {})()`. The autouse
 `cleanup_storage` fixture raises `AttributeError: 'C' object has no attribute
 'storage'`, so the suite stops before distributed scenarios run.
 `uv run pytest tests/unit -k "storage" -q --maxfail=1` reproduces the
 failure at `tests/unit/test_monitor_cli.py::test_metrics_skips_storage`.
-【d541c6†L1-L58】【35a0a9†L63-L73】 CLI helper and data analysis suites run with
+【eeec82†L1-L57】 CLI helper and data analysis suites run with
 `PYTHONWARNINGS=error::DeprecationWarning` without warnings. `uv run mkdocs
 build` still fails until docs extras install `mkdocs`, so run `task docs` (or
 `uv run --extra docs mkdocs build`) to pull the dependencies automatically.
-【fef027†L1-L3】 Release blockers remain
+【3109f7†L1-L3】 Release blockers remain
 in [restore-distributed-coordination-simulation-exports](
 issues/restore-distributed-coordination-simulation-exports.md),
 [handle-config-loader-patches-in-storage-teardown](

--- a/STATUS.md
+++ b/STATUS.md
@@ -10,28 +10,31 @@ checks are required.
 ## September 17, 2025
 - `uv sync --extra dev-minimal --extra test` installs the linting and coverage
   extras so `uv run python scripts/check_env.py` reports only the missing Go
-  Task CLI in this environment. 【12a21c†L1-L9】【0525bf†L1-L26】
+  Task CLI in this environment. 【8e4fc3†L1-L27】【37a1fe†L1-L26】
 - `task --version` still reports `command not found`, so install Task with
-  `scripts/setup.sh` before using the Taskfile.
+  `scripts/setup.sh` before using the Taskfile. 【15b3ab†L1-L2】
 - Targeted unit suites pass where helpers exist: the config validator, DuckDB
   extension fallback, and VSS loader all succeed with the `[test]` extras.
-  【4567c0†L1-L2】【3108ac†L1-L2】【abaaf2†L1-L2】
+  【5b737c†L1-L3】【a7a5ea†L1-L2】【93e5f9†L1-L2】
+- Distributed coordination property tests pass when invoked directly, but the
+  full suite cannot reach them until storage teardown stops failing.
+  【1daaef†L1-L3】【eeec82†L1-L57】
 - Integration coverage for ranking and optional extras remains stable once
   weights are legal: `tests/integration/test_ranking_formula_consistency.py -q`
   and `tests/integration/test_optional_extras.py -q` both pass.
-  【897640†L1-L3】【d26393†L1-L2】
+  【9a935a†L1-L2】【ee8c19†L1-L2】
 - `uv run pytest tests/unit -q` fails in teardown because monitor CLI metrics
   tests patch `ConfigLoader.load_config` to return `type("C", (), {})()`. The
   autouse `cleanup_storage` fixture raises `AttributeError: 'C' object has no
   attribute 'storage'`, so the suite stops before the remaining modules run.
   `uv run pytest tests/unit -k "storage" -q --maxfail=1` reproduces the
   failure at `tests/unit/test_monitor_cli.py::test_metrics_skips_storage`.
-  【d541c6†L1-L58】【35a0a9†L63-L73】
+  【eeec82†L1-L57】
 - CLI helper and data analysis suites run with
   `PYTHONWARNINGS=error::DeprecationWarning` and report no warnings.
 - `uv run mkdocs build` still fails with `No such file or directory` because
   docs extras are not installed; run `task docs` (or `uv run --extra docs
-  mkdocs build`) to pull them automatically. 【fef027†L1-L3】
+  mkdocs build`) to pull them automatically. 【3109f7†L1-L3】
 - Contributor docs and the release checklist now direct maintainers to run
   `task docs` or `uv run --extra docs mkdocs build` before building the site,
   keeping the workflow aligned with the Taskfile.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -6,11 +6,13 @@ the evaluation container still lacks the Go Task CLI by default, so
 `uv run task check` fails until `scripts/setup.sh` installs the binary.
 Running `uv sync --extra dev-minimal --extra test` followed by
 `uv run python scripts/check_env.py` leaves only the missing Go Task warning in
-this environment. 【12a21c†L1-L9】【0525bf†L1-L26】 Targeted unit tests confirm
+this environment. 【8e4fc3†L1-L27】【37a1fe†L1-L26】 Targeted unit tests confirm
 that the config validator, DuckDB offline fallback, and VSS extension loader
-all pass with the `[test]` extras installed. 【4567c0†L1-L2】【3108ac†L1-L2】
-【abaaf2†L1-L2】 Integration scenarios for ranking consistency and optional extras
-also succeed with the `[test]` extras installed. 【897640†L1-L3】【d26393†L1-L2】
+all pass with the `[test]` extras installed. 【5b737c†L1-L3】【a7a5ea†L1-L2】
+【93e5f9†L1-L2】 Integration scenarios for ranking consistency and optional extras
+also succeed with the `[test]` extras installed. 【9a935a†L1-L2】【ee8c19†L1-L2】
+Distributed coordination property tests likewise pass when run directly even
+though the full suite cannot reach them yet. 【1daaef†L1-L3】【eeec82†L1-L57】
 However, `uv run pytest tests/unit -q` now fails in teardown because
 monitor CLI metrics tests patch `ConfigLoader.load_config` to return
 `type("C", (), {})()`. The autouse `cleanup_storage` fixture raises
@@ -18,9 +20,9 @@ monitor CLI metrics tests patch `ConfigLoader.load_config` to return
 before the remaining modules run. `uv run pytest tests/unit -k "storage" -q
 --maxfail=1` reproduces the failure at
 `tests/unit/test_monitor_cli.py::test_metrics_skips_storage`.
-【d541c6†L1-L58】【35a0a9†L63-L73】 `uv run mkdocs build` still fails until the
+【eeec82†L1-L57】 `uv run mkdocs build` still fails until the
 docs extras install `mkdocs`, so run `task docs` (or `uv run --extra docs
-mkdocs build`) to pull the dependencies automatically. 【fef027†L1-L3】 Unit
+mkdocs build`) to pull the dependencies automatically. 【3109f7†L1-L3】 Unit
 coverage and `task verify` remain blocked while the Task CLI is missing and
 the storage teardown regression persists.
 See [docs/release_plan.md](docs/release_plan.md) for current test and coverage

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -24,11 +24,11 @@ evaluation environment still omits the Go Task CLI. `uv run task check` fails
 with `No such file or directory` until `scripts/setup.sh` installs the binary.
 Running `uv sync --extra dev-minimal --extra test` followed by
 `uv run python scripts/check_env.py` leaves only the missing Go Task warning in
-this setup. 【12a21c†L1-L9】【0525bf†L1-L26】 Targeted unit runs on **September 17,
+this setup. 【8e4fc3†L1-L27】【37a1fe†L1-L26】 Targeted unit runs on **September 17,
 2025** show that the config validator, DuckDB offline fallback, and VSS
-extension loader now pass with the `[test]` extras installed. 【4567c0†L1-L2】
-【3108ac†L1-L2】【abaaf2†L1-L2】 Integration ranking checks and optional extras
-still pass with the `[test]` extras installed. 【897640†L1-L3】【d26393†L1-L2】
+extension loader now pass with the `[test]` extras installed. 【5b737c†L1-L3】
+【a7a5ea†L1-L2】【93e5f9†L1-L2】 Integration ranking checks and optional extras
+still pass with the `[test]` extras installed. 【9a935a†L1-L2】【ee8c19†L1-L2】
 However, `uv run pytest tests/unit -q` now fails in teardown because
 monitor CLI metrics tests patch `ConfigLoader.load_config` to return
 `type("C", (), {})()`. The autouse `cleanup_storage` fixture raises
@@ -36,9 +36,9 @@ monitor CLI metrics tests patch `ConfigLoader.load_config` to return
 before distributed scenarios run. `uv run pytest tests/unit -k "storage" -q
 --maxfail=1` reproduces the failure at
 `tests/unit/test_monitor_cli.py::test_metrics_skips_storage`.
-【d541c6†L1-L58】【35a0a9†L63-L73】 `uv run mkdocs build` still fails until the
+【eeec82†L1-L57】 `uv run mkdocs build` still fails until the
 docs extras add `mkdocs` to the PATH, so run `task docs` (or `uv run
---extra docs mkdocs build`) to install them automatically. 【fef027†L1-L3】
+--extra docs mkdocs build`) to install them automatically. 【3109f7†L1-L3】
 `task verify` remains blocked by the missing CLI and the storage teardown
 regression, so coverage numbers are still unavailable. These items are tracked
 in

--- a/issues/handle-config-loader-patches-in-storage-teardown.md
+++ b/issues/handle-config-loader-patches-in-storage-teardown.md
@@ -9,7 +9,7 @@ and the fixture subsequently raises `AttributeError: 'C' object has no
 attribute 'storage'` when `storage.teardown(remove_db=True)` runs.
 `uv run pytest tests/unit -k "storage" -q --maxfail=1` stops at that failure,
 so `uv run pytest tests/unit -q` never reaches the remaining suites.
-【F:tests/unit/test_monitor_cli.py†L41-L85】【d541c6†L1-L58】【35a0a9†L63-L73】
+【F:tests/unit/test_monitor_cli.py†L41-L85】【eeec82†L1-L57】
 
 ## Dependencies
 - None

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -5,13 +5,14 @@ The project remains unreleased even though the codebase and documentation are
 public. To tag v0.1.0a1 we still need a coordinated push across testing,
 documentation, and packaging while keeping workflows dispatch-only. As of
 2025-09-17 the Go Task CLI is still absent in a fresh environment, so running
-`uv run task check` fails until contributors install Task manually. After
-syncing the `dev-minimal` and `test` extras, `uv run python scripts/check_env.py`
-now reports only the missing Go Task CLI. 【12a21c†L1-L9】【0525bf†L1-L26】
-Targeted test suites continue to pass where helpers exist: the config weight
-validator, DuckDB extension fallback, VSS extension loader, ranking
-consistency, and optional extras checks all succeed with the `[test]` extras
-installed. 【4567c0†L1-L2】【3108ac†L1-L2】【abaaf2†L1-L2】【897640†L1-L3】【d26393†L1-L2】
+`uv run task check` fails until contributors install Task manually. `task
+--version` still reports `command not found`, and after syncing the
+`dev-minimal` and `test` extras, `uv run python scripts/check_env.py` reports
+only the missing Go Task CLI. 【15b3ab†L1-L2】【37a1fe†L1-L26】 Targeted test
+suites continue to pass where helpers exist: the config weight validator,
+DuckDB extension fallback, VSS extension loader, ranking consistency, and
+optional extras checks all succeed with the `[test]` extras installed.
+【5b737c†L1-L3】【a7a5ea†L1-L2】【93e5f9†L1-L2】【9a935a†L1-L2】【ee8c19†L1-L2】
 However, `uv run pytest tests/unit -q` now stops in the monitor metrics suite
 because several tests patch `ConfigLoader.load_config` to return bare objects
 without a `storage` attribute. The autouse `cleanup_storage` fixture then calls
@@ -19,10 +20,10 @@ without a `storage` attribute. The autouse `cleanup_storage` fixture then calls
 `AttributeError: 'C' object has no attribute 'storage'`, so the full suite
 never reaches the remaining modules. `uv run pytest tests/unit -k "storage" -q
 --maxfail=1` reproduces the failure at
-`tests/unit/test_monitor_cli.py::test_metrics_skips_storage`. 【d541c6†L1-L58】
+`tests/unit/test_monitor_cli.py::test_metrics_skips_storage`. 【eeec82†L1-L57】
 `uv run pytest tests/unit -q` therefore reports hundreds of errors rooted in
-the same teardown regression. 【35a0a9†L63-L73】 `uv run mkdocs build` still
-fails when docs extras are absent. 【fef027†L1-L3】 These gaps block the release
+the same teardown regression. 【eeec82†L1-L57】 `uv run mkdocs build` still
+fails when docs extras are absent. 【3109f7†L1-L3】 These gaps block the release
 checklist and require targeted fixes before we can draft reliable release
 notes.
 
@@ -41,6 +42,8 @@ notes.
 - Release notes for v0.1.0a1 are drafted in CHANGELOG.md.
 - Git tag v0.1.0a1 is created only after tests pass and documentation is
   updated.
+- `task docs` (or `uv run --extra docs mkdocs build`) completes after docs
+  extras sync.
 - Workflows remain manual or dispatch-only.
 
 ## Status

--- a/issues/resolve-deprecation-warnings-in-tests.md
+++ b/issues/resolve-deprecation-warnings-in-tests.md
@@ -20,7 +20,7 @@ Task installed to confirm the absence of warnings across the full suite, but
 tests patch `ConfigLoader.load_config` to return `type("C", (), {})()`. The
 autouse `cleanup_storage` fixture raises `AttributeError: 'C' object has no
 attribute 'storage'`, so the suite aborts before we can rerun the warnings
-sweep under Task. 【d541c6†L1-L58】【35a0a9†L63-L73】
+sweep under Task. 【eeec82†L1-L57】
 
 ## Dependencies
 None

--- a/issues/resolve-resource-tracker-errors-in-verify.md
+++ b/issues/resolve-resource-tracker-errors-in-verify.md
@@ -6,18 +6,19 @@
 coverage from completing.
 
 On September 17, 2025, the environment still lacks the Go Task CLI by default,
-so a fresh `task verify` run has not been attempted. After syncing the
-`dev-minimal` and `test` extras, `uv run python scripts/check_env.py` confirms
-that Go Task is the remaining prerequisite. 【12a21c†L1-L9】【0525bf†L1-L26】
-Targeted retries of the DuckDB extension fallback, ranking consistency, and
-optional extras suites complete without resource tracker errors, suggesting the
-fixture cleanup helpers remain effective when the suite reaches teardown.
-【3108ac†L1-L2】【897640†L1-L3】【d26393†L1-L2】 However, `uv run pytest tests/unit -q`
+so a fresh `task verify` run has not been attempted. `task --version` continues
+to report `command not found`, and after syncing the `dev-minimal` and `test`
+extras, `uv run python scripts/check_env.py` confirms that Go Task is the
+remaining prerequisite. 【15b3ab†L1-L2】【37a1fe†L1-L26】 Targeted retries of the
+DuckDB extension fallback, ranking consistency, optional extras, and
+distributed coordination property suites complete without resource tracker
+errors, suggesting the fixture cleanup helpers remain effective when the suite
+reaches teardown. 【a7a5ea†L1-L2】【9a935a†L1-L2】【ee8c19†L1-L2】【1daaef†L1-L3】 However, `uv run pytest tests/unit -q`
 now fails in teardown because the monitor metrics tests patch
 `ConfigLoader.load_config` to return `type("C", (), {})()`. The autouse
 `cleanup_storage` fixture calls `storage.teardown(remove_db=True)` during
 teardown and raises `AttributeError: 'C' object has no attribute 'storage'`,
-so the suite aborts before coverage can run. 【d541c6†L1-L58】【35a0a9†L63-L73】 Until
+so the suite aborts before coverage can run. 【eeec82†L1-L57】 Until
 the storage teardown regression is fixed and the Go Task CLI is available, we
 still cannot exercise the full unit suite under coverage to confirm the
 resource tracker fix.

--- a/issues/restore-distributed-coordination-simulation-exports.md
+++ b/issues/restore-distributed-coordination-simulation-exports.md
@@ -10,9 +10,11 @@ tests patch `ConfigLoader.load_config` to return `type("C", (), {})()`. The
 autouse `cleanup_storage` fixture invokes `storage.teardown(remove_db=True)`
 during teardown and raises `AttributeError: 'C' object has no attribute
 'storage'`, so `uv run pytest tests/unit -q` aborts early and never reaches the
-distributed scenarios. 【d541c6†L1-L58】【35a0a9†L63-L73】 We must keep this ticket
-open until the storage teardown regression is resolved and the property suites
-can execute again.
+distributed scenarios. 【eeec82†L1-L57】 A targeted run of
+`tests/unit/distributed/test_coordination_properties.py` passes, confirming the
+helpers behave as expected once the suite reaches them, but we must keep this
+ticket open until the storage teardown regression is resolved and the property
+suites can execute again. 【1daaef†L1-L3】
 
 ## Dependencies
 None.


### PR DESCRIPTION
## Summary
- refresh STATUS.md, TASK_PROGRESS.md, ROADMAP.md, and docs/release_plan.md with the latest environment diagnostics and targeted test results
- update open release issues with current log references, distributed test status, and a documentation build acceptance criterion

## Testing
- `uv sync --extra dev-minimal --extra test`
- `uv run python scripts/check_env.py`
- `task --version`
- `uv run pytest tests/unit -k "storage" -q --maxfail=1`
- `uv run pytest tests/unit/test_config_validation_errors.py::test_weights_must_sum_to_one -q`
- `uv run pytest tests/unit/test_download_duckdb_extensions.py -q`
- `uv run pytest tests/unit/test_vss_extension_loader.py -q`
- `uv run pytest tests/unit/distributed/test_coordination_properties.py -q`
- `uv run pytest tests/integration/test_ranking_formula_consistency.py -q`
- `uv run pytest tests/integration/test_optional_extras.py -q`
- `uv run mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68cad44f90d08333826e7ba705850a0f