### PR TITLE
Add release metadata consistency check

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,6 +55,10 @@ tasks:
     cmds:
       - uv run python scripts/lint_specs.py
     desc: "Audit spec files for required sections"
+  check-release-metadata:
+    cmds:
+      - uv run python scripts/check_release_metadata.py
+    desc: "Validate release version and date alignment"
   check:
     vars:
       EXTRAS: "{{.EXTRAS | default \"\"}}"
@@ -72,6 +76,7 @@ tasks:
       - uv run flake8 src
       - uv run mypy src --exclude src/autoresearch/distributed
       - task lint-specs
+      - task check-release-metadata
       - uv run python scripts/check_spec_tests.py
       - uv run pytest -c /dev/null tests/unit/test_version.py tests/unit/test_cli_help.py -q
     desc: "Run lint, type check, and selected fast tests"
@@ -334,6 +339,7 @@ tasks:
       - uv run flake8 src tests
       - uv run mypy src --exclude src/autoresearch/a2a_interface.py
       - task lint-specs
+      - task check-release-metadata
       - uv run python scripts/check_spec_tests.py
       - task: coverage
         vars:
@@ -394,6 +400,8 @@ tasks:
       - uv run mypy src
       - echo "[release:alpha] linting specs"
       - uv run python scripts/lint_specs.py
+      - echo "[release:alpha] checking release metadata"
+      - uv run python scripts/check_release_metadata.py
       - echo "[release:alpha] running task verify"
       - uv run task verify EXTRAS="{{.OPTIONAL_EXTRAS}}"
       - echo "[release:alpha] running task coverage"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,8 +7,12 @@ Follow these steps to publish a new version of Autoresearch.
   (excluding `gpu`), then runs lint, type checks, spec lint, `task verify`,
   `task coverage`, `python -m build`, `twine check`, and the TestPyPI dry run.
   Provide `EXTRAS="gpu"` to include GPU wheels when available.
-- Update the version in `pyproject.toml` and
-  `src/autoresearch/__init__.py`. Commit the change and tag the release.
+- Update the version and release date in `pyproject.toml`
+  (`project.version`, `tool.autoresearch.release_date`),
+  `src/autoresearch/__init__.py` (`__version__`, `__release_date__`), and the
+  top entry in `CHANGELOG.md`. Run `task check-release-metadata` to confirm the
+  guard passes; it also runs as part of `task check`, `task verify`, and
+  `task release:alpha`. Commit the change and tag the release.
 - Validate the package builds if you need to re-run individual steps.
 
   ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3",
 ]
 
+[tool.autoresearch]
+release_date = "Unreleased" # keep in sync with autoresearch.__release_date__
+
 [tool.setuptools]
 include-package-data = true
 

--- a/scripts/check_release_metadata.py
+++ b/scripts/check_release_metadata.py
@@ -1,0 +1,185 @@
+"""Validate release metadata consistency across project files.
+
+Usage:
+    uv run python scripts/check_release_metadata.py
+
+The check verifies that the version and release date recorded in
+``pyproject.toml``, ``src/autoresearch/__init__.py``, and the top release entry
+in ``CHANGELOG.md`` are aligned. Intended to run via ``task`` targets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import tomllib
+
+
+RELEASE_HEADER_PATTERN = re.compile(r"^## \[(?P<version>[^\]]+)\] - (?P<date>.+)$")
+
+
+class ReleaseMetadataError(RuntimeError):
+    """Raised when release metadata is inconsistent."""
+
+
+@dataclass(frozen=True)
+class ReleaseMetadata:
+    """Normalized release metadata extracted from project files."""
+
+    version: str
+    release_date: str
+
+
+def parse_args() -> argparse.Namespace:
+    """Return CLI arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Path to the repository root (defaults to project root)",
+    )
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=None,
+        help="Path to the changelog file (defaults to CHANGELOG.md)",
+    )
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=None,
+        help="Path to the pyproject file (defaults to pyproject.toml)",
+    )
+    parser.add_argument(
+        "--package-init",
+        type=Path,
+        default=None,
+        help="Path to autoresearch/__init__.py",
+    )
+    return parser.parse_args()
+
+
+def load_pyproject(path: Path) -> ReleaseMetadata:
+    """Load version and release date from ``pyproject.toml``."""
+
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    project = data.get("project")
+    if not project or "version" not in project:
+        raise ReleaseMetadataError("`project.version` missing from pyproject.toml")
+    version = project["version"]
+
+    tool_section = data.get("tool", {})
+    autoresearch_section = tool_section.get("autoresearch", {})
+    release_date = autoresearch_section.get("release_date")
+    if release_date is None:
+        raise ReleaseMetadataError(
+            "`tool.autoresearch.release_date` missing from pyproject.toml",
+        )
+    return ReleaseMetadata(version=version, release_date=release_date)
+
+
+def load_init_metadata(path: Path) -> ReleaseMetadata:
+    """Extract fallback metadata literals from ``autoresearch.__init__``."""
+
+    source = path.read_text(encoding="utf-8")
+    version_literals = list(_iter_literal_assignments(source, "__version__"))
+    if not version_literals:
+        raise ReleaseMetadataError("`__version__` literal not found in __init__.py")
+
+    release_literals = list(_iter_literal_assignments(source, "__release_date__"))
+    if not release_literals:
+        raise ReleaseMetadataError(
+            "`__release_date__` literal not found in __init__.py",
+        )
+
+    return ReleaseMetadata(version=version_literals[-1], release_date=release_literals[-1])
+
+
+def _iter_literal_assignments(source: str, symbol: str) -> Iterable[str]:
+    """Yield string literals assigned to ``symbol`` within ``source``."""
+
+    pattern = re.compile(
+        rf"{re.escape(symbol)}\s*=\s*([\"\'])(?P<value>[^\"\']+)\1",
+        re.MULTILINE,
+    )
+    for match in pattern.finditer(source):
+        yield match.group("value")
+
+
+def load_changelog_metadata(path: Path) -> ReleaseMetadata:
+    """Read the first release entry from ``CHANGELOG.md``."""
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = RELEASE_HEADER_PATTERN.match(line.strip())
+        if not match:
+            continue
+        version = match.group("version").strip()
+        if version.lower() == "unreleased":
+            # Skip the placeholder entry at the top of the changelog.
+            continue
+        release_date = match.group("date").strip()
+        if not release_date:
+            raise ReleaseMetadataError("Changelog entry missing release date")
+        return ReleaseMetadata(version=version, release_date=release_date)
+    raise ReleaseMetadataError("No release entries found in CHANGELOG.md")
+
+
+def validate_alignment(*entries: ReleaseMetadata) -> None:
+    """Ensure all provided metadata entries agree on version and date."""
+
+    versions = {entry.version for entry in entries}
+    if len(versions) != 1:
+        raise ReleaseMetadataError(
+            f"Mismatched versions detected: {', '.join(sorted(versions))}",
+        )
+
+    release_dates = {entry.release_date for entry in entries}
+    if len(release_dates) != 1:
+        raise ReleaseMetadataError(
+            "Mismatched release dates detected: "
+            f"{', '.join(sorted(release_dates))}",
+        )
+
+    release_date = next(iter(release_dates))
+    if release_date != "Unreleased" and not re.fullmatch(r"\d{4}-\d{2}-\d{2}", release_date):
+        raise ReleaseMetadataError(
+            "Release date must be 'Unreleased' or follow YYYY-MM-DD format",
+        )
+
+
+def main() -> int:
+    """Entry point for the CLI."""
+
+    args = parse_args()
+    repo_root = args.repo_root
+    changelog_path = args.changelog or repo_root / "CHANGELOG.md"
+    pyproject_path = args.pyproject or repo_root / "pyproject.toml"
+    init_path = args.package_init or repo_root / "src" / "autoresearch" / "__init__.py"
+
+    try:
+        pyproject = load_pyproject(pyproject_path)
+        package_metadata = load_init_metadata(init_path)
+        changelog = load_changelog_metadata(changelog_path)
+        validate_alignment(pyproject, package_metadata, changelog)
+    except (FileNotFoundError, ReleaseMetadataError) as exc:
+        print(f"Release metadata check failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        "Release metadata aligned: version={version}, date={date}".format(
+            version=pyproject.version,
+            date=pyproject.release_date,
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/src/autoresearch/__init__.py
+++ b/src/autoresearch/__init__.py
@@ -25,6 +25,9 @@ try:
 except PackageNotFoundError:  # pragma: no cover - fallback for tests
     __version__ = "0.1.0a1"
 
+# Keep release metadata aligned with pyproject.toml and CHANGELOG.md.
+__release_date__ = "Unreleased"
+
 if TYPE_CHECKING:  # pragma: no cover - import for type checkers only
     from .distributed import (
         InMemoryBroker,
@@ -40,6 +43,7 @@ if TYPE_CHECKING:  # pragma: no cover - import for type checkers only
 
 __all__ = [
     "__version__",
+    "__release_date__",
     "RayExecutor",
     "ProcessExecutor",
     "StorageCoordinator",

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -11,5 +11,12 @@ def test_init_version_matches_pyproject():
     assert autoresearch.__version__ == data["project"]["version"]
 
 
+def test_release_date_matches_pyproject():
+    pyproject = Path(__file__).parents[2] / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text())
+    release_date = data["tool"]["autoresearch"]["release_date"]
+    assert autoresearch.__release_date__ == release_date
+
+
 def test_init_version_matches_metadata():
     assert autoresearch.__version__ == importlib.metadata.version("autoresearch")


### PR DESCRIPTION
## Summary
- add a release metadata validator that compares pyproject, package, and changelog entries
- surface the check through Taskfile targets and extend the release workflow documentation
- record release date metadata in pyproject/__init__ and exercise it in tests

## Testing
- uv run python scripts/check_release_metadata.py
- uv run pytest tests/unit/test_version.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d44522ea308333a68a67e1ad33f354