### PR TITLE
Align docs with FastAPI 0.116.1 requirement

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,7 @@ extensions, and monitor packages were reviewed and archived after confirming
 the docs match the implementation. Scheduler resource benchmarks
 (`scripts/scheduling_resource_benchmark.py`) offer utilization and memory
 estimates documented in `docs/orchestrator_perf.md`. Dependency pins:
-`fastapi>=0.115.12` and `slowapi==0.1.9`. Use Python 3.12+ with:
+`fastapi>=0.116.1` and `slowapi==0.1.9`. Use Python 3.12+ with:
 
 ```
 uv venv && uv sync --all-extras &&

--- a/STATUS.md
+++ b/STATUS.md
@@ -516,7 +516,7 @@ Separating `uv sync` from `task check-env` in `Taskfile.yml` lets `task check` r
 `scripts/check_spec_tests.py`, and targeted `pytest` in a fresh environment. A full `uv run
 --all-extras task verify` attempt began downloading large GPU dependencies and was aborted. With
 test extras only, the fixed `tests/unit/distributed/test_coordination_properties.py` now runs
-without the previous `tmp_path` `KeyError`. Dependency pins for `fastapi` (>=0.115.12) and `slowapi`
+without the previous `tmp_path` `KeyError`. Dependency pins for `fastapi` (>=0.116.1) and `slowapi`
 (==0.1.9) remain in place.
 
 Run `scripts/setup.sh` or `task install` before executing tests. These

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -263,7 +263,7 @@ been verified to install successfully with `uv pip install`.
 | a2a-sdk | 0.3.0 |
 | dspy-ai | 2.6.27 |
 | duckdb | 1.3.0 |
-| fastapi | 0.115.12 |
+| fastapi | 0.116.1 |
 | fastmcp | 2.11.2 |
 | httpx | 0.28.1 |
 | kuzu | 0.11.1 |

--- a/docs/release_notes/v0.1.0a1.md
+++ b/docs/release_notes/v0.1.0a1.md
@@ -11,7 +11,7 @@
 
 ## Dependencies
 
-- `fastapi` (>=0.115.12)
+- `fastapi` (>=0.116.1)
 - `slowapi` (==0.1.9)
 
 ## Release steps

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -18,7 +18,7 @@ STATUS.md, ROADMAP.md, and CHANGELOG.md for aligned progress. Phase 3
 
 ## Status
 
-The dependency pins for `fastapi` (>=0.115.12) and `slowapi` (==0.1.9) remain
+The dependency pins for `fastapi` (>=0.116.1) and `slowapi` (==0.1.9) remain
 confirmed in `pyproject.toml` and [installation.md](installation.md), but the
 evaluation environment still omits the Go Task CLI. `uv run task check` fails
 with `No such file or directory` until `scripts/setup.sh` installs the binary.
@@ -41,8 +41,7 @@ docs extras add `mkdocs` to the PATH, so run `task docs` (or `uv run
 --extra docs mkdocs build`) to install them automatically. 【3109f7†L1-L3】
 `task verify` remains blocked by the missing CLI and the storage teardown
 regression, so coverage numbers are still unavailable. These items are tracked
-in
-[STATUS.md](../STATUS.md) and the open issues listed there.
+in STATUS.md and the open issues listed there.
 ## Milestones
 
 - **0.1.0a1** (2026-09-15, status: in progress): Alpha preview to collect

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -113,7 +113,7 @@ Must     | Unit tests for logging utilities.          |
 
 SlowAPI supplies request rate limiting for FastAPI. It is pinned to
 version 0.1.9 because newer releases require Starlette APIs that
-conflict with FastAPI 0.115.12. The pin prevents runtime errors until
+conflict with FastAPI 0.116.1. The pin prevents runtime errors until
 the libraries align on compatible versions.
 
 ---


### PR DESCRIPTION
## Summary
- update the release plan and roadmap status sections to cite fastapi>=0.116.1 alongside slowapi==0.1.9
- refresh other documentation references (STATUS, installation table, release notes, requirements) to match the new FastAPI minimum
- adjust the release plan status link to mention STATUS.md without an invalid MkDocs relative URL

## Testing
- uv run --extra docs mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68cae232b7f08333b0857aed85153f32