### PR TITLE
Update release readiness documentation and issue dependencies

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -13,6 +13,20 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
 ## September 24, 2025
+- Reconfirmed the base environment: `python --version` reports 3.12.10,
+  `uv --version` reports 0.7.22, and `task --version` still fails, so the
+  Taskfile commands must run via `uv` or the PATH helper until we package a
+  new Task binary. 【c0ed6e†L1-L2】【7b55df†L1-L2】【311dfe†L1-L2】
+- Reran `uv run --extra test pytest tests/unit -m "not slow" -rxX`; 890 tests
+  passed with the expected eight XFAIL guards and five XPASS promotions,
+  matching the open ranking, search, metrics, and storage tickets in
+  SPEC_COVERAGE. This keeps the release dialectic focused on closing the
+  proof gaps before we lift the guards. 【5b78c5†L1-L71】
+  【F:SPEC_COVERAGE.md†L26-L52】
+- Spot-checked the fast verification entry points—`flake8`, `mypy`, and the
+  MkDocs build—all pass under `uv`, confirming the docs and lint gates stay
+  green while we iterate on the outstanding issues. 【6c5abf†L1-L1】
+  【16543c†L1-L1】【84bbfd†L1-L4】【5b4d9e†L1-L1】
 - Verified the local runtime before running tests: `python --version` reports
   3.12.10 and `uv --version` reports 0.7.22, while `task --version` still
   fails because the Go Task CLI is not installed in the Codex shell by

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -67,6 +67,14 @@ tracker, warnings sweep, and coverage refresh tasks that remain open.
 【F:issues/archive/resolve-deprecation-warnings-in-tests.md†L1-L93】
 【F:issues/archive/rerun-task-coverage-after-storage-fix.md†L1-L36】【F:issues/archive/fix-testing-guidelines-gpu-link.md†L1-L27】
 
+As of **September 24, 2025** we revalidated the fast gates with the Codex
+toolchain: `uv run --extra test pytest tests/unit -m "not slow" -rxX` returned
+890 passes, 33 skips, eight expected failures, and five xpass promotions,
+mirroring the outstanding tickets covering ranking, search, metrics, and
+storage. Linting (`flake8`), typing (`mypy`), and the MkDocs build also succeed
+under `uv`, so the alpha track can focus on the listed issue dependencies.
+【5b78c5†L1-L71】【6c5abf†L1-L1】【16543c†L1-L1】【84bbfd†L1-L4】【5b4d9e†L1-L1】
+
 See [docs/release_plan.md](docs/release_plan.md) for current test and coverage
 status and the alpha release checklist. An **0.1.0-alpha.1** preview remains
 targeted for **September 15, 2026**, with the final **0.1.0** release targeted

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -9,7 +9,7 @@ The publishing workflow follows the steps in
 ROADMAP.md for high-level milestones.
 
 The project kicked off in **May 2025** (see the initial commit dated
-`2025-05-18`). This schedule was last updated on **September 19, 2025** and
+`2025-05-18`). This schedule was last updated on **September 24, 2025** and
 reflects that the codebase currently sits at the **unreleased 0.1.0a1** version
 defined in `autoresearch.__version__`. The project targets **0.1.0a1** for
 **September 15, 2026** and **0.1.0** for **October 1, 2026**. See
@@ -20,31 +20,24 @@ STATUS.md, ROADMAP.md, and CHANGELOG.md for aligned progress. Phase 3
 
 The dependency pins for `fastapi` (>=0.116.1) and `slowapi` (==0.1.9) remain
 confirmed in `pyproject.toml` and [installation.md](installation.md). In the
-Codex shell the Go Task CLI is not on `PATH` until
-`./scripts/setup.sh --print-path` is sourced, so linting, typing, and test smoke
-checks currently run via `uv`. `uv run --extra dev-minimal --extra test flake8
-src tests` and `uv run --extra dev-minimal --extra test mypy src` both succeed,
-and `uv run --extra test pytest tests/unit -m 'not slow' --maxfail=1 -rxX`
-passes with five XPASS cases now tracked in
-[issues/retire-stale-xfail-markers-in-unit-suite.md], while the same run
-reports eight remaining XFAIL guards covered by
-[issues/stabilize-ranking-weight-property.md],
-[issues/restore-external-lookup-search-flow.md],
-[issues/finalize-search-parser-backends.md], and
-[issues/stabilize-storage-eviction-property.md].
-[issues/refresh-token-budget-monotonicity-proof.md] and
+Codex shell `python --version` reports 3.12.10, `uv --version` reports 0.7.22,
+and `task --version` still fails, so linting, typing, and test smoke checks run
+via `uv` or the PATH helper from `./scripts/setup.sh --print-path`.
+`uv run --extra dev-minimal --extra test flake8 src tests` and `uv run --extra
+dev-minimal --extra test mypy src` both succeed, and `uv run --extra test pytest
+tests/unit -m 'not slow' -rxX` returns 890 passes, 33 skips, eight XFAIL guards,
+and five XPASS promotions that align with the open ranking, search, metrics, and
+storage tickets. `uv run --extra docs mkdocs build` completes without warnings
+after the GPU wheel documentation move, and
+[issues/refresh-token-budget-monotonicity-proof.md] plus
 [issues/stage-0-1-0a1-release-artifacts.md] capture the proof refresh and
-release staging before tagging. Integration and behavior suites succeed
-with optional extras skipped, and `uv run --extra docs mkdocs build`
-finishes without warnings after the GPU wheel documentation move.
-【2d7183†L1-L3】【dab3a6†L1-L1】【240ff7†L1-L1】【3fa75b†L1-L1】【8434e0†L1-L2】
-【8e97b0†L1-L1】【ba4d58†L1-L104】【ab24ed†L1-L1】【187f22†L1-L9】【87aa99†L1-L1】
-【88b85b†L1-L2】【6618c7†L1-L4】【69c7fe†L1-L3】【896928†L1-L4】【bc4521†L101-L114】
-Spec lint remains
-recovered—`docs/specs/monitor.md` and `docs/specs/extensions.md` retain the
-required `## Simulation Expectations` sections—and coverage artifacts stay in
-sync with `baseline/coverage.xml` after the September 23 run documented in
-`docs/status/task-coverage-2025-09-23.md`.
+release staging before tagging. Integration and behavior suites succeed with
+optional extras skipped, and spec lint remains recovered—`docs/specs/monitor.md`
+and `docs/specs/extensions.md` retain the required `## Simulation Expectations`
+sections—while coverage artifacts stay in sync with `baseline/coverage.xml`
+after the September 23 run documented in `docs/status/task-coverage-2025-09-23.md`.
+【c0ed6e†L1-L2】【7b55df†L1-L2】【311dfe†L1-L2】【6c5abf†L1-L1】【16543c†L1-L1】
+【5b78c5†L1-L71】【84bbfd†L1-L4】【5b4d9e†L1-L1】
 【F:docs/specs/monitor.md†L126-L165】【F:docs/specs/extensions.md†L1-L69】
 【F:baseline/coverage.xml†L1-L12】
 【F:docs/status/task-coverage-2025-09-23.md†L1-L32】

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -26,6 +26,15 @@ proves what the tests assert and whether our packaging instructions
 match a fresh dry run. New issues cover each thread so that we can close
 this release ticket once the dependencies land.
 
+A fresh September 24 verification rechecked the supporting lint (`uv run
+--extra dev-minimal --extra test flake8 src tests`), typing (`uv run
+--extra dev-minimal --extra test mypy src`), and documentation (`uv run
+--extra docs mkdocs build`) gates. Each command succeeded while
+`task --version` still fails, reinforcing the need to rely on `uv`
+wrappers or the PATH helper until we package a Task binary alongside the
+alpha tag. 【6c5abf†L1-L1】【16543c†L1-L1】【84bbfd†L1-L4】【5b4d9e†L1-L1】
+【311dfe†L1-L2】
+
 ### PR-sized tasks
 - [retire-stale-xfail-markers-in-unit-suite.md]
   (retire-stale-xfail-markers-in-unit-suite.md)

--- a/issues/retire-stale-xfail-markers-in-unit-suite.md
+++ b/issues/retire-stale-xfail-markers-in-unit-suite.md
@@ -27,6 +27,10 @@ coherence, and token budgeting—should therefore drive the promotions.
 ## Dependencies
 - [refresh-token-budget-monotonicity-proof.md]
   (refresh-token-budget-monotonicity-proof.md)
+- [stabilize-ranking-weight-property.md]
+  (stabilize-ranking-weight-property.md)
+- [restore-external-lookup-search-flow.md]
+  (restore-external-lookup-search-flow.md)
 
 ## Acceptance Criteria
 - Remove or tighten the guard on


### PR DESCRIPTION
## Summary
- extend the September 24 status log with the latest environment check, unit run, and fast lint/doc gates
- refresh TASK_PROGRESS and docs/release_plan.md to capture the new verification snapshot and toolchain expectations
- add the fresh lint/mypy/mkdocs validation context to prepare-first-alpha-release and align the xfail clean-up dependencies

## Testing
- uv run --extra test pytest tests/unit -m "not slow" -rxX
- uv run --extra dev-minimal --extra test flake8 src tests
- uv run --extra dev-minimal --extra test mypy src
- uv run --extra docs mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d36038e19c8333aa6a824397ba27e3