### PR TITLE
Fix deterministic storage eviction fallback for missing RAM metrics

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -24,6 +24,12 @@ checks are required.
 - The latest log stops at the known RAM eviction regression without any
   `DeprecationWarning` entries, confirming the cleanup held through the rerun.
   【F:baseline/logs/verify-warnings-20250920T042735Z.log†L409-L466】
+- Adjusted `_enforce_ram_budget` to skip deterministic node caps when RAM
+  metrics report 0 MB without an explicit override. The targeted
+  `uv run --extra test pytest tests/unit/test_storage_eviction_sim.py::
+  test_under_budget_keeps_nodes -q` run passes again, and the broader storage
+  selection finishes with 136 passed, 2 skipped, 819 deselected, and 1 xfailed
+  tests. 【F:src/autoresearch/storage.py†L596-L606】【c1571c†L1-L2】【861261†L1-L2】
 
 ## September 19, 2025
 - From a clean tree, reloaded the PATH helper via `./scripts/setup.sh --print-path`

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,27 +1,27 @@
 # Autoresearch Project - Task Progress
 
 This document tracks the progress of tasks for the Autoresearch project,
-organized by phases from the code complete plan. As of **September 19, 2025**
+organized by phases from the code complete plan. As of **September 20, 2025**
 the Go Task CLI is available after evaluating `./scripts/setup.sh --print-path`,
 so `task --version` reports 3.45.4 in a fresh shell without re-running setup.
 【5d8a01†L1-L2】 `uv run python scripts/check_env.py` continues to list the
 expected toolchain when the `dev-minimal` and `test` extras are synced.
 【0feb5e†L1-L17】【fa650a†L1-L10】 Storage tests that previously aborted now
 complete: `uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1`
-returns 136 passed, 2 skipped, 1 xfailed, and 818 deselected tests after the
-RDF store fix. 【1c20bc†L1-L2】 `tests/unit/test_storage_errors.py::
-test_setup_rdf_store_error` passes cleanly, so
-`issues/remove-stale-xfail-for-rdf-store-error.md` can be closed once notes are
-updated. 【f873bf†L1-L2】【F:issues/remove-stale-xfail-for-rdf-store-error.md†L1-L29】
-`uv run python scripts/lint_specs.py` currently fails because the monitor and
-extensions specs drifted from the template, so
-`issues/restore-spec-lint-template-compliance.md` tracks the spec lint repair
-before `task check` can proceed. 【4076c9†L1-L2】【F:issues/restore-spec-lint-template-compliance.md†L1-L33】
-`uv run --extra docs mkdocs build` still succeeds without navigation warnings,
-keeping the docs pipeline clear for the release. 【e808c5†L1-L2】 `task verify`
-and coverage remain blocked on verifying the resource tracker fix and
-re-running the warnings sweep now that the xfail is cleared.
-【F:issues/resolve-resource-tracker-errors-in-verify.md†L1-L33】【F:issues/rerun-task-coverage-after-storage-fix.md†L1-L33】
+returns 136 passed, 2 skipped, 1 xfailed, and 819 deselected tests after
+skipping deterministic caps when RAM metrics report 0 MB.
+【861261†L1-L2】 `tests/unit/test_storage_errors.py::test_setup_rdf_store_error`
+passes cleanly, and `tests/unit/test_storage_eviction_sim.py::
+test_under_budget_keeps_nodes` is green again once `_enforce_ram_budget`
+ignores deterministic limits without an override.
+【f873bf†L1-L2】【c1571c†L1-L2】【F:src/autoresearch/storage.py†L596-L606】 Spec lint
+also holds: `uv run python scripts/lint_specs.py` exits cleanly and `uv run task
+check` reaches the remaining warnings work.
+【36f4f1†L1-L1】【F:STATUS.md†L33-L36】 `uv run --extra docs mkdocs build` continues to
+finish without navigation warnings, keeping the docs pipeline clear for the
+release. 【e808c5†L1-L2】 `task verify` and coverage remain blocked on verifying
+the resource tracker fix and rerunning the warnings sweep with the new eviction
+logic.【F:issues/resolve-resource-tracker-errors-in-verify.md†L1-L33】【F:issues/rerun-task-coverage-after-storage-fix.md†L1-L33】
 See [docs/release_plan.md](docs/release_plan.md) for current test and coverage
 status and the alpha release checklist. An **0.1.0-alpha.1** preview remains
 targeted for **September 15, 2026**, with the final **0.1.0** release targeted

--- a/docs/algorithms/storage_eviction.md
+++ b/docs/algorithms/storage_eviction.md
@@ -42,6 +42,10 @@ therefore observe a state satisfying the invariant and leave it intact.
 - **Usage at or below budget:** When `U₀ \leq B` no nodes are evicted.
 - **Empty graph:** The loop exits with no effect when there are no nodes to
   remove.
+- **Missing metrics:** A 0 MB usage reading is treated as "unknown" and leaves
+  the graph unchanged unless a deterministic override is configured. The
+  deterministic fallback derived from `ram_budget_mb` only activates when
+  metrics confirm `U > B`, keeping under-budget scenarios intact.
 
 These arguments assume each node consumes at least `s_min > 0` MB, so the
 termination bound above is finite.

--- a/issues/resolve-deprecation-warnings-in-tests.md
+++ b/issues/resolve-deprecation-warnings-in-tests.md
@@ -34,6 +34,11 @@ part of the cleanup. We must also restore spec lint compliance
 stops in `scripts/lint_specs.py`, preventing `task verify` from reaching the
 warnings sweep until the monitor and extensions specs adopt the required
 headings.【4076c9†L1-L2】【F:issues/restore-spec-lint-template-compliance.md†L1-L33】
+`StorageManager._enforce_ram_budget` now skips deterministic node caps when the
+RAM helper reports 0 MB and no override is configured, so
+`tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes` passes
+again and the storage selection no longer fails for that scenario.
+【F:src/autoresearch/storage.py†L596-L606】【c1571c†L1-L2】【861261†L1-L2】
 
 ## Latest failure signatures (2025-09-20)
 

--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -589,13 +589,15 @@ class StorageManager(metaclass=StorageManagerMeta):
             deterministic_limit, deterministic_override = StorageManager._deterministic_node_limit(
                 budget_mb, cfg
             )
+            if not ram_measurement_available and not deterministic_override:
+                deterministic_limit = None
             over_budget = ram_measurement_available and current_mb > budget_mb
             needs_deterministic_budget = (
                 deterministic_limit is not None
                 and len(graph.nodes) > deterministic_limit
             )
             should_use_deterministic = needs_deterministic_budget and (
-                deterministic_override or over_budget or not ram_measurement_available
+                deterministic_override or over_budget
             )
 
             if not over_budget and not deterministic_override and not should_use_deterministic:


### PR DESCRIPTION
## Summary
- skip deterministic node caps when RAM metrics report zero without a deterministic override so under-budget simulations keep their nodes
- document the missing-metrics guard and record the storage regression fix in project status and the deprecation warnings issue
- refresh task progress notes to capture the passing storage selections after the eviction fix

## Testing
- uv run --extra test pytest tests/unit/test_storage_eviction_sim.py::test_under_budget_keeps_nodes -q
- uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68cf2aa332f483338819dec8abb9e3df