### PR TITLE
Quieten VSS extension loader offline fallbacks

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -28,8 +28,10 @@ checks are required.
   available, confirming the restored simulation exports behave as expected
   outside the storage regression. 【f15357†L1-L2】
 - `uv run --extra test pytest tests/unit/test_vss_extension_loader.py -q`
-  passes, so the loader remains stable while the storage regression is under
-  investigation. 【5f6286†L1-L1】
+  still passes, and the loader's offline fallbacks now emit only INFO/WARNING
+  records while deduplicating repeated errors. The new log-focused test guards
+  the quieter behavior. 【F:src/autoresearch/extensions.py†L57-L179】
+  【F:tests/unit/test_vss_extension_loader.py†L173-L227】【6ec3f1†L1-L2】
 - `SPEC_COVERAGE.md` continues to list specifications plus proofs or
   simulations for every module, confirming the spec-driven baseline stays in
   sync with the implementation. 【F:SPEC_COVERAGE.md†L1-L120】

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -15,8 +15,10 @@ storage eviction simulation. `uv run --extra test pytest tests/unit -k "storage"
 test_under_budget_keeps_nodes` because `_enforce_ram_budget` prunes nodes even
 when mocked RAM usage stays within the budget. 【04f707†L1-L3】【3b2b52†L1-L60】
 Distributed coordination property tests succeed once the `[test]` extras are
-installed, and the VSS extension loader suite remains green.
-【f15357†L1-L2】【5f6286†L1-L1】 After syncing the docs extras, `uv run --extra docs
+installed, and the VSS extension loader suite remains green while the offline
+fallback logs stay at INFO/WARNING thanks to the deduplicated logging helper
+and guard test. 【f15357†L1-L2】【F:src/autoresearch/extensions.py†L57-L179】
+【F:tests/unit/test_vss_extension_loader.py†L173-L227】【6ec3f1†L1-L2】 After syncing the docs extras, `uv run --extra docs
 mkdocs build` completes without warnings, clearing the release packaging
 blocker. 【586050†L1-L1】 Unit coverage and `task verify` remain blocked while the
 Task CLI is absent and the eviction regression persists.


### PR DESCRIPTION
## Summary
- adjust `VSSExtensionLoader` logging so DuckDB installation errors fall back at INFO/WARNING levels and deduplicate repeated error records
- add a parameterized caplog test covering package, local stub, and marker fallbacks to ensure no error-level logs are emitted
- document the quieter behavior in `STATUS.md` and `TASK_PROGRESS.md`

## Testing
- uv run --extra test pytest tests/unit/test_vss_extension_loader.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cb73d07c148333b5ed36d842ccbbf3