### PR TITLE
Align spec template with linted headings

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -62,7 +62,10 @@ documented behaviour.
 
 ## Spec template
 
-Start new specs with the following structure:
+Start new specs with the following structure.
+Keep the headings verbatim so `scripts/lint_specs.py` continues to recognize
+the document; consult that script for the authoritative list of required
+sections.
 
 ```markdown
 # Module name
@@ -76,8 +79,14 @@ Explain key algorithms and decision logic.
 ## Invariants
 List conditions maintained across operations.
 
-## Proofs
-Reasoning or links showing the invariants hold.
+## Proof Sketch
+Outline why the invariants hold and link to supporting arguments.
+
+## Simulation Expectations
+Describe scenarios and metrics used in simulation exercises.
+
+## Traceability
+Link to related modules and tests that validate the behaviour.
 ```
 
 ## Extending specs


### PR DESCRIPTION
## Summary
- remind spec authors to keep required headings verbatim and point to `scripts/lint_specs.py`
- update the template to include every section enforced by the spec linter

## Testing
- uv run --extra docs mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68cd6efce4b88333ba26eabbefb464b0