### PR TITLE
test: centralize stub module helpers

### DIFF
--- a/tests/benchmark/test_token_memory.py
+++ b/tests/benchmark/test_token_memory.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-import sys
-import types
-
 import pytest
 
-pdf_ns = types.SimpleNamespace(extract_text=lambda *a, **k: "")
-sys.modules.setdefault("docx", types.SimpleNamespace(Document=object))
-sys.modules.setdefault("pdfminer", types.SimpleNamespace(high_level=pdf_ns))
-sys.modules.setdefault("pdfminer.high_level", pdf_ns)
+from tests.helpers.modules import ensure_stub_module
+
+ensure_stub_module("docx", {"Document": object})
+ensure_stub_module(
+    "pdfminer.high_level", {"extract_text": lambda *a, **k: ""}
+)
 
 from scripts.benchmark_token_memory import run_benchmark  # noqa: E402
 

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,5 @@
+"""Test helper utilities."""
+
+from .modules import create_stub_module, ensure_stub_module
+
+__all__ = ["create_stub_module", "ensure_stub_module"]

--- a/tests/helpers/modules.py
+++ b/tests/helpers/modules.py
@@ -1,0 +1,80 @@
+"""Utilities for installing stub modules during tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+import sys
+from types import ModuleType
+from typing import Any
+
+__all__ = ["StubModule", "create_stub_module", "ensure_stub_module"]
+
+
+class StubModule(ModuleType):
+    """Module with dynamic attribute support for typing."""
+
+    def __getattr__(self, name: str) -> Any:  # pragma: no cover - dynamic fallback
+        try:
+            return self.__dict__[name]
+        except KeyError as exc:  # pragma: no cover - match ModuleType semantics
+            raise AttributeError(name) from exc
+
+
+def create_stub_module(
+    name: str,
+    attributes: Mapping[str, Any] | None = None,
+) -> StubModule:
+    """Create a :class:`ModuleType` populated with ``attributes``.
+
+    Args:
+        name: Fully qualified module name.
+        attributes: Optional mapping of attribute names to values.
+
+    Returns:
+        A new module instance with the provided attributes.
+    """
+
+    module = StubModule(name)
+    if attributes:
+        for attr, value in attributes.items():
+            setattr(module, attr, value)
+    return module
+
+
+def ensure_stub_module(
+    name: str,
+    attributes: Mapping[str, Any] | None = None,
+    modules: MutableMapping[str, ModuleType] | None = None,
+) -> ModuleType:
+    """Install a stub module into ``modules`` if it is missing.
+
+    The helper mirrors :func:`dict.setdefault` semantics for ``sys.modules``
+    while ensuring that a proper :class:`ModuleType` instance is registered.
+
+    Args:
+        name: Fully qualified module name.
+        attributes: Optional attributes to set on the module. Attributes are only
+            applied when missing to avoid clobbering real implementations.
+        modules: Registry to update. Defaults to :data:`sys.modules`.
+
+    Returns:
+        The stub module registered under ``name``.
+    """
+
+    registry = modules if modules is not None else sys.modules
+    module = registry.get(name)
+    if not isinstance(module, ModuleType):
+        module = create_stub_module(name)
+        registry[name] = module
+    if attributes:
+        for attr, value in attributes.items():
+            if not hasattr(module, attr):
+                setattr(module, attr, value)
+    parent_name, _, child_name = name.rpartition(".")
+    if parent_name:
+        parent = ensure_stub_module(parent_name, modules=registry)
+        if getattr(parent, child_name, None) is not module:
+            setattr(parent, child_name, module)
+        if getattr(module, "__package__", None) != parent_name:
+            module.__package__ = parent_name
+    return module

--- a/tests/targeted/test_budgeting.py
+++ b/tests/targeted/test_budgeting.py
@@ -1,11 +1,16 @@
 """Coverage for adaptive token budgeting."""
 
-import sys
 from types import SimpleNamespace
 
-sys.modules.setdefault(
+from tests.helpers.modules import ensure_stub_module
+
+ensure_stub_module(
     "pydantic_settings",
-    SimpleNamespace(BaseSettings=object, CliApp=object, SettingsConfigDict=dict),
+    {
+        "BaseSettings": object,
+        "CliApp": object,
+        "SettingsConfigDict": dict,
+    },
 )
 
 from autoresearch.orchestration.budgeting import _apply_adaptive_token_budget  # noqa: E402

--- a/tests/targeted/test_http_session.py
+++ b/tests/targeted/test_http_session.py
@@ -3,11 +3,17 @@
 import sys
 from types import SimpleNamespace
 
-sys.modules.setdefault(
+from tests.helpers.modules import ensure_stub_module
+
+ensure_stub_module(
     "pydantic_settings",
-    SimpleNamespace(BaseSettings=object, CliApp=object, SettingsConfigDict=dict),
+    {
+        "BaseSettings": object,
+        "CliApp": object,
+        "SettingsConfigDict": dict,
+    },
 )
-sys.modules.setdefault("docx", SimpleNamespace(Document=object))
+ensure_stub_module("docx", {"Document": object})
 
 import autoresearch.search.http as http  # noqa: E402
 

--- a/tests/targeted/test_orchestration_metrics.py
+++ b/tests/targeted/test_orchestration_metrics.py
@@ -1,14 +1,19 @@
 """Tests for token recording, regression checks, and coverage targets."""
 
 import json
-import sys
 import types
 
 from coverage import Coverage
 
-sys.modules.setdefault(
+from tests.helpers.modules import ensure_stub_module
+
+ensure_stub_module(
     "pydantic_settings",
-    types.SimpleNamespace(BaseSettings=object, CliApp=object, SettingsConfigDict=dict),
+    {
+        "BaseSettings": object,
+        "CliApp": object,
+        "SettingsConfigDict": dict,
+    },
 )
 
 from autoresearch.orchestration.metrics import OrchestrationMetrics  # noqa: E402

--- a/tests/targeted/test_search_context.py
+++ b/tests/targeted/test_search_context.py
@@ -1,16 +1,21 @@
 """Tests for SearchContext entity extraction and query expansion."""
 
-import sys
 import types
 
-sys.modules.setdefault(
+from tests.helpers.modules import ensure_stub_module
+
+ensure_stub_module(
     "pydantic_settings",
-    types.SimpleNamespace(BaseSettings=object, CliApp=object, SettingsConfigDict=dict),
+    {
+        "BaseSettings": object,
+        "CliApp": object,
+        "SettingsConfigDict": dict,
+    },
 )
-sys.modules.setdefault("docx", types.SimpleNamespace(Document=object))
-sys.modules.setdefault(
+ensure_stub_module("docx", {"Document": object})
+ensure_stub_module(
     "autoresearch.search.core",
-    types.SimpleNamespace(Search=object, get_search=lambda *a, **k: None),
+    {"Search": object, "get_search": lambda *a, **k: None},
 )
 
 from autoresearch.search.context import SearchContext  # noqa: E402

--- a/tests/targeted/test_storage_helpers.py
+++ b/tests/targeted/test_storage_helpers.py
@@ -1,11 +1,14 @@
 """Tests for lightweight helpers in :mod:`autoresearch.storage`."""
 
-import sys
-import types
+from tests.helpers.modules import ensure_stub_module
 
-sys.modules.setdefault(
+ensure_stub_module(
     "pydantic_settings",
-    types.SimpleNamespace(BaseSettings=object, CliApp=object, SettingsConfigDict=dict),
+    {
+        "BaseSettings": object,
+        "CliApp": object,
+        "SettingsConfigDict": dict,
+    },
 )
 
 from autoresearch import storage  # noqa: E402

--- a/tests/unit/test_distributed_extra.py
+++ b/tests/unit/test_distributed_extra.py
@@ -1,15 +1,14 @@
-import sys
-import types
-
 import pytest
 
+from tests.helpers.modules import ensure_stub_module
+
 # Stub heavy modules before importing distributed
-sys.modules.setdefault("ray", types.SimpleNamespace(remote=lambda f: f))
-sys.modules.setdefault("autoresearch.orchestration.state", types.SimpleNamespace(QueryState=object))
-sys.modules.setdefault(
-    "autoresearch.orchestration.orchestrator", types.SimpleNamespace(AgentFactory=object)
+ensure_stub_module("ray", {"remote": lambda f: f})
+ensure_stub_module("autoresearch.orchestration.state", {"QueryState": object})
+ensure_stub_module(
+    "autoresearch.orchestration.orchestrator", {"AgentFactory": object}
 )
-sys.modules.setdefault("autoresearch.models", types.SimpleNamespace())
+ensure_stub_module("autoresearch.models")
 
 from autoresearch.distributed import (  # noqa: E402
     get_message_broker,

--- a/tests/unit/test_search_extra.py
+++ b/tests/unit/test_search_extra.py
@@ -1,23 +1,21 @@
-import sys
 import json
-import types
+import sys
+
 import pytest
 
+from tests.helpers.modules import ensure_stub_module
+
 # Provide dummy optional modules before importing Search
-sys.modules.setdefault("kuzu", types.SimpleNamespace())
-sys.modules.setdefault(
-    "spacy",
-    types.SimpleNamespace(
-        load=lambda *_: None, cli=types.SimpleNamespace(download=lambda *_: None)
-    ),
-)
-sys.modules.setdefault("bertopic", types.SimpleNamespace())
-sys.modules.setdefault(
+ensure_stub_module("kuzu")
+ensure_stub_module("spacy.cli", {"download": lambda *_: None})
+ensure_stub_module("spacy", {"load": lambda *_: None})
+ensure_stub_module("bertopic")
+ensure_stub_module(
     "fastembed",
-    types.SimpleNamespace(
-        OnnxTextEmbedding=lambda *_: None,
-        TextEmbedding=lambda *_: None,
-    ),
+    {
+        "OnnxTextEmbedding": lambda *_: None,
+        "TextEmbedding": lambda *_: None,
+    },
 )
 
 from autoresearch.search import (  # noqa: E402


### PR DESCRIPTION
## Summary
- add tests/helpers/modules.py to create ModuleType-backed stubs for optional dependencies
- replace SimpleNamespace sys.modules patches in benchmark, targeted, and unit tests with the shared helper

## Testing
- `uv run --extra dev-minimal --extra test mypy tests/unit tests/integration tests/targeted` *(fails: existing mypy errors across tests unrelated to stub helper changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d4bc1f7a448333ad1584dc7ec887eb