### PR TITLE
Document alpha release follow-up plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,17 +25,17 @@ Reference issues by slugged filename (for example,
   [docs/specs/config.md](docs/specs/config.md).
 - Logged the config weight validation regression in
   [fix-config-weight-sum-validation](
-    issues/fix-config-weight-sum-validation.md).
+    issues/archive/fix-config-weight-sum-validation.md).
 - Captured offline DuckDB extension fallback failures in
   [fix-duckdb-extension-offline-fallback](
-    issues/fix-duckdb-extension-offline-fallback.md).
+    issues/archive/fix-duckdb-extension-offline-fallback.md).
 - Narrowed the search regression scope in
   [fix-search-ranking-and-extension-tests](
-    issues/fix-search-ranking-and-extension-tests.md), which now focuses on
+    issues/archive/fix-search-ranking-and-extension-tests.md), which now focuses on
   aligning the overweight ranking unit test with the validator while extension
   loader suites pass.
 - Continued to track documentation build warnings in
-  [fix-mkdocs-griffe-warnings](issues/fix-mkdocs-griffe-warnings.md).
+  [fix-mkdocs-griffe-warnings](issues/archive/fix-mkdocs-griffe-warnings.md).
 - Replaced deprecated `fastembed.TextEmbedding` imports with the new
   `OnnxTextEmbedding` entry point, updated stubs and tests to mirror the public
   API, and noted the migration in

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap summarizes planned features for upcoming releases.
 Dates and milestones align with the [release plan](docs/release_plan.md).
 See [STATUS.md](STATUS.md) and [CHANGELOG.md](CHANGELOG.md) for current results
 and recent changes. Installation and environment details are covered in the
-[README](README.md). Last updated **September 23, 2025**.
+[README](README.md). Last updated **September 24, 2025**.
 
 ## Status
 
@@ -51,6 +51,12 @@ work.【F:issues/archive/resolve-resource-tracker-errors-in-verify.md†L37-L49�
 【F:issues/archive/fix-release-plan-issue-links.md†L26-L28】
 The spec template lint cleanup is archived as
 [spec lint template ticket (archived)][restore-spec-lint-template-compliance-archived].
+Fresh September 24 planning added
+[refresh-token-budget-monotonicity-proof](issues/refresh-token-budget-monotonicity-proof.md)
+ to document the heuristics proof gap and
+[stage-0-1-0a1-release-artifacts](issues/stage-0-1-0a1-release-artifacts.md)
+ to stage packaging outputs before tagging; both now sit under
+[prepare-first-alpha-release](issues/prepare-first-alpha-release.md).
 
 ## Milestones
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,6 +12,25 @@ checks are required. `task verify` always syncs the `dev-minimal` and `test`
 extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
+## September 24, 2025
+- Verified the local runtime before running tests: `python --version` reports
+  3.12.10 and `uv --version` reports 0.7.22, while `task --version` still
+  fails because the Go Task CLI is not installed in the Codex shell by
+  default. Continue using `uv` wrappers or source `scripts/setup.sh` before
+  invoking Taskfile commands.
+- Reviewed `baseline/logs/task-verify-20250923T204732Z.log` to confirm the
+  XPASS cases for Ray execution and ranking remain green under
+  warnings-as-errors, then opened
+  [refresh-token-budget-monotonicity-proof](issues/refresh-token-budget-monotonicity-proof.md)
+  so the heuristics proof matches behaviour and updated
+  [retire-stale-xfail-markers-in-unit-suite](issues/retire-stale-xfail-markers-in-unit-suite.md)
+  to depend on it.
+- Documented release staging gaps with
+  [stage-0-1-0a1-release-artifacts](issues/stage-0-1-0a1-release-artifacts.md)
+  and refreshed
+  [prepare-first-alpha-release](issues/prepare-first-alpha-release.md) to
+  align on packaging dry runs, changelog work, and dispatch-only workflows.
+
 ## September 23, 2025
 - Confirmed the lint, type, unit, integration, and behavior pipelines with `uv`
   commands while the Task CLI remains off `PATH` in the Codex shell. The lint

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -18,6 +18,13 @@ requiring the Task CLI on `PATH`; the unit run reports six XPASS cases tracked i
 [issues/retire-stale-xfail-markers-in-unit-suite.md], while integration and
 behavior suites pass with optional extras skipped. `uv run --extra docs mkdocs
 build` completes without warnings after prior documentation fixes.
+September 24 planning added
+[refresh-token-budget-monotonicity-proof](issues/refresh-token-budget-monotonicity-proof.md)
+ and
+[stage-0-1-0a1-release-artifacts](issues/stage-0-1-0a1-release-artifacts.md)
+ as dependencies of
+[prepare-first-alpha-release](issues/prepare-first-alpha-release.md) so the
+XPASS promotions, heuristics proof, and packaging dry runs land before tagging.
 【2d7183†L1-L3】【dab3a6†L1-L1】【240ff7†L1-L1】【3fa75b†L1-L1】【8434e0†L1-L2】
 【8e97b0†L1-L1】【ba4d58†L1-L104】【ab24ed†L1-L1】【187f22†L1-L9】【87aa99†L1-L1】
 【88b85b†L1-L2】【6618c7†L1-L4】【69c7fe†L1-L3】【896928†L1-L4】

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -26,7 +26,10 @@ checks currently run via `uv`. `uv run --extra dev-minimal --extra test flake8
 src tests` and `uv run --extra dev-minimal --extra test mypy src` both succeed,
 and `uv run --extra test pytest tests/unit -m 'not slow' --maxfail=1 -rxX`
 passes with six XPASS cases now tracked in
-[issues/retire-stale-xfail-markers-in-unit-suite.md]. Integration and behavior
+[issues/retire-stale-xfail-markers-in-unit-suite.md], with
+[issues/refresh-token-budget-monotonicity-proof.md] and
+[issues/stage-0-1-0a1-release-artifacts.md] capturing the proof refresh and
+release staging before tagging. Integration and behavior
 suites succeed with optional extras skipped, and `uv run --extra docs mkdocs
 build` finishes without warnings after the GPU wheel documentation move.
 【2d7183†L1-L3】【dab3a6†L1-L1】【240ff7†L1-L1】【3fa75b†L1-L1】【8434e0†L1-L2】
@@ -37,7 +40,8 @@ required `## Simulation Expectations` sections—and coverage artifacts stay in
 sync with `baseline/coverage.xml` after the September 23 run documented in
 `docs/status/task-coverage-2025-09-23.md`.
 【F:docs/specs/monitor.md†L126-L165】【F:docs/specs/extensions.md†L1-L69】
-【F:baseline/coverage.xml†L1-L12】【F:docs/status/task-coverage-2025-09-23.md†L1-L32】
+【F:baseline/coverage.xml†L1-L12】
+【F:docs/status/task-coverage-2025-09-23.md†L1-L32】
 ## Milestones
 
 - **0.1.0a1** (2026-09-15, status: in progress): Alpha preview to collect
@@ -84,6 +88,13 @@ These tasks completed in order: environment bootstrap → packaging verification
   【5d8a01†L1-L2】
 - Dry-run publish to TestPyPI succeeded using `uv run scripts/publish_dev.py`
   with `--dry-run --repository testpypi`.
+- Close [issues/retire-stale-xfail-markers-in-unit-suite.md],
+  [issues/refresh-token-budget-monotonicity-proof.md], and
+  [issues/stage-0-1-0a1-release-artifacts.md] before tagging so XPASS
+  promotions, heuristic proofs, and packaging logs land together.
+- Record the latest `uv run python -m build` output and TestPyPI dry run in
+  `baseline/logs/` and reference the timestamps here once the stage issue
+  closes.
 
 The **0.1.0a1** date is re-targeted for **September 15, 2026** and the release
 remains in progress until these prerequisites are satisfied.

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -1,62 +1,55 @@
 # Prepare first alpha release
 
 ## Context
+The repository remains publicly visible yet untagged, so the first alpha
+release still depends on a coordinated push across testing, packaging,
+and documentation. The September 23 baselines captured in
+`baseline/logs/task-verify-20250923T204732Z.log` and
+`baseline/logs/verify-warnings-20250923T224648Z.log` confirm that
+`task verify`, `task coverage`, and the warnings-as-errors sweep all pass
+with 890 unit, 324 integration, and 29 behavior tests. Those runs also
+highlight five XPASS cases that continue to carry `xfail` markers, which
+prevents the release gate from failing fast when regressions appear. The
+Go Task CLI is still absent from the default Codex shell, so release
+operators must keep using `uv` invocations unless they source the
+`scripts/setup.sh` PATH helper.
 
-The project remains unreleased even though the codebase and documentation are
-public, so tagging v0.1.0a1 still needs a coordinated push across testing,
-documentation, and packaging while workflows stay dispatch-only.
-The September 23 `task verify` baseline shows the suite passing while five
-tests marked `xfail` reported XPASS—`tests/unit/test_distributed_executors.py::test_execute_agent_remote`,
-`tests/unit/test_metrics_token_budget_spec.py::test_convergence_bound_holds`,
-`tests/unit/test_ranking_idempotence.py::test_rank_results_idempotent`,
-`tests/unit/test_relevance_ranking.py::test_calculate_semantic_similarity`, and
-`tests/unit/test_relevance_ranking.py::test_external_lookup_uses_cache`—so those
-guards must be retired before the release can fail fast on regressions.
-【F:baseline/logs/task-verify-20250923T204732Z.log†L342-L343】【F:baseline/logs/task-verify-20250923T204732Z.log†L557-L558】
-【F:baseline/logs/task-verify-20250923T204732Z.log†L721-L721】【F:baseline/logs/task-verify-20250923T204732Z.log†L736-L737】
-【F:baseline/logs/task-verify-20250923T204732Z.log†L747-L748】 The follow-on
-`task verify:warnings` run captured on September 23 completed cleanly, giving a
-warnings-as-errors baseline with coverage, token-usage, and documentation checks
-finishing without failures while optional extras remain manual-only.
-【F:baseline/logs/verify-warnings-20250923T224648Z.log†L1-L44】【F:baseline/logs/verify-warnings-20250923T224648Z.log†L1749-L1786】
-`SPEC_COVERAGE.md` continues to map each module to specifications plus proofs,
-simulations, or tests, so every component still aligns with the project's
-spec-first mandate ahead of the release.【F:SPEC_COVERAGE.md†L1-L125】 With those
-baselines recorded, the remaining work centers on promoting the five XPASS cases
-and staging release artifacts—dry-run builds, changelog notes, and tag
-preparation—before drafting release notes and cutting v0.1.0a1.
-【F:docs/release_plan.md†L95-L109】【F:.github/workflows/ci.yml†L1-L22】
+A dialectical review of the outstanding work surfaces three threads: the
+XPASS promotions, refreshed mathematical backing for the token budget
+heuristic, and staging of packaging artifacts. Socratic questioning asks
+whether the existing documentation actually proves what the tests assert
+and whether our packaging instructions match a fresh dry run. New issues
+cover each thread so that we can close this release ticket once the
+dependencies land.
 
 ### PR-sized tasks
-
-- **Retire stale xfail markers** – Promote the five XPASS cases in the unit
-  suite so release verification runs fail fast when regressions reappear.
-  ([retire-stale-xfail-markers-in-unit-suite](retire-stale-xfail-markers-in-unit-suite.md))
-- ✅ **Refresh warnings-as-errors coverage** – Completed with the September 23
-  `task verify:warnings` run; keep
-  `baseline/logs/verify-warnings-20250923T224648Z.log` as the
-  `PYTHONWARNINGS=error::DeprecationWarning` reference when optional extras
-  change.【F:baseline/logs/verify-warnings-20250923T224648Z.log†L1-L44】【F:baseline/logs/verify-warnings-20250923T224648Z.log†L1749-L1786】
-- **Stage release artifacts** – Draft CHANGELOG.md notes, confirm packaging
-  metadata with dry-run builds, and line up the `v0.1.0a1` tag plan once the
-  XPASS removals and documentation updates land.【F:docs/release_plan.md†L95-L109】【F:CHANGELOG.md†L1-L200】
+- [retire-stale-xfail-markers-in-unit-suite.md]
+  (retire-stale-xfail-markers-in-unit-suite.md)
+- [refresh-token-budget-monotonicity-proof.md]
+  (refresh-token-budget-monotonicity-proof.md)
+- [stage-0-1-0a1-release-artifacts.md]
+  (stage-0-1-0a1-release-artifacts.md)
 
 ## Dependencies
-
-- [retire-stale-xfail-markers-in-unit-suite](retire-stale-xfail-markers-in-unit-suite.md)
+- [retire-stale-xfail-markers-in-unit-suite.md]
+  (retire-stale-xfail-markers-in-unit-suite.md)
+- [refresh-token-budget-monotonicity-proof.md]
+  (refresh-token-budget-monotonicity-proof.md)
+- [stage-0-1-0a1-release-artifacts.md]
+  (stage-0-1-0a1-release-artifacts.md)
 
 ## Acceptance Criteria
-- All dependency issues, including
-  [retire-stale-xfail-markers-in-unit-suite](retire-stale-xfail-markers-in-unit-suite.md),
-  are closed.
-- The "Prerequisites for tagging 0.1.0a1" in `docs/release_plan.md` are
-  satisfied before tagging.【F:docs/release_plan.md†L66-L91】
-- Release notes for v0.1.0a1 are drafted in CHANGELOG.md.【F:CHANGELOG.md†L1-L200】
-- Git tag v0.1.0a1 is created only after tests pass and documentation is
-  updated.
-- `task docs` (or `uv run --extra docs mkdocs build`) completes after docs
-  extras sync.
-- Workflows remain manual or dispatch-only.【F:.github/workflows/ci.yml†L1-L22】
+- All dependency issues listed above are closed.
+- The "Prerequisites for tagging 0.1.0a1" section in
+  `docs/release_plan.md` reflects the latest dry-run packaging logs and
+  XPASS retirements.
+- `CHANGELOG.md` includes drafted release notes for `0.1.0a1` that cite
+  the staging sweep.
+- `task docs` (or `uv run --extra docs mkdocs build`) succeeds after the
+  documentation extras are synced.
+- Workflows under `.github/workflows` remain dispatch-only.
+- The `v0.1.0a1` tag is created only after the above steps and a fresh
+  `task verify` pass succeed.
 
 ## Status
 Open

--- a/issues/refresh-token-budget-monotonicity-proof.md
+++ b/issues/refresh-token-budget-monotonicity-proof.md
@@ -1,0 +1,46 @@
+# Refresh token budget monotonicity proof
+
+## Context
+The heuristics suite still marks
+`tests/unit/test_heuristic_properties.py::test_token_budget_monotonicity`
+with `xfail` even though `task verify` now reports the case as XPASS.
+The marker was introduced while we investigated non-monotonic updates in
+`OrchestrationMetrics.suggest_token_budget`, so the remaining guard
+blocks release gating from catching regressions early.
+`docs/algorithms/token_budgeting.md` and `docs/specs/metrics.md`
+already describe the convergence proof, yet neither document reconciles
+the hypothesis counterexamples that originally justified the `xfail`.
+The current behaviour appears to be *piecewise monotonic*: rounding and
+the max-of-means derivation protect against budget collapse, but
+short-term averages can still dip when a fresh spike pushes another
+candidate out of the max window.
+
+We therefore need to revisit the proof against actual code paths,
+simulate the edge cases, and decide whether the heuristic should be
+tightened or the specification amended. A Socratic review of the
+derivation will let us contrast the original monotonicity claim with
+observed behaviour, while the dialectical step requires challenging the
+assumption that strict monotonicity is even appropriate for bursty
+workloads.
+
+## Dependencies
+- [retire-stale-xfail-markers-in-unit-suite.md]
+  (retire-stale-xfail-markers-in-unit-suite.md)
+
+## Acceptance Criteria
+- Reproduce the historical counterexample that motivated the `xfail` and
+  document it in `docs/algorithms/token_budgeting.md` alongside the
+  convergence proof. Highlight the assumptions that fail.
+- Decide between tightening the heuristic or reframing the specification,
+  for example by proving monotonicity under constrained margins, and
+  record the dialectical reasoning in `docs/specs/metrics.md`.
+- Add deterministic regression coverage in
+  `tests/unit/test_heuristic_properties.py` (Hypothesis or targeted
+  fixtures) so that XPASS promotions remain stable.
+- Update `SPEC_COVERAGE.md` to map the refreshed proof or simulation to
+  `autoresearch/orchestration/metrics.py`.
+- Remove the `xfail` marker once the proof, simulation, and tests agree.
+- Capture the result in `CHANGELOG.md` under the Unreleased section.
+
+## Status
+Open

--- a/issues/retire-stale-xfail-markers-in-unit-suite.md
+++ b/issues/retire-stale-xfail-markers-in-unit-suite.md
@@ -1,57 +1,61 @@
 # Retire stale xfail markers in unit suite
 
 ## Context
-Running `uv run --extra test pytest tests/unit -m 'not slow' --maxfail=1 -rxX`
-now reports six XPASS entries for tests that still carry `xfail` markers even
-though their underlying behaviors succeed. Five of those cases—
+`uv run --extra test pytest tests/unit -m 'not slow' --maxfail=1 -rxX`
+now reports XPASS for six tests that still carry `xfail` markers, five of
+which exercise production paths that have stabilised in the Ray executor
+and ranking pipelines. The September 23 verification log at
+`baseline/logs/task-verify-20250923T204732Z.log` shows
 `test_execute_agent_remote`, `test_convergence_bound_holds`,
 `test_rank_results_idempotent`,
 `test_calculate_semantic_similarity`, and
-`test_external_lookup_uses_cache`—exercise stabilized implementations in the
-Ray executor pipeline and ranking stack
-(`src/autoresearch/distributed/executors.py`,
-`src/autoresearch/search/core.py`). 【ba4d58†L1-L104】 The remaining marker on
-`test_token_budget_monotonicity` still guards an unproven monotonicity claim
-while `autoresearch.orchestration.metrics` awaits updated proofs and
-simulations. These tests should either graduate to normal assertions with
-updated documentation or regain a failure mode that justifies the `xfail`
-markers.
+`test_external_lookup_uses_cache` all passing under the warnings-as-errors
+harness. The remaining guard on
+`tests/unit/test_heuristic_properties.py::test_token_budget_monotonicity`
+reflects an unresolved proof gap in
+`autoresearch.orchestration.metrics` rather than an unstable runtime
+path.
+
+Dialectically, keeping the `xfail` markers hides true regressions and
+masks coverage gaps; removing them without strengthening the surrounding
+proofs risks enshrining brittle heuristics. A Socratic review of each
+path—Ray serialization, ranking determinism, semantic similarity, cache
+coherence, and token budgeting—should therefore drive the promotions.
 
 ## Dependencies
-- None
+- [refresh-token-budget-monotonicity-proof.md]
+  (refresh-token-budget-monotonicity-proof.md)
 
 ## Acceptance Criteria
-- Remove or tighten the `xfail` on
-  `tests/unit/test_distributed_executors.py::test_execute_agent_remote` so it
-  only fires on genuine Ray serialization regressions, documenting the Ray path
-  maintained in `src/autoresearch/distributed/executors.py` within
-  `SPEC_COVERAGE.md` and `docs/algorithms/distributed.md`.
-- Retain the guard on
-  `tests/unit/test_heuristic_properties.py::test_token_budget_monotonicity`
-  until `autoresearch.orchestration.metrics` lands the refreshed monotonicity
-  proof and the revisions propagate through
-  `docs/algorithms/token_budgeting.md`, `docs/specs/metrics.md`, and
+- Remove or tighten the guard on
+  `tests/unit/test_distributed_executors.py::test_execute_agent_remote` so
+  it only triggers on genuine Ray serialization regressions, documenting
+  the Ray path in `docs/algorithms/distributed.md` and
   `SPEC_COVERAGE.md`.
 - Lift the `xfail` from
   `tests/unit/test_metrics_token_budget_spec.py::test_convergence_bound_holds`
-  after synchronizing the convergence proof with the production algorithm and
-  recording the change in `docs/algorithms/token_budgeting.md`,
-  `docs/specs/metrics.md`, and `SPEC_COVERAGE.md`.
+  after aligning the proof, simulation, and implementation. Update
+  `docs/algorithms/token_budgeting.md`, `docs/specs/metrics.md`, and
+  `SPEC_COVERAGE.md` accordingly.
 - Restore deterministic expectations for
-  `tests/unit/test_ranking_idempotence.py::test_rank_results_idempotent` using
-  the stabilized ranking pipeline in `src/autoresearch/search/core.py`, then
-  update `docs/algorithms/relevance_ranking.md`, `docs/algorithms/search.md`,
-  and `SPEC_COVERAGE.md` to reflect the live check.
+  `tests/unit/test_ranking_idempotence.py::test_rank_results_idempotent`
+  using the live ranking pipeline in `src/autoresearch/search/core.py`,
+  updating `docs/algorithms/relevance_ranking.md`,
+  `docs/algorithms/search.md`, and `SPEC_COVERAGE.md`.
 - Ensure
   `tests/unit/test_relevance_ranking.py::test_calculate_semantic_similarity`
-  exercises the production scoring path from
-  `src/autoresearch/search/core.py` without an `xfail`, updating
-  `docs/algorithms/semantic_similarity.md` and `SPEC_COVERAGE.md` once the
-  guard is removed.
-- Make `tests/unit/test_relevance_ranking.py::test_external_lookup_uses_cache`
-  fast and reliable without an `xfail` marker, capturing the cache behavior in
+  executes the production scoring path without an `xfail`, recording the
+  decision in `docs/algorithms/semantic_similarity.md` and
+  `SPEC_COVERAGE.md`.
+- Make
+  `tests/unit/test_relevance_ranking.py::test_external_lookup_uses_cache`
+  fast and reliable without `xfail`, documenting the cache behaviour in
   `docs/algorithms/search.md`, `docs/algorithms/cache.md`, and
   `SPEC_COVERAGE.md`.
+- Keep the monotonicity guard in
+  `tests/unit/test_heuristic_properties.py::test_token_budget_monotonicity`
+  until the dependency issue lands, then convert it to a standard
+  assertion and cite the refreshed proof.
 
 ## Status
 Open

--- a/issues/stage-0-1-0a1-release-artifacts.md
+++ b/issues/stage-0-1-0a1-release-artifacts.md
@@ -1,0 +1,41 @@
+# Stage 0.1.0a1 release artifacts
+
+## Context
+`docs/release_plan.md` and `CHANGELOG.md` both outline the path to the
+first alpha tag, yet we still need a focused effort that synthesises the
+packaging, documentation, and verification outputs into releasable
+artifacts. The September 23 baselines confirm `task verify`,
+`task coverage`, and warnings-as-errors sweeps succeed, but the lack of a
+recent `uv build` dry run and the absence of draft release notes leave a
+tangible gap before we can create the `v0.1.0a1` tag.
+
+`issues/prepare-first-alpha-release.md` tracks the overall coordination;
+this ticket isolates the concrete PR-sized work: run the packaging
+pipeline under `uv`, capture hashes, update the changelog with a drafted
+release entry, and sync documentation pointers. From a dialectical point
+of view we must weigh the risk of stale metadata against the effort of
+rerunning expensive builds. The Socratic step asks whether our existing
+baselines truly guarantee installability without this staging sweep.
+
+## Dependencies
+- [retire-stale-xfail-markers-in-unit-suite.md]
+  (retire-stale-xfail-markers-in-unit-suite.md)
+- [prepare-first-alpha-release.md](prepare-first-alpha-release.md)
+
+## Acceptance Criteria
+- Execute `uv run python -m build` and
+  `uv run scripts/publish_dev.py --dry-run --repository testpypi` in a
+  clean environment, saving logs under `baseline/logs/` with timestamps.
+- Update `CHANGELOG.md` with a drafted `0.1.0a1` section covering staged
+  artifacts, citing the packaging logs.
+- Record the dry-run commands, checksums, and resulting wheel tree in
+  `docs/release_plan.md` under "Prerequisites for tagging 0.1.0a1".
+- Document any environment adjustments, such as `TASK_INSTALL_DIR`, in
+  `STATUS.md` so future releases can replicate the setup.
+- Ensure `mkdocs.yml` navigation references the updated release notes if
+  new sections are added.
+- Attach the packaging log paths and resulting artifact hashes to the
+  issue comment thread when closing.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- update the alpha release coordination issue to call out new dependencies for the XPASS cleanup, proof refresh, and packaging staging
- add dedicated issues for refreshing the token budget monotonicity proof and staging the v0.1.0a1 artifacts
- align STATUS, ROADMAP, TASK_PROGRESS, the release plan, and the changelog with the new planning threads and fixed archive links

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d359306a648333908d315d75013dc7