### PR TITLE
Align code completion plan with updated release dates

### DIFF
--- a/CODE_COMPLETE_PLAN.md
+++ b/CODE_COMPLETE_PLAN.md
@@ -5,13 +5,13 @@ Based on a thorough analysis of the Autoresearch codebase, I've developed a comp
 
 ## Status
 
-As of **August 20, 2025**, Autoresearch targets an **0.1.0-alpha.1**
-preview on **2026-03-01** and a final **0.1.0** release on
-**July 1, 2026**. `uv run flake8 src tests` and `uv run mypy src` both
-pass, and `uv run pytest tests/unit -q` reports 253 passing tests.
-`uv run pytest tests/integration -m "not slow and not requires_ui and not
-requires_vss" -q` currently yields numerous failures, so integration and
-behavior suites remain outstanding.
+As of **August 20, 2025**, Autoresearch targets an **0.1.0a1** preview on
+**September 15, 2026** and a final **0.1.0** release on **October 1, 2026**.
+`uv run flake8 src tests` and `uv run mypy src` both pass, and `uv run
+pytest tests/unit -q` reports 253 passing tests. `uv run pytest
+tests/integration -m "not slow and not requires_ui and not requires_vss" -q`
+currently yields numerous failures, so integration and behavior suites remain
+outstanding.
 
 ## 1. Core System Completion
 


### PR DESCRIPTION
## Summary
- update the CODE_COMPLETE_PLAN status section to reflect the September 15, 2026 0.1.0a1 preview and October 1, 2026 0.1.0 release
- ensure the plan no longer references the retired March and July 2026 milestones

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cb505a68f08333aaed2d1f11dd5c80