### PR TITLE
Refine spec documentation and confirm lint compliance

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -16,9 +16,9 @@ checks are required.
   available. 【0feb5e†L1-L17】【fa650a†L1-L10】
 - Sourcing `.autoresearch/path.sh` via `./scripts/setup.sh --print-path` keeps
   `task --version` at 3.45.4 in fresh shells. 【5d8a01†L1-L2】
-- `uv run python scripts/lint_specs.py` continues to fail because the monitor
-  and extensions specs are missing required headings, so `task check` remains
-  blocked on restoring the template. 【4076c9†L1-L2】
+- `uv run python scripts/lint_specs.py` now exits cleanly, and `uv run task
+  check` flows through the `lint-specs` gate and finishes, so spec lint
+  compliance is restored. 【53ce5c†L1-L2】【5e12ab†L1-L3】【ba6f1a†L1-L2】
 - `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` still
   completes with 135 passed, 2 skipped, 1 xfailed, and 1 xpassed tests, so the
   storage guard fix holds. 【dbf750†L1-L1】

--- a/docs/specs/extensions.md
+++ b/docs/specs/extensions.md
@@ -9,43 +9,42 @@ stubs, and stub markers. Strict mode (`AUTORESEARCH_STRICT_EXTENSIONS=true`)
 raises `StorageError` when no strategy succeeds, and unexpected exceptions
 propagate so operators see actionable traces.
 
-## Loader strategy
+## Algorithms
 
-### Offline path discovery
+### Offline Ladder
 
-1. Use `ConfigLoader().config.storage.vector_extension_path` when set.
+1. Use `ConfigLoader().config.storage.vector_extension_path` when it is set.
 2. Otherwise call `_env_extension_path()` to read `VECTOR_EXTENSION_PATH` from
    the environment or `.env.offline`.
-3. Resolve the candidate path. Warn and skip the load when the suffix is not
-   `.duckdb_extension`, and warn again if the file is missing.
-4. Attempt `LOAD '<path>'` when the file is present and invoke
-   `verify_extension` before returning. DuckDB-specific errors fall through to
-   the remaining strategies while unexpected exceptions bubble up.
+3. Resolve the candidate path, warning when the suffix is not
+   `.duckdb_extension` or the file is missing so operators can correct
+   provisioning issues.
+4. Attempt `LOAD '<path>'` when the file exists and invoke `verify_extension`
+   before returning. DuckDB-specific errors fall through to the remaining
+   strategies while unexpected exceptions bubble up for visibility.
+5. When the load is skipped or raises `duckdb.Error`, walk the fallback ladder:
+   - `_load_from_package` imports `duckdb_extension_vss`, preferring its
+     `load()` helper before trying a bundled `vss.duckdb_extension`, and calls
+     `verify_extension` after each attempt.
+   - `_load_local_stub` loads `extensions/vss/vss.duckdb_extension` populated by
+     the repository or provisioning scripts, again verifying the result.
+   - `_create_stub_marker` creates a temporary `vss_stub` table so downstream
+     code can detect stubbed mode via `verify_extension`.
+6. After all attempts fail, strict mode raises `StorageError`; relaxed mode
+   returns `False` so callers can continue with stubbed reads and degrade
+   gracefully.
 
-### Controlled network install
+### Network Ladder
 
 1. Evaluate `ENABLE_ONLINE_EXTENSION_INSTALL` (default `true`).
 2. If enabled, execute `INSTALL vss` then `LOAD vss`, propagating non-DuckDB
-   errors to preserve diagnostics.
+   errors to preserve diagnostics while `duckdb.Error` triggers the offline
+   ladder.
 3. Verify the extension. A passing probe sets `extension_loaded`; a failure
-   returns `False` but only DuckDB install errors invoke the offline ladder.
+   returns `False` but leaves strict-versus-relaxed handling to the offline
+   ladder.
 4. When disabled, skip network calls entirely so air-gapped environments enter
-   the fallback ladder immediately.
-
-### Offline fallback ladder
-
-When the network install path is skipped or raises `duckdb.Error`, the loader
-walks the following ladder:
-
-1. `_load_from_package` imports `duckdb_extension_vss`, preferring its
-   `load()` helper before trying a bundled `vss.duckdb_extension`. Each route
-   calls `verify_extension`.
-2. `_load_local_stub` loads `extensions/vss/vss.duckdb_extension` that the
-   repository or provisioning scripts populate, again verifying the result.
-3. `_create_stub_marker` creates a temporary `vss_stub` table so downstream
-   code can detect stubbed mode via `verify_extension`.
-4. After all attempts fail, strict mode raises `StorageError`; relaxed mode
-   returns `False` so callers can continue with stubbed reads.
+   the offline ladder immediately.
 
 ## Verification
 
@@ -57,7 +56,18 @@ walks the following ladder:
   install fallbacks, stub creation, strict mode, and non-DuckDB propagation to
   ensure the verification contract stays intact.[t3]
 
-## Offline determinism
+## Invariants
+
+- Strict mode (`AUTORESEARCH_STRICT_EXTENSIONS=true`) raises `StorageError`
+  after every ladder fails, preventing the application from continuing without
+  a verified extension.
+- Relaxed mode records stub markers and returns `False`, signalling downstream
+  callers to operate in degraded read-only mode without masking missing
+  extensions.
+- Verification always follows a load attempt, so neither ladder can report a
+  success without confirming the DuckDB extension or the stub marker.
+
+## Offline Determinism
 
 - `.env.offline` caches `VECTOR_EXTENSION_PATH`, letting the loader reuse
   binaries without network access between runs.
@@ -68,7 +78,7 @@ walks the following ladder:
   `check_storage()` to confirm stub creation, stub marker detection, and
   logging when the real extension is absent.[s1]
 
-## Proof sketch
+## Proof Sketch
 
 The loader enumerates a finite sequence of fallbacks guarded by
 `verify_extension`. Because verification only succeeds after loading a real
@@ -79,7 +89,7 @@ decision tree.[t3] Storage backend tests propagate failures to user-facing
 APIs, confirming strict mode raises early and non-strict mode preserves stub
 access.[t1][t2]
 
-## Simulation expectations
+## Simulation Expectations
 
 - Rebuilds that pre-run `scripts/download_duckdb_extensions.py` should record
   a deterministic offline path so CI and local runs agree on binaries.[s2]

--- a/docs/specs/monitor.md
+++ b/docs/specs/monitor.md
@@ -140,18 +140,16 @@ that wraps `NodeHealthMonitor` for Redis and Ray health reporting.
   resource sampling tables, and counter increments across the CLI and HTTP
   surfaces.
 
-## Simulation Evidence
+## Simulation Expectations
 
 `scripts/monitor_cli_reliability.py` performs a Monte Carlo simulation of
-metrics collection latency and failure probability. Run
-
-```
-uv run scripts/monitor_cli_reliability.py --runs 1000 --fail-rate 0.05
-```
-
-to obtain `average_latency_ms` and `success_rate` estimates. Integration tests
-also exercise GPU present and absent scenarios so resource sampling and counter
-snapshots degrade gracefully when GPU metrics are unavailable.
+metrics collection latency and failure probability. Supply the number of trial
+cycles with `--runs` and optionally set the simulated sampler failure rate with
+`--fail-rate`. The script emits `average_latency_ms` and `success_rate` as the
+primary outputs, along with log lines for individual failure events when they
+occur. Integration tests also exercise GPU present and absent scenarios so
+resource sampling and counter snapshots degrade gracefully when GPU metrics are
+unavailable.
 
 ## Traceability
 


### PR DESCRIPTION
## Summary
- rename the monitor spec simulation section to "Simulation Expectations" and document its expected inputs and outputs
- restructure the extensions spec to follow the enforced algorithms/invariants template while keeping the simulation notes intact
- note in STATUS.md that the spec lint stage now completes successfully

## Testing
- uv run python scripts/lint_specs.py
- uv run task check

------
https://chatgpt.com/codex/tasks/task_e_68cd6eec77e883339de989471a6158e2