### PR TITLE
Clarify release blockers and add coverage log to MkDocs navigation

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -14,6 +14,9 @@ checks are required.
 - `task --version` still returns "command not found", so install Go Task with
   `scripts/setup.sh` (or a package manager) before using the Taskfile.
   【6c3849†L1-L3】
+- Resynced the `dev-minimal`, `test`, and `docs` extras and reran the
+  environment audit; `scripts/check_env.py` now flags only the missing Go Task
+  CLI in this container. 【ecec62†L1-L24】【5505fc†L1-L27】
 - `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` fails in
   teardown because `test_monitor_cli.py::test_metrics_skips_storage` replaces
   `ConfigLoader.load_config` with a bare object that lacks `storage`. The
@@ -22,6 +25,10 @@ checks are required.
   `AttributeError: 'C' object has no attribute 'storage'`. This blocks the
   broader unit suite until teardown tolerates patched loaders or the test
   supplies a storage stub. 【990fdc†L1-L66】【d23bdc†L1-L66】【93fac3†L10-L52】
+- Reproduced the storage teardown regression after resyncing extras; the
+  targeted storage suite still halts with
+  `AttributeError: 'C' object has no attribute 'storage'` in
+  `storage.teardown`, so coverage remains blocked. 【1ffd0e†L1-L56】
 - Distributed coordination property tests still pass when invoked directly,
   confirming the restored simulation exports once the suite reaches them.
   【09e2a9†L1-L2】
@@ -31,6 +38,9 @@ checks are required.
   but warns that `docs/status/task-coverage-2025-09-17.md` is not listed in the
   navigation. Add the status coverage log to `mkdocs.yml` to clear the warning
   before release notes are drafted. 【d78ca2†L1-L4】【F:docs/status/task-coverage-2025-09-17.md†L1-L30】
+- Added the task coverage log to the MkDocs navigation and confirmed
+  `uv run --extra docs mkdocs build` now finishes without navigation
+  warnings. 【781a25†L1-L1】【a05d60†L1-L2】【bc0d4c†L1-L1】
 - Regenerated `SPEC_COVERAGE.md` with
   `uv run python scripts/generate_spec_coverage.py --output SPEC_COVERAGE.md`
   to confirm every module retains spec and proof references. 【a99f8d†L1-L2】

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -4,26 +4,26 @@ This document tracks the progress of tasks for the Autoresearch project,
 organized by phases from the code complete plan. As of **September 17, 2025**
 the evaluation container still lacks the Go Task CLI by default, so
 `uv run task check` fails until `scripts/setup.sh` installs the binary.
-Running `uv sync --extra dev-minimal --extra test` followed by
+Running `uv sync --extra dev-minimal --extra test --extra docs` followed by
 `uv run python scripts/check_env.py` now reports Go Task as the only missing
-prerequisite. 【93590e†L1-L7】【7f1069†L1-L7】【57477e†L1-L26】 `task --version` still
-returns "command not found", so the CLI must be installed manually.
+prerequisite. 【ecec62†L1-L24】【5505fc†L1-L27】 `task --version` still returns
+"command not found", so the CLI must be installed manually.
 【6c3849†L1-L3】 The monitor CLI metrics tests patch `ConfigLoader.load_config`
 to return `type("C", (), {})()`, and the autouse `cleanup_storage` fixture then
 calls `storage.teardown` on an object without a `storage` attribute.
 `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` reproduces
 the resulting `AttributeError: 'C' object has no attribute 'storage'`,
-preventing the full unit suite from running. 【990fdc†L1-L66】【d23bdc†L1-L66】 The
-teardown helper needs a safe fallback for missing storage settings.
-【93fac3†L10-L52】 Distributed coordination property tests pass when invoked
-directly, confirming the restored simulation exports once teardown is fixed.
+preventing the full unit suite from running. 【1ffd0e†L1-L56】 The teardown
+helper needs a safe fallback for missing storage settings.
+Distributed coordination property tests pass when invoked directly,
+confirming the restored simulation exports once teardown is fixed.
 【09e2a9†L1-L2】 The VSS extension loader suite also passes with the `[test]`
 extras, showing the remaining regression is isolated to storage cleanup.
-【669da8†L1-L2】 After syncing the docs extras, `uv run --extra docs mkdocs
-build` completes but warns that `docs/status/task-coverage-2025-09-17.md` is
-missing from the `nav` configuration; add it to `mkdocs.yml` before release
-packaging. 【d78ca2†L1-L4】【F:docs/status/task-coverage-2025-09-17.md†L1-L30】
-Unit coverage and `task verify` remain blocked while the Task CLI is absent and
+【669da8†L1-L2】 After syncing the docs extras, we added
+`docs/status/task-coverage-2025-09-17.md` to the navigation and confirmed
+`uv run --extra docs mkdocs build` completes without warnings, clearing the
+release packaging blocker. 【781a25†L1-L1】【a05d60†L1-L2】【bc0d4c†L1-L1】 Unit
+coverage and `task verify` remain blocked while the Task CLI is absent and
 storage teardown fails.
 See [docs/release_plan.md](docs/release_plan.md) for current test and coverage
 status and the alpha release checklist. An **0.1.0-alpha.1** preview remains

--- a/issues/archive/add-status-coverage-page-to-docs-nav.md
+++ b/issues/archive/add-status-coverage-page-to-docs-nav.md
@@ -9,6 +9,13 @@ orphaned. The warning reappears on every docs build until the page is linked
 from `mkdocs.yml`, which also means MkDocs will exclude it from published
 navigation menus. 【d78ca2†L1-L4】【F:docs/status/task-coverage-2025-09-17.md†L1-L30】
 
+On September 17, 2025 we added the coverage log under a "Status Reports"
+section in `mkdocs.yml` and reran `uv run --extra docs mkdocs build`, which now
+finishes without navigation warnings. STATUS.md and TASK_PROGRESS.md both note
+the update so release checklists remain synchronized.
+【F:mkdocs.yml†L18-L26】【781a25†L1-L1】【a05d60†L1-L2】【bc0d4c†L1-L1】
+【F:STATUS.md†L10-L30】【F:TASK_PROGRESS.md†L1-L26】
+
 ## Dependencies
 - None
 
@@ -21,4 +28,4 @@ navigation menus. 【d78ca2†L1-L4】【F:docs/status/task-coverage-2025-09-17.
   in sync.
 
 ## Status
-Open
+Archived

--- a/issues/handle-config-loader-patches-in-storage-teardown.md
+++ b/issues/handle-config-loader-patches-in-storage-teardown.md
@@ -8,10 +8,13 @@ during teardown. After syncing the `dev-minimal` and `test` extras,
 `tests/unit/test_monitor_cli.py::test_metrics_skips_storage`, raising
 `AttributeError: 'C' object has no attribute 'storage'` when
 `storage.teardown(remove_db=True)` runs. A focused invocation of the same test
-produces the identical teardown failure. The fixture loads the active
-configuration to locate RDF paths; when the patched loader returns an object
-without `storage`, `storage.teardown` raises. 【F:tests/unit/test_monitor_cli.py†L41-L88】
-【93590e†L1-L7】【7f1069†L1-L7】【990fdc†L1-L66】【d23bdc†L1-L66】【93fac3†L10-L52】
+produces the identical teardown failure. Re-running the targeted storage suite
+after resyncing the `dev-minimal`, `test`, and `docs` extras still raises the
+same `AttributeError`, so coverage remains blocked until teardown handles the
+patched config. The fixture loads the active configuration to locate RDF paths;
+when the patched loader returns an object without `storage`,
+`storage.teardown` raises. 【F:tests/unit/test_monitor_cli.py†L41-L88】
+【ecec62†L1-L24】【1ffd0e†L1-L56】
 
 ## Dependencies
 - None

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -6,10 +6,9 @@ public. To tag v0.1.0a1 we still need a coordinated push across testing,
 documentation, and packaging while keeping workflows dispatch-only. As of
 2025-09-17 the Go Task CLI is still absent in a fresh environment, so running
 `uv run task check` fails until contributors install Task manually. `task
---version` continues to return "command not found", and after syncing the
-`dev-minimal` and `test` extras, `uv run python scripts/check_env.py` reports Go
-Task as the only missing prerequisite. 【6c3849†L1-L3】【93590e†L1-L7】【7f1069†L1-L7】
-【57477e†L1-L26】 Targeted test suites confirm that distributed coordination
+--version` continues to return "command not found", and after resyncing the
+`dev-minimal`, `test`, and `docs` extras, `uv run python scripts/check_env.py` reports Go
+Task as the only missing prerequisite. 【6c3849†L1-L3】【ecec62†L1-L24】【5505fc†L1-L27】 Targeted test suites confirm that distributed coordination
 properties and VSS extension scenarios still pass with the `[test]` extras
 installed. `uv run --extra test pytest tests/unit/distributed/
 test_coordination_properties.py -q` and `uv run --extra test pytest
@@ -22,14 +21,12 @@ without a `storage` attribute. The autouse `cleanup_storage` fixture calls
 `AttributeError: 'C' object has no attribute 'storage'`, so the full suite never
 reaches the remaining modules. `uv run --extra test pytest tests/unit -k
 "storage" -q --maxfail=1` reproduces the failure at
-`tests/unit/test_monitor_cli.py::test_metrics_skips_storage`. The teardown helper
-needs a safe fallback when storage settings are missing to unblock coverage.
-【990fdc†L1-L66】【d23bdc†L1-L66】【93fac3†L10-L52】 After syncing the docs extras,
-`uv run --extra docs mkdocs build` succeeds but warns that
-`docs/status/task-coverage-2025-09-17.md` is missing from the navigation, so the
-status log must be added to `mkdocs.yml` before release notes are drafted.
-【d78ca2†L1-L4】【F:docs/status/task-coverage-2025-09-17.md†L1-L30】 These gaps
-block the release checklist and require targeted fixes before we can tag
+`tests/unit/test_monitor_cli.py::test_metrics_skips_storage`, even after the
+extras resync, so the teardown helper still needs a safe fallback when storage
+settings are missing to unblock coverage. 【1ffd0e†L1-L56】 Adding the task
+coverage log to `mkdocs.yml` cleared the documentation warning; `uv run --extra
+docs mkdocs build` now completes without navigation errors.
+【781a25†L1-L1】【a05d60†L1-L2】【bc0d4c†L1-L1】 These gaps block the release checklist and require targeted fixes before we can tag
 0.1.0a1.
 
 ## Dependencies
@@ -41,8 +38,6 @@ block the release checklist and require targeted fixes before we can tag
   resolve-deprecation-warnings-in-tests.md)
 - [handle-config-loader-patches-in-storage-teardown](
   handle-config-loader-patches-in-storage-teardown.md)
-- [add-status-coverage-page-to-docs-nav](
-  add-status-coverage-page-to-docs-nav.md)
 - [rerun-task-coverage-after-storage-fix](
   rerun-task-coverage-after-storage-fix.md)
 

--- a/issues/reduce-gpu-monitor-warning-noise.md
+++ b/issues/reduce-gpu-monitor-warning-noise.md
@@ -1,0 +1,24 @@
+# Reduce GPU monitor warning noise when dependencies are absent
+
+## Context
+Targeted storage tests emit `WARNING` logs from
+`autoresearch.resource_monitor` whenever `pynvml` or `nvidia-smi` is
+unavailable. Running
+`uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1`
+without the GPU extras shows repeated warnings even though GPU metrics are
+optional for these suites. The noise obscures real failures while providing
+little value for CPU-only environments. 【1ffd0e†L33-L54】
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- Update GPU monitoring to downgrade missing dependency warnings to `INFO`
+  (or suppress them entirely) when the GPU extras are not installed.
+- Ensure storage-focused unit tests complete without emitting GPU warning
+  noise on CPU-only environments.
+- Document the expected behavior in STATUS.md or TASK_PROGRESS.md if GPU
+  metrics remain optional.
+
+## Status
+Open

--- a/issues/rerun-task-coverage-after-storage-fix.md
+++ b/issues/rerun-task-coverage-after-storage-fix.md
@@ -4,16 +4,9 @@
 The last recorded coverage run (`uv run task coverage EXTRAS="nlp ui vss git distributed analysis llm parsers gpu"`)
 reported 90% line coverage, but storage teardown regressions now prevent
 rerunning the task to verify the current baseline.
-`uv sync --extra dev-minimal --extra test` installs the development and test
-extras, and `uv run python scripts/check_env.py` confirms that only the Go Task
-CLI remains missing. However, `uv run --extra test pytest tests/unit -k
-"storage" -q --maxfail=1` still fails because patched monitor CLI tests trigger
-`AttributeError: 'C' object has no attribute 'storage'`, so the full unit suite
-never reaches coverage. We need to rerun `task coverage` once the storage fixture
-and Go Task availability issues are resolved to refresh `baseline/coverage.xml`
-and publish a new docs status log.
-【93590e†L1-L7】【7f1069†L1-L7】【57477e†L1-L26】【990fdc†L1-L66】
-【F:docs/status/task-coverage-2025-09-17.md†L1-L28】
+`uv sync --extra dev-minimal --extra test --extra docs` installs the development, test, and documentation extras, and `uv run python scripts/check_env.py` confirms that only the Go Task CLI remains missing. However, `uv run --extra test pytest tests/unit -k
+"storage" -q --maxfail=1` still fails because patched monitor CLI tests trigger `AttributeError: 'C' object has no attribute 'storage'`, so the full unit suite never reaches coverage. We need to rerun `task coverage` once the storage fixture and Go Task availability issues are resolved to refresh `baseline/coverage.xml` and publish a new docs status log.
+【ecec62†L1-L24】【5505fc†L1-L27】【1ffd0e†L1-L56】【F:docs/status/task-coverage-2025-09-17.md†L1-L28】
 
 ## Dependencies
 - [handle-config-loader-patches-in-storage-teardown](handle-config-loader-patches-in-storage-teardown.md)

--- a/issues/resolve-deprecation-warnings-in-tests.md
+++ b/issues/resolve-deprecation-warnings-in-tests.md
@@ -14,14 +14,16 @@ On September 17, 2025, targeted retries with
 showed no remaining warnings in the CLI helper suite or distributed perf
 comparison test. The `sitecustomize.py` shim that rewrites
 `weasel.util.config` appears to be working, and the Click bump to 8.2.1 removed
-the original warning. After syncing the `dev-minimal` and `test` extras,
-`uv run python scripts/check_env.py` now reports only the missing Go Task CLI,
-but `uv run --extra test pytest tests/unit -q` still fails in teardown when
+the original warning. After resyncing the `dev-minimal`, `test`, and `docs` extras,
+`uv run python scripts/check_env.py` still reports only the missing Go Task
+CLI, but `uv run --extra test pytest tests/unit -q` fails in teardown when
 monitor CLI metrics tests patch `ConfigLoader.load_config` to return
 `type("C", (), {})()`. The autouse `cleanup_storage` fixture raises
 `AttributeError: 'C' object has no attribute 'storage'`, so the suite aborts
-before we can rerun the warnings sweep under Task. 【57477e†L1-L26】
-【990fdc†L1-L66】【d23bdc†L1-L66】
+before we can rerun the warnings sweep under Task. Targeted reruns of the
+storage-focused subset reproduce the same teardown error, confirming we must
+stabilize cleanup before checking for residual warnings.
+【ecec62†L1-L24】【5505fc†L1-L27】【1ffd0e†L1-L56】
 
 ## Dependencies
 None

--- a/issues/resolve-resource-tracker-errors-in-verify.md
+++ b/issues/resolve-resource-tracker-errors-in-verify.md
@@ -7,9 +7,9 @@ coverage from completing.
 
 On September 17, 2025, the environment still lacks the Go Task CLI by default,
 so a fresh `task verify` run has not been attempted. `task --version` continues
-to report "command not found", and after syncing the `dev-minimal` and `test`
-extras, `uv run python scripts/check_env.py` confirms that Go Task is the
-remaining prerequisite. 【6c3849†L1-L3】【93590e†L1-L7】【7f1069†L1-L7】【57477e†L1-L26】
+to report "command not found", and after resyncing the `dev-minimal`, `test`,
+and `docs` extras, `uv run python scripts/check_env.py` confirms that Go Task
+is the remaining prerequisite. 【6c3849†L1-L3】【ecec62†L1-L24】【5505fc†L1-L27】
 Targeted retries of the distributed coordination property suite and the VSS
 extension loader tests complete without resource tracker errors, suggesting the
 cleanup helpers remain effective when the suite reaches teardown.
@@ -18,7 +18,9 @@ now fails in teardown because the monitor metrics tests patch
 `ConfigLoader.load_config` to return `type("C", (), {})()`. The autouse
 `cleanup_storage` fixture calls `storage.teardown(remove_db=True)` during
 teardown and raises `AttributeError: 'C' object has no attribute 'storage'`, so
-the suite aborts before coverage can run. 【990fdc†L1-L66】【d23bdc†L1-L66】 Until
+the suite aborts before coverage can run. Targeted reruns of the storage subset
+after the resync reproduce the same error, confirming coverage remains blocked
+on the teardown regression. 【1ffd0e†L1-L56】 Until
 the storage teardown regression is fixed and the Go Task CLI is available, we
 still cannot exercise the full unit suite under coverage to confirm the
 resource tracker fix.

--- a/issues/restore-distributed-coordination-simulation-exports.md
+++ b/issues/restore-distributed-coordination-simulation-exports.md
@@ -10,7 +10,10 @@ tests patch `ConfigLoader.load_config` to return `type("C", (), {})()`. The
 autouse `cleanup_storage` fixture invokes `storage.teardown(remove_db=True)`
 during teardown and raises `AttributeError: 'C' object has no attribute 'storage'`,
 so `uv run --extra test pytest tests/unit -k "storage" -q` aborts
-before the distributed scenarios execute. 【990fdc†L1-L66】【d23bdc†L1-L66】 A
+before the distributed scenarios execute. Rerunning the storage subset after
+resyncing the development extras reproduces the same teardown failure, so the
+property suite remains blocked until storage cleanup is hardened.
+【ecec62†L1-L24】【1ffd0e†L1-L56】 A
 targeted run of `tests/unit/distributed/test_coordination_properties.py` still
 passes, confirming the helpers behave as expected once the suite reaches them,
 but we must keep this ticket open until the storage teardown regression is

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,8 @@ nav:
     - Contributing: contributing.md
     - Releasing Workflow: releasing.md
     - Release Plan: release_plan.md
+    - Status Reports:
+        - Task coverage – 2025-09-17: status/task-coverage-2025-09-17.md
     - Release Notes:
         - Overview: release_notes.md
         - Version 0.1.0a1: release_notes/v0.1.0a1.md


### PR DESCRIPTION
## Summary
- add the task coverage status log to the MkDocs navigation and archive the resolved planning ticket
- refresh release tracking docs and open issues with the latest environment audit and storage teardown findings
- log a follow-up issue to quiet GPU monitor warning noise when optional dependencies are absent

## Testing
- uv run python scripts/check_env.py
- uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1 *(fails with AttributeError from storage.teardown as documented)*
- uv run --extra docs mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68caf62c216883339c71fa910d7d28eb