### PR TITLE
Add targeted Streamlit UI coverage tests

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -12,6 +12,12 @@ checks are required. `task verify` always syncs the `dev-minimal` and `test`
 extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
+## September 22, 2025
+- Targeted the Streamlit UI helpers with `coverage run -m pytest` against the
+  UI unit tests plus the new `tests/targeted` coverage checks; the follow-up
+  report shows `autoresearch.streamlit_ui.py` now at **100 %** line coverage.
+  【4a66bf†L1-L9】【5fb807†L1-L6】
+
 ## September 20, 2025
 - Ran `task verify:warnings:log` to rerun the warnings-as-errors sweep; the
   wrapper reuses `task verify:warnings` so


### PR DESCRIPTION
## Summary
- add high-contrast coverage checks for Streamlit accessibility helpers
- capture both light and dark theme CSS via targeted UI extras test
- record the coverage improvement in the status log

## Testing
- uv run pytest tests/targeted/test_extras_codepaths.py -vv
- uv run coverage run -m pytest tests/unit/test_streamlit_ui.py tests/targeted/test_extras_codepaths.py::test_apply_theme_settings tests/targeted/test_extras_codepaths.py::test_apply_accessibility_settings_high_contrast -vv
- uv run coverage report --include=src/autoresearch/streamlit_ui.py -m

------
https://chatgpt.com/codex/tasks/task_e_68d0af32cfb48333a914255cddf0092e