### PR TITLE
Align issue dependencies on spec lint fix

### DIFF
--- a/issues/rerun-task-coverage-after-storage-fix.md
+++ b/issues/rerun-task-coverage-after-storage-fix.md
@@ -23,6 +23,7 @@ reference point.【F:docs/status/task-coverage-2025-09-17.md†L1-L28】
 ## Dependencies
 - [resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md)
 - [remove-stale-xfail-for-rdf-store-error](remove-stale-xfail-for-rdf-store-error.md)
+- [restore-spec-lint-template-compliance](restore-spec-lint-template-compliance.md)
 
 ## Acceptance Criteria
 - `uv run task coverage EXTRAS="nlp ui vss git distributed analysis llm parsers gpu"`

--- a/issues/resolve-deprecation-warnings-in-tests.md
+++ b/issues/resolve-deprecation-warnings-in-tests.md
@@ -38,6 +38,7 @@ headings.【4076c9†L1-L2】【F:issues/restore-spec-lint-template-compliance.m
 ## Dependencies
 - [resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md)
 - [remove-stale-xfail-for-rdf-store-error](remove-stale-xfail-for-rdf-store-error.md)
+- [restore-spec-lint-template-compliance](restore-spec-lint-template-compliance.md)
 
 ## Acceptance Criteria
 - Unit and integration tests run without deprecation warnings, including a

--- a/issues/resolve-resource-tracker-errors-in-verify.md
+++ b/issues/resolve-resource-tracker-errors-in-verify.md
@@ -19,7 +19,7 @@ scripts/lint_specs.py` still fails, blocking the verify workflow until the
 headings are restored.【4076c9†L1-L2】【F:issues/restore-spec-lint-template-compliance.md†L1-L33】
 
 ## Dependencies
-- None
+- [restore-spec-lint-template-compliance](restore-spec-lint-template-compliance.md)
 
 ## Acceptance Criteria
 - `task verify` completes without resource tracker errors.


### PR DESCRIPTION
## Summary
- link resolve-resource-tracker-errors-in-verify to the spec lint compliance issue
- propagate the same dependency to the deprecation-warning and coverage rerun issues to reflect the true ordering
- verified that prepare-first-alpha-release already depends on the spec lint compliance work

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68cd8dee8cc08333baa3a818e5a58cd5