### PR TITLE
Update release docs and issues after latest verification

### DIFF
--- a/.env.offline
+++ b/.env.offline
@@ -2,7 +2,7 @@
 # This file is used in test environments to ensure they can run without network access
 
 # Path to the VSS extension
-VECTOR_EXTENSION_PATH=./extensions/extensions/vss/vss.duckdb_extension
+VECTOR_EXTENSION_PATH=./extensions/vss/vss.duckdb_extension
 
 # Database path
 DUCKDB_PATH=./test_kg.duckdb

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap summarizes planned features for upcoming releases.
 Dates and milestones align with the [release plan](docs/release_plan.md).
 See [STATUS.md](STATUS.md) and [CHANGELOG.md](CHANGELOG.md) for current results
 and recent changes. Installation and environment details are covered in the
-[README](README.md). Last updated **September 17, 2025**.
+[README](README.md). Last updated **September 18, 2025**.
 
 ## Status
 
@@ -16,20 +16,18 @@ CLI on first boot, so `uv run task check` fails until `scripts/setup.sh` or a
 manual install provides the binary. Running `uv run python scripts/check_env.py`
 in a fresh container reports the Go Task CLI plus unsynced development and test
 tooling (e.g., `black`, `flake8`, `fakeredis`, `hypothesis`) until `task
-install` or `uv sync` installs the extras. 【cd57a1†L1-L24】 `task --version`
+install` or `uv sync` installs the extras. 【0f3265†L1-L24】 `task --version`
 continues to return "command not found", so contributors must install the CLI
-before using the Taskfile. 【74a609†L1-L2】 On **September 17, 2025** the storage
-teardown regression was cleared and the patched monitor metrics test now
-passes, but `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1`
-fails at `tests/unit/test_storage_eviction_sim.py::
-test_under_budget_keeps_nodes` because `_enforce_ram_budget` prunes nodes even
-when mocked RAM usage stays within the budget. 【04f707†L1-L3】【d7c968†L1-L164】
-Distributed coordination property tests still pass when run directly, and the
-VSS extension loader suite succeeds with the `[test]` extras installed.
-【d3124a†L1-L2】【669da8†L1-L2】 After syncing the docs extras,
-`uv run --extra docs mkdocs build` completes without navigation warnings after
-adding `docs/status/task-coverage-2025-09-17.md` to `mkdocs.yml`.
-【781a25†L1-L1】【a05d60†L1-L2】【bc0d4c†L1-L1】 Release blockers remain in
+before using the Taskfile. 【d853f2†L1-L2】 The storage teardown regression was
+cleared and the patched monitor metrics test now passes, but
+`uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` fails at
+`tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes`
+because `_enforce_ram_budget` prunes nodes even when mocked RAM usage stays
+within the budget. 【04f707†L1-L3】【3b2b52†L1-L60】 Distributed
+coordination property tests succeed once the `[test]` extras are installed, and
+the VSS extension loader suite continues to pass. 【f15357†L1-L2】【5f6286†L1-L1】
+After syncing the docs extras, `uv run --extra docs mkdocs build` completes
+without navigation warnings. 【586050†L1-L1】 Release blockers remain in
 [restore-distributed-coordination-simulation-exports](
 issues/restore-distributed-coordination-simulation-exports.md),
 [resolve-resource-tracker-errors-in-verify](

--- a/STATUS.md
+++ b/STATUS.md
@@ -9,20 +9,27 @@ checks are required.
 
 ## September 18, 2025
 - `task --version` still reports "command not found", confirming the Go Task
-  CLI is absent in a fresh container until `scripts/setup.sh` or an
-  equivalent manual install runs. 【74a609†L1-L2】
-- `uv run python scripts/check_env.py` now flags missing development and test
+  CLI is absent in a fresh container until `scripts/setup.sh` or an equivalent
+  manual install runs. 【d853f2†L1-L2】
+- `uv run python scripts/check_env.py` flags missing development and test
   tooling (e.g., `black`, `flake8`, `fakeredis`, `hypothesis`) in addition to
-  Go Task, showing that contributors must run `task install` or `uv sync`
-  before invoking the Taskfile. 【cd57a1†L1-L24】
-- `uv run pytest tests/unit/test_storage_eviction_sim.py::
-  test_under_budget_keeps_nodes -q` still fails, demonstrating that the
-  deterministic fallback in `_enforce_ram_budget` evicts nodes even when RAM
-  usage is mocked at zero and leaving the regression open. 【fa283d†L1-L62】
-- `uv run pytest tests/unit/distributed/test_coordination_properties.py -q`
-  errors during collection because `hypothesis` is missing, so installing the
-  `[test]` extras remains a prerequisite before re-running the coordination
-  property suite. 【791df7†L1-L18】
+  Go Task, reinforcing that contributors must run `task install` or `uv sync`
+  before invoking the Taskfile. 【0f3265†L1-L24】
+- `uv run --extra test pytest tests/unit/test_storage_eviction_sim.py::
+  test_under_budget_keeps_nodes -q` still fails, showing the deterministic
+  fallback in `_enforce_ram_budget` evicts nodes even when RAM usage is mocked
+  at zero and leaving the regression open. 【3b2b52†L1-L60】
+- Updated `.env.offline` to point at `extensions/vss/vss.duckdb_extension`,
+  removing the doubled `extensions/` prefix in offline logs; the storage
+  simulation now reports the corrected path while still exercising the stub
+  fallback. 【F:.env.offline†L1-L11】【3b2b52†L18-L24】
+- `uv run --extra test pytest tests/unit/distributed/
+  test_coordination_properties.py -q` succeeds once the `[test]` extras are
+  available, confirming the restored simulation exports behave as expected
+  outside the storage regression. 【f15357†L1-L2】
+- `uv run --extra test pytest tests/unit/test_vss_extension_loader.py -q`
+  passes, so the loader remains stable while the storage regression is under
+  investigation. 【5f6286†L1-L1】
 - `SPEC_COVERAGE.md` continues to list specifications plus proofs or
   simulations for every module, confirming the spec-driven baseline stays in
   sync with the implementation. 【F:SPEC_COVERAGE.md†L1-L120】

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -4,26 +4,22 @@ This document tracks the progress of tasks for the Autoresearch project,
 organized by phases from the code complete plan. As of **September 18, 2025**
 the evaluation container still lacks the Go Task CLI by default, so
 `uv run task check` fails until `scripts/setup.sh` installs the binary.
-Running `uv run python scripts/check_env.py` now reports the Go Task CLI plus
+Running `uv run python scripts/check_env.py` reports the Go Task CLI plus
 unsynced development and test tooling (e.g., `black`, `flake8`, `fakeredis`,
 `hypothesis`) until `task install` or `uv sync` installs the extras.
-【cd57a1†L1-L24】 `task --version` still returns "command not found", so the CLI
-must be installed manually. 【74a609†L1-L2】 The storage
-teardown regression is fixed—the patched monitor metrics test now passes—so the
-suite advances to the storage eviction simulation.
-`uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` currently
-fails at `tests/unit/test_storage_eviction_sim.py::
+【0f3265†L1-L24】 `task --version` still returns "command not found", so the CLI
+must be installed manually. 【d853f2†L1-L2】 The storage teardown regression is
+fixed—the patched monitor metrics test now passes—so the suite advances to the
+storage eviction simulation. `uv run --extra test pytest tests/unit -k "storage"
+-q --maxfail=1` currently fails at `tests/unit/test_storage_eviction_sim.py::
 test_under_budget_keeps_nodes` because `_enforce_ram_budget` prunes nodes even
-when mocked RAM usage stays within the budget. 【04f707†L1-L3】【d7c968†L1-L164】
-Distributed coordination property tests require the `[test]` extras; without
-them Hypothesis is missing and the suite errors during collection, so install
-the extras before rerunning the properties.
-【791df7†L1-L18】【d3124a†L1-L2】【669da8†L1-L2】 After syncing the docs extras, we
-added `docs/status/task-coverage-2025-09-17.md` to the navigation and confirmed
-`uv run --extra docs mkdocs build` completes without warnings, clearing the
-release packaging blocker. 【781a25†L1-L1】【a05d60†L1-L2】【bc0d4c†L1-L1】 Unit
-coverage and `task verify` remain blocked while the Task CLI is absent and the
-eviction regression persists.
+when mocked RAM usage stays within the budget. 【04f707†L1-L3】【3b2b52†L1-L60】
+Distributed coordination property tests succeed once the `[test]` extras are
+installed, and the VSS extension loader suite remains green.
+【f15357†L1-L2】【5f6286†L1-L1】 After syncing the docs extras, `uv run --extra docs
+mkdocs build` completes without warnings, clearing the release packaging
+blocker. 【586050†L1-L1】 Unit coverage and `task verify` remain blocked while the
+Task CLI is absent and the eviction regression persists.
 See [docs/release_plan.md](docs/release_plan.md) for current test and coverage
 status and the alpha release checklist. An **0.1.0-alpha.1** preview remains
 targeted for **September 15, 2026**, with the final **0.1.0** release targeted

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -9,7 +9,7 @@ The publishing workflow follows the steps in
 ROADMAP.md for high-level milestones.
 
 The project kicked off in **May 2025** (see the initial commit dated
-`2025-05-18`). This schedule was last updated on **September 17, 2025** and
+`2025-05-18`). This schedule was last updated on **September 18, 2025** and
 reflects that the codebase currently sits at the **unreleased 0.1.0a1** version
 defined in `autoresearch.__version__`. The project targets **0.1.0a1** for
 **September 15, 2026** and **0.1.0** for **October 1, 2026**. See
@@ -22,27 +22,25 @@ The dependency pins for `fastapi` (>=0.116.1) and `slowapi` (==0.1.9) remain
 confirmed in `pyproject.toml` and [installation.md](installation.md), but the
 evaluation environment still omits the Go Task CLI. `uv run task check` fails
 with `No such file or directory` until `scripts/setup.sh` installs the binary.
-Running `uv run python scripts/check_env.py` now reports the Go Task CLI plus
+Running `uv run python scripts/check_env.py` reports the Go Task CLI plus
 unsynced development and test tooling (e.g., `black`, `flake8`, `fakeredis`,
 `hypothesis`) until contributors run `task install` or `uv sync` to install the
-extras. 【cd57a1†L1-L24】 `task --version` continues to return "command not
-found", so the CLI must be bootstrapped manually. 【74a609†L1-L2】 Targeted unit
-runs on **September 17, 2025** confirm that the storage teardown regression is
-resolved—the patched monitor metrics test now passes—yet
+extras. 【0f3265†L1-L24】 `task --version` continues to return "command not
+found", so the CLI must be bootstrapped manually. 【d853f2†L1-L2】 Targeted unit
+runs confirm that the storage teardown regression is resolved—the patched
+monitor metrics test now passes—yet
 `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` fails at
 `tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes`
 because `_enforce_ram_budget` prunes nodes even when mocked RAM usage stays
-within the budget. 【04f707†L1-L3】【d7c968†L1-L164】 Integration ranking checks and
-optional extras continue to pass with the `[test]` extras installed. Without
-those extras Hypothesis is unavailable and the distributed coordination suite
-errors during collection, so install the dependencies before rerunning it.
-【791df7†L1-L18】【d3124a†L1-L2】【669da8†L1-L2】 After syncing the docs extras,
-`uv run --extra docs mkdocs build` completes without navigation warnings after
-adding `docs/status/task-coverage-2025-09-17.md` to `mkdocs.yml`.
-【781a25†L1-L1】【a05d60†L1-L2】【bc0d4c†L1-L1】 `task verify` remains blocked by the
-missing CLI and the eviction regression, so coverage numbers are still
-unavailable. These items are tracked in STATUS.md and the open issues listed
-there.
+within the budget. 【04f707†L1-L3】【3b2b52†L1-L60】 Integration
+ranking checks and optional extras continue to pass with the `[test]` extras
+installed, and the distributed coordination property suite succeeds once those
+dependencies are available. 【f15357†L1-L2】 The VSS extension loader suite also
+remains green. 【5f6286†L1-L1】 After syncing the docs extras,
+`uv run --extra docs mkdocs build` completes without navigation warnings.
+【586050†L1-L1】 `task verify` remains blocked by the missing CLI and the
+eviction regression, so coverage numbers are still unavailable. These items are
+tracked in STATUS.md and the open issues listed there.
 ## Milestones
 
 - **0.1.0a1** (2026-09-15, status: in progress): Alpha preview to collect

--- a/issues/fix-storage-eviction-under-budget-regression.md
+++ b/issues/fix-storage-eviction-under-budget-regression.md
@@ -6,8 +6,8 @@ now fails at `tests/unit/test_storage_eviction_sim.py::
 test_under_budget_keeps_nodes`. The scenario sets
 `StorageManager._current_ram_mb` to return `0` so the workload stays
 below the `1` MB budget, yet `_enforce_ram_budget` still prunes nodes
-until only one remains. 【d7c968†L1-L164】 The regression stems from the
-fallback that derives a deterministic node limit from the RAM budget.
+until only one remains. 【3b2b52†L1-L60】 The regression stems from
+the fallback that derives a deterministic node limit from the RAM budget.
 With the default configuration the helper returns `budget_mb`, so the
 loop removes entries whenever the graph holds more than one node even
 though RAM usage is reported within bounds.

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -7,24 +7,22 @@ documentation, and packaging while keeping workflows dispatch-only. As of
 2025-09-18 the Go Task CLI is still absent in a fresh environment, so running
 `uv run task check` fails until contributors install Task manually. `task
 --version` continues to return "command not found", and running `uv run python
-scripts/check_env.py` now flags the Go Task CLI plus unsynced development and
+scripts/check_env.py` flags the Go Task CLI plus unsynced development and
 test tooling (e.g., `black`, `flake8`, `fakeredis`, `hypothesis`) until `task
 install` or `uv sync` installs the extras.
-【74a609†L1-L2】【cd57a1†L1-L24】 Targeted test suites confirm that distributed
-coordination properties and VSS extension scenarios still pass with the `[test]`
-extras installed, but without those extras Hypothesis is missing and the
-coordination suite errors during collection.
-【791df7†L1-L18】【d3124a†L1-L2】【669da8†L1-L2】 The storage teardown
-regression that blocked the monitor metrics suite has been resolved; the patched
-scenario now passes. 【04f707†L1-L3】 The unit run now halts at
-`tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes`
+【d853f2†L1-L2】【0f3265†L1-L24】 Targeted test suites confirm that distributed
+coordination properties and VSS extension scenarios pass with the `[test]`
+extras installed; without those extras Hypothesis is missing and the
+coordination suite errors during collection. 【f15357†L1-L2】【5f6286†L1-L1】 The
+storage teardown regression that blocked the monitor metrics suite has been
+resolved; the patched scenario now passes. 【04f707†L1-L3】 The unit run now
+halts at `tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes`
 because `_enforce_ram_budget` evicts nodes even when the mocked RAM usage stays
 within the budget, preventing coverage and release rehearsals from finishing.
-【d7c968†L1-L164】 Adding the task coverage log to `mkdocs.yml` cleared the
-documentation warning; `uv run --extra docs mkdocs build` still completes
-without navigation errors. 【781a25†L1-L1】【a05d60†L1-L2】【bc0d4c†L1-L1】 These gaps
-block the release checklist and require targeted fixes before we can tag
-0.1.0a1.
+【3b2b52†L1-L60】 Adding the task coverage log to `mkdocs.yml`
+cleared the documentation warning; `uv run --extra docs mkdocs build` still
+completes without navigation errors. 【586050†L1-L1】 These gaps block the release
+checklist and require targeted fixes before we can tag 0.1.0a1.
 
 ## Dependencies
 - [restore-distributed-coordination-simulation-exports](restore-distributed-coordination-simulation-exports.md)

--- a/issues/reduce-vss-extension-error-noise-offline.md
+++ b/issues/reduce-vss-extension-error-noise-offline.md
@@ -1,12 +1,13 @@
 # Reduce VSS extension error noise when offline
 
 ## Context
-Running `uv run pytest tests/unit/test_storage_eviction_sim.py::
+Running `uv run --extra test pytest tests/unit/test_storage_eviction_sim.py::
 test_under_budget_keeps_nodes -q` in the evaluation container emits
 repeated error-level logs from DuckDB while the VSS extension loader
 falls back to the stub file. The output reports failed HTTP downloads
-and missing catalog settings before the stub completes, even though the
-simulation ultimately proceeds. 【fa283d†L1-L46】 The noise obscures the
+and missing catalog settings before the stub completes, including
+repeated "Failed to create HNSW index" messages, even though the
+simulation ultimately proceeds. 【3b2b52†L1-L60】 The noise obscures the
 storage regression signal and suggests a fatal failure despite the
 existing offline fallback. We should downgrade or consolidate these
 messages when the loader falls back to stubbed extensions so offline

--- a/issues/rerun-task-coverage-after-storage-fix.md
+++ b/issues/rerun-task-coverage-after-storage-fix.md
@@ -7,13 +7,13 @@ suite cannot reach coverage today. `uv run --extra test pytest tests/unit -k
 "storage" -q --maxfail=1` now fails at
 `tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes`
 because `_enforce_ram_budget` trims nodes even when the mocked RAM usage stays
-within the budget. 【d7c968†L1-L164】 After syncing the `dev-minimal`, `test`, and
-`docs` extras, `uv run python scripts/check_env.py` in a fresh container now
-flags the Go Task CLI plus unsynced development and test tooling (e.g., `black`,
-`flake8`, `fakeredis`, `hypothesis`) until `task install` or `uv sync` installs
-the extras. Both the eviction regression and the tooling gap must be resolved
-before we can refresh `baseline/coverage.xml` and publish a new status log.
-【cd57a1†L1-L24】【F:docs/status/task-coverage-2025-09-17.md†L1-L28】
+within the budget. 【3b2b52†L1-L60】 After syncing the `dev-minimal`,
+`test`, and `docs` extras, `uv run python scripts/check_env.py` in a fresh
+container flags the Go Task CLI plus unsynced development and test tooling
+(e.g., `black`, `flake8`, `fakeredis`, `hypothesis`) until `task install` or
+`uv sync` installs the extras. Both the eviction regression and the tooling gap
+must be resolved before we can refresh `baseline/coverage.xml` and publish a
+new status log. 【0f3265†L1-L24】【F:docs/status/task-coverage-2025-09-17.md†L1-L28】
 
 ## Dependencies
 - [fix-storage-eviction-under-budget-regression](fix-storage-eviction-under-budget-regression.md)

--- a/issues/resolve-deprecation-warnings-in-tests.md
+++ b/issues/resolve-deprecation-warnings-in-tests.md
@@ -15,21 +15,21 @@ showed no remaining warnings in the CLI helper suite or distributed perf
 comparison test. The `sitecustomize.py` shim that rewrites
 `weasel.util.config` appears to be working, and the Click bump to 8.2.1 removed
 the original warning. After resyncing the `dev-minimal`, `test`, and `docs`
-extras, `uv run python scripts/check_env.py` in a fresh container now flags the
+extras, `uv run python scripts/check_env.py` in a fresh container flags the
 Go Task CLI plus unsynced development and test tooling (e.g., `black`,
 `flake8`, `fakeredis`, `hypothesis`) until `task install` or `uv sync` installs
-the extras. 【cd57a1†L1-L24】 The storage teardown regression is fixed—the patched
+the extras. 【0f3265†L1-L24】 The storage teardown regression is fixed—the patched
 monitor metrics test now passes—so the unit suite advances to the storage
 eviction simulation. 【04f707†L1-L3】 `uv run --extra test pytest tests/unit -k
 "storage" -q --maxfail=1` currently fails at
 `tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes`
 because `_enforce_ram_budget` prunes nodes even when the mocked RAM usage stays
-within the budget. 【d7c968†L1-L164】 We must repair that regression and restore
-the Task CLI before rerunning the warnings sweep under Task with
+within the budget. 【3b2b52†L1-L60】 We must repair that regression
+and restore the Task CLI before rerunning the warnings sweep under Task with
 `PYTHONWARNINGS=error::DeprecationWarning`. Without the `[test]` extras Pytest
 also emits `PytestConfigWarning: Unknown config option: bdd_features_base_dir`
 during the storage simulations, so ensuring the extras are installed is part of
-the cleanup. 【fa283d†L43-L53】
+the cleanup. 【3b2b52†L22-L36】
 
 ## Dependencies
 - [fix-storage-eviction-under-budget-regression](fix-storage-eviction-under-budget-regression.md)

--- a/issues/resolve-resource-tracker-errors-in-verify.md
+++ b/issues/resolve-resource-tracker-errors-in-verify.md
@@ -8,23 +8,22 @@ coverage from completing.
 On September 18, 2025, the environment still lacks the Go Task CLI by default,
 so a fresh `task verify` run has not been attempted. `task --version` continues
 to report "command not found", and running `uv run python scripts/check_env.py`
-now flags the Go Task CLI plus unsynced development and test tooling (e.g.,
+flags the Go Task CLI plus unsynced development and test tooling (e.g.,
 `black`, `flake8`, `fakeredis`, `hypothesis`) until the extras are installed via
-`task install` or `uv sync`. 【74a609†L1-L2】【cd57a1†L1-L24】 Targeted retries of
+`task install` or `uv sync`. 【d853f2†L1-L2】【0f3265†L1-L24】 Targeted retries of
 the distributed coordination property suite and the VSS extension loader tests
-still demonstrate clean shutdowns when the `[test]` extras are present, but
-without those extras Hypothesis is missing and the coordination suite errors
-during collection.
-【791df7†L1-L18】【d3124a†L1-L2】【669da8†L1-L2】
+still demonstrate clean shutdowns when the `[test]` extras are present; without
+those extras Hypothesis is missing and the coordination suite errors during
+collection. 【f15357†L1-L2】【5f6286†L1-L1】
 The storage teardown regression has been fixed—the patched
 `ConfigLoader.load_config` scenario now passes—so the unit suite progresses to
 the storage eviction simulation. 【04f707†L1-L3】 `uv run --extra test pytest
 tests/unit -k "storage" -q --maxfail=1` now fails at
 `tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes`
 because `_enforce_ram_budget` trims nodes even when usage stays within the
-budget. 【d7c968†L1-L164】 Until the eviction regression and Go Task gap are
-resolved we still cannot exercise `task verify` end-to-end to confirm the
-resource tracker fix.
+budget. 【3b2b52†L1-L60】 Until the eviction regression and Go Task gap are
+resolved we still cannot exercise `task verify` end-to-end to confirm
+the resource tracker fix.
 
 ## Dependencies
 - [fix-storage-eviction-under-budget-regression](

--- a/issues/restore-distributed-coordination-simulation-exports.md
+++ b/issues/restore-distributed-coordination-simulation-exports.md
@@ -10,12 +10,12 @@ storage teardown regression has been cleared—the patched
 far enough to hit the storage eviction simulation. 【04f707†L1-L3】 The latest
 run halts at `tests/unit/test_storage_eviction_sim.py::
 test_under_budget_keeps_nodes`, where `_enforce_ram_budget` prunes nodes even
-though the mocked RAM usage stays within budget. 【d7c968†L1-L164】 That failure
-prevents the distributed property suite from executing during the targeted
-`-k "storage"` run. A focused invocation of
+though the mocked RAM usage stays within budget. 【3b2b52†L1-L60】
+That failure prevents the distributed property suite from executing during the
+targeted `-k "storage"` run. A focused invocation of
 `tests/unit/distributed/test_coordination_properties.py` still passes,
 confirming the helpers behave as expected once the suite reaches them, so we
-remain blocked only by the eviction regression. 【d3124a†L1-L2】
+remain blocked only by the eviction regression. 【f15357†L1-L2】
 
 ## Dependencies
 - [fix-storage-eviction-under-budget-regression](


### PR DESCRIPTION
## Summary
- capture the latest environment check and storage regression findings in `STATUS.md`, `ROADMAP.md`, `docs/release_plan.md`, and `TASK_PROGRESS.md` so release planning reflects current blockers
- correct `.env.offline` to point at `extensions/vss/vss.duckdb_extension`, preventing double-`extensions` paths during offline VSS fallback
- refresh release-blocking issue tickets with new citations for storage failures, environment gaps, and documentation status

## Testing
- `uv run python scripts/check_env.py`
- `uv run --extra test pytest tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes -q`
- `uv run --extra test pytest tests/unit/distributed/test_coordination_properties.py -q`
- `uv run --extra test pytest tests/unit/test_vss_extension_loader.py -q`
- `uv run --extra docs mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68cb58d7a2108333bcf21085e0421cf2