### PR TITLE
Update release status and add xfail remediation ticket

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -12,16 +12,15 @@ the refreshed run, allowing
 【abdf1f†L1-L1】【4e6478†L1-L8】【74e81d†L1-L74】【887934†L1-L54】【15fae0†L1-L20】
 【b68e0e†L38-L68】【F:baseline/coverage.xml†L1-L12】
 【F:docs/status/task-coverage-2025-09-23.md†L1-L32】
-【F:issues/archive/rerun-task-coverage-after-storage-fix.md†L1-L36】
-The Go Task CLI remains available after sourcing the helper emitted by
-`./scripts/setup.sh --print-path`, and `uv run task check` now completes with
-`flake8`, `mypy`, and the smoke tests succeeding after the routing lifespan
-logs storage setup failures and the search storage helper drops the unused
-import tracked in
-[issues/clean-up-flake8-regressions-in-routing-and-search-storage.md].
-【744f05†L1-L7】【152f28†L1-L2】【48cdde†L1-L25】【910056†L1-L9】【60cf8b†L1-L35】
-【0e7eac†L1-L4】【68d011†L1-L1】【F:src/autoresearch/api/routing.py†L55-L489】
-【F:src/autoresearch/search/storage.py†L1-L33】
+【F:issues/archive/rerun-task-coverage-after-storage-fix.md†L1-L36】 Direct
+`uv run` commands now verify the day-to-day lint, type, and smoke suites without
+requiring the Task CLI on `PATH`; the unit run reports six XPASS cases tracked in
+[issues/retire-stale-xfail-markers-in-unit-suite.md], while integration and
+behavior suites pass with optional extras skipped. `uv run --extra docs mkdocs
+build` completes without warnings after prior documentation fixes.
+【2d7183†L1-L3】【dab3a6†L1-L1】【240ff7†L1-L1】【3fa75b†L1-L1】【8434e0†L1-L2】
+【8e97b0†L1-L1】【ba4d58†L1-L104】【ab24ed†L1-L1】【187f22†L1-L9】【87aa99†L1-L1】
+【88b85b†L1-L2】【6618c7†L1-L4】【69c7fe†L1-L3】【896928†L1-L4】
 The first warnings-as-errors `task verify` attempt, captured in
 `baseline/logs/task-verify-20250923T204706Z.log`, stopped at
 `tests/targeted/test_extras_codepaths.py:13:5: F401 'sys' imported but unused`.

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -19,27 +19,25 @@ STATUS.md, ROADMAP.md, and CHANGELOG.md for aligned progress. Phase 3
 ## Status
 
 The dependency pins for `fastapi` (>=0.116.1) and `slowapi` (==0.1.9) remain
-confirmed in `pyproject.toml` and [installation.md](installation.md). Sourcing
-`./scripts/setup.sh --print-path` keeps Go Task 3.45.4 on the PATH, and
-`task check` still bootstraps the environment with Python 3.12.10 plus the
-expected tooling before halting in `flake8` due to the unused `e` assignment
-and lingering `StorageError` import tracked in the
-clean-up-flake8-regressions-in-routing-and-search-storage issue.
-【744f05†L1-L7】【152f28†L1-L2】【48cdde†L1-L25】【910056†L1-L9】【cd3ade†L1-L3】 The
-storage suites stay green: `uv run --extra test pytest tests/unit -k "storage"
--q --maxfail=1` finishes with 136 passed, 2 skipped, 822 deselected, and 1
-xfailed tests, and the RDF store regression test passes without an xfail
-marker. 【714199†L1-L2】【F:issues/clean-up-flake8-regressions-in-routing-and-search-storage.md†L1-L40】
-Documentation builds succeed but emit a warning about the testing guidelines
-linking to `../wheels/gpu/README.md`, so the fix-testing-guidelines-gpu-link
-issue is now part of the release scope.
-【9eabf1†L1-L6】【F:docs/testing_guidelines.md†L90-L102】 Spec lint remains
+confirmed in `pyproject.toml` and [installation.md](installation.md). In the
+Codex shell the Go Task CLI is not on `PATH` until
+`./scripts/setup.sh --print-path` is sourced, so linting, typing, and test smoke
+checks currently run via `uv`. `uv run --extra dev-minimal --extra test flake8
+src tests` and `uv run --extra dev-minimal --extra test mypy src` both succeed,
+and `uv run --extra test pytest tests/unit -m 'not slow' --maxfail=1 -rxX`
+passes with six XPASS cases now tracked in
+[issues/retire-stale-xfail-markers-in-unit-suite.md]. Integration and behavior
+suites succeed with optional extras skipped, and `uv run --extra docs mkdocs
+build` finishes without warnings after the GPU wheel documentation move.
+【2d7183†L1-L3】【dab3a6†L1-L1】【240ff7†L1-L1】【3fa75b†L1-L1】【8434e0†L1-L2】
+【8e97b0†L1-L1】【ba4d58†L1-L104】【ab24ed†L1-L1】【187f22†L1-L9】【87aa99†L1-L1】
+【88b85b†L1-L2】【6618c7†L1-L4】【69c7fe†L1-L3】【896928†L1-L4】 Spec lint remains
 recovered—`docs/specs/monitor.md` and `docs/specs/extensions.md` retain the
-required `## Simulation Expectations` sections—so the remaining release work
-hinges on fixing the lint regression, confirming the resource tracker teardown,
-running the warnings-as-errors sweep, refreshing coverage with optional extras,
-and repairing the MkDocs warning noted above.
-【F:docs/specs/monitor.md†L126-L165】【F:docs/specs/extensions.md†L1-L69】【F:issues/resolve-resource-tracker-errors-in-verify.md†L1-L33】【F:issues/archive/resolve-deprecation-warnings-in-tests.md†L1-L93】【F:issues/rerun-task-coverage-after-storage-fix.md†L1-L33】【F:issues/fix-testing-guidelines-gpu-link.md†L1-L27】
+required `## Simulation Expectations` sections—and coverage artifacts stay in
+sync with `baseline/coverage.xml` after the September 23 run documented in
+`docs/status/task-coverage-2025-09-23.md`.
+【F:docs/specs/monitor.md†L126-L165】【F:docs/specs/extensions.md†L1-L69】
+【F:baseline/coverage.xml†L1-L12】【F:docs/status/task-coverage-2025-09-23.md†L1-L32】
 ## Milestones
 
 - **0.1.0a1** (2026-09-15, status: in progress): Alpha preview to collect

--- a/issues/archive/clean-up-flake8-regressions-in-routing-and-search-storage.md
+++ b/issues/archive/clean-up-flake8-regressions-in-routing-and-search-storage.md
@@ -27,7 +27,8 @@ Clearing these lint failures is required before `task verify` and
 - STATUS.md and TASK_PROGRESS.md record the lint cleanup.
 
 ## Status
-Closed – `uv run task check` now succeeds after the API lifespan logs storage
-setup failures and the search storage helper drops the unused import.
-【60cf8b†L1-L35】【0e7eac†L1-L4】【68d011†L1-L1】
+Archived – `uv run --extra dev-minimal --extra test flake8 src tests`
+reproduces a clean run after the routing lifespan logs storage setup
+failures and the search storage helper drops the unused import.
+【dab3a6†L1-L1】【240ff7†L1-L1】
 【F:src/autoresearch/api/routing.py†L55-L489】【F:src/autoresearch/search/storage.py†L1-L33】

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -3,71 +3,47 @@
 ## Context
 
 The project remains unreleased even though the codebase and documentation are
-public. To tag v0.1.0a1 we still need a coordinated push across testing,
-documentation, and packaging while keeping workflows dispatch-only.
-Sourcing the PATH helper emitted by `./scripts/setup.sh --print-path` keeps
-`task --version` at 3.45.4, and the `task check` bootstrap reconfirms Python
-3.12.10 plus the expected development tooling before halting in `flake8`
-because `src/autoresearch/api/routing.py` still assigns an unused `e` variable
-and `src/autoresearch/search/storage.py` imports `StorageError` without using
-it. 【744f05†L1-L7】【152f28†L1-L2】【48cdde†L1-L25】【910056†L1-L9】【cd3ade†L1-L3】
-`uv run python scripts/lint_specs.py` already succeeds and
-`docs/specs/monitor.md` plus `docs/specs/extensions.md` retain the required
-`## Simulation Expectations` heading, so the spec-driven baseline remains
-intact. 【F:docs/specs/monitor.md†L126-L165】【F:docs/specs/extensions.md†L1-L69】
-`uv run --extra test pytest tests/unit -k "storage" -q --maxfail=1` finishes
-with 136 passed, 2 skipped, 822 deselected, and 1 xfailed tests, confirming the
-storage teardown fixes hold. 【714199†L1-L2】 Documentation builds now emit
-warnings because `docs/testing_guidelines.md` links to `../wheels/gpu/README.md`
-outside MkDocs' tree and `docs/release_plan.md` references the lint tickets via
-`../issues/...`, so the release scope must cover both documentation fixes.
-【aaf0c5†L1-L7】【F:docs/testing_guidelines.md†L90-L102】【F:docs/release_plan.md†L20-L36】
-All GitHub Actions workflows remain `workflow_dispatch` only.
-【F:.github/workflows/ci.yml†L1-L22】【F:.github/workflows/ranking-benchmark.yml†L1-L14】
-【F:.github/workflows/release-images.yml†L1-L14】
+public. Tagging v0.1.0a1 still requires a coordinated push across testing,
+documentation, and packaging while workflows stay dispatch-only. In the current
+Codex shell the Go Task CLI is not on `PATH` until
+`./scripts/setup.sh --print-path` is sourced, so we validated linting and type
+checks directly with `uv`. 【2d7183†L1-L3】 `uv run --extra dev-minimal --extra
+test flake8 src tests` and `uv run --extra dev-minimal --extra test mypy src`
+both succeed, confirming the earlier lint regressions remain resolved.
+【dab3a6†L1-L1】【240ff7†L1-L1】【3fa75b†L1-L1】【8434e0†L1-L2】 The unit suite now
+passes under `uv run --extra test pytest tests/unit -m 'not slow' --maxfail=1
+-rxX`, but six tests marked `xfail` report XPASS and require promotion to
+ordinary assertions before release. 【8e97b0†L1-L1】【ba4d58†L1-L104】 Integration
+and behavior suites complete with skips only for optional extras.
+【ab24ed†L1-L1】【187f22†L1-L9】【87aa99†L1-L1】【88b85b†L1-L2】 `uv run --extra docs
+mkdocs build` now finishes without warnings after prior documentation fixes, and
+all GitHub Actions workflows remain `workflow_dispatch` only.
+【6618c7†L1-L4】【69c7fe†L1-L3】【896928†L1-L4】【F:.github/workflows/ci.yml†L1-L22】
 `SPEC_COVERAGE.md` continues to map each module to specifications plus proofs,
 simulations, or tests, so every component still aligns with the project's
-spec-first mandate ahead of the release. 【F:SPEC_COVERAGE.md†L1-L120】 The
-remaining work involves closing the lint regression, validating the resource
-tracker tear-down under warnings-as-errors, hardening the deprecation sweep,
-refreshing coverage with optional extras, and repairing the MkDocs warning
-before drafting release notes and tagging v0.1.0a1.
+spec-first mandate ahead of the release. 【F:SPEC_COVERAGE.md†L1-L125】 The
+remaining work focuses on retiring the stale `xfail` markers, capturing
+warnings-as-errors baselines with optional extras, and staging the packaging
+artifacts before drafting release notes and tagging v0.1.0a1.
 
 ### PR-sized tasks
 
-- **Clear lint regressions** – Resolve
-  `autoresearch/api/routing.py`'s unused `e` variable and the dead
-  `StorageError` import so `task check` passes again.
-  ([clean-up-flake8-regressions-in-routing-and-search-storage](clean-up-flake8-regressions-in-routing-and-search-storage.md))
-- **Verify resource tracker teardown** – Re-run `task verify` (ideally with
-  `PYTHONWARNINGS=error::DeprecationWarning`) to ensure the multiprocessing
-  shutdown path remains stable.
-  ([resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md))
-- **Harden warnings-as-errors harness** – Implement the multi-PR remediation
-  plan to capture deprecations, refactor callers, and pin or filter remaining
-  warnings so future runs stay clean.
-  ([resolve-deprecation-warnings-in-tests (archived)](archive/resolve-deprecation-warnings-in-tests.md))
-- **Refresh coverage with optional extras** – Execute
-  `task coverage EXTRAS="nlp ui vss git distributed analysis llm parsers gpu"`
-  once the suite passes and update `baseline/coverage.xml` plus docs status.
-  ([rerun-task-coverage-after-storage-fix](rerun-task-coverage-after-storage-fix.md))
-- **Repair MkDocs GPU wheels link** – Update the testing guidelines so
-  `uv run --extra docs mkdocs build` completes without warnings.
-  ([fix-testing-guidelines-gpu-link](fix-testing-guidelines-gpu-link.md))
-- **Repair release plan issue links** – Update the release plan so it references
-  open tickets without pointing outside the MkDocs tree.
-  ([fix-release-plan-issue-links](fix-release-plan-issue-links.md))
+- **Retire stale xfail markers** – Promote the six XPASS cases in the unit
+  suite so release verification runs fail fast when regressions reappear.
+  ([retire-stale-xfail-markers-in-unit-suite](retire-stale-xfail-markers-in-unit-suite.md))
+- **Refresh warnings-as-errors coverage** – Capture a new
+  `PYTHONWARNINGS=error::DeprecationWarning` run with all optional extras to
+  ensure the resource tracker cleanup, DuckDB extension fallback, and
+  distributed paths stay quiet. (Reuses archived playbooks in
+  [`issues/archive/resolve-resource-tracker-errors-in-verify.md`](archive/resolve-resource-tracker-errors-in-verify.md)
+  and [`issues/archive/resolve-deprecation-warnings-in-tests.md`](archive/resolve-deprecation-warnings-in-tests.md).)
 - **Stage release artifacts** – Draft CHANGELOG.md notes, confirm packaging
-  metadata, and plan the `v0.1.0a1` tag once the above tickets land.
+  metadata, and plan the `v0.1.0a1` tag once verification runs and documentation
+  updates land.
 
 ## Dependencies
 
-- [resolve-resource-tracker-errors-in-verify](resolve-resource-tracker-errors-in-verify.md)
-- [resolve-deprecation-warnings-in-tests (archived)](archive/resolve-deprecation-warnings-in-tests.md)
-- [rerun-task-coverage-after-storage-fix](rerun-task-coverage-after-storage-fix.md)
-- [clean-up-flake8-regressions-in-routing-and-search-storage](clean-up-flake8-regressions-in-routing-and-search-storage.md)
-- [fix-testing-guidelines-gpu-link](fix-testing-guidelines-gpu-link.md)
-- [fix-release-plan-issue-links](fix-release-plan-issue-links.md)
+- [retire-stale-xfail-markers-in-unit-suite](retire-stale-xfail-markers-in-unit-suite.md)
 
 ## Acceptance Criteria
 - All dependency issues are closed.

--- a/issues/retire-stale-xfail-markers-in-unit-suite.md
+++ b/issues/retire-stale-xfail-markers-in-unit-suite.md
@@ -1,0 +1,37 @@
+# Retire stale xfail markers in unit suite
+
+## Context
+Running `uv run --extra test pytest tests/unit -m 'not slow' --maxfail=1 -rxX`
+now reports six XPASS entries for tests that still carry `xfail` markers even
+though their underlying behaviors succeed. The affected cases include the Ray
+remote executor, token budget heuristics, metrics convergence bounds, ranking
+idempotence, and two relevance-ranking helpers. 【ba4d58†L1-L104】 These tests
+should either graduate to normal assertions with updated proofs and simulations
+or regain a failure mode that justifies the `xfail` markers.
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- Remove or tighten the `xfail` on
+  `tests/unit/test_distributed_executors.py::test_execute_agent_remote` so it
+  only triggers when Ray serialization genuinely fails under Python 3.12.
+- Promote `tests/unit/test_heuristic_properties.py::test_token_budget_monotonicity`
+  to a normal test backed by heuristic proofs or document why the monotonicity
+  guarantee must be relaxed.
+- Update `tests/unit/test_metrics_token_budget_spec.py::test_convergence_bound_holds`
+  so the convergence proof aligns with the current algorithm, keeping the test
+  active without an `xfail` guard.
+- Restore deterministic expectations for
+  `tests/unit/test_ranking_idempotence.py::test_rank_results_idempotent` and
+  remove its `xfail` marker.
+- Ensure `tests/unit/test_relevance_ranking.py::test_calculate_semantic_similarity`
+  exercises the real scoring implementation and no longer relies on an
+  `xfail`.
+- Make `tests/unit/test_relevance_ranking.py::test_external_lookup_uses_cache`
+  fast and reliable so it runs without an `xfail` marker.
+- Document the updated proofs, simulations, or benchmark data in
+  `SPEC_COVERAGE.md` and linked specs where applicable.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- refresh STATUS.md and TASK_PROGRESS.md with the latest uv-based linting, typing, testing, and documentation results
- revise the release plan status/dependencies and prepare-first-alpha-release tracker to focus on retiring stale xfail markers and rerunning warnings-as-errors coverage
- archive the resolved flake8 cleanup ticket and open a follow-up issue to remove the six XPASS guards in the unit suite

## Testing
- uv run --extra dev-minimal --extra test flake8 src tests
- uv run --extra dev-minimal --extra test mypy src
- uv run --extra test pytest tests/unit -m 'not slow' --maxfail=1 -rxX
- uv run --extra test pytest tests/integration -m 'not slow' -q --maxfail=1
- uv run --extra test pytest tests/behavior -m 'not slow' -q --maxfail=1
- uv run --extra docs mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d3302349dc83339fea55b8c478ff68