### PR TITLE
tests: stub BERTopic import and extend DOCX backend coverage

### DIFF
--- a/tests/targeted/test_gpu_parsers.py
+++ b/tests/targeted/test_gpu_parsers.py
@@ -1,17 +1,55 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
 from tests.optional_imports import import_or_skip
 
 
-@pytest.mark.requires_gpu
-def test_bertopic_integration(monkeypatch):
-    """BERTopic integration activates when GPU extras are available."""
-    bertopic = import_or_skip("bertopic")
+@pytest.fixture
+def stub_bertopic_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Provide a stub BERTopic module and restore ``sys.modules`` afterward."""
+
+    original = sys.modules.get("bertopic")
+    stub = ModuleType("bertopic")
+
+    class _StubBERTopic:  # pragma: no cover - simple container
+        pass
+
+    stub.BERTopic = _StubBERTopic
+    monkeypatch.setitem(sys.modules, "bertopic", stub)
+    try:
+        yield stub
+    finally:
+        if original is not None:
+            sys.modules["bertopic"] = original
+        else:
+            sys.modules.pop("bertopic", None)
+
+
+@pytest.fixture
+def reset_bertopic_state() -> ModuleType:
+    """Reset ``context`` globals before and after a BERTopic import test."""
+
     from autoresearch.search import context
+
+    original_cls = context.BERTopic
+    original_flag = context.BERTOPIC_AVAILABLE
+    context.BERTopic = None
+    context.BERTOPIC_AVAILABLE = False
+    try:
+        yield context
+    finally:
+        context.BERTopic = original_cls
+        context.BERTOPIC_AVAILABLE = original_flag
+
+
+@pytest.mark.requires_gpu
+def test_bertopic_integration(monkeypatch, stub_bertopic_module, reset_bertopic_state):
+    """BERTopic integration activates when GPU extras are available."""
+    context = reset_bertopic_state
 
     monkeypatch.setattr(
         context,
@@ -20,9 +58,15 @@ def test_bertopic_integration(monkeypatch):
             search=SimpleNamespace(context_aware=SimpleNamespace(enabled=True))
         ),
     )
-    if not context._try_import_bertopic():  # pragma: no cover - import issues
-        pytest.skip("BERTopic import failed")
-    assert bertopic.BERTopic is context.BERTopic
+
+    assert context._try_import_bertopic() is True
+    assert context.BERTopic is stub_bertopic_module.BERTopic
+    assert context.BERTOPIC_AVAILABLE is True
+
+    # Second call should be a no-op while still reporting success.
+    assert context._try_import_bertopic() is True
+    assert context.BERTopic is stub_bertopic_module.BERTopic
+    assert context.BERTOPIC_AVAILABLE is True
 
 
 @pytest.mark.requires_parsers
@@ -32,14 +76,33 @@ def test_docx_backend_search(tmp_path, monkeypatch):
     from autoresearch.search import core
 
     doc_path = tmp_path / "example.docx"
-    doc = docx.Document()
-    if not hasattr(doc, "add_paragraph"):
+    document = docx.Document()
+    if not hasattr(document, "add_paragraph"):
         pytest.skip("docx package lacks add_paragraph")
-    doc.add_paragraph("hello world")
-    doc.save(doc_path)
+    seed_text = "hello world"
+    document.add_paragraph(seed_text)
+    document.save(doc_path)
+
+    consumed = False
+
+    class TrackingParagraphs(list):
+        def __iter__(self):  # pragma: no cover - simple flag update
+            nonlocal consumed
+            consumed = True
+            return super().__iter__()
+
+    class StubDocument:
+        def __init__(self, path: str) -> None:
+            assert path == str(doc_path)
+            self.paragraphs = TrackingParagraphs([SimpleNamespace(text=seed_text)])
+
     cfg = SimpleNamespace(
         search=SimpleNamespace(local_file=SimpleNamespace(path=str(tmp_path), file_types=["docx"]))
     )
     monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
+    monkeypatch.setattr("autoresearch.search.core.Document", StubDocument)
+
     results = core._local_file_backend("hello", max_results=1)
     assert results and results[0]["title"] == "example.docx"
+    assert seed_text in results[0]["snippet"]
+    assert consumed


### PR DESCRIPTION
## Summary
- add fixtures that stub the BERTopic module and reset context globals so `_try_import_bertopic` can be exercised twice without a real GPU dependency
- extend the targeted DOCX backend test to assert the snippet includes the seeded paragraph and that the stub Document is fully consumed

## Testing
- `PYTEST_ADDOPTS="" uv run pytest tests/targeted/test_gpu_parsers.py -k "bertopic or docx" -vv`

## Coverage
- Attempted to measure targeted coverage but the environment lacks several optional dependencies (`duckdb`, `rdflib`, `prometheus_client`), so the coverage tool aborted before reporting baseline/updated percentages.

------
https://chatgpt.com/codex/tasks/task_e_68d0a2c4ae9483339d97424e53bcc3dc