### PR TITLE
Quiet GPU monitoring when extras missing

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -553,6 +553,10 @@ References to pre-built wheels for GPU-only packages live under `wheels/gpu`.
 features are required. Setup helpers and Taskfile commands consult this
 directory automatically when GPU extras are installed.
 
+Resource monitoring now treats missing GPU tooling as informational when GPU
+extras are absent, so CPU-only workflows no longer emit warning noise when
+`pynvml` or `nvidia-smi` is unavailable.
+
 Running tests without first executing `scripts/setup.sh` or `task install`
 leaves the Go Task CLI unavailable. `uv run task check` then fails with
 `command not found: task`, and `uv run pytest tests/unit/test_version.py -q`

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -209,8 +209,9 @@ These behavior test issues remain open until the test suite passes.
 - [x] Enhance memory management
   - [x] Implement efficient caching strategies
   - [x] Add support for memory-constrained environments
-  - [x] Create resource monitoring tools
+- [x] Create resource monitoring tools
   - [x] Extend monitoring to GPU usage
+    - [x] Downgrade missing GPU dependencies to INFO logs when extras are absent
 
 ### 5.2 Scalability Enhancements
 

--- a/tests/unit/test_resource_monitor_gpu.py
+++ b/tests/unit/test_resource_monitor_gpu.py
@@ -3,6 +3,7 @@ import sys
 import types
 
 from autoresearch import resource_monitor
+from structlog.testing import capture_logs
 
 
 def test_get_gpu_stats_pynvml(monkeypatch):
@@ -31,9 +32,9 @@ def test_get_gpu_stats_cli_psutil(monkeypatch):
     monkeypatch.setattr(
         builtins,
         "__import__",
-        lambda name, *a, **k: (_ for _ in ()).throw(ImportError())
-        if name == "pynvml"
-        else orig_import(name, *a, **k),
+        lambda name, *a, **k: (
+            (_ for _ in ()).throw(ImportError()) if name == "pynvml" else orig_import(name, *a, **k)
+        ),
     )
     util, mem = resource_monitor._get_gpu_stats()
     assert util == 25.0
@@ -44,17 +45,90 @@ def test_get_gpu_stats_cli_subprocess(monkeypatch):
     def fake_run(*args, **kwargs):
         class FakeRes:
             stdout = "30, 1024"
+
         return FakeRes()
 
     orig_import = builtins.__import__
     monkeypatch.setattr(
         builtins,
         "__import__",
-        lambda name, *a, **k: (_ for _ in ()).throw(ImportError())
-        if name in {"pynvml", "psutil"}
-        else orig_import(name, *a, **k),
+        lambda name, *a, **k: (
+            (_ for _ in ()).throw(ImportError())
+            if name in {"pynvml", "psutil"}
+            else orig_import(name, *a, **k)
+        ),
     )
-    monkeypatch.setitem(sys.modules, "subprocess", types.SimpleNamespace(run=fake_run, PIPE=None, DEVNULL=None))
+    monkeypatch.setitem(
+        sys.modules, "subprocess", types.SimpleNamespace(run=fake_run, PIPE=None, DEVNULL=None)
+    )
     util, mem = resource_monitor._get_gpu_stats()
     assert util == 30.0
     assert mem == 1024.0
+
+
+def test_get_gpu_stats_logs_info_without_gpu_extra(monkeypatch):
+    monkeypatch.setattr(resource_monitor, "_gpu_extra_enabled", lambda: False)
+    monkeypatch.delitem(sys.modules, "pynvml", raising=False)
+    monkeypatch.delitem(sys.modules, "psutil", raising=False)
+
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in {"pynvml", "psutil"}:
+            raise ModuleNotFoundError(name)
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    fake_subprocess = types.ModuleType("subprocess")
+    fake_subprocess.PIPE = object()
+    fake_subprocess.DEVNULL = object()
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("nvidia-smi missing")
+
+    fake_subprocess.run = fake_run
+    monkeypatch.setitem(sys.modules, "subprocess", fake_subprocess)
+
+    with capture_logs() as logs:
+        util, mem = resource_monitor._get_gpu_stats()
+
+    assert (util, mem) == (0.0, 0.0)
+    dependency_events = [
+        entry for entry in logs if entry.get("event") == "gpu_metrics_dependency_missing"
+    ]
+    assert {entry["dependency"] for entry in dependency_events} == {
+        "pynvml",
+        "nvidia-smi",
+    }
+    assert all(entry["log_level"] == "info" for entry in dependency_events)
+
+
+def test_get_gpu_stats_logs_debug_with_gpu_extra(monkeypatch):
+    monkeypatch.setattr(resource_monitor, "_gpu_extra_enabled", lambda: True)
+    monkeypatch.delitem(sys.modules, "pynvml", raising=False)
+    monkeypatch.delitem(sys.modules, "psutil", raising=False)
+
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in {"pynvml", "psutil"}:
+            raise ModuleNotFoundError(name)
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    fake_subprocess = types.ModuleType("subprocess")
+    fake_subprocess.PIPE = object()
+    fake_subprocess.DEVNULL = object()
+    fake_subprocess.run = lambda *args, **kwargs: types.SimpleNamespace(stdout="0, 0")
+    monkeypatch.setitem(sys.modules, "subprocess", fake_subprocess)
+
+    with capture_logs() as logs:
+        resource_monitor._get_gpu_stats()
+
+    dependency_events = [
+        entry for entry in logs if entry.get("event") == "gpu_metrics_dependency_missing"
+    ]
+    assert dependency_events
+    assert all(entry["log_level"] == "debug" for entry in dependency_events)


### PR DESCRIPTION
## Summary
- detect whether GPU extras are present before collecting NVML metrics and downgrade missing dependency logs to info/debug levels
- cover the new logging behaviour with structlog-based unit tests and keep legacy GPU sampling tests intact
- document the quieter CPU-only monitoring behaviour in STATUS and TASK_PROGRESS

## Testing
- uv run --extra test pytest tests/unit/test_resource_monitor_gpu.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cafc01ccac8333aa5bd1c8a0652208