### PR TITLE
Document token budget counterexample and enforce piecewise monotonicity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Reference issues by slugged filename (for example,
 `issues/archive/example-issue.md`) and avoid numeric prefixes.
 
 ## [Unreleased]
+- Reframed the token budget spec around piecewise monotonicity,
+  documented the zero-usage counterexample, and promoted deterministic
+  regression coverage for
+  [refresh-token-budget-monotonicity-proof](issues/refresh-token-budget-monotonicity-proof.md).
 - Archived [resolve-deprecation-warnings-in-tests](issues/archive/resolve-deprecation-warnings-in-tests.md)
   after removing the repository-wide `pkg_resources` suppression from
   `sitecustomize.py` and capturing a clean `task verify:warnings:log` run at

--- a/SPEC_COVERAGE.md
+++ b/SPEC_COVERAGE.md
@@ -56,7 +56,7 @@
 | `autoresearch/monitor/node_health.py` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
 | `autoresearch/monitor/system_monitor.py` | [monitor.md](docs/specs/monitor.md) | [s12], [t81], [t82], [t83], [t84], [t85], [t86] | OK |
 | `autoresearch/orchestration` | [orchestration.md](docs/specs/orchestration.md) | [p18], [s13], [t87], [t88], [t89], [t90], [t91] | OK |
-| `autoresearch/orchestration/metrics.py` | [metrics.md](docs/specs/metrics.md) | [p16], [s14], [t92], [t93] | Needs proof refresh ([issues/refresh-token-budget-monotonicity-proof.md](issues/refresh-token-budget-monotonicity-proof.md)) |
+| `autoresearch/orchestration/metrics.py` | [metrics.md](docs/specs/metrics.md) | [p16], [s14], [t92], [t93], [t126] | OK (piecewise monotonic after first usage) |
 | `autoresearch/orchestrator_perf.py` | [orchestrator-perf.md](docs/specs/orchestrator-perf.md)<br>[orchestrator_scheduling.md](docs/specs/orchestrator_scheduling.md) | [s15], [t94], [t95], [t96] | OK |
 | `autoresearch/output_format.py` | [output-format.md](docs/specs/output-format.md) | [t97], [t98] | OK |
 | `autoresearch/resource_monitor.py` | [monitor.md](docs/specs/monitor.md)<br>[resource-monitor.md](docs/specs/resource-monitor.md) | [p19], [s12], [s16], [t81], [t82], [t83], [t84], [t85], [t99], [t86] | OK |
@@ -202,6 +202,7 @@
 [s14]: scripts/token_budget_convergence.py
 [t92]: tests/unit/test_metrics_token_budget_spec.py
 [t93]: tests/unit/test_token_budget_convergence.py
+[t126]: tests/unit/test_heuristic_properties.py
 [s15]: scripts/orchestrator_perf_sim.py
 [t94]: tests/integration/test_orchestrator_performance.py
 [t95]: tests/unit/test_orchestrator_perf_sim.py

--- a/docs/algorithms/token_budgeting.md
+++ b/docs/algorithms/token_budgeting.md
@@ -11,13 +11,15 @@ idle. Define `a_t = \max_i a_{i,t}` and `\bar{a}_t = \max_i \bar{a}_{i,t}`.
 With margin `m`, the update is
 
 \[
-b_{t+1} = \left\lceil \max(u_t, \bar{u}_t, a_t, \bar{a}_t) (1 + m) \right\rceil.
+b_{t+1} = \text{round\_with\_margin}\left(
+  \max(u_t, \bar{u}_t, a_t, \bar{a}_t), m
+\right).
 \]
 
 Negative margins are clamped to zero to avoid suggesting budgets below
-observed usage. The implementation uses ``Decimal`` for rounding,
-applying ``ceil`` so halfway cases round up without floating-point
-drift.
+observed usage. The implementation uses ``Decimal`` with round-half-up
+semantics, so ``.5`` cases round up while fractions such as ``1.1`` round
+down to ``1`` without floating-point drift.
 
 When the new target differs from the current budget the algorithm
 immediately adjusts. If no usage has ever been recorded, the budget is
@@ -30,16 +32,16 @@ Consider two agents, ``A`` and ``B``, with margin ``m = 0.1``:
 
 1. **Cycle 1** – ``A`` uses five tokens. Candidates: ``u_1 = 5``,
    ``\bar{u}_1 = 5``, ``a_1 = 5`` and ``\bar{a}_1 = 5``. The budget is
-   ``ceil(5 \times 1.1) = 6``.
+   ``round_with_margin(5, 0.1) = 6``.
 2. **Cycle 2** – ``B`` uses thirty tokens while ``A`` is idle, so its
    history records a zero. ``\bar{a}_{A,2} = (5 + 0) / 2 = 2.5`` and
    ``\bar{a}_{B,2} = 30``. Candidates become ``u_2 = 30``,
    ``\bar{u}_2 = 17.5``, ``a_2 = 30`` and ``\bar{a}_2 = 30``. The budget
-   rises to ``ceil(30 \times 1.1) = 33``.
+   rises to ``round_with_margin(30, 0.1) = 33``.
 3. **Cycle 3** – ``A`` again uses five tokens. ``B`` contributes zero so
    ``\bar{a}_{B,3} = (30 + 0) / 2 = 15``. The candidates are now
    ``u_3 = 5``, ``\bar{u}_3 = 13.3``, ``a_3 = 5`` and ``\bar{a}_3 = 15``.
-   The budget drops to ``ceil(15 \times 1.1) = 17``.
+   The budget drops to ``round_with_margin(15, 0.1) = 17``.
 
 This illustrates how an agent's past activity influences future budgets
 even when another agent was responsible for a prior spike.
@@ -47,8 +49,8 @@ even when another agent was responsible for a prior spike.
 ## Convergence
 
 Let usage settle at a constant value `u` and define
-`b* = ceil(u * (1 + m))`. Averaging the last ten non-zero samples blocks
-isolated spikes from influencing the limit.
+`b* = round_with_margin(u, m)`. Averaging the last ten non-zero samples
+blocks isolated spikes from influencing the limit.
 
 ### Assumptions
 
@@ -61,18 +63,18 @@ isolated spikes from influencing the limit.
 
 ### Bounds and derivation
 
-Define `M_t = \max(u_t, \bar{u}_t, a_t, \bar{a}_t)`. For `t >= T`
-the update rule becomes
+Define `M_t = \max(u_t, \bar{u}_t, a_t, \bar{a}_t)` and
+`R(x) = round_with_margin(x, m)`. For `t >= T` the update rule becomes
 
 \[
-b_{t+1} = \left\lceil M_t (1 + m) \right\rceil.
+b_{t+1} = R(M_t).
 \]
 
 Let `U = \max_{j < T} u_j`. While history retains a pre-`T` spike,
 `u \le M_t \le U`, giving the bounds
 
 \[
-\left\lceil u (1 + m) \right\rceil \le b_{t+1} \le \left\lceil U (1 + m) \right\rceil.
+R(u) \le b_{t+1} \le R(U).
 \]
 
 Each cycle after `T` replaces one pre-`T` value in the running averages.
@@ -80,13 +82,44 @@ Hence `M_t` decreases monotonically to `u` and for `t >= T + 10` the
 window contains only the constant usage. Substituting `M_t = u` yields
 
 \[
-b_{t+1} = \left\lceil u (1 + m) \right\rceil = b*.
+b_{t+1} = R(u) = b*.
 \]
 
 Thus convergence occurs within ten cycles of stable usage. Ten
 consecutive zero-usage cycles after activity force all candidates to
 zero. The implementation floors the suggestion at one token, giving the
 fixed point `b_t = 1` in that case.
+
+### Counterexample
+
+The historical monotonicity proof assumed two properties that do not
+hold in the implementation:
+
+- Both metric histories contain at least one positive usage sample, so
+  the fallback path that returns the existing budget is never taken.
+- Rounding behaves like ``ceil`` instead of round-half-up.
+
+Dropping either assumption breaks strict monotonicity. Hypothesis
+generated the following counterexample, which now lives as a regression
+test:
+
+```python
+from autoresearch.orchestration.metrics import OrchestrationMetrics
+
+idle = OrchestrationMetrics()
+active = OrchestrationMetrics()
+idle.record_tokens("a", 0, 0)
+active.record_tokens("a", 1, 0)
+print(idle.suggest_token_budget(10))   # -> 10, fallback to current budget
+print(active.suggest_token_budget(10)) # -> 1, first positive sample
+```
+
+`idle` never marks `_ever_used_tokens`, so its suggestion leaves the
+current budget unchanged. The `active` run records a single token and
+computes `round_with_margin(1, 0.1) = 1`, shrinking the budget. After a
+positive sample has been recorded, subsequent increases remain
+monotonic; only the zero-history fallback violates the strict proof
+claim.
 
 ## Simulation
 
@@ -104,8 +137,8 @@ final budget: 60
 ```
 
 The regression test [`test_token_budget_convergence.py`][tb-test]
-asserts that the limit `ceil(u * (1 + m))` is reached for constant usage
-and after temporary workload spikes. Simulation tests
+asserts that the limit `round_with_margin(u, m)` is reached for constant
+usage and after temporary workload spikes. Simulation tests
 [`test_metrics_token_budget_spec.py`][bounds-test] verify the bounds on
 intermediate budgets and use Hypothesis to explore edge cases such as
 large spikes and near-zero margins.


### PR DESCRIPTION
## Summary
- document the zero-history counterexample and update the token budgeting proof to reflect `round_with_margin`
- capture a Socratic review of monotonicity in the metrics spec and mark the refreshed coverage in `SPEC_COVERAGE.md`
- replace the xfailed monotonicity property with piecewise checks and a deterministic regression, and note the change in the changelog

## Testing
- uv run --extra test pytest tests/unit/test_heuristic_properties.py
- uv run --extra docs mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d36a3e703483338375579f6ac04802