### PR TITLE
Add verify warnings task and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ synced in previous sessions:
 task verify EXTRAS="dev-minimal test"
 ```
 
+`task verify:warnings` runs the same pipeline with `DeprecationWarning`
+promoted to errors. Run it after `task install` (or any sync that includes the
+`dev-minimal` and `test` extras) so plugins like `pytest-bdd` stay available.
+
 Use the same `EXTRAS` flag with `task install` to sync them for local
 development. Include `EXTRAS="llm"` when verifying or installing LLM
 libraries; the environment check skips them otherwise. Run `task check

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -315,6 +315,18 @@ tasks:
       Installs the `dev-minimal` and `test` extras by default; set EXTRAS to
       add optional groups, including "gpu".
 
+  verify:warnings:
+    vars:
+      EXTRAS: "{{.EXTRAS | default \"dev-minimal test\"}}"
+    env:
+      PYTHONWARNINGS: "error::DeprecationWarning"
+    cmds:
+      - task verify EXTRAS="{{.EXTRAS}}"
+    desc: |
+      Run the verify pipeline with DeprecationWarning treated as errors.
+      Use after syncing the dev-minimal and test extras so pytest-bdd and
+      related plugins are available.
+
   clean:
     cmds:
       - find . -type d -name '__pycache__' -exec rm -rf {} +

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -15,10 +15,14 @@ groups or add `gpu` packages.
 
 ## Deprecation warnings
 
+- Run `task verify:warnings` after syncing the `dev-minimal` and `test` extras
+  to treat `DeprecationWarning` as errors. `task install` or
+  `uv sync --extra test` keeps plugins such as `pytest-bdd` available for the
+  run.
 - No deprecation warnings are expected when running `task verify`.
-- `sitecustomize.py` re-exports `click.shell_completion.split_arg_string`
-  and rewrites `weasel.util.config` to import it so Click no longer warns
-  about the deprecated `click.parser` module during tests.
+- `sitecustomize.py` re-exports `click.shell_completion.split_arg_string` and
+  rewrites `weasel.util.config` to import it so Click no longer warns about the
+  deprecated `click.parser` module during tests.
 - `pytest.ini` keeps the default `.hypothesis` ignore entry so Hypothesis'
   plugin does not emit warnings when collecting tests.
 - Record any remaining unavoidable warnings here, along with a link to the
@@ -102,6 +106,10 @@ Two installation strategies support different workflows:
 `task check` offers fast feedback, while `task verify` enforces coverage and is
 expected before committing.
 
+Run `task verify:warnings` after the `dev-minimal` and `test` extras are synced
+when you need to gate on deprecation warnings. It reuses the `verify` pipeline
+and fails if any `DeprecationWarning` surfaces.
+
 To keep local runs lightweight, pin verify to the default extras when heavy
 groups were previously synced:
 
@@ -155,6 +163,7 @@ task test:fast         # unit, integration, and behavior tests (no slow)
 task test:slow         # only tests marked as slow
 task test:all          # entire suite including slow tests
 task verify           # lint, type checks, targeted tests with coverage
+task verify:warnings  # verify with DeprecationWarning promoted to errors
 task coverage          # full suite with coverage and regression checks
 ```
 Run `task verify` before committing to ensure linting, type checks, and


### PR DESCRIPTION
## Summary
- add a `verify:warnings` Task that delegates to the existing verify pipeline with `DeprecationWarning` promoted to errors
- document the new command in the testing guidelines and README, including the dependency sync guidance for pytest-bdd

## Testing
- task verify:warnings *(fails: tests/unit/test_eviction.py::test_ram_eviction asserts persisted node eviction)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc76bd3348333a6547d62e23103ba