### PR TITLE
Update release planning after environment audit

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,23 +14,24 @@ targets **September 15, 2026**, with **0.1.0** planned for **October 1, 2026**
 across project documentation. The evaluation container still lacks the Go Task
 CLI on first boot, so `uv run task check` fails until `scripts/setup.sh` or a
 manual install provides the binary. Running `uv sync --extra dev-minimal --extra
-test` followed by `uv run python scripts/check_env.py` leaves only the missing
-Go Task CLI warning in this environment. 【8e4fc3†L1-L27】【37a1fe†L1-L26】
-Targeted tests on **September 17, 2025** show the config validator, DuckDB
-extension fallback, VSS loader, ranking consistency, and optional extras suites
-now pass with the `[test]` extras installed. 【5b737c†L1-L3】【a7a5ea†L1-L2】
-【93e5f9†L1-L2】【9a935a†L1-L2】【ee8c19†L1-L2】 However, `uv run pytest
-tests/unit -q` now fails in teardown because monitor CLI metrics tests patch
-`ConfigLoader.load_config` to return `type("C", (), {})()`. The autouse
-`cleanup_storage` fixture raises `AttributeError: 'C' object has no attribute
-'storage'`, so the suite stops before distributed scenarios run.
-`uv run pytest tests/unit -k "storage" -q --maxfail=1` reproduces the
-failure at `tests/unit/test_monitor_cli.py::test_metrics_skips_storage`.
-【eeec82†L1-L57】 CLI helper and data analysis suites run with
-`PYTHONWARNINGS=error::DeprecationWarning` without warnings. `uv run mkdocs
-build` still fails until docs extras install `mkdocs`, so run `task docs` (or
-`uv run --extra docs mkdocs build`) to pull the dependencies automatically.
-【3109f7†L1-L3】 Release blockers remain
+test` followed by `uv run python scripts/check_env.py` now reports Go Task as
+the only missing prerequisite. 【80552a†L1-L10】 `task --version` continues to
+return "command not found", so contributors must install the CLI before using
+the Taskfile. 【0b96f0†L1-L2】 On **September 17, 2025** the monitor CLI metrics
+tests patched `ConfigLoader.load_config` with an object lacking `storage`, and
+the autouse `cleanup_storage` fixture invoked `storage.teardown(remove_db=True)`
+on the stub, triggering `AttributeError: 'C' object has no attribute
+'storage'`. `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1`
+reproduces the failure at `tests/unit/test_monitor_cli.py::
+test_metrics_skips_storage`. 【529dfa†L1-L57】【4f24c8†L64-L88】【a3c726†L25-L38】
+Distributed coordination property tests pass when run directly, and integration
+suites for ranking consistency and optional extras continue to succeed with the
+`[test]` extras installed. 【b35e17†L1-L2】【71af25†L1-L2】【b8990e†L1-L2】 After
+syncing the docs extras, `uv run --extra docs mkdocs build` completes but warns
+that `docs/status/task-coverage-2025-09-17.md` is missing from the navigation;
+update `mkdocs.yml` to keep the release documentation clean.
+【d860f2†L1-L4】【f44ab7†L1-L1】【F:docs/status/task-coverage-2025-09-17.md†L1-L30】
+Release blockers remain
 in [restore-distributed-coordination-simulation-exports](
 issues/restore-distributed-coordination-simulation-exports.md),
 [handle-config-loader-patches-in-storage-teardown](

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -5,26 +5,26 @@ organized by phases from the code complete plan. As of **September 17, 2025**
 the evaluation container still lacks the Go Task CLI by default, so
 `uv run task check` fails until `scripts/setup.sh` installs the binary.
 Running `uv sync --extra dev-minimal --extra test` followed by
-`uv run python scripts/check_env.py` leaves only the missing Go Task warning in
-this environment. 【8e4fc3†L1-L27】【37a1fe†L1-L26】 Targeted unit tests confirm
-that the config validator, DuckDB offline fallback, and VSS extension loader
-all pass with the `[test]` extras installed. 【5b737c†L1-L3】【a7a5ea†L1-L2】
-【93e5f9†L1-L2】 Integration scenarios for ranking consistency and optional extras
-also succeed with the `[test]` extras installed. 【9a935a†L1-L2】【ee8c19†L1-L2】
-Distributed coordination property tests likewise pass when run directly even
-though the full suite cannot reach them yet. 【1daaef†L1-L3】【eeec82†L1-L57】
-However, `uv run pytest tests/unit -q` now fails in teardown because
-monitor CLI metrics tests patch `ConfigLoader.load_config` to return
-`type("C", (), {})()`. The autouse `cleanup_storage` fixture raises
-`AttributeError: 'C' object has no attribute 'storage'`, so the suite stops
-before the remaining modules run. `uv run pytest tests/unit -k "storage" -q
---maxfail=1` reproduces the failure at
-`tests/unit/test_monitor_cli.py::test_metrics_skips_storage`.
-【eeec82†L1-L57】 `uv run mkdocs build` still fails until the
-docs extras install `mkdocs`, so run `task docs` (or `uv run --extra docs
-mkdocs build`) to pull the dependencies automatically. 【3109f7†L1-L3】 Unit
-coverage and `task verify` remain blocked while the Task CLI is missing and
-the storage teardown regression persists.
+`uv run python scripts/check_env.py` now reports Go Task as the only missing
+prerequisite. 【80552a†L1-L10】 `task --version` still returns "command not
+found", so the CLI must be installed manually. 【0b96f0†L1-L2】 The monitor CLI
+metrics tests patch `ConfigLoader.load_config` to return `type("C", (), {})()`,
+and the autouse `cleanup_storage` fixture then calls `storage.teardown` on an
+object without a `storage` attribute. `uv run --extra test pytest tests/unit -k
+"storage" -q --maxfail=1` reproduces the resulting
+`AttributeError: 'C' object has no attribute 'storage'`, preventing the full
+unit suite from running. 【529dfa†L1-L57】【4f24c8†L64-L88】【a3c726†L25-L38】 The
+teardown helper needs a safe fallback for missing storage settings.
+【93fac3†L10-L52】 Distributed coordination property tests pass when invoked
+directly, confirming the restored simulation exports once teardown is fixed.
+【b35e17†L1-L2】 Integration scenarios for ranking consistency and optional
+extras also pass with the `[test]` extras installed. 【71af25†L1-L2】【b8990e†L1-L2】
+After syncing the docs extras, `uv run --extra docs mkdocs build` completes but
+warns that `docs/status/task-coverage-2025-09-17.md` is missing from the `nav`
+configuration; add it to `mkdocs.yml` before release packaging.
+【d860f2†L1-L4】【f44ab7†L1-L1】【F:docs/status/task-coverage-2025-09-17.md†L1-L30】
+Unit coverage and `task verify` remain blocked while the Task CLI is absent and
+storage teardown fails.
 See [docs/release_plan.md](docs/release_plan.md) for current test and coverage
 status and the alpha release checklist. An **0.1.0-alpha.1** preview remains
 targeted for **September 15, 2026**, with the final **0.1.0** release targeted

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -23,22 +23,25 @@ confirmed in `pyproject.toml` and [installation.md](installation.md), but the
 evaluation environment still omits the Go Task CLI. `uv run task check` fails
 with `No such file or directory` until `scripts/setup.sh` installs the binary.
 Running `uv sync --extra dev-minimal --extra test` followed by
-`uv run python scripts/check_env.py` leaves only the missing Go Task warning in
-this setup. 【8e4fc3†L1-L27】【37a1fe†L1-L26】 Targeted unit runs on **September 17,
-2025** show that the config validator, DuckDB offline fallback, and VSS
-extension loader now pass with the `[test]` extras installed. 【5b737c†L1-L3】
-【a7a5ea†L1-L2】【93e5f9†L1-L2】 Integration ranking checks and optional extras
-still pass with the `[test]` extras installed. 【9a935a†L1-L2】【ee8c19†L1-L2】
-However, `uv run pytest tests/unit -q` now fails in teardown because
-monitor CLI metrics tests patch `ConfigLoader.load_config` to return
-`type("C", (), {})()`. The autouse `cleanup_storage` fixture raises
-`AttributeError: 'C' object has no attribute 'storage'`, so the suite stops
-before distributed scenarios run. `uv run pytest tests/unit -k "storage" -q
---maxfail=1` reproduces the failure at
-`tests/unit/test_monitor_cli.py::test_metrics_skips_storage`.
-【eeec82†L1-L57】 `uv run mkdocs build` still fails until the
-docs extras add `mkdocs` to the PATH, so run `task docs` (or `uv run
---extra docs mkdocs build`) to install them automatically. 【3109f7†L1-L3】
+`uv run python scripts/check_env.py` now reports Go Task as the only missing
+prerequisite. 【80552a†L1-L10】 `task --version` continues to return "command not
+found", so the CLI must be bootstrapped manually. 【0b96f0†L1-L2】 Targeted unit
+runs on **September 17, 2025** reveal that
+`tests/unit/test_monitor_cli.py::test_metrics_skips_storage` patches
+`ConfigLoader.load_config` with an object that lacks `storage`, and the autouse
+`cleanup_storage` fixture then calls `storage.teardown(remove_db=True)` and
+raises `AttributeError: 'C' object has no attribute 'storage'`. The regression
+prevents the full suite from reaching other modules until teardown tolerates
+patched loaders or the test injects a storage stub.
+【529dfa†L1-L57】【4f24c8†L64-L88】【a3c726†L25-L38】 Integration ranking checks and
+optional extras continue to pass with the `[test]` extras installed.
+【71af25†L1-L2】【b8990e†L1-L2】 Distributed coordination property tests also pass
+when invoked directly, confirming the restored simulation exports once
+teardown is fixed. 【b35e17†L1-L2】 After syncing the docs extras,
+`uv run --extra docs mkdocs build` succeeds but warns that
+`docs/status/task-coverage-2025-09-17.md` is missing from the navigation;
+update `mkdocs.yml` before finalizing release notes.
+【d860f2†L1-L4】【f44ab7†L1-L1】【F:docs/status/task-coverage-2025-09-17.md†L1-L30】
 `task verify` remains blocked by the missing CLI and the storage teardown
 regression, so coverage numbers are still unavailable. These items are tracked
 in STATUS.md and the open issues listed there.

--- a/issues/add-status-coverage-page-to-docs-nav.md
+++ b/issues/add-status-coverage-page-to-docs-nav.md
@@ -1,0 +1,24 @@
+# Add status coverage page to docs nav
+
+## Context
+`uv run --extra docs mkdocs build` now succeeds, but the build warns that
+`docs/status/task-coverage-2025-09-17.md` is missing from the navigation.
+Release preparation should include all published status reports so
+contributors do not miss coverage requirements or wonder whether the file is
+orphaned. The warning reappears on every docs build until the page is linked
+from `mkdocs.yml`, which also means MkDocs will exclude it from published
+navigation menus. 【d860f2†L1-L4】【f44ab7†L1-L1】【F:docs/status/task-coverage-2025-09-17.md†L1-L30】
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- Add the status coverage log to `mkdocs.yml` (or another appropriate navigation
+  grouping) without breaking existing section ordering.
+- `uv run --extra docs mkdocs build` completes without navigation warnings in a
+  fresh environment with the docs extras synced.
+- STATUS.md or TASK_PROGRESS.md notes the resolution so release checklists stay
+  in sync.
+
+## Status
+Open

--- a/issues/handle-config-loader-patches-in-storage-teardown.md
+++ b/issues/handle-config-loader-patches-in-storage-teardown.md
@@ -7,9 +7,12 @@ during teardown. `test_metrics_skips_storage` in
 `tests/unit/test_monitor_cli.py` replaces the loader with `type("C", (), {})()`
 and the fixture subsequently raises `AttributeError: 'C' object has no
 attribute 'storage'` when `storage.teardown(remove_db=True)` runs.
-`uv run pytest tests/unit -k "storage" -q --maxfail=1` stops at that failure,
-so `uv run pytest tests/unit -q` never reaches the remaining suites.
-【F:tests/unit/test_monitor_cli.py†L41-L85】【eeec82†L1-L57】
+`uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` stops at
+that failure, so `uv run --extra test pytest tests/unit -q` never reaches the
+remaining suites. The fixture loads the active configuration to locate RDF
+paths; when the patched loader returns an object without `storage`,
+`storage.teardown` raises. 【F:tests/unit/test_monitor_cli.py†L41-L88】
+【529dfa†L1-L57】【a3c726†L25-L38】【93fac3†L10-L52】
 
 ## Dependencies
 - None

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -6,26 +6,28 @@ public. To tag v0.1.0a1 we still need a coordinated push across testing,
 documentation, and packaging while keeping workflows dispatch-only. As of
 2025-09-17 the Go Task CLI is still absent in a fresh environment, so running
 `uv run task check` fails until contributors install Task manually. `task
---version` still reports `command not found`, and after syncing the
-`dev-minimal` and `test` extras, `uv run python scripts/check_env.py` reports
-only the missing Go Task CLI. 【15b3ab†L1-L2】【37a1fe†L1-L26】 Targeted test
-suites continue to pass where helpers exist: the config weight validator,
-DuckDB extension fallback, VSS extension loader, ranking consistency, and
-optional extras checks all succeed with the `[test]` extras installed.
-【5b737c†L1-L3】【a7a5ea†L1-L2】【93e5f9†L1-L2】【9a935a†L1-L2】【ee8c19†L1-L2】
-However, `uv run pytest tests/unit -q` now stops in the monitor metrics suite
-because several tests patch `ConfigLoader.load_config` to return bare objects
-without a `storage` attribute. The autouse `cleanup_storage` fixture then calls
+--version` continues to return "command not found", and after syncing the
+`dev-minimal` and `test` extras, `uv run python scripts/check_env.py` reports Go
+Task as the only missing prerequisite. 【0b96f0†L1-L2】【80552a†L1-L10】 Targeted
+test suites confirm that distributed coordination properties, ranking
+consistency, and optional extras still pass with the `[test]` extras installed.
+【b35e17†L1-L2】【71af25†L1-L2】【b8990e†L1-L2】 However,
+`uv run --extra test pytest tests/unit -q` stops in the monitor metrics suite
+because the tests patch `ConfigLoader.load_config` to return bare objects
+without a `storage` attribute. The autouse `cleanup_storage` fixture calls
 `storage.teardown(remove_db=True)` during teardown and raises
-`AttributeError: 'C' object has no attribute 'storage'`, so the full suite
-never reaches the remaining modules. `uv run pytest tests/unit -k "storage" -q
---maxfail=1` reproduces the failure at
-`tests/unit/test_monitor_cli.py::test_metrics_skips_storage`. 【eeec82†L1-L57】
-`uv run pytest tests/unit -q` therefore reports hundreds of errors rooted in
-the same teardown regression. 【eeec82†L1-L57】 `uv run mkdocs build` still
-fails when docs extras are absent. 【3109f7†L1-L3】 These gaps block the release
-checklist and require targeted fixes before we can draft reliable release
-notes.
+`AttributeError: 'C' object has no attribute 'storage'`, so the full suite never
+reaches the remaining modules. `uv run --extra test pytest tests/unit -k
+"storage" -q --maxfail=1` reproduces the failure at
+`tests/unit/test_monitor_cli.py::test_metrics_skips_storage`. The teardown helper
+needs a safe fallback when storage settings are missing to unblock coverage.
+【529dfa†L1-L57】【4f24c8†L64-L88】【a3c726†L25-L38】【93fac3†L10-L52】 After syncing
+the docs extras, `uv run --extra docs mkdocs build` succeeds but warns that
+`docs/status/task-coverage-2025-09-17.md` is missing from the navigation, so the
+status log must be added to `mkdocs.yml` before release notes are drafted.
+【d860f2†L1-L4】【f44ab7†L1-L1】【F:docs/status/task-coverage-2025-09-17.md†L1-L30】
+These gaps block the release checklist and require targeted fixes before we can
+tag 0.1.0a1.
 
 ## Dependencies
 - [restore-distributed-coordination-simulation-exports](
@@ -36,6 +38,8 @@ notes.
   resolve-deprecation-warnings-in-tests.md)
 - [handle-config-loader-patches-in-storage-teardown](
   handle-config-loader-patches-in-storage-teardown.md)
+- [add-status-coverage-page-to-docs-nav](
+  add-status-coverage-page-to-docs-nav.md)
 
 ## Acceptance Criteria
 - All dependency issues are closed.

--- a/issues/resolve-deprecation-warnings-in-tests.md
+++ b/issues/resolve-deprecation-warnings-in-tests.md
@@ -16,11 +16,11 @@ comparison test. The `sitecustomize.py` shim that rewrites
 `weasel.util.config` appears to be working, and the Click bump to 8.2.1 removed
 the original warning. We still need an end-to-end `task verify` run with Go
 Task installed to confirm the absence of warnings across the full suite, but
-`uv run pytest tests/unit -q` now fails in teardown when monitor CLI metrics
-tests patch `ConfigLoader.load_config` to return `type("C", (), {})()`. The
-autouse `cleanup_storage` fixture raises `AttributeError: 'C' object has no
+`uv run --extra test pytest tests/unit -q` now fails in teardown when monitor
+CLI metrics tests patch `ConfigLoader.load_config` to return `type("C", (), {})()`.
+The autouse `cleanup_storage` fixture raises `AttributeError: 'C' object has no
 attribute 'storage'`, so the suite aborts before we can rerun the warnings
-sweep under Task. 【eeec82†L1-L57】
+sweep under Task. 【529dfa†L1-L57】【4f24c8†L64-L88】【a3c726†L25-L38】
 
 ## Dependencies
 None

--- a/issues/resolve-resource-tracker-errors-in-verify.md
+++ b/issues/resolve-resource-tracker-errors-in-verify.md
@@ -7,18 +7,19 @@ coverage from completing.
 
 On September 17, 2025, the environment still lacks the Go Task CLI by default,
 so a fresh `task verify` run has not been attempted. `task --version` continues
-to report `command not found`, and after syncing the `dev-minimal` and `test`
+to report "command not found", and after syncing the `dev-minimal` and `test`
 extras, `uv run python scripts/check_env.py` confirms that Go Task is the
-remaining prerequisite. 【15b3ab†L1-L2】【37a1fe†L1-L26】 Targeted retries of the
-DuckDB extension fallback, ranking consistency, optional extras, and
-distributed coordination property suites complete without resource tracker
-errors, suggesting the fixture cleanup helpers remain effective when the suite
-reaches teardown. 【a7a5ea†L1-L2】【9a935a†L1-L2】【ee8c19†L1-L2】【1daaef†L1-L3】 However, `uv run pytest tests/unit -q`
-now fails in teardown because the monitor metrics tests patch
-`ConfigLoader.load_config` to return `type("C", (), {})()`. The autouse
-`cleanup_storage` fixture calls `storage.teardown(remove_db=True)` during
-teardown and raises `AttributeError: 'C' object has no attribute 'storage'`,
-so the suite aborts before coverage can run. 【eeec82†L1-L57】 Until
+remaining prerequisite. 【0b96f0†L1-L2】【80552a†L1-L10】 Targeted retries of the
+distributed coordination property suite, ranking consistency check, and
+optional extras tests complete without resource tracker errors, suggesting the
+cleanup helpers remain effective when the suite reaches teardown.
+【b35e17†L1-L2】【71af25†L1-L2】【b8990e†L1-L2】 However,
+`uv run --extra test pytest tests/unit -q` now fails in teardown because the
+monitor metrics tests patch `ConfigLoader.load_config` to return
+`type("C", (), {})()`. The autouse `cleanup_storage` fixture calls
+`storage.teardown(remove_db=True)` during teardown and raises
+`AttributeError: 'C' object has no attribute 'storage'`, so the suite aborts
+before coverage can run. 【529dfa†L1-L57】【4f24c8†L64-L88】【a3c726†L25-L38】 Until
 the storage teardown regression is fixed and the Go Task CLI is available, we
 still cannot exercise the full unit suite under coverage to confirm the
 resource tracker fix.

--- a/issues/restore-distributed-coordination-simulation-exports.md
+++ b/issues/restore-distributed-coordination-simulation-exports.md
@@ -9,15 +9,16 @@ suite still fails before the property tests run because monitor CLI metrics
 tests patch `ConfigLoader.load_config` to return `type("C", (), {})()`. The
 autouse `cleanup_storage` fixture invokes `storage.teardown(remove_db=True)`
 during teardown and raises `AttributeError: 'C' object has no attribute
-'storage'`, so `uv run pytest tests/unit -q` aborts early and never reaches the
-distributed scenarios. 【eeec82†L1-L57】 A targeted run of
-`tests/unit/distributed/test_coordination_properties.py` passes, confirming the
-helpers behave as expected once the suite reaches them, but we must keep this
-ticket open until the storage teardown regression is resolved and the property
-suites can execute again. 【1daaef†L1-L3】
+'storage'`, so `uv run --extra test pytest tests/unit -q` aborts early and never
+reaches the distributed scenarios. 【529dfa†L1-L57】【a3c726†L25-L38】 A targeted
+run of `tests/unit/distributed/test_coordination_properties.py` passes,
+confirming the helpers behave as expected once the suite reaches them, but we
+must keep this ticket open until the storage teardown regression is resolved
+and the property suites can execute again. 【b35e17†L1-L2】
 
 ## Dependencies
-None.
+- [handle-config-loader-patches-in-storage-teardown](
+  handle-config-loader-patches-in-storage-teardown.md)
 
 ## Acceptance Criteria
 - Reintroduce `elect_leader` and `process_messages` in


### PR DESCRIPTION
## Summary
- refresh STATUS.md, TASK_PROGRESS.md, ROADMAP.md, and docs/release_plan.md with the latest environment audit results, storage teardown regression details, and mkdocs navigation warning
- update open issues to reflect the current teardown failure, add the docs navigation dependency to release planning, and create a new ticket to wire the status coverage page into mkdocs.yml

## Testing
- uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1
- uv run --extra test pytest tests/unit/distributed/test_coordination_properties.py -q
- uv run --extra test pytest tests/integration/test_ranking_formula_consistency.py -q
- uv run --extra test pytest tests/integration/test_optional_extras.py -q
- uv run --extra docs mkdocs build


------
https://chatgpt.com/codex/tasks/task_e_68cae8c9db488333a7986b48452d6465