### PR TITLE
Remove stale xfail from RDF store error test

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -19,12 +19,12 @@ checks are required.
 - `uv run python scripts/lint_specs.py` now exits cleanly, and `uv run task
   check` flows through the `lint-specs` gate and finishes, so spec lint
   compliance is restored. 【53ce5c†L1-L2】【5e12ab†L1-L3】【ba6f1a†L1-L2】
-- `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` still
-  completes with 135 passed, 2 skipped, 1 xfailed, and 1 xpassed tests, so the
-  storage guard fix holds. 【dbf750†L1-L1】
 - `uv run --extra test pytest tests/unit/test_storage_errors.py::
-  test_setup_rdf_store_error -q` continues to xpass, confirming the stale
-  xfail marker must be removed. 【cd543d†L1-L1】
+  test_setup_rdf_store_error -q` now passes without an xfail, confirming the
+  RDF store setup path is stable again. 【f873bf†L1-L2】
+- `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` returns
+  136 passed, 2 skipped, 1 xfailed, and 818 deselected tests after the stale
+  xfail removal. 【1c20bc†L1-L2】
 - `uv run --extra docs mkdocs build` succeeds after syncing docs extras,
   showing the navigation fix still applies. 【e808c5†L1-L2】
 

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -8,18 +8,20 @@ so `task --version` reports 3.45.4 in a fresh shell without re-running setup.
 expected toolchain when the `dev-minimal` and `test` extras are synced.
 【0feb5e†L1-L17】【fa650a†L1-L10】 Storage tests that previously aborted now
 complete: `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1`
-finishes with 135 passed, 2 skipped, 1 xfailed, and 1 xpassed tests.
-【dbf750†L1-L1】 `tests/unit/test_storage_errors.py::test_setup_rdf_store_error`
-still xpasses, so `issues/remove-stale-xfail-for-rdf-store-error.md` remains
-open to drop the stale marker. 【cd543d†L1-L1】【F:issues/remove-stale-xfail-for-rdf-store-error.md†L1-L29】
+returns 136 passed, 2 skipped, 1 xfailed, and 818 deselected tests after the
+RDF store fix. 【1c20bc†L1-L2】 `tests/unit/test_storage_errors.py::
+test_setup_rdf_store_error` passes cleanly, so
+`issues/remove-stale-xfail-for-rdf-store-error.md` can be closed once notes are
+updated. 【f873bf†L1-L2】【F:issues/remove-stale-xfail-for-rdf-store-error.md†L1-L29】
 `uv run python scripts/lint_specs.py` currently fails because the monitor and
 extensions specs drifted from the template, so
 `issues/restore-spec-lint-template-compliance.md` tracks the spec lint repair
 before `task check` can proceed. 【4076c9†L1-L2】【F:issues/restore-spec-lint-template-compliance.md†L1-L33】
 `uv run --extra docs mkdocs build` still succeeds without navigation warnings,
 keeping the docs pipeline clear for the release. 【e808c5†L1-L2】 `task verify`
-and coverage remain blocked on verifying the resource tracker fix, removing the
-xfail, and re-running the warnings sweep.【F:issues/resolve-resource-tracker-errors-in-verify.md†L1-L33】【F:issues/rerun-task-coverage-after-storage-fix.md†L1-L33】
+and coverage remain blocked on verifying the resource tracker fix and
+re-running the warnings sweep now that the xfail is cleared.
+【F:issues/resolve-resource-tracker-errors-in-verify.md†L1-L33】【F:issues/rerun-task-coverage-after-storage-fix.md†L1-L33】
 See [docs/release_plan.md](docs/release_plan.md) for current test and coverage
 status and the alpha release checklist. An **0.1.0-alpha.1** preview remains
 targeted for **September 15, 2026**, with the final **0.1.0** release targeted

--- a/tests/unit/test_storage_errors.py
+++ b/tests/unit/test_storage_errors.py
@@ -5,7 +5,6 @@ from autoresearch.storage import StorageManager, setup
 from autoresearch.errors import StorageError, NotFoundError
 
 
-@pytest.mark.xfail(reason="RDF store path handling differs in CI")
 def test_setup_rdf_store_error(mock_config, assert_error):
     """Test that setup handles RDF store errors properly."""
     # Setup
@@ -30,10 +29,11 @@ def test_setup_rdf_store_error(mock_config, assert_error):
                     return_value=mock_db_backend,
                 ):
                     with patch("rdflib.Graph", return_value=mock_graph_instance):
-                        with mock_config(config=config):
-                            with patch("autoresearch.storage._cached_config", None):
-                                with pytest.raises(StorageError) as excinfo:
-                                    setup()
+                        with patch("importlib.util.find_spec", return_value=MagicMock()):
+                            with mock_config(config=config):
+                                with patch("autoresearch.storage._cached_config", None):
+                                    with pytest.raises(StorageError) as excinfo:
+                                        setup()
 
     # Verify
     mock_graph_instance.open.assert_called_once()


### PR DESCRIPTION
## Summary
- remove the stale xfail from `test_setup_rdf_store_error` by stubbing the RDF plugin probe so the failure path is deterministic
- refresh STATUS.md and TASK_PROGRESS.md with the new storage test outcomes and guidance on closing the related issue

## Testing
- uv run --extra test pytest tests/unit/test_storage_errors.py::test_setup_rdf_store_error -q
- uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68cd8212bda08333be8e52be388c1c35