### PR TITLE
Remove stale xfail from RDF store setup test

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -19,12 +19,14 @@ checks are required.
 - `uv run python scripts/lint_specs.py` continues to fail because the monitor
   and extensions specs are missing required headings, so `task check` remains
   blocked on restoring the template. 【4076c9†L1-L2】
-- `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` still
-  completes with 135 passed, 2 skipped, 1 xfailed, and 1 xpassed tests, so the
-  storage guard fix holds. 【dbf750†L1-L1】
+- `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` now
+  finishes with 136 passed, 2 skipped, 818 deselected, and 1 xfailed tests,
+  confirming the storage sweep stays stable after dropping the stale xfail.
+  【98baa8†L2-L2】
 - `uv run --extra test pytest tests/unit/test_storage_errors.py::
-  test_setup_rdf_store_error -q` continues to xpass, confirming the stale
-  xfail marker must be removed. 【cd543d†L1-L1】
+  test_setup_rdf_store_error -q` passes in isolation after removing the
+  decorator, so the RDF store setup path now runs as part of the default
+  storage checks. 【7cca17†L1-L1】
 - `uv run --extra docs mkdocs build` succeeds after syncing docs extras,
   showing the navigation fix still applies. 【e808c5†L1-L2】
 

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -8,10 +8,12 @@ so `task --version` reports 3.45.4 in a fresh shell without re-running setup.
 expected toolchain when the `dev-minimal` and `test` extras are synced.
 【0feb5e†L1-L17】【fa650a†L1-L10】 Storage tests that previously aborted now
 complete: `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1`
-finishes with 135 passed, 2 skipped, 1 xfailed, and 1 xpassed tests.
-【dbf750†L1-L1】 `tests/unit/test_storage_errors.py::test_setup_rdf_store_error`
-still xpasses, so `issues/remove-stale-xfail-for-rdf-store-error.md` remains
-open to drop the stale marker. 【cd543d†L1-L1】【F:issues/remove-stale-xfail-for-rdf-store-error.md†L1-L29】
+finishes with 136 passed, 2 skipped, 818 deselected, and 1 xfailed tests,
+confirming the suite stays stable after dropping the stale xfail.
+【98baa8†L2-L2】 `tests/unit/test_storage_errors.py::test_setup_rdf_store_error`
+now passes without the decorator, so
+`issues/remove-stale-xfail-for-rdf-store-error.md` is ready to close once the
+follow-up warnings sweep lands. 【7cca17†L1-L1】【F:issues/remove-stale-xfail-for-rdf-store-error.md†L1-L29】
 `uv run python scripts/lint_specs.py` currently fails because the monitor and
 extensions specs drifted from the template, so
 `issues/restore-spec-lint-template-compliance.md` tracks the spec lint repair

--- a/tests/unit/test_storage_errors.py
+++ b/tests/unit/test_storage_errors.py
@@ -5,7 +5,6 @@ from autoresearch.storage import StorageManager, setup
 from autoresearch.errors import StorageError, NotFoundError
 
 
-@pytest.mark.xfail(reason="RDF store path handling differs in CI")
 def test_setup_rdf_store_error(mock_config, assert_error):
     """Test that setup handles RDF store errors properly."""
     # Setup


### PR DESCRIPTION
## Summary
- remove the xfail decorator from the RDF store setup error test so it runs with the suite
- document the refreshed storage test results in STATUS.md and TASK_PROGRESS.md

## Testing
- uv run --extra test pytest tests/unit/test_storage_errors.py::test_setup_rdf_store_error -q
- uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68cd6f11c4f88333bdd9ae4baaf1751d