### PR TITLE
Archive release blockers and sync umbrella status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,17 @@ Reference issues by slugged filename (for example,
 - Bucketed relevance scores at a :math:`10^{-6}` resolution to preserve
   deterministic tie-breaking, exposed the bucket metadata for property and
   idempotence regressions, refreshed the relevance ranking algorithm note, and
-  recorded the guarantee in the spec coverage ledger.【F:src/autoresearch/search/core.py†L175-L181】【F:src/autoresearch/search/core.py†L813-L866】【F:tests/unit/test_property_search_ranking.py†L12-L235】【F:tests/unit/test_ranking_idempotence.py†L1-L55】【F:tests/unit/test_relevance_ranking.py†L372-L414】【F:docs/algorithms/relevance_ranking.md†L40-L49】【F:SPEC_COVERAGE.md†L64-L64】【F:SPEC_COVERAGE.md†L263-L263】
+  recorded the guarantee in the spec coverage ledger, addressing
+  [stabilize-ranking-weight-property](issues/archive/stabilize-ranking-weight-property.md).【F:src/autoresearch/search/core.py†L175-L181】【F:src/autoresearch/search/core.py†L813-L866】【F:tests/unit/test_property_search_ranking.py†L12-L235】【F:tests/unit/test_ranking_idempotence.py†L1-L55】【F:tests/unit/test_relevance_ranking.py†L372-L414】【F:docs/algorithms/relevance_ranking.md†L40-L49】【F:SPEC_COVERAGE.md†L64-L64】【F:SPEC_COVERAGE.md†L263-L263】
 - Retired the remaining search, distributed, and budgeting XFAIL markers,
   refreshing the corresponding docs/algorithms entries, SPEC_COVERAGE.md, and
-  changelog coverage to lock in the XPASS promotions.【F:docs/algorithms/distributed.md†L19-L30】【F:docs/algorithms/relevance_ranking.md†L75-L83】【F:docs/algorithms/semantic_similarity.md†L24-L34】【F:docs/algorithms/cache.md†L24-L37】【F:docs/algorithms/token_budgeting.md†L159-L169】【F:SPEC_COVERAGE.md†L23-L64】
+  changelog coverage to lock in the XPASS promotions, closing
+  [retire-stale-xfail-markers-in-unit-suite](issues/archive/retire-stale-xfail-markers-in-unit-suite.md).【F:docs/algorithms/distributed.md†L19-L30】【F:docs/algorithms/relevance_ranking.md†L75-L83】【F:docs/algorithms/semantic_similarity.md†L24-L34】【F:docs/algorithms/cache.md†L24-L37】【F:docs/algorithms/token_budgeting.md†L159-L169】【F:SPEC_COVERAGE.md†L23-L64】
 - Finalized PDF and DOCX ingestion for 0.1.0a1 by expanding regression
   coverage across dependency failures and text normalization, updating the
   spec ledger, and aligning README plus installation guidance with the
   optional parsers extra, addressing
-  [finalize-search-parser-backends](issues/finalize-search-parser-backends.md).
+  [finalize-search-parser-backends](issues/archive/finalize-search-parser-backends.md).
   【F:tests/unit/test_search_parsers.py†L55-L172】【F:README.md†L214-L245】
   【F:docs/installation.md†L105-L170】【F:SPEC_COVERAGE.md†L65-L65】
   【F:SPEC_COVERAGE.md†L250-L268】
@@ -26,14 +28,16 @@ Reference issues by slugged filename (for example,
   the `ExternalLookupResult` bundle for `return_handles=True`,
   rehydrating vector, BM25, and ontology signals during
   `Search.external_lookup`, and promoting the vector and hybrid query
-  regressions with documentation and spec updates.
+  regressions with documentation and spec updates, closing
+  [restore-external-lookup-search-flow](issues/archive/restore-external-lookup-search-flow.md).
   【F:src/autoresearch/search/__init__.py†L1-L38】【F:src/autoresearch/search/core.py†L85-L117】
   【F:src/autoresearch/search/core.py†L1326-L1496】【F:docs/algorithms/search.md†L49-L70】
   【F:docs/algorithms/cache.md†L27-L41】【F:docs/specs/search.md†L23-L44】
   【F:tests/unit/test_search.py†L296-L340】【F:SPEC_COVERAGE.md†L64-L64】
 - Stabilized storage eviction by documenting the stale-LRU counterexample,
   adding a fallback when caches are empty, extending the property-based
-  regression, and introducing a `stale_lru` simulation scenario.
+  regression, and introducing a `stale_lru` simulation scenario, closing
+  [stabilize-storage-eviction-property](issues/archive/stabilize-storage-eviction-property.md).
 - Captured the Hypothesis metrics-dropout regression for
   `_enforce_ram_budget`, ensured deterministic caps continue when RAM metrics
   vanish mid-run, seeded the property and simulation with the regression
@@ -43,7 +47,7 @@ Reference issues by slugged filename (for example,
   counterexample, codifying the piecewise specification, refreshing the
   metrics review, adding deterministic regressions, updating spec coverage,
   and lifting the former `xfail` guard for
-  [refresh-token-budget-monotonicity-proof](issues/refresh-token-budget-monotonicity-proof.md).【F:docs/algorithms/token_budgeting.md†L93-L142】【F:docs/specs/token-budget.md†L20-L59】【F:docs/specs/metrics.md†L44-L67】【F:tests/unit/test_heuristic_properties.py†L25-L59】【F:SPEC_COVERAGE.md†L59-L59】
+  [refresh-token-budget-monotonicity-proof](issues/archive/refresh-token-budget-monotonicity-proof.md).【F:docs/algorithms/token_budgeting.md†L93-L142】【F:docs/specs/token-budget.md†L20-L59】【F:docs/specs/metrics.md†L44-L67】【F:tests/unit/test_heuristic_properties.py†L25-L59】【F:SPEC_COVERAGE.md†L59-L59】
 - Archived [resolve-deprecation-warnings-in-tests](issues/archive/resolve-deprecation-warnings-in-tests.md)
   after removing the repository-wide `pkg_resources` suppression from
   `sitecustomize.py` and capturing a clean `task verify:warnings:log` run at
@@ -94,7 +98,9 @@ Reference issues by slugged filename (for example,
 - Staged the packaging dry run with Python 3.12.10 and `uv 0.7.22`; archived the
   build log (`baseline/logs/build-20250924T033349Z.log`), the TestPyPI dry run
   log (`baseline/logs/publish-dev-20250924T033415Z.log`), and the recorded
-  wheel and sdist checksums in [docs/release_plan.md](docs/release_plan.md).
+  wheel and sdist checksums in [docs/release_plan.md](docs/release_plan.md),
+  closing
+  [stage-0-1-0a1-release-artifacts](issues/archive/stage-0-1-0a1-release-artifacts.md).
 
 [add-test-coverage]: issues/archive/add-test-coverage-for-optional-components.md
 [streamline-extras]: issues/archive/streamline-task-verify-extras.md

--- a/CODE_COMPLETE_PLAN.md
+++ b/CODE_COMPLETE_PLAN.md
@@ -10,7 +10,7 @@ As of **September 23, 2025**, Autoresearch targets an **0.1.0a1** preview on
 The September 23 verification runs keep `uv run flake8 src tests` and
 `uv run mypy src` green. `uv run pytest tests/unit -q` now passes with six
 XPASS cases tracked in
-[retire-stale-xfail-markers-in-unit-suite](issues/retire-stale-xfail-markers-in-unit-suite.md),
+[retire-stale-xfail-markers-in-unit-suite](issues/archive/retire-stale-xfail-markers-in-unit-suite.md),
 and both the integration suite (`uv run pytest tests/integration -m "not slow
 and not requires_ui and not requires_vss" -q`) and behavior suite pass.
 `task coverage EXTRAS="nlp ui vss git distributed analysis llm parsers gpu"`
@@ -22,7 +22,7 @@ Release preparation now focuses on XPASS cleanup and staging
 ### Immediate Follow-ups
 
 - [ ] Retire the six XPASS cases documented in
-  [retire-stale-xfail-markers-in-unit-suite](issues/retire-stale-xfail-markers-in-unit-suite.md)
+  [retire-stale-xfail-markers-in-unit-suite](issues/archive/retire-stale-xfail-markers-in-unit-suite.md)
   so the unit suite fails fast on regressions.
 - [ ] Complete the
   [prepare-first-alpha-release](issues/prepare-first-alpha-release.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,16 +52,16 @@ work.【F:issues/archive/resolve-resource-tracker-errors-in-verify.md†L37-L49�
 The spec template lint cleanup is archived as
 [spec lint template ticket (archived)][restore-spec-lint-template-compliance-archived].
 Fresh September 24 planning added
-[refresh-token-budget-monotonicity-proof](issues/refresh-token-budget-monotonicity-proof.md)
+[refresh-token-budget-monotonicity-proof](issues/archive/refresh-token-budget-monotonicity-proof.md)
  to document the heuristics proof gap and
-[stage-0-1-0a1-release-artifacts](issues/stage-0-1-0a1-release-artifacts.md)
+[stage-0-1-0a1-release-artifacts](issues/archive/stage-0-1-0a1-release-artifacts.md)
  to stage packaging outputs before tagging; both now sit under
 [prepare-first-alpha-release](issues/prepare-first-alpha-release.md).
 The same review opened
-[stabilize-ranking-weight-property](issues/stabilize-ranking-weight-property.md),
-[restore-external-lookup-search-flow](issues/restore-external-lookup-search-flow.md),
-[finalize-search-parser-backends](issues/finalize-search-parser-backends.md),
-and [stabilize-storage-eviction-property](issues/stabilize-storage-eviction-property.md)
+[stabilize-ranking-weight-property](issues/archive/stabilize-ranking-weight-property.md),
+[restore-external-lookup-search-flow](issues/archive/restore-external-lookup-search-flow.md),
+[finalize-search-parser-backends](issues/archive/finalize-search-parser-backends.md),
+and [stabilize-storage-eviction-property](issues/archive/stabilize-storage-eviction-property.md)
 to close the remaining XFAIL guards before tagging 0.1.0a1.
 
 ## Milestones

--- a/STATUS.md
+++ b/STATUS.md
@@ -48,12 +48,12 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 - Reviewed `baseline/logs/task-verify-20250923T204732Z.log` to confirm the
   XPASS cases for Ray execution and ranking remain green under
   warnings-as-errors, then opened
-  [refresh-token-budget-monotonicity-proof](issues/refresh-token-budget-monotonicity-proof.md)
+  [refresh-token-budget-monotonicity-proof](issues/archive/refresh-token-budget-monotonicity-proof.md)
   so the heuristics proof matches behaviour and updated
-  [retire-stale-xfail-markers-in-unit-suite](issues/retire-stale-xfail-markers-in-unit-suite.md)
+  [retire-stale-xfail-markers-in-unit-suite](issues/archive/retire-stale-xfail-markers-in-unit-suite.md)
   to depend on it.
 - Documented release staging gaps with
-  [stage-0-1-0a1-release-artifacts](issues/stage-0-1-0a1-release-artifacts.md)
+  [stage-0-1-0a1-release-artifacts](issues/archive/stage-0-1-0a1-release-artifacts.md)
   and refreshed
   [prepare-first-alpha-release](issues/prepare-first-alpha-release.md) to
   align on packaging dry runs, changelog work, and dispatch-only workflows.
@@ -62,15 +62,15 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   five XPASS promotions, and eight remaining XFAIL guards across ranking,
   search, parser, and storage modules. Logged the Ray, ranking, semantic
   similarity, cache, and token budget XPASS entries to unblock
-  [retire-stale-xfail-markers-in-unit-suite](issues/retire-stale-xfail-markers-in-unit-suite.md)
+  [retire-stale-xfail-markers-in-unit-suite](issues/archive/retire-stale-xfail-markers-in-unit-suite.md)
   and opened follow-up tickets for the persistent XFAILs.
   【bc4521†L101-L114】
 - Added
-  [stabilize-ranking-weight-property](issues/stabilize-ranking-weight-property.md),
-  [restore-external-lookup-search-flow](issues/restore-external-lookup-search-flow.md),
-  [finalize-search-parser-backends](issues/finalize-search-parser-backends.md),
+  [stabilize-ranking-weight-property](issues/archive/stabilize-ranking-weight-property.md),
+  [restore-external-lookup-search-flow](issues/archive/restore-external-lookup-search-flow.md),
+  [finalize-search-parser-backends](issues/archive/finalize-search-parser-backends.md),
   and
-  [stabilize-storage-eviction-property](issues/stabilize-storage-eviction-property.md)
+  [stabilize-storage-eviction-property](issues/archive/stabilize-storage-eviction-property.md)
   to cover the ranking, search, parser, and storage guards surfaced by the
   unit run so they land before the 0.1.0a1 tag.
 
@@ -81,7 +81,7 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   --extra dev-minimal --extra test mypy src`), unit (`uv run --extra test
   pytest tests/unit -m 'not slow' --maxfail=1 -rxX`), integration, and behavior
   suites all pass; the unit run reports six XPASS cases now tracked in
-  [issues/retire-stale-xfail-markers-in-unit-suite.md].【2d7183†L1-L3】【dab3a6†L1-L1】
+  [issues/archive/retire-stale-xfail-markers-in-unit-suite.md].【2d7183†L1-L3】【dab3a6†L1-L1】
   【240ff7†L1-L1】【3fa75b†L1-L1】【8434e0†L1-L2】【8e97b0†L1-L1】【ba4d58†L1-L104】
   【ab24ed†L1-L1】【187f22†L1-L9】【87aa99†L1-L1】【88b85b†L1-L2】
 - Reran `task coverage EXTRAS="nlp ui vss git distributed analysis llm parsers
@@ -827,6 +827,6 @@ regression is resolved.
   Coordinate release notes, warnings-as-errors coverage with optional extras,
   and final smoke tests before tagging v0.1.0a1.
 - [retire-stale-xfail-markers-in-unit-suite](
-  issues/retire-stale-xfail-markers-in-unit-suite.md) – Promote the six XPASS
-  unit tests back to ordinary assertions so release verification can fail fast
-  on regressions.
+  issues/archive/retire-stale-xfail-markers-in-unit-suite.md) – Archived after
+  promoting the six XPASS unit tests back to ordinary assertions so release
+  verification can fail fast on regressions.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -15,19 +15,20 @@ the refreshed run, allowing
 【F:issues/archive/rerun-task-coverage-after-storage-fix.md†L1-L36】 Direct
 `uv run` commands now verify the day-to-day lint, type, and smoke suites without
 requiring the Task CLI on `PATH`; the unit run reports five XPASS cases tracked
-in [issues/retire-stale-xfail-markers-in-unit-suite.md] and eight remaining
-XFAIL guards now covered by
-[issues/stabilize-ranking-weight-property.md],
-[issues/restore-external-lookup-search-flow.md],
-[issues/finalize-search-parser-backends.md], and
-[issues/stabilize-storage-eviction-property.md]. Integration and behavior suites
+in [issues/archive/retire-stale-xfail-markers-in-unit-suite.md] and eight
+remaining XFAIL guards now covered by
+[issues/archive/stabilize-ranking-weight-property.md],
+[issues/archive/restore-external-lookup-search-flow.md],
+[issues/archive/finalize-search-parser-backends.md], and
+[issues/archive/stabilize-storage-eviction-property.md]. Integration and
+behavior suites
 pass with optional extras skipped, and `uv run --extra docs mkdocs build`
 completes without warnings after prior documentation fixes. September 24
 planning added
-[refresh-token-budget-monotonicity-proof](issues/refresh-token-budget-monotonicity-proof.md)
- and
-[stage-0-1-0a1-release-artifacts](issues/stage-0-1-0a1-release-artifacts.md)
- as dependencies of
+[refresh-token-budget-monotonicity-proof](issues/archive/refresh-token-budget-monotonicity-proof.md)
+and
+[stage-0-1-0a1-release-artifacts](issues/archive/stage-0-1-0a1-release-artifacts.md)
+as dependencies of
 [prepare-first-alpha-release](issues/prepare-first-alpha-release.md) so the
 XPASS promotions, heuristics proof, and packaging dry runs land before tagging.
 【2d7183†L1-L3】【dab3a6†L1-L1】【240ff7†L1-L1】【3fa75b†L1-L1】【8434e0†L1-L2】

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -29,8 +29,8 @@ tests/unit -m 'not slow' -rxX` returns 890 passes, 33 skips, eight XFAIL guards,
 and five XPASS promotions that align with the open ranking, search, metrics, and
 storage tickets. `uv run --extra docs mkdocs build` completes without warnings
 after the GPU wheel documentation move, and
-[issues/refresh-token-budget-monotonicity-proof.md] plus
-[issues/stage-0-1-0a1-release-artifacts.md] capture the proof refresh and
+[issues/archive/refresh-token-budget-monotonicity-proof.md] plus
+[issues/archive/stage-0-1-0a1-release-artifacts.md] capture the proof refresh and
 release staging before tagging. Integration and behavior suites succeed with
 optional extras skipped, and spec lint remains recovered—`docs/specs/monitor.md`
 and `docs/specs/extensions.md` retain the required `## Simulation Expectations`
@@ -106,14 +106,14 @@ These tasks completed in order: environment bootstrap → packaging verification
   ```
   - Log: `baseline/logs/publish-dev-20250924T033415Z.log`.
     【F:baseline/logs/publish-dev-20250924T033415Z.log†L1-L14】
-- Close [issues/retire-stale-xfail-markers-in-unit-suite.md],
-  [issues/refresh-token-budget-monotonicity-proof.md], and
-  [issues/stage-0-1-0a1-release-artifacts.md] before tagging so XPASS
+- Close [issues/archive/retire-stale-xfail-markers-in-unit-suite.md],
+  [issues/archive/refresh-token-budget-monotonicity-proof.md], and
+  [issues/archive/stage-0-1-0a1-release-artifacts.md] before tagging so XPASS
   promotions, heuristic proofs, and packaging logs land together.
-- Close [issues/stabilize-ranking-weight-property.md],
-  [issues/restore-external-lookup-search-flow.md],
-  [issues/finalize-search-parser-backends.md], and
-  [issues/stabilize-storage-eviction-property.md] so the remaining XFAIL
+- Close [issues/archive/stabilize-ranking-weight-property.md],
+  [issues/archive/restore-external-lookup-search-flow.md],
+  [issues/archive/finalize-search-parser-backends.md], and
+  [issues/archive/stabilize-storage-eviction-property.md] so the remaining XFAIL
   guards are resolved before tagging.
 - Record future `uv run python -m build` and TestPyPI dry-run logs in
   `baseline/logs/` when the stage issue requests refreshed artifacts.

--- a/issues/archive/finalize-search-parser-backends.md
+++ b/issues/archive/finalize-search-parser-backends.md
@@ -35,5 +35,16 @@ existing heuristics suffice without real parsers.
 - Update `SPEC_COVERAGE.md` to reference the finalized parser coverage
   and record the change in `CHANGELOG.md` under Unreleased.
 
+## Resolution
+- Cross-checked the Unreleased changelog entry that links to this ticket
+  and records the parser backend stabilization alongside refreshed tests,
+  docs, and installation guidance.
+- Verified `tests/unit/test_search_parsers.py` now asserts deterministic
+  PDF, DOCX, and local file behavior without `xfail` guards and that
+  `README.md`, `docs/installation.md`, and `SPEC_COVERAGE.md` describe the
+  finalized coverage.
+- Parser integrations and documentation now align with the 0.1.0a1 scope,
+  so the issue can be archived.
+
 ## Status
-Open
+Archived

--- a/issues/archive/refresh-token-budget-monotonicity-proof.md
+++ b/issues/archive/refresh-token-budget-monotonicity-proof.md
@@ -44,5 +44,16 @@ workloads.
 - Remove the `xfail` marker once the proof, simulation, and tests agree.
 - Capture the result in `CHANGELOG.md` under the Unreleased section.
 
+## Resolution
+- Confirmed the Unreleased changelog records the refreshed token budget
+  dialectic and links to this ticket along with the updated docs, specs,
+  and deterministic regression coverage.
+- Verified `tests/unit/test_heuristic_properties.py` asserts the
+  monotonicity guarantee without an `xfail` guard and that
+  `SPEC_COVERAGE.md` maps the proof back to
+  `autoresearch/orchestration/metrics.py`.
+- Dependency tickets have been archived, so the proof update is now
+  complete.
+
 ## Status
-Open
+Archived

--- a/issues/archive/restore-external-lookup-search-flow.md
+++ b/issues/archive/restore-external-lookup-search-flow.md
@@ -37,5 +37,16 @@ work so that the alpha release matches the advertised behavior.
 - Map the refreshed behavior in `SPEC_COVERAGE.md` and record the change
   in `CHANGELOG.md` under the Unreleased section.
 
+## Resolution
+- Verified the Unreleased changelog entry that documents the restored
+  storage-backed hybrid lookup flow, including references to the search
+  exports, hydrated caches, refreshed docs, and unit coverage closing
+  this ticket.
+- Confirmed `tests/unit/test_search.py` executes the vector and hybrid
+  lookup paths without `xfail` markers and that the documentation and
+  spec ledger now describe the hydrated flow.
+- With external lookup functionality stabilized, no further action is
+  required before archiving.
+
 ## Status
-Open
+Archived

--- a/issues/archive/retire-stale-xfail-markers-in-unit-suite.md
+++ b/issues/archive/retire-stale-xfail-markers-in-unit-suite.md
@@ -63,5 +63,18 @@ coherence, and token budgeting—should therefore drive the promotions.
   until the dependency issue lands, then convert it to a standard
   assertion and cite the refreshed proof.
 
+## Resolution
+- Cross-checked the Unreleased changelog entry documenting the retirement
+  of search, distributed, and budgeting XFAIL markers. The references
+  cover the Ray executor, ranking, semantic similarity, cache, and token
+  budget updates that satisfy the acceptance criteria.
+- Verified the suite no longer carries `xfail` markers for
+  `tests/unit/test_distributed_executors.py`,
+  `tests/unit/test_ranking_idempotence.py`,
+  `tests/unit/test_relevance_ranking.py`, and
+  `tests/unit/test_heuristic_properties.py`.
+- With the dependent ranking, search, storage, and token budget tickets
+  archived, no further follow-up remains.
+
 ## Status
-Open
+Archived

--- a/issues/archive/stabilize-ranking-weight-property.md
+++ b/issues/archive/stabilize-ranking-weight-property.md
@@ -38,5 +38,16 @@ alpha release work moves forward.
   the refreshed proof or simulation artifacts.
 - Note the stabilization in `CHANGELOG.md` under the Unreleased section.
 
+## Resolution
+- Reviewed the Unreleased changelog entries covering score quantization,
+  deterministic tie-breaking, and overweight vector validation, which
+  document the fixes closing this ticket.
+- Confirmed `tests/unit/test_property_search_ranking.py` now exercises
+  deterministic fixtures without an `xfail` marker and that
+  `docs/algorithms/relevance_ranking.md` and `SPEC_COVERAGE.md` reflect
+  the updated proof.
+- No outstanding ranking regressions remain after dependent issues were
+  archived alongside this change.
+
 ## Status
-Open
+Archived

--- a/issues/archive/stabilize-storage-eviction-property.md
+++ b/issues/archive/stabilize-storage-eviction-property.md
@@ -35,5 +35,16 @@ will surface the missing invariants before the release staging proceeds.
 - Add a regression scenario to `scripts/storage_eviction_sim.py` or a new
   simulation helper demonstrating the fixed invariant.
 
+## Resolution
+- Reviewed the Unreleased changelog entry for the RAM budget regression,
+  which captures the deterministic fallback, refreshed docs, simulation
+  coverage, and spec updates closing this ticket.
+- Confirmed `_enforce_ram_budget` and the associated property and
+  simulation tests now run without `xfail` markers, with supporting
+  documentation in `docs/algorithms/storage_eviction.md` and
+  `docs/specs/storage.md`.
+- Storage eviction stability is now tracked in regression coverage, so
+  the release no longer depends on this work.
+
 ## Status
-Open
+Archived

--- a/issues/archive/stage-0-1-0a1-release-artifacts.md
+++ b/issues/archive/stage-0-1-0a1-release-artifacts.md
@@ -37,5 +37,15 @@ baselines truly guarantee installability without this staging sweep.
 - Attach the packaging log paths and resulting artifact hashes to the
   issue comment thread when closing.
 
+## Resolution
+- Verified the `[0.1.0a1] - Unreleased` changelog entry documenting the
+  staged `uv build` and TestPyPI dry run, including the archived logs and
+  release plan updates that satisfy this ticket.
+- Confirmed `docs/release_plan.md` now records the commands, artifact
+  checksums, and navigation updates, and `STATUS.md` notes the
+  environment adjustments for reproducible packaging.
+- With packaging evidence captured under `baseline/logs/`, staging is
+  complete for the alpha release.
+
 ## Status
-Open
+Archived

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -35,37 +35,37 @@ wrappers or the PATH helper until we package a Task binary alongside the
 alpha tag. 【6c5abf†L1-L1】【16543c†L1-L1】【84bbfd†L1-L4】【5b4d9e†L1-L1】
 【311dfe†L1-L2】
 
-### PR-sized tasks
+### Completed PR-sized tasks
 - [retire-stale-xfail-markers-in-unit-suite.md]
-  (retire-stale-xfail-markers-in-unit-suite.md)
+  (archive/retire-stale-xfail-markers-in-unit-suite.md)
 - [refresh-token-budget-monotonicity-proof.md]
-  (refresh-token-budget-monotonicity-proof.md)
+  (archive/refresh-token-budget-monotonicity-proof.md)
 - [stabilize-ranking-weight-property.md]
-  (stabilize-ranking-weight-property.md)
+  (archive/stabilize-ranking-weight-property.md)
 - [restore-external-lookup-search-flow.md]
-  (restore-external-lookup-search-flow.md)
+  (archive/restore-external-lookup-search-flow.md)
 - [finalize-search-parser-backends.md]
-  (finalize-search-parser-backends.md)
+  (archive/finalize-search-parser-backends.md)
 - [stabilize-storage-eviction-property.md]
-  (stabilize-storage-eviction-property.md)
+  (archive/stabilize-storage-eviction-property.md)
 - [stage-0-1-0a1-release-artifacts.md]
-  (stage-0-1-0a1-release-artifacts.md)
+  (archive/stage-0-1-0a1-release-artifacts.md)
 
 ## Dependencies
 - [retire-stale-xfail-markers-in-unit-suite.md]
-  (retire-stale-xfail-markers-in-unit-suite.md)
+  (archive/retire-stale-xfail-markers-in-unit-suite.md)
 - [refresh-token-budget-monotonicity-proof.md]
-  (refresh-token-budget-monotonicity-proof.md)
+  (archive/refresh-token-budget-monotonicity-proof.md)
 - [stabilize-ranking-weight-property.md]
-  (stabilize-ranking-weight-property.md)
+  (archive/stabilize-ranking-weight-property.md)
 - [restore-external-lookup-search-flow.md]
-  (restore-external-lookup-search-flow.md)
+  (archive/restore-external-lookup-search-flow.md)
 - [finalize-search-parser-backends.md]
-  (finalize-search-parser-backends.md)
+  (archive/finalize-search-parser-backends.md)
 - [stabilize-storage-eviction-property.md]
-  (stabilize-storage-eviction-property.md)
+  (archive/stabilize-storage-eviction-property.md)
 - [stage-0-1-0a1-release-artifacts.md]
-  (stage-0-1-0a1-release-artifacts.md)
+  (archive/stage-0-1-0a1-release-artifacts.md)
 
 ## Acceptance Criteria
 - All dependency issues listed above are closed.
@@ -79,6 +79,13 @@ alpha tag. 【6c5abf†L1-L1】【16543c†L1-L1】【84bbfd†L1-L4】【5b4d9e
 - Workflows under `.github/workflows` remain dispatch-only.
 - The `v0.1.0a1` tag is created only after the above steps and a fresh
   `task verify` pass succeed.
+
+## Resolution
+All dependency tickets have now been archived alongside the Unreleased
+changelog updates that document their fixes. Capture a final
+`task verify` run (including warnings-as-errors) after the upcoming
+verification sweep, then archive this umbrella issue with the resulting
+log references.
 
 ## Status
 Open


### PR DESCRIPTION
## Summary
- archive the resolved release-blocker issues with resolution notes and move them under `issues/archive/`
- update CHANGELOG and reference docs to point to the archived tickets and capture the completed work
- refresh the umbrella alpha release ticket to reflect the closed dependencies and pending final verification

## Testing
- not run (documentation and issue updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d423ea5e148333b71fb88a7961d787