### PR TITLE
Document Sep 18 environment check and add VSS log noise issue

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,11 +13,12 @@ See [STATUS.md](STATUS.md) for current results and
 targets **September 15, 2026**, with **0.1.0** planned for **October 1, 2026**
 across project documentation. The evaluation container still lacks the Go Task
 CLI on first boot, so `uv run task check` fails until `scripts/setup.sh` or a
-manual install provides the binary. Running `uv sync --extra dev-minimal --extra
-test --extra docs` followed by `uv run python scripts/check_env.py` reports Go
-Task as the only missing prerequisite. 【e6706c†L1-L26】 `task --version`
+manual install provides the binary. Running `uv run python scripts/check_env.py`
+in a fresh container reports the Go Task CLI plus unsynced development and test
+tooling (e.g., `black`, `flake8`, `fakeredis`, `hypothesis`) until `task
+install` or `uv sync` installs the extras. 【cd57a1†L1-L24】 `task --version`
 continues to return "command not found", so contributors must install the CLI
-before using the Taskfile. 【cef78e†L1-L2】 On **September 17, 2025** the storage
+before using the Taskfile. 【74a609†L1-L2】 On **September 17, 2025** the storage
 teardown regression was cleared and the patched monitor metrics test now
 passes, but `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1`
 fails at `tests/unit/test_storage_eviction_sim.py::

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,6 +7,26 @@ Run `task check` for linting and smoke tests, then `task verify` before
 committing. Include `EXTRAS="llm"` only when LLM features or dependency
 checks are required.
 
+## September 18, 2025
+- `task --version` still reports "command not found", confirming the Go Task
+  CLI is absent in a fresh container until `scripts/setup.sh` or an
+  equivalent manual install runs. 【74a609†L1-L2】
+- `uv run python scripts/check_env.py` now flags missing development and test
+  tooling (e.g., `black`, `flake8`, `fakeredis`, `hypothesis`) in addition to
+  Go Task, showing that contributors must run `task install` or `uv sync`
+  before invoking the Taskfile. 【cd57a1†L1-L24】
+- `uv run pytest tests/unit/test_storage_eviction_sim.py::
+  test_under_budget_keeps_nodes -q` still fails, demonstrating that the
+  deterministic fallback in `_enforce_ram_budget` evicts nodes even when RAM
+  usage is mocked at zero and leaving the regression open. 【fa283d†L1-L62】
+- `uv run pytest tests/unit/distributed/test_coordination_properties.py -q`
+  errors during collection because `hypothesis` is missing, so installing the
+  `[test]` extras remains a prerequisite before re-running the coordination
+  property suite. 【791df7†L1-L18】
+- `SPEC_COVERAGE.md` continues to list specifications plus proofs or
+  simulations for every module, confirming the spec-driven baseline stays in
+  sync with the implementation. 【F:SPEC_COVERAGE.md†L1-L120】
+
 ## September 17, 2025
 - After installing the `dev-minimal`, `test`, and `docs` extras,
   `uv run python scripts/check_env.py` reports that Go Task is still the lone
@@ -626,3 +646,9 @@ regression is resolved.
 - [prepare-first-alpha-release](issues/prepare-first-alpha-release.md) –
   Coordinate release notes, docs extras, Task installation, and final smoke
   tests once the dependent issues above close.
+
+### Additional issues
+- [reduce-vss-extension-error-noise-offline](
+  issues/reduce-vss-extension-error-noise-offline.md) –
+  Tone down DuckDB VSS download errors during offline storage simulations so
+  regression logs remain readable while the stub fallback is active.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,22 +1,24 @@
 # Autoresearch Project - Task Progress
 
 This document tracks the progress of tasks for the Autoresearch project,
-organized by phases from the code complete plan. As of **September 17, 2025**
+organized by phases from the code complete plan. As of **September 18, 2025**
 the evaluation container still lacks the Go Task CLI by default, so
 `uv run task check` fails until `scripts/setup.sh` installs the binary.
-Running `uv sync --extra dev-minimal --extra test --extra docs` followed by
-`uv run python scripts/check_env.py` reports Go Task as the only missing
-prerequisite. 【e6706c†L1-L26】 `task --version` still returns "command not
-found", so the CLI must be installed manually. 【cef78e†L1-L2】 The storage
+Running `uv run python scripts/check_env.py` now reports the Go Task CLI plus
+unsynced development and test tooling (e.g., `black`, `flake8`, `fakeredis`,
+`hypothesis`) until `task install` or `uv sync` installs the extras.
+【cd57a1†L1-L24】 `task --version` still returns "command not found", so the CLI
+must be installed manually. 【74a609†L1-L2】 The storage
 teardown regression is fixed—the patched monitor metrics test now passes—so the
 suite advances to the storage eviction simulation.
 `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` currently
 fails at `tests/unit/test_storage_eviction_sim.py::
 test_under_budget_keeps_nodes` because `_enforce_ram_budget` prunes nodes even
 when mocked RAM usage stays within the budget. 【04f707†L1-L3】【d7c968†L1-L164】
-Distributed coordination property tests and the VSS extension loader suite pass
-with the `[test]` extras, showing recent fixes hold once the eviction regression
-is addressed. 【d3124a†L1-L2】【669da8†L1-L2】 After syncing the docs extras, we
+Distributed coordination property tests require the `[test]` extras; without
+them Hypothesis is missing and the suite errors during collection, so install
+the extras before rerunning the properties.
+【791df7†L1-L18】【d3124a†L1-L2】【669da8†L1-L2】 After syncing the docs extras, we
 added `docs/status/task-coverage-2025-09-17.md` to the navigation and confirmed
 `uv run --extra docs mkdocs build` completes without warnings, clearing the
 release packaging blocker. 【781a25†L1-L1】【a05d60†L1-L2】【bc0d4c†L1-L1】 Unit

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -22,20 +22,21 @@ The dependency pins for `fastapi` (>=0.116.1) and `slowapi` (==0.1.9) remain
 confirmed in `pyproject.toml` and [installation.md](installation.md), but the
 evaluation environment still omits the Go Task CLI. `uv run task check` fails
 with `No such file or directory` until `scripts/setup.sh` installs the binary.
-Running `uv sync --extra dev-minimal --extra test --extra docs` followed by
-`uv run python scripts/check_env.py` reports Go Task as the only missing
-prerequisite. 【e6706c†L1-L26】 `task --version` continues to return "command not
-found", so the CLI must be bootstrapped manually. 【cef78e†L1-L2】 Targeted unit
+Running `uv run python scripts/check_env.py` now reports the Go Task CLI plus
+unsynced development and test tooling (e.g., `black`, `flake8`, `fakeredis`,
+`hypothesis`) until contributors run `task install` or `uv sync` to install the
+extras. 【cd57a1†L1-L24】 `task --version` continues to return "command not
+found", so the CLI must be bootstrapped manually. 【74a609†L1-L2】 Targeted unit
 runs on **September 17, 2025** confirm that the storage teardown regression is
 resolved—the patched monitor metrics test now passes—yet
 `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` fails at
 `tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes`
 because `_enforce_ram_budget` prunes nodes even when mocked RAM usage stays
 within the budget. 【04f707†L1-L3】【d7c968†L1-L164】 Integration ranking checks and
-optional extras continue to pass with the `[test]` extras installed. Distributed
-coordination property tests and the VSS extension loader suite also pass when
-invoked directly, confirming the restored helpers once the eviction regression
-is fixed. 【d3124a†L1-L2】【669da8†L1-L2】 After syncing the docs extras,
+optional extras continue to pass with the `[test]` extras installed. Without
+those extras Hypothesis is unavailable and the distributed coordination suite
+errors during collection, so install the dependencies before rerunning it.
+【791df7†L1-L18】【d3124a†L1-L2】【669da8†L1-L2】 After syncing the docs extras,
 `uv run --extra docs mkdocs build` completes without navigation warnings after
 adding `docs/status/task-coverage-2025-09-17.md` to `mkdocs.yml`.
 【781a25†L1-L1】【a05d60†L1-L2】【bc0d4c†L1-L1】 `task verify` remains blocked by the

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -4,17 +4,17 @@
 The project remains unreleased even though the codebase and documentation are
 public. To tag v0.1.0a1 we still need a coordinated push across testing,
 documentation, and packaging while keeping workflows dispatch-only. As of
-2025-09-17 the Go Task CLI is still absent in a fresh environment, so running
+2025-09-18 the Go Task CLI is still absent in a fresh environment, so running
 `uv run task check` fails until contributors install Task manually. `task
---version` continues to return "command not found", and after resyncing the
-`dev-minimal`, `test`, and `docs` extras, `uv run python scripts/check_env.py`
-reports Go Task as the only missing prerequisite. 【6c3849†L1-L3】【e6706c†L1-L26】
-Targeted test suites confirm that distributed coordination properties and VSS
-extension scenarios still pass with the `[test]` extras installed. Running
-`uv run --extra test pytest tests/unit/distributed/`
-`test_coordination_properties.py -q` and `uv run --extra test pytest`
-`tests/unit/test_vss_extension_loader.py -q` both complete successfully.
-【d3124a†L1-L2】【669da8†L1-L2】 The storage teardown
+--version` continues to return "command not found", and running `uv run python
+scripts/check_env.py` now flags the Go Task CLI plus unsynced development and
+test tooling (e.g., `black`, `flake8`, `fakeredis`, `hypothesis`) until `task
+install` or `uv sync` installs the extras.
+【74a609†L1-L2】【cd57a1†L1-L24】 Targeted test suites confirm that distributed
+coordination properties and VSS extension scenarios still pass with the `[test]`
+extras installed, but without those extras Hypothesis is missing and the
+coordination suite errors during collection.
+【791df7†L1-L18】【d3124a†L1-L2】【669da8†L1-L2】 The storage teardown
 regression that blocked the monitor metrics suite has been resolved; the patched
 scenario now passes. 【04f707†L1-L3】 The unit run now halts at
 `tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes`

--- a/issues/reduce-vss-extension-error-noise-offline.md
+++ b/issues/reduce-vss-extension-error-noise-offline.md
@@ -1,0 +1,28 @@
+# Reduce VSS extension error noise when offline
+
+## Context
+Running `uv run pytest tests/unit/test_storage_eviction_sim.py::
+test_under_budget_keeps_nodes -q` in the evaluation container emits
+repeated error-level logs from DuckDB while the VSS extension loader
+falls back to the stub file. The output reports failed HTTP downloads
+and missing catalog settings before the stub completes, even though the
+simulation ultimately proceeds. 【fa283d†L1-L46】 The noise obscures the
+storage regression signal and suggests a fatal failure despite the
+existing offline fallback. We should downgrade or consolidate these
+messages when the loader falls back to stubbed extensions so offline
+test runs remain readable.
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- Offline runs of the storage eviction simulation avoid repeated
+  error-level log lines about VSS extension downloads when the stub
+  fallback engages.
+- Logging documents the fallback path at `INFO` or lower while still
+  surfacing genuine loader errors.
+- STATUS.md or TASK_PROGRESS.md notes the quieter behavior once the
+  logging change ships.
+
+## Status
+Open

--- a/issues/rerun-task-coverage-after-storage-fix.md
+++ b/issues/rerun-task-coverage-after-storage-fix.md
@@ -8,10 +8,12 @@ suite cannot reach coverage today. `uv run --extra test pytest tests/unit -k
 `tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes`
 because `_enforce_ram_budget` trims nodes even when the mocked RAM usage stays
 within the budget. 【d7c968†L1-L164】 After syncing the `dev-minimal`, `test`, and
-`docs` extras, `uv run python scripts/check_env.py` still reports the missing Go
-Task CLI, so both the eviction regression and the CLI gap must be resolved
+`docs` extras, `uv run python scripts/check_env.py` in a fresh container now
+flags the Go Task CLI plus unsynced development and test tooling (e.g., `black`,
+`flake8`, `fakeredis`, `hypothesis`) until `task install` or `uv sync` installs
+the extras. Both the eviction regression and the tooling gap must be resolved
 before we can refresh `baseline/coverage.xml` and publish a new status log.
-【e6706c†L1-L26】【F:docs/status/task-coverage-2025-09-17.md†L1-L28】
+【cd57a1†L1-L24】【F:docs/status/task-coverage-2025-09-17.md†L1-L28】
 
 ## Dependencies
 - [fix-storage-eviction-under-budget-regression](fix-storage-eviction-under-budget-regression.md)

--- a/issues/resolve-deprecation-warnings-in-tests.md
+++ b/issues/resolve-deprecation-warnings-in-tests.md
@@ -15,8 +15,10 @@ showed no remaining warnings in the CLI helper suite or distributed perf
 comparison test. The `sitecustomize.py` shim that rewrites
 `weasel.util.config` appears to be working, and the Click bump to 8.2.1 removed
 the original warning. After resyncing the `dev-minimal`, `test`, and `docs`
-extras, `uv run python scripts/check_env.py` still reports only the missing Go
-Task CLI. 【e6706c†L1-L26】 The storage teardown regression is fixed—the patched
+extras, `uv run python scripts/check_env.py` in a fresh container now flags the
+Go Task CLI plus unsynced development and test tooling (e.g., `black`,
+`flake8`, `fakeredis`, `hypothesis`) until `task install` or `uv sync` installs
+the extras. 【cd57a1†L1-L24】 The storage teardown regression is fixed—the patched
 monitor metrics test now passes—so the unit suite advances to the storage
 eviction simulation. 【04f707†L1-L3】 `uv run --extra test pytest tests/unit -k
 "storage" -q --maxfail=1` currently fails at
@@ -24,7 +26,10 @@ eviction simulation. 【04f707†L1-L3】 `uv run --extra test pytest tests/unit
 because `_enforce_ram_budget` prunes nodes even when the mocked RAM usage stays
 within the budget. 【d7c968†L1-L164】 We must repair that regression and restore
 the Task CLI before rerunning the warnings sweep under Task with
-`PYTHONWARNINGS=error::DeprecationWarning`.
+`PYTHONWARNINGS=error::DeprecationWarning`. Without the `[test]` extras Pytest
+also emits `PytestConfigWarning: Unknown config option: bdd_features_base_dir`
+during the storage simulations, so ensuring the extras are installed is part of
+the cleanup. 【fa283d†L43-L53】
 
 ## Dependencies
 - [fix-storage-eviction-under-budget-regression](fix-storage-eviction-under-budget-regression.md)

--- a/issues/resolve-resource-tracker-errors-in-verify.md
+++ b/issues/resolve-resource-tracker-errors-in-verify.md
@@ -5,14 +5,17 @@
 `KeyError` messages after unit tests, preventing integration tests and
 coverage from completing.
 
-On September 17, 2025, the environment still lacks the Go Task CLI by default,
+On September 18, 2025, the environment still lacks the Go Task CLI by default,
 so a fresh `task verify` run has not been attempted. `task --version` continues
-to report "command not found", and after resyncing the `dev-minimal`, `test`,
-and `docs` extras, `uv run python scripts/check_env.py` confirms that Go Task
-is the remaining prerequisite. 【6c3849†L1-L3】【e6706c†L1-L26】 Targeted retries
-of the distributed coordination property suite and the VSS extension loader
-tests complete without resource tracker errors, suggesting the cleanup helpers
-remain effective once the suite reaches teardown. 【d3124a†L1-L2】【669da8†L1-L2】
+to report "command not found", and running `uv run python scripts/check_env.py`
+now flags the Go Task CLI plus unsynced development and test tooling (e.g.,
+`black`, `flake8`, `fakeredis`, `hypothesis`) until the extras are installed via
+`task install` or `uv sync`. 【74a609†L1-L2】【cd57a1†L1-L24】 Targeted retries of
+the distributed coordination property suite and the VSS extension loader tests
+still demonstrate clean shutdowns when the `[test]` extras are present, but
+without those extras Hypothesis is missing and the coordination suite errors
+during collection.
+【791df7†L1-L18】【d3124a†L1-L2】【669da8†L1-L2】
 The storage teardown regression has been fixed—the patched
 `ConfigLoader.load_config` scenario now passes—so the unit suite progresses to
 the storage eviction simulation. 【04f707†L1-L3】 `uv run --extra test pytest


### PR DESCRIPTION
## Summary
- add a September 18, 2025 status update and align the roadmap, task progress, and release plan with the latest `check_env` results and missing extras
- refresh open release issues to reference the new environment findings and note the Hypothesis import error when `[test]` extras are absent
- capture the noisy offline DuckDB VSS logging as a new planning issue so storage regressions remain readable

## Testing
- uv run python scripts/check_env.py
- uv run pytest tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes -q
- uv run pytest tests/unit/distributed/test_coordination_properties.py -q


------
https://chatgpt.com/codex/tasks/task_e_68cb561155f08333bf9ed7d1bc93e1e3