### PR TITLE
docs: clarify Task CLI setup before release runs

### DIFF
--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -75,6 +75,12 @@ default optional extras (excluding `gpu`). It then runs lint, type checks, spec
 lint, the verify and coverage tasks, packaging builds, metadata checks, and the
 TestPyPI dry run. Pass `EXTRAS="gpu"` when GPU wheels are staged.
 
+- [ ] Source the Task PATH helper or invoke release commands through
+  `uv run task …` as described in
+  [releasing.md](releasing.md#preparing-the-environment) so the CLI is
+  available in fresh shells. Reference the [STATUS.md][status-cli] log when
+  that guidance changes.
+
 - [x] `uv run --extra dev-minimal --extra test flake8 src tests` ran as part of
   the sweep before coverage began and the log advanced to the mypy step without
   surfacing lint errors.
@@ -162,4 +168,7 @@ installs only `dev-minimal` and `test` extras by default; add groups with
   in sync and stay above **90%**
 - [ ] `scripts/update_coverage_docs.py` syncs docs with
   `baseline/coverage.xml`
+
+[status-cli]:
+  https://github.com/autoresearch/autoresearch/blob/main/STATUS.md#status
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,6 +2,19 @@
 
 Follow these steps to publish a new version of Autoresearch.
 
+## Preparing the environment
+
+`task` commands require the Go Task CLI. Fresh shells may not expose the
+binary on `PATH`; see [STATUS.md][status-cli] for the current availability
+notes. Before running any release workflow, pick one of the supported helpers:
+
+- **Source the PATH helper.** Run `./scripts/setup.sh` once, then start new
+  shells with `eval "$(./scripts/setup.sh --print-path)"` to load the Task
+  binary and synced extras.
+- **Use `uv run task …` wrappers.** The `uv` launcher injects the packaged
+  Task CLI, so commands like `uv run task release:alpha` work even when the
+  helper is not sourced.
+
 - Run `uv run task release:alpha` to automate the alpha readiness sweep before
   tagging. It installs the dev-minimal, test, and default optional extras
   (excluding `gpu`), then runs lint, type checks, spec lint, `task verify`,
@@ -28,6 +41,9 @@ Follow these steps to publish a new version of Autoresearch.
   ```bash
   uv run scripts/publish_dev.py
   ```
+
+[status-cli]:
+  https://github.com/autoresearch/autoresearch/blob/main/STATUS.md#status
 
 ## TestPyPI authentication
 


### PR DESCRIPTION
## Summary
- add a “Preparing the environment” section to the release guide that links to STATUS.md and covers the PATH helper and `uv run task …` workflow options
- extend the release plan prerequisites with a reminder to load the Task CLI via the helper or `uv` wrappers and reference the same STATUS.md note

## Testing
- uv run --extra docs mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d44765a4508333bfb5f81cb28ec5b7