### PR TITLE
Add config stubs for search/orchestration tests

### DIFF
--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,5 +1,22 @@
 """Test helper utilities."""
 
+from .config import (  # noqa: F401 - re-exported for convenience
+    ConfigModelStub,
+    ContextAwareSearchConfigStub,
+    SearchConfigStub,
+    make_config_model,
+    make_context_aware_config,
+    make_search_config,
+)
 from .modules import create_stub_module, ensure_stub_module
 
-__all__ = ["create_stub_module", "ensure_stub_module"]
+__all__ = [
+    "ConfigModelStub",
+    "ContextAwareSearchConfigStub",
+    "SearchConfigStub",
+    "create_stub_module",
+    "ensure_stub_module",
+    "make_config_model",
+    "make_context_aware_config",
+    "make_search_config",
+]

--- a/tests/helpers/config.py
+++ b/tests/helpers/config.py
@@ -1,0 +1,115 @@
+"""Configuration helpers tailored for unit tests.
+
+These dataclasses provide a light-weight stand-in for :class:`ConfigModel`
+instances. They expose the attributes accessed by orchestrator and search
+unit tests without importing the full pydantic models.  Factory helpers
+produce instances with sensible defaults while still allowing tests to
+override specific fields explicitly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, replace
+from typing import Any, Dict, Mapping, Optional
+
+
+@dataclass(slots=True)
+class ContextAwareSearchConfigStub:
+    """Subset of context-aware search settings required in unit tests."""
+
+    enabled: bool = True
+    use_query_expansion: bool = True
+    expansion_factor: float = 0.3
+    use_search_history: bool = True
+    max_history_items: int = 10
+
+
+@dataclass(slots=True)
+class SearchConfigStub:
+    """Search configuration stub exposing the context-aware settings."""
+
+    context_aware: ContextAwareSearchConfigStub = field(
+        default_factory=ContextAwareSearchConfigStub
+    )
+
+
+@dataclass(slots=True)
+class ConfigModelStub:
+    """Minimal configuration object compatible with ``ConfigModel`` access."""
+
+    token_budget: Optional[int] = None
+    loops: int = 2
+    adaptive_max_factor: int = 20
+    adaptive_min_buffer: int = 10
+    search: SearchConfigStub = field(default_factory=SearchConfigStub)
+
+    def model_dump(self) -> Dict[str, Any]:
+        """Return a dictionary representation mirroring ``BaseModel``."""
+
+        return asdict(self)
+
+
+def make_context_aware_config(
+    overrides: Mapping[str, Any] | None = None,
+) -> ContextAwareSearchConfigStub:
+    """Return a context-aware configuration stub with optional overrides."""
+
+    if overrides is None:
+        return ContextAwareSearchConfigStub()
+    return replace(ContextAwareSearchConfigStub(), **overrides)
+
+
+def make_search_config(
+    *,
+    context_overrides: Mapping[str, Any] | None = None,
+    overrides: Mapping[str, Any] | None = None,
+) -> SearchConfigStub:
+    """Construct a search configuration stub for unit tests."""
+
+    context_cfg = make_context_aware_config(context_overrides)
+    search_cfg = SearchConfigStub(context_aware=context_cfg)
+    if overrides:
+        for key, value in overrides.items():
+            if key == "context_aware":
+                raise ValueError(
+                    "Use 'context_overrides' to customise context-aware settings"
+                )
+            if not hasattr(search_cfg, key):
+                raise AttributeError(
+                    f"SearchConfigStub has no attribute '{key}' to override"
+                )
+            setattr(search_cfg, key, value)
+    return search_cfg
+
+
+def make_config_model(
+    *,
+    token_budget: Optional[int] = None,
+    loops: int = 2,
+    adaptive_max_factor: int = 20,
+    adaptive_min_buffer: int = 10,
+    search_overrides: Mapping[str, Any] | None = None,
+    context_overrides: Mapping[str, Any] | None = None,
+) -> ConfigModelStub:
+    """Create a :class:`ConfigModelStub` with explicit overrides when needed."""
+
+    search_cfg = make_search_config(
+        context_overrides=context_overrides, overrides=search_overrides
+    )
+    return ConfigModelStub(
+        token_budget=token_budget,
+        loops=loops,
+        adaptive_max_factor=adaptive_max_factor,
+        adaptive_min_buffer=adaptive_min_buffer,
+        search=search_cfg,
+    )
+
+
+__all__ = [
+    "ConfigModelStub",
+    "ContextAwareSearchConfigStub",
+    "SearchConfigStub",
+    "make_config_model",
+    "make_search_config",
+    "make_context_aware_config",
+]

--- a/tests/unit/orchestration/test_budgeting_algorithm.py
+++ b/tests/unit/orchestration/test_budgeting_algorithm.py
@@ -1,21 +1,24 @@
-from types import SimpleNamespace
-
 from autoresearch.orchestration.budgeting import _apply_adaptive_token_budget
+from tests.helpers import make_config_model
 
 
 def test_budget_scaled_by_loops_and_limits() -> None:
-    config = SimpleNamespace(token_budget=300, loops=3, adaptive_max_factor=20)
+    config = make_config_model(
+        token_budget=300, loops=3, adaptive_max_factor=20
+    )
     _apply_adaptive_token_budget(config, "one two three four")
     assert config.token_budget == 80
 
 
 def test_budget_minimum_buffer_applied() -> None:
-    config = SimpleNamespace(token_budget=1, loops=1, adaptive_min_buffer=10)
+    config = make_config_model(
+        token_budget=1, loops=1, adaptive_min_buffer=10
+    )
     _apply_adaptive_token_budget(config, "a b c d e")
     assert config.token_budget == 15
 
 
 def test_budget_unchanged_within_bounds() -> None:
-    config = SimpleNamespace(token_budget=50, loops=1)
+    config = make_config_model(token_budget=50, loops=1)
     _apply_adaptive_token_budget(config, "a b c d e")
     assert config.token_budget == 50

--- a/tests/unit/search/test_query_expansion_convergence.py
+++ b/tests/unit/search/test_query_expansion_convergence.py
@@ -1,23 +1,22 @@
+import sys
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import autoresearch.search.context as ctx
-import sys
 from autoresearch.search.context import SearchContext
+from tests.helpers import make_config_model
 
 
 @patch(
     "autoresearch.search.context.get_config",
-    lambda: SimpleNamespace(
-        search=SimpleNamespace(
-            context_aware=SimpleNamespace(
-                enabled=True,
-                max_history_items=5,
-                use_search_history=True,
-                use_query_expansion=True,
-                expansion_factor=1.0,
-            )
-        )
+    lambda: make_config_model(
+        context_overrides={
+            "enabled": True,
+            "max_history_items": 5,
+            "use_search_history": True,
+            "use_query_expansion": True,
+            "expansion_factor": 1.0,
+        }
     ),
 )
 def test_query_expansion_converges():
@@ -68,11 +67,7 @@ def test_build_topic_model_with_insufficient_docs(monkeypatch):
     With only one query recorded, build_topic_model leaves topic_model unset,
     confirming the guard against sparse history.
     """
-    cfg = SimpleNamespace(
-        search=SimpleNamespace(
-            context_aware=SimpleNamespace(enabled=True)
-        )
-    )
+    cfg = make_config_model(context_overrides={"enabled": True})
     monkeypatch.setattr(
         "autoresearch.search.context.get_config", lambda: cfg
     )
@@ -88,7 +83,7 @@ def test_try_imports_disabled(monkeypatch):
     Disabling context-aware search causes all import helpers to return False
     without altering availability flags.
     """
-    cfg = SimpleNamespace(search=SimpleNamespace(context_aware=SimpleNamespace(enabled=False)))
+    cfg = make_config_model(context_overrides={"enabled": False})
     monkeypatch.setattr(ctx, "get_config", lambda: cfg)
     ctx.SPACY_AVAILABLE = False
     ctx.BERTOPIC_AVAILABLE = False
@@ -107,7 +102,7 @@ def test_try_import_sentence_transformers_success(monkeypatch):
     Injecting a dummy module simulates a successful import and flips the
     availability flag to True.
     """
-    cfg = SimpleNamespace(search=SimpleNamespace(context_aware=SimpleNamespace(enabled=True)))
+    cfg = make_config_model(context_overrides={"enabled": True})
     monkeypatch.setattr(ctx, "get_config", lambda: cfg)
 
     class DummyST:

--- a/tests/unit/test_budgeting.py
+++ b/tests/unit/test_budgeting.py
@@ -1,17 +1,26 @@
-from types import SimpleNamespace
-
 from autoresearch.orchestration.budgeting import _apply_adaptive_token_budget
+from tests.helpers import make_config_model
 
 
 def test_apply_adaptive_token_budget_paths():
-    cfg = SimpleNamespace(token_budget=100, loops=2, adaptive_max_factor=10, adaptive_min_buffer=5)
+    cfg = make_config_model(
+        token_budget=100,
+        loops=2,
+        adaptive_max_factor=10,
+        adaptive_min_buffer=5,
+    )
     _apply_adaptive_token_budget(cfg, "one two three four five")
     assert cfg.token_budget == 50  # reduced due to loops then limited by max factor
 
-    cfg2 = SimpleNamespace(token_budget=1, loops=1, adaptive_max_factor=20, adaptive_min_buffer=10)
+    cfg2 = make_config_model(
+        token_budget=1,
+        loops=1,
+        adaptive_max_factor=20,
+        adaptive_min_buffer=10,
+    )
     _apply_adaptive_token_budget(cfg2, "two words")
     assert cfg2.token_budget == 12  # increased due to query longer than budget
 
-    cfg3 = SimpleNamespace(token_budget=None)
+    cfg3 = make_config_model(token_budget=None)
     _apply_adaptive_token_budget(cfg3, "any")
     assert getattr(cfg3, "token_budget", None) is None

--- a/tests/unit/test_search_context_history_trim.py
+++ b/tests/unit/test_search_context_history_trim.py
@@ -1,25 +1,23 @@
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from autoresearch.search.context import SearchContext
+from tests.helpers import ConfigModelStub, make_config_model
 
 
 pytestmark = pytest.mark.requires_nlp
 
 
-def make_config(max_history):
-    return SimpleNamespace(
-        search=SimpleNamespace(
-            context_aware=SimpleNamespace(
-                max_history_items=max_history,
-                enabled=True,
-                use_search_history=True,
-                use_query_expansion=True,
-                expansion_factor=0.5,
-            )
-        )
+def make_config(max_history: int) -> ConfigModelStub:
+    return make_config_model(
+        context_overrides={
+            "max_history_items": max_history,
+            "enabled": True,
+            "use_search_history": True,
+            "use_query_expansion": True,
+            "expansion_factor": 0.5,
+        }
     )
 
 

--- a/tests/unit/test_search_context_imports.py
+++ b/tests/unit/test_search_context_imports.py
@@ -3,14 +3,11 @@ import sys
 import types
 
 import autoresearch.search.context as context
+from tests.helpers import ConfigModelStub, make_config_model
 
 
-def _make_cfg(enabled: bool) -> types.SimpleNamespace:
-    return types.SimpleNamespace(
-        search=types.SimpleNamespace(
-            context_aware=types.SimpleNamespace(enabled=enabled)
-        )
-    )
+def _make_cfg(enabled: bool) -> ConfigModelStub:
+    return make_config_model(context_overrides={"enabled": enabled})
 
 
 def _reload_ctx(monkeypatch, enabled: bool):


### PR DESCRIPTION
## Summary
- add ConfigModel-compatible dataclasses for unit tests in `tests/helpers`
- update search context unit tests to use the shared configuration factory
- refactor budgeting tests to rely on the shared helper instead of `SimpleNamespace`

## Testing
- uv run pytest tests/unit/search/test_query_expansion_convergence.py tests/unit/test_search_context_history_trim.py tests/unit/test_search_context_imports.py tests/unit/orchestration/test_budgeting_algorithm.py tests/unit/test_budgeting.py

------
https://chatgpt.com/codex/tasks/task_e_68d55ebd160083339caaa1fb2b7d2d7c