### PR TITLE
Track outstanding 0.1.0a1 blockers in planning docs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,6 +57,12 @@ Fresh September 24 planning added
 [stage-0-1-0a1-release-artifacts](issues/stage-0-1-0a1-release-artifacts.md)
  to stage packaging outputs before tagging; both now sit under
 [prepare-first-alpha-release](issues/prepare-first-alpha-release.md).
+The same review opened
+[stabilize-ranking-weight-property](issues/stabilize-ranking-weight-property.md),
+[restore-external-lookup-search-flow](issues/restore-external-lookup-search-flow.md),
+[finalize-search-parser-backends](issues/finalize-search-parser-backends.md),
+and [stabilize-storage-eviction-property](issues/stabilize-storage-eviction-property.md)
+to close the remaining XFAIL guards before tagging 0.1.0a1.
 
 ## Milestones
 

--- a/SPEC_COVERAGE.md
+++ b/SPEC_COVERAGE.md
@@ -56,14 +56,14 @@
 | `autoresearch/monitor/node_health.py` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
 | `autoresearch/monitor/system_monitor.py` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
 | `autoresearch/orchestration` | [orchestration.md](docs/specs/orchestration.md) | [p18], [s13], [t87], [t88], [t89], [t90], [t91] | OK |
-| `autoresearch/orchestration/metrics.py` | [metrics.md](docs/specs/metrics.md) | [p16], [s14], [t92], [t93] | OK |
+| `autoresearch/orchestration/metrics.py` | [metrics.md](docs/specs/metrics.md) | [p16], [s14], [t92], [t93] | Needs proof refresh ([issues/refresh-token-budget-monotonicity-proof.md](issues/refresh-token-budget-monotonicity-proof.md)) |
 | `autoresearch/orchestrator_perf.py` | [orchestrator-perf.md](docs/specs/orchestrator-perf.md)<br>[orchestrator_scheduling.md](docs/specs/orchestrator_scheduling.md) | [s15], [t94], [t95], [t96] | OK |
 | `autoresearch/output_format.py` | [output-format.md](docs/specs/output-format.md) | [t97], [t98] | OK |
 | `autoresearch/resource_monitor.py` | [monitor.md](docs/specs/monitor.md)<br>[resource-monitor.md](docs/specs/resource-monitor.md) | [p19], [s12], [s16], [t81], [t82], [t83], [t84], [t85], [t99], [t86] | OK |
 | `autoresearch/scheduler_benchmark.py` | [scheduler-benchmark.md](docs/specs/scheduler-benchmark.md) | [t96] | OK |
-| `autoresearch/search` | [search.md](docs/specs/search.md) | [t100], [t101], [t102], [t103], [t104], [t41], [t105], [t106] | OK |
-| `autoresearch/search/ranking_convergence.py` | [search_ranking.md](docs/specs/search_ranking.md) | [t100], [t102], [t107] | OK |
-| `autoresearch/storage.py` | [storage.md](docs/specs/storage.md) | [p20], [s17], [s18], [s19], [s20], [s22], [t103], [t108], [t109], [t106], [t110], [t111], [t112], [t113], [t114], [t125] | OK |
+| `autoresearch/search` | [search.md](docs/specs/search.md) | [t100], [t101], [t102], [t103], [t104], [t41], [t105], [t106] | Needs XFAIL cleanup ([issues/restore-external-lookup-search-flow.md](issues/restore-external-lookup-search-flow.md),<br>[issues/finalize-search-parser-backends.md](issues/finalize-search-parser-backends.md)) |
+| `autoresearch/search/ranking_convergence.py` | [search_ranking.md](docs/specs/search_ranking.md) | [t100], [t102], [t107] | Needs deterministic ranking proof ([issues/stabilize-ranking-weight-property.md](issues/stabilize-ranking-weight-property.md)) |
+| `autoresearch/storage.py` | [storage.md](docs/specs/storage.md) | [p20], [s17], [s18], [s19], [s20], [s22], [t103], [t108], [t109], [t106], [t110], [t111], [t112], [t113], [t114], [t125] | Needs eviction invariant refresh ([issues/stabilize-storage-eviction-property.md](issues/stabilize-storage-eviction-property.md)) |
 | `autoresearch/storage_backends.py` | [storage-backends.md](docs/specs/storage-backends.md) | [s21], [t109], [t65], [t66] | OK |
 | `autoresearch/storage_backup.py` | [storage-backup.md](docs/specs/storage-backup.md) | [t115] | OK |
 | `autoresearch/storage_utils.py` | [storage-utils.md](docs/specs/storage-utils.md) | [t116] | OK |

--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,10 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   fails because the Go Task CLI is not installed in the Codex shell by
   default. Continue using `uv` wrappers or source `scripts/setup.sh` before
   invoking Taskfile commands.
+- Confirmed the base shell still lacks the Go Task CLI during this review;
+  `task --version` prints "command not found", so the release plan continues
+  to rely on `uv run` wrappers until `scripts/setup.sh --print-path` is
+  sourced. 【2aa5eb†L1-L2】
 - Reviewed `baseline/logs/task-verify-20250923T204732Z.log` to confirm the
   XPASS cases for Ray execution and ranking remain green under
   warnings-as-errors, then opened
@@ -30,6 +34,22 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   and refreshed
   [prepare-first-alpha-release](issues/prepare-first-alpha-release.md) to
   align on packaging dry runs, changelog work, and dispatch-only workflows.
+- Re-ran `uv run --extra test pytest tests/unit -m "not slow" -rxX` to capture
+  the current XPASS and XFAIL list: 890 passed, 33 skipped, 25 deselected,
+  five XPASS promotions, and eight remaining XFAIL guards across ranking,
+  search, parser, and storage modules. Logged the Ray, ranking, semantic
+  similarity, cache, and token budget XPASS entries to unblock
+  [retire-stale-xfail-markers-in-unit-suite](issues/retire-stale-xfail-markers-in-unit-suite.md)
+  and opened follow-up tickets for the persistent XFAILs.
+  【bc4521†L101-L114】
+- Added
+  [stabilize-ranking-weight-property](issues/stabilize-ranking-weight-property.md),
+  [restore-external-lookup-search-flow](issues/restore-external-lookup-search-flow.md),
+  [finalize-search-parser-backends](issues/finalize-search-parser-backends.md),
+  and
+  [stabilize-storage-eviction-property](issues/stabilize-storage-eviction-property.md)
+  to cover the ranking, search, parser, and storage guards surfaced by the
+  unit run so they land before the 0.1.0a1 tag.
 
 ## September 23, 2025
 - Confirmed the lint, type, unit, integration, and behavior pipelines with `uv`

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -14,11 +14,16 @@ the refreshed run, allowing
 【F:docs/status/task-coverage-2025-09-23.md†L1-L32】
 【F:issues/archive/rerun-task-coverage-after-storage-fix.md†L1-L36】 Direct
 `uv run` commands now verify the day-to-day lint, type, and smoke suites without
-requiring the Task CLI on `PATH`; the unit run reports six XPASS cases tracked in
-[issues/retire-stale-xfail-markers-in-unit-suite.md], while integration and
-behavior suites pass with optional extras skipped. `uv run --extra docs mkdocs
-build` completes without warnings after prior documentation fixes.
-September 24 planning added
+requiring the Task CLI on `PATH`; the unit run reports five XPASS cases tracked
+in [issues/retire-stale-xfail-markers-in-unit-suite.md] and eight remaining
+XFAIL guards now covered by
+[issues/stabilize-ranking-weight-property.md],
+[issues/restore-external-lookup-search-flow.md],
+[issues/finalize-search-parser-backends.md], and
+[issues/stabilize-storage-eviction-property.md]. Integration and behavior suites
+pass with optional extras skipped, and `uv run --extra docs mkdocs build`
+completes without warnings after prior documentation fixes. September 24
+planning added
 [refresh-token-budget-monotonicity-proof](issues/refresh-token-budget-monotonicity-proof.md)
  and
 [stage-0-1-0a1-release-artifacts](issues/stage-0-1-0a1-release-artifacts.md)
@@ -27,7 +32,7 @@ September 24 planning added
 XPASS promotions, heuristics proof, and packaging dry runs land before tagging.
 【2d7183†L1-L3】【dab3a6†L1-L1】【240ff7†L1-L1】【3fa75b†L1-L1】【8434e0†L1-L2】
 【8e97b0†L1-L1】【ba4d58†L1-L104】【ab24ed†L1-L1】【187f22†L1-L9】【87aa99†L1-L1】
-【88b85b†L1-L2】【6618c7†L1-L4】【69c7fe†L1-L3】【896928†L1-L4】
+【88b85b†L1-L2】【6618c7†L1-L4】【69c7fe†L1-L3】【896928†L1-L4】【bc4521†L101-L114】
 The first warnings-as-errors `task verify` attempt, captured in
 `baseline/logs/task-verify-20250923T204706Z.log`, stopped at
 `tests/targeted/test_extras_codepaths.py:13:5: F401 'sys' imported but unused`.

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -25,16 +25,22 @@ Codex shell the Go Task CLI is not on `PATH` until
 checks currently run via `uv`. `uv run --extra dev-minimal --extra test flake8
 src tests` and `uv run --extra dev-minimal --extra test mypy src` both succeed,
 and `uv run --extra test pytest tests/unit -m 'not slow' --maxfail=1 -rxX`
-passes with six XPASS cases now tracked in
-[issues/retire-stale-xfail-markers-in-unit-suite.md], with
+passes with five XPASS cases now tracked in
+[issues/retire-stale-xfail-markers-in-unit-suite.md], while the same run
+reports eight remaining XFAIL guards covered by
+[issues/stabilize-ranking-weight-property.md],
+[issues/restore-external-lookup-search-flow.md],
+[issues/finalize-search-parser-backends.md], and
+[issues/stabilize-storage-eviction-property.md].
 [issues/refresh-token-budget-monotonicity-proof.md] and
-[issues/stage-0-1-0a1-release-artifacts.md] capturing the proof refresh and
-release staging before tagging. Integration and behavior
-suites succeed with optional extras skipped, and `uv run --extra docs mkdocs
-build` finishes without warnings after the GPU wheel documentation move.
+[issues/stage-0-1-0a1-release-artifacts.md] capture the proof refresh and
+release staging before tagging. Integration and behavior suites succeed
+with optional extras skipped, and `uv run --extra docs mkdocs build`
+finishes without warnings after the GPU wheel documentation move.
 【2d7183†L1-L3】【dab3a6†L1-L1】【240ff7†L1-L1】【3fa75b†L1-L1】【8434e0†L1-L2】
 【8e97b0†L1-L1】【ba4d58†L1-L104】【ab24ed†L1-L1】【187f22†L1-L9】【87aa99†L1-L1】
-【88b85b†L1-L2】【6618c7†L1-L4】【69c7fe†L1-L3】【896928†L1-L4】 Spec lint remains
+【88b85b†L1-L2】【6618c7†L1-L4】【69c7fe†L1-L3】【896928†L1-L4】【bc4521†L101-L114】
+Spec lint remains
 recovered—`docs/specs/monitor.md` and `docs/specs/extensions.md` retain the
 required `## Simulation Expectations` sections—and coverage artifacts stay in
 sync with `baseline/coverage.xml` after the September 23 run documented in
@@ -92,6 +98,11 @@ These tasks completed in order: environment bootstrap → packaging verification
   [issues/refresh-token-budget-monotonicity-proof.md], and
   [issues/stage-0-1-0a1-release-artifacts.md] before tagging so XPASS
   promotions, heuristic proofs, and packaging logs land together.
+- Close [issues/stabilize-ranking-weight-property.md],
+  [issues/restore-external-lookup-search-flow.md],
+  [issues/finalize-search-parser-backends.md], and
+  [issues/stabilize-storage-eviction-property.md] so the remaining XFAIL
+  guards are resolved before tagging.
 - Record the latest `uv run python -m build` output and TestPyPI dry run in
   `baseline/logs/` and reference the timestamps here once the stage issue
   closes.

--- a/issues/finalize-search-parser-backends.md
+++ b/issues/finalize-search-parser-backends.md
@@ -1,0 +1,39 @@
+# Finalize search parser backends
+
+## Context
+The document parser unit tests remain guarded by `xfail` markers:
+`tests/unit/test_search_parsers.py::test_extract_pdf_text`,
+`tests/unit/test_search_parsers.py::test_extract_docx_text`, and
+`tests/unit/test_search_parsers.py::test_search_local_file_backend`. The
+September 24 unit run of `uv run --extra test pytest tests/unit -m "not
+slow" -rxX` shows all three cases as XFAIL, citing flaky PDF extraction,
+DOCX parsing gaps, and an incomplete local file backend. Documentation in
+`docs/algorithms/search.md` advertises support for document ingestion,
+while installation instructions flag optional parser extras. The mismatch
+between docs, code, and tests blocks a confident 0.1.0a1 tag.
+
+A multi-disciplinary review needs to weigh the ergonomics of bringing the
+parsers into the default bundle versus clarifying optional support. The
+Socratic approach should surface the minimal guarantees we can uphold in
+an alpha release and the dialectical step should challenge whether the
+existing heuristics suffice without real parsers.
+
+## Dependencies
+- _None_
+
+## Acceptance Criteria
+- Decide whether PDF and DOCX parsing ship in 0.1.0a1 or remain optional,
+  documenting the rationale in `docs/algorithms/search.md` and
+  `docs/algorithms/cache.md`.
+- Implement stable parser integrations (or deterministic shims) in
+  `src/autoresearch/search/parsers.py` and related helpers so the unit
+  tests pass without `xfail` markers.
+- Add regression coverage for failure modes (e.g., corrupted files) and
+  update the tests to assert on specific parser outputs.
+- Note any environment requirements in `README.md` and
+  `docs/installation.md`, including extras or optional dependencies.
+- Update `SPEC_COVERAGE.md` to reference the finalized parser coverage
+  and record the change in `CHANGELOG.md` under Unreleased.
+
+## Status
+Open

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -7,26 +7,38 @@ and documentation. The September 23 baselines captured in
 `baseline/logs/task-verify-20250923T204732Z.log` and
 `baseline/logs/verify-warnings-20250923T224648Z.log` confirm that
 `task verify`, `task coverage`, and the warnings-as-errors sweep all pass
-with 890 unit, 324 integration, and 29 behavior tests. Those runs also
-highlight five XPASS cases that continue to carry `xfail` markers, which
-prevents the release gate from failing fast when regressions appear. The
-Go Task CLI is still absent from the default Codex shell, so release
+with 890 unit, 324 integration, and 29 behavior tests. A fresh
+September 24 run of
+`uv run --extra test pytest tests/unit -m "not slow" -rxX` reproduces the
+same pass counts while reporting five XPASS promotions and eight
+remaining XFAIL guards across ranking, search, parser, and storage
+modules. Those results surface additional alignment work before tagging.
+The Go Task CLI is still absent from the default Codex shell, so release
 operators must keep using `uv` invocations unless they source the
 `scripts/setup.sh` PATH helper.
 
-A dialectical review of the outstanding work surfaces three threads: the
-XPASS promotions, refreshed mathematical backing for the token budget
-heuristic, and staging of packaging artifacts. Socratic questioning asks
-whether the existing documentation actually proves what the tests assert
-and whether our packaging instructions match a fresh dry run. New issues
-cover each thread so that we can close this release ticket once the
-dependencies land.
+A dialectical review of the outstanding work now surfaces four themes:
+the XPASS promotions, refreshed mathematical backing for the token
+budget heuristic, completion of the remaining XFAIL clean-up in ranking,
+search, parser, and storage modules, and staging of packaging artifacts.
+Socratic questioning asks whether the existing documentation actually
+proves what the tests assert and whether our packaging instructions
+match a fresh dry run. New issues cover each thread so that we can close
+this release ticket once the dependencies land.
 
 ### PR-sized tasks
 - [retire-stale-xfail-markers-in-unit-suite.md]
   (retire-stale-xfail-markers-in-unit-suite.md)
 - [refresh-token-budget-monotonicity-proof.md]
   (refresh-token-budget-monotonicity-proof.md)
+- [stabilize-ranking-weight-property.md]
+  (stabilize-ranking-weight-property.md)
+- [restore-external-lookup-search-flow.md]
+  (restore-external-lookup-search-flow.md)
+- [finalize-search-parser-backends.md]
+  (finalize-search-parser-backends.md)
+- [stabilize-storage-eviction-property.md]
+  (stabilize-storage-eviction-property.md)
 - [stage-0-1-0a1-release-artifacts.md]
   (stage-0-1-0a1-release-artifacts.md)
 
@@ -35,6 +47,14 @@ dependencies land.
   (retire-stale-xfail-markers-in-unit-suite.md)
 - [refresh-token-budget-monotonicity-proof.md]
   (refresh-token-budget-monotonicity-proof.md)
+- [stabilize-ranking-weight-property.md]
+  (stabilize-ranking-weight-property.md)
+- [restore-external-lookup-search-flow.md]
+  (restore-external-lookup-search-flow.md)
+- [finalize-search-parser-backends.md]
+  (finalize-search-parser-backends.md)
+- [stabilize-storage-eviction-property.md]
+  (stabilize-storage-eviction-property.md)
 - [stage-0-1-0a1-release-artifacts.md]
   (stage-0-1-0a1-release-artifacts.md)
 

--- a/issues/refresh-token-budget-monotonicity-proof.md
+++ b/issues/refresh-token-budget-monotonicity-proof.md
@@ -3,7 +3,9 @@
 ## Context
 The heuristics suite still marks
 `tests/unit/test_heuristic_properties.py::test_token_budget_monotonicity`
-with `xfail` even though `task verify` now reports the case as XPASS.
+with `xfail` even though `task verify` and the September 24 rerun of
+`uv run --extra test pytest tests/unit -m "not slow" -rxX` now report the
+case as XPASS.
 The marker was introduced while we investigated non-monotonic updates in
 `OrchestrationMetrics.suggest_token_budget`, so the remaining guard
 blocks release gating from catching regressions early.

--- a/issues/restore-external-lookup-search-flow.md
+++ b/issues/restore-external-lookup-search-flow.md
@@ -1,0 +1,41 @@
+# Restore external lookup search flow
+
+## Context
+`tests/unit/test_search.py::test_external_lookup_vector_search` and
+`tests/unit/test_search.py::test_external_lookup_hybrid_query` remain
+marked with `xfail` and still report as XFAIL after the September 24 run
+of `uv run --extra test pytest tests/unit -m "not slow" -rxX`. The
+markers document two gaps: the search module does not expose the
+configured `StorageManager`, and the hybrid lookup path still treats the
+embedding backend as a placeholder. Documentation in
+`docs/algorithms/search.md` and `docs/algorithms/cache.md` claims that
+external lookups hydrate semantic caches before ranking, yet the tests
+prove the integration is incomplete.
+
+A dialectical review needs to decide whether the hybrid lookup should be
+delivered as part of 0.1.0a1 or deferred with explicit documentation.
+Socratic questioning of the assumptions—particularly the expectation
+that storage-backed lookups are optional—will guide the implementation
+work so that the alpha release matches the advertised behavior.
+
+## Dependencies
+- _None_
+
+## Acceptance Criteria
+- Surface a `StorageManager` handle (or an equivalent cache abstraction)
+  through `src/autoresearch/search/__init__.py` so external lookup flows
+  can persist and retrieve nodes without private imports.
+- Implement the hybrid external lookup path with deterministic behavior
+  across BM25, semantic, and ontology stores, updating
+  `src/autoresearch/search/core.py` as needed.
+- Remove the `xfail` markers from the affected tests and ensure they pass
+  consistently under `uv run --extra test pytest tests/unit -m "not slow"
+  -rxX`.
+- Update `docs/algorithms/search.md` and `docs/algorithms/cache.md` to
+  describe the hydrated external lookup sequence, including any fallback
+  strategies.
+- Map the refreshed behavior in `SPEC_COVERAGE.md` and record the change
+  in `CHANGELOG.md` under the Unreleased section.
+
+## Status
+Open

--- a/issues/retire-stale-xfail-markers-in-unit-suite.md
+++ b/issues/retire-stale-xfail-markers-in-unit-suite.md
@@ -2,15 +2,17 @@
 
 ## Context
 `uv run --extra test pytest tests/unit -m 'not slow' --maxfail=1 -rxX`
-now reports XPASS for six tests that still carry `xfail` markers, five of
-which exercise production paths that have stabilised in the Ray executor
-and ranking pipelines. The September 23 verification log at
-`baseline/logs/task-verify-20250923T204732Z.log` shows
+continues to report XPASS for five tests that still carry `xfail`
+markers, each exercising production paths that have stabilised in the
+Ray executor and ranking pipelines. The September 23 verification log at
+`baseline/logs/task-verify-20250923T204732Z.log`, along with the
+September 24 rerun of
+`uv run --extra test pytest tests/unit -m "not slow" -rxX`, shows
 `test_execute_agent_remote`, `test_convergence_bound_holds`,
 `test_rank_results_idempotent`,
 `test_calculate_semantic_similarity`, and
-`test_external_lookup_uses_cache` all passing under the warnings-as-errors
-harness. The remaining guard on
+`test_external_lookup_uses_cache` all passing under the
+warnings-as-errors harness. The remaining guard on
 `tests/unit/test_heuristic_properties.py::test_token_budget_monotonicity`
 reflects an unresolved proof gap in
 `autoresearch.orchestration.metrics` rather than an unstable runtime

--- a/issues/stabilize-ranking-weight-property.md
+++ b/issues/stabilize-ranking-weight-property.md
@@ -1,0 +1,42 @@
+# Stabilize ranking weight property
+
+## Context
+The unit suite still marks `tests/unit/test_property_search_ranking.py::
+test_rank_results_orders_by_weighted_scores` with `xfail`, and the
+September 24 run of `uv run --extra test pytest tests/unit -m "not slow"
+-rxX` reports it as XFAIL alongside the XPASS for
+`tests/unit/test_ranking_idempotence.py::test_rank_results_idempotent`.
+The proof in `docs/algorithms/relevance_ranking.md` asserts that sorting
+by the weighted score is idempotent, yet the property test covers the
+same invariants and continues to fail intermittently. The implementation
+in `src/autoresearch/search/core.py` still relies on floating point
+comparisons without an explicit tie-breaker, so rankings with equal
+scores can flip between runs.
+
+We need a focused effort to reconcile the specification, tests, and
+implementation. The dialectical review should question whether the proof
+requires additional constraints (for example, stable sorting with a
+secondary key) or if the production ranking must be hardened. A
+Socratic walkthrough of the failure cases—especially ties where BM25 and
+semantic scores cancel—will clarify the necessary correction before the
+alpha release work moves forward.
+
+## Dependencies
+- _None_
+
+## Acceptance Criteria
+- Implement deterministic tie-breaking or score quantization in
+  `src/autoresearch/search/core.py` so ranking outputs are stable across
+  runs.
+- Update `docs/algorithms/relevance_ranking.md` to incorporate the new
+  assumptions or derivation and record the dialectical analysis that led
+  to the change.
+- Extend the regression coverage in
+  `tests/unit/test_property_search_ranking.py` to capture the corrected
+  behavior and remove the `xfail` marker.
+- Sync `SPEC_COVERAGE.md` for the affected search modules to reference
+  the refreshed proof or simulation artifacts.
+- Note the stabilization in `CHANGELOG.md` under the Unreleased section.
+
+## Status
+Open

--- a/issues/stabilize-storage-eviction-property.md
+++ b/issues/stabilize-storage-eviction-property.md
@@ -1,0 +1,39 @@
+# Stabilize storage eviction property
+
+## Context
+`tests/unit/test_storage_eviction.py::test_enforce_ram_budget_reduces_usage_property`
+remains marked with `xfail` and still reports as XFAIL under the
+September 24 run of `uv run --extra test pytest tests/unit -m "not slow"
+-rxX`. The reason cites "Eviction property generation unstable" even
+though `docs/algorithms/storage_eviction.md` presents a proof that the
+RAM budget enforcement always terminates below the target threshold. The
+implementation in `src/autoresearch/storage.py` recently added
+`_enforce_ram_budget` guardrails for zero metrics, yet property-based
+generation can still emit sequences that break the invariant.
+
+A dialectical review must determine whether the proof requires refined
+assumptions (for example, minimum node sizes) or if the algorithm needs
+additional bookkeeping. Socratic probing of the counterexamples—such as
+graphs with zero-weight nodes or repeated evictions of the same entity—
+will surface the missing invariants before the release staging proceeds.
+
+## Dependencies
+- _None_
+
+## Acceptance Criteria
+- Reproduce and document the counterexample currently triggering the
+  property `xfail`, linking the reasoning in
+  `docs/algorithms/storage_eviction.md` and
+  `docs/specs/storage.md`.
+- Update `_enforce_ram_budget` (or related helpers) to address the
+  counterexample, ensuring deterministic convergence under the stated
+  assumptions.
+- Strengthen `tests/unit/test_storage_eviction.py` with targeted fixtures
+  or Hypothesis strategies and remove the `xfail` marker.
+- Capture the resolution in `SPEC_COVERAGE.md` and summarize it in the
+  Unreleased section of `CHANGELOG.md`.
+- Add a regression scenario to `scripts/storage_eviction_sim.py` or a new
+  simulation helper demonstrating the fixed invariant.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- add in-repo issues to cover ranking, search, parser, and storage xfail cleanup before the alpha tag
- refresh release planning docs (release_plan, roadmap, task_progress, status) with the latest unit run results and new dependencies
- mark spec coverage rows needing proof or implementation updates so gaps remain visible

## Testing
- uv run --extra docs mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d35c611f848333a00b8462f542eb27