### PR TITLE
Document manual verification status for 0.1.0a1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,19 @@ Reference issues by slugged filename (for example,
   [docs/release_plan.md](docs/release_plan.md), closing
   [stage-0-1-0a1-release-artifacts](issues/archive/stage-0-1-0a1-release-artifacts.md).【F:baseline/logs/build-20250924T033349Z.log†L1-L13】【F:baseline/logs/publish-dev-20250924T033415Z.log†L1-L13】【F:STATUS.md†L33-L38】【F:issues/archive/stage-0-1-0a1-release-artifacts.md†L1-L40】
 
+### Verification Evidence
+- Replayed `uv run task verify` on 2025-09-25; both the legacy and VSS-enabled
+  parametrisations of `test_search_stub_backend` plus the new
+  `return_handles` fallback passed before the sweep stopped on the deterministic
+  LRU eviction regression. The log captures the vector search extension loading
+  at 00:10:00Z alongside the eviction trace, confirming the stub behaviour while
+  documenting the remaining storage fix.【F:baseline/logs/task-verify-20250925T000904Z.log†L320-L323】【F:baseline/logs/task-verify-20250925T000904Z.log†L430-L476】
+- Followed with `uv run task coverage` in the same window; Ray still cannot
+  serialise `QueryState`, so `test_execute_agent_remote` aborts while the other
+  stub scenarios continue to pass under coverage. The log records the
+  cloudpickle failure for `_thread.RLock`, keeping the distributed regression on
+  the blocker list for the alpha tag.【F:baseline/logs/task-coverage-20250925T001017Z.log†L460-L515】
+
 [add-test-coverage]: issues/archive/add-test-coverage-for-optional-components.md
 [streamline-extras]: issues/archive/streamline-task-verify-extras.md
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -42,11 +42,14 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   guidance; the run now stops at
   `tests/unit/test_eviction.py::test_lru_eviction_sequence` because the LRU
   policy evicts both `c1` and `c2` once the VSS extras hydrate vector search.
-  Archived the failure at `baseline/logs/task-verify-20250925T000904Z.log` and
-  opened
+  The log also records the `test_search_stub_backend[legacy]`,
+  `[vss-enabled]`, and `return_handles` fallback parametrisations passing before
+  the eviction failure, confirming the stub fix while we document the storage
+  regression. Archived the failure at `baseline/logs/task-verify-20250925T000904Z.log`
+  and opened
   [investigate-lru-eviction-regression](issues/investigate-lru-eviction-regression.md)
   to restore the expected ordering before repeating the sweep.
-  【F:baseline/logs/task-verify-20250925T000904Z.log†L416-L489】【F:issues/investigate-lru-eviction-regression.md†L1-L24】
+  【F:baseline/logs/task-verify-20250925T000904Z.log†L320-L476】【F:issues/investigate-lru-eviction-regression.md†L1-L24】
 - Reran `uv run task coverage` with the full extras list; Ray now fails to
   serialize `QueryState`, causing
   `tests/unit/test_distributed_executors.py::test_execute_agent_remote` to abort
@@ -60,6 +63,10 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   `baseline/logs/python-build-20250925T001554Z.log` confirm the docs and
   packaging gates are clear pending the verify and coverage fixes.
   【F:baseline/logs/mkdocs-build-20250925T001535Z.log†L1-L15】【F:baseline/logs/python-build-20250925T001554Z.log†L1-L14】
+- Reaffirmed that GitHub workflows remain dispatch-only, so these verifications
+  continue to run manually via the documented `uv run` wrappers until we reissue
+  the alpha automation through Actions.
+  【F:.github/workflows/ci.yml†L1-L8】
 
 ## September 24, 2025
 - Reconfirmed the base environment: `python --version` reports 3.12.10,

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -6,22 +6,28 @@ organized by phases from the code complete plan. As of **2025-09-25** at
 `uv run --extra docs mkdocs build`, and `uv run --extra build python -m build`
 through the `uv` wrappers in fresh shells. `task verify` now halts in
 `tests/unit/test_eviction.py::test_lru_eviction_sequence` because the LRU
-policy removes both `c1` and `c2`; the regression log lives at
-`baseline/logs/task-verify-20250925T000904Z.log` and is tracked in
+policy removes both `c1` and `c2`, but the log shows
+`test_search_stub_backend[legacy]`, `[vss-enabled]`, and the
+`return_handles` fallback succeeding before the eviction failure, confirming the
+stub fix while we track the regression in
+`baseline/logs/task-verify-20250925T000904Z.log` and
 [investigate-lru-eviction-regression](issues/investigate-lru-eviction-regression.md).
-`task coverage` fails earlier when Ray cannot serialize `QueryState`, so the
-run ends at
-`tests/unit/test_distributed_executors.py::test_execute_agent_remote` with
-details recorded in `baseline/logs/task-coverage-20250925T001017Z.log` and the
-follow-up ticket
+`task coverage` fails earlier when Ray cannot serialize `QueryState`, so the run
+ends at `tests/unit/test_distributed_executors.py::test_execute_agent_remote`
+with details recorded in `baseline/logs/task-coverage-20250925T001017Z.log` and
+the follow-up ticket
 [address-ray-serialization-regression](issues/address-ray-serialization-regression.md).
 MkDocs and packaging both completed; their logs are archived at
 `baseline/logs/mkdocs-build-20250925T001535Z.log` and
-`baseline/logs/python-build-20250925T001554Z.log` while we work through the
-open verify and coverage failures.
-【F:baseline/logs/task-verify-20250925T000904Z.log†L416-L489】【F:issues/investigate-lru-eviction-regression.md†L1-L24】
+`baseline/logs/python-build-20250925T001554Z.log` while we work through the open
+verify and coverage failures.
+【F:baseline/logs/task-verify-20250925T000904Z.log†L320-L489】【F:issues/investigate-lru-eviction-regression.md†L1-L24】
 【F:baseline/logs/task-coverage-20250925T001017Z.log†L484-L669】【F:issues/address-ray-serialization-regression.md†L1-L20】
 【F:baseline/logs/mkdocs-build-20250925T001535Z.log†L1-L15】【F:baseline/logs/python-build-20250925T001554Z.log†L1-L14】
+All GitHub workflows remain dispatch-only, so the verification reruns continue
+to execute manually through these `uv run` wrappers until the alpha gate is
+cleared and the Actions jobs are retriggered.
+【F:.github/workflows/ci.yml†L1-L8】
 As of **2025-09-24** at
 23:30 UTC we repeated the stub backend sanity check and the full
 `release:alpha` sweep. The targeted invocation

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -37,6 +37,22 @@ stages pending.【F:baseline/logs/release-alpha-20250924T233058Z.log†L488-L585
 `baseline/logs/release-alpha-20250924T233058Z.summary.md` tracks the open work
 to relax the stub assertion for VSS-aware runs before rerunning the automation.
 【F:baseline/logs/release-alpha-20250924T233058Z.summary.md†L1-L12】
+
+Follow-up `uv run task verify` and `uv run task coverage` runs on
+**September 25, 2025 at 00:09 Z** demonstrate the updated stub behaviour: the
+legacy, VSS-enabled, and `return_handles` fallback parametrisations pass before
+the verify sweep halts on the deterministic LRU eviction regression, and the
+coverage sweep stops on Ray serialising `_thread.RLock` in `QueryState`.
+【F:baseline/logs/task-verify-20250925T000904Z.log†L320-L323】【F:baseline/logs/task-verify-20250925T000904Z.log†L430-L476】【F:baseline/logs/task-coverage-20250925T001017Z.log†L460-L515】
+*Q:* Does the stub backend respect vector search handles now?
+*A:* Yes—the verify log captures the VSS extension loading at 00:10:00Z and the
+passing parametrisations immediately before the eviction failure, providing a
+reproducible trace for the manual reruns.
+【F:baseline/logs/task-verify-20250925T000904Z.log†L320-L476】
+
+All GitHub workflows remain dispatch-only, so these verifications were invoked
+manually via the documented `uv run` wrappers to mirror a
+`workflow_dispatch` execution.【F:.github/workflows/ci.yml†L1-L8】
 ## Milestones
 
 - **0.1.0a1** (2026-09-15, status: in progress): Alpha preview to collect
@@ -103,14 +119,14 @@ TestPyPI dry run. Pass `EXTRAS="gpu"` when GPU wheels are staged.
   extras compile cleanly while verify remains blocked.
   【F:baseline/logs/mkdocs-build-20250925T001535Z.log†L1-L15】
 - [ ] `task verify` and `task coverage` were rerun via `uv` wrappers on
-  2025-09-25, but they now fail in
-  `tests/unit/test_eviction.py::test_lru_eviction_sequence` and
-  `tests/unit/test_distributed_executors.py::test_execute_agent_remote`,
-  respectively. The new logs and follow-up tickets capture the regressions so
-  the sweep can resume once storage and Ray serialization are repaired.
-  【F:baseline/logs/task-verify-20250925T000904Z.log†L416-L489】
+  2025-09-25; the stub parametrisations now pass with VSS enabled, but the runs
+  fail in `tests/unit/test_eviction.py::test_lru_eviction_sequence` and
+  `tests/unit/test_distributed_executors.py::test_execute_agent_remote`.
+  The new logs and follow-up tickets capture the regressions so the sweep can
+  resume once storage and Ray serialization are repaired.
+  【F:baseline/logs/task-verify-20250925T000904Z.log†L320-L489】
   【F:issues/investigate-lru-eviction-regression.md†L1-L24】
-  【F:baseline/logs/task-coverage-20250925T001017Z.log†L484-L669】
+  【F:baseline/logs/task-coverage-20250925T001017Z.log†L460-L669】
   【F:issues/address-ray-serialization-regression.md†L1-L20】
 - [x] `uv run --extra build python -m build` succeeded out of band and archived
   `baseline/logs/python-build-20250925T001554Z.log`, so packaging is ready to


### PR DESCRIPTION
## Summary
- add a 0.1.0a1 verification evidence section to the changelog covering the 25 September manual runs
- sync release_plan.md, STATUS.md, and TASK_PROGRESS.md with the latest verify/coverage outcomes and manual workflow policy
- note that the vector-search-aware stub parametrisations now pass while storage and distributed regressions remain open

## Testing
- Not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d48d76fb6c8333bde3c0eb9112543d