### PR TITLE
Enforce mypy on tests and remove unused ignores

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -63,6 +63,9 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   `baseline/logs/task-coverage-20250925T001017Z.log` and tracked in
   [address-ray-serialization-regression](issues/address-ray-serialization-regression.md).
   【F:baseline/logs/task-coverage-20250925T001017Z.log†L484-L669】【F:issues/address-ray-serialization-regression.md†L1-L20】
+- Added a dedicated typing sweep for the test suites: `task verify` now runs
+  `uv run mypy tests/unit tests/integration` alongside the existing source
+  check so CI catches fixture regressions immediately. 【F:Taskfile.yml†L338-L348】
 - Patched `QueryState` to drop its private lock during pickle and rebuild it on
   load, keeping Ray workers from crashing on `_thread.RLock` while adding
   regression guards around Ray and cloudpickle transports. A fresh coverage run

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -338,6 +338,7 @@ tasks:
       - task check-env EXTRAS="{{.EXTRAS}}"
       - uv run flake8 src tests
       - uv run mypy src --exclude src/autoresearch/a2a_interface.py
+      - uv run mypy tests/unit tests/integration
       - task lint-specs
       - task check-release-metadata
       - uv run python scripts/check_spec_tests.py

--- a/scripts/distributed_coordination_sim.py
+++ b/scripts/distributed_coordination_sim.py
@@ -188,8 +188,10 @@ def _simulate_messages(
         aggregator.join()
         aggregated = list(aggregator.results)
         aggregator.results[:] = []
-        with suppress(Exception):
-            aggregator._manager.shutdown()  # type: ignore[attr-defined]
+        manager = getattr(aggregator, "_manager", None)
+        if manager is not None:
+            with suppress(Exception):
+                manager.shutdown()
         result_broker.shutdown()
 
     storage_broker.publish({"action": ACTION_STOP})

--- a/scripts/distributed_perf_sim.py
+++ b/scripts/distributed_perf_sim.py
@@ -73,7 +73,7 @@ def _plot(results: Sequence[Dict[str, float]], output: Path) -> None:
     latency = [r["latency_s"] for r in results]
 
     try:
-        import matplotlib.pyplot as plt  # type: ignore
+        import matplotlib.pyplot as plt
     except Exception:  # pragma: no cover - missing optional dependency
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text("<svg xmlns='http://www.w3.org/2000/svg'></svg>")

--- a/scripts/ram_budget_enforcement_sim.py
+++ b/scripts/ram_budget_enforcement_sim.py
@@ -8,6 +8,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from collections.abc import Callable
 
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel, StorageConfig
@@ -30,8 +31,8 @@ def _run(items: int) -> int:
     StorageManager.state = st
     StorageManager.context = ctx
 
-    original = StorageManager._current_ram_mb
-    StorageManager._current_ram_mb = staticmethod(lambda: 1000)
+    original: Callable[[], float] = StorageManager._current_ram_mb
+    StorageManager._current_ram_mb = staticmethod(lambda: 1000.0)
     try:
         StorageManager.setup(db_path=":memory:", context=ctx, state=st)
         for i in range(items):
@@ -42,7 +43,7 @@ def _run(items: int) -> int:
         StorageManager.teardown(remove_db=True, context=ctx, state=st)
         StorageManager.state = StorageState()
         StorageManager.context = StorageContext()
-        StorageManager._current_ram_mb = original  # type: ignore[assignment]
+        StorageManager._current_ram_mb = staticmethod(original)
         ConfigLoader.reset_instance()
 
     return remaining

--- a/scripts/storage_concurrency_sim.py
+++ b/scripts/storage_concurrency_sim.py
@@ -8,6 +8,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from collections.abc import Callable
 from dataclasses import dataclass
 from threading import Barrier, BrokenBarrierError, Lock, Thread
 from time import perf_counter
@@ -48,8 +49,8 @@ def _run(threads: int, items: int) -> SimulationResult:
     StorageManager.state = st
     StorageManager.context = ctx
 
-    original_ram = StorageManager._current_ram_mb
-    StorageManager._current_ram_mb = staticmethod(lambda: 1000)
+    original_ram: Callable[[], float] = StorageManager._current_ram_mb
+    StorageManager._current_ram_mb = staticmethod(lambda: 1000.0)
     original_setup = storage_module.setup
 
     setup_calls = 0
@@ -129,7 +130,7 @@ def _run(threads: int, items: int) -> SimulationResult:
         StorageManager.teardown(remove_db=True, context=ctx, state=st)
         StorageManager.state = StorageState()
         StorageManager.context = StorageContext()
-        StorageManager._current_ram_mb = original_ram  # type: ignore[assignment]
+        StorageManager._current_ram_mb = staticmethod(original_ram)
         ConfigLoader.reset_instance()
         storage_module.setup = original_setup
 

--- a/tests/integration/storage/test_simulation_benchmarks.py
+++ b/tests/integration/storage/test_simulation_benchmarks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from scripts.storage_concurrency_sim import _run as concurrency_run
 
 from autoresearch.config.loader import ConfigLoader
@@ -32,8 +34,8 @@ def _ram_budget_run(items: int) -> int:
     StorageManager.state = st
     StorageManager.context = ctx
 
-    original = StorageManager._current_ram_mb
-    StorageManager._current_ram_mb = staticmethod(lambda: 1000)
+    original: Callable[[], float] = StorageManager._current_ram_mb
+    StorageManager._current_ram_mb = staticmethod(lambda: 1000.0)
     original_reasoner = storage_module.run_ontology_reasoner
     storage_module.run_ontology_reasoner = lambda *a, **k: None
     try:
@@ -48,7 +50,7 @@ def _ram_budget_run(items: int) -> int:
         StorageManager.teardown(remove_db=True, context=ctx, state=st)
         StorageManager.state = StorageState()
         StorageManager.context = StorageContext()
-        StorageManager._current_ram_mb = original  # type: ignore[assignment]
+        StorageManager._current_ram_mb = staticmethod(original)
         storage_module.run_ontology_reasoner = original_reasoner
         ConfigLoader.reset_instance()
 

--- a/tests/integration/test_process_executor_simple.py
+++ b/tests/integration/test_process_executor_simple.py
@@ -85,8 +85,10 @@ def process_executor(
             with contextlib.suppress(Exception):
                 queue.join_thread()
         with contextlib.suppress(Exception):
-            cache = resource_tracker._resource_tracker._cache  # type: ignore[attr-defined]
-            cache.clear()
+            tracker = getattr(resource_tracker, "_resource_tracker", None)
+            cache = getattr(tracker, "_cache", None)
+            if cache is not None:
+                cache.clear()
         assert pool.closed and pool.joined
 
     request.addfinalizer(_cleanup)

--- a/tests/integration/test_storage_schema.py
+++ b/tests/integration/test_storage_schema.py
@@ -28,7 +28,8 @@ def test_initialize_storage_creates_tables(tmp_path, db_path):
 
     initialize_storage(path, context=ctx, state=st)
     try:
-        conn = ctx.db_backend.get_connection()  # type: ignore[union-attr]
+        assert ctx.db_backend is not None
+        conn = ctx.db_backend.get_connection()
         conn.execute("SELECT * FROM nodes")
         conn.execute("SELECT * FROM edges")
         conn.execute("SELECT * FROM embeddings")

--- a/tests/integration/test_upgrade_path.py
+++ b/tests/integration/test_upgrade_path.py
@@ -6,37 +6,36 @@ import shutil
 from pathlib import Path
 
 import pytest
+from typing import Any, Sequence
+from unittest.mock import patch
 
 
 SCRIPT = Path(__file__).parents[2] / "scripts" / "upgrade.py"
 
 
-def run_upgrade(tmp_path: Path, poetry_env: bool):
+def run_upgrade(tmp_path: Path, poetry_env: bool) -> list[Sequence[Any] | Any]:
     if poetry_env:
         (tmp_path / "pyproject.toml").write_text("")
 
-    calls = []
+    calls: list[Sequence[Any] | Any] = []
 
-    def fake_call(cmd, *a, **k):
+    def fake_call(cmd: Sequence[Any] | Any, *args: Any, **kwargs: Any) -> None:
         calls.append(cmd)
 
-    def fake_which(name):
+    def fake_which(name: str) -> str | None:
         if poetry_env and name == "poetry":
             return "poetry"
         return None
 
-    orig_call = subprocess.check_call
-    orig_which = shutil.which
-    subprocess.check_call = fake_call  # type: ignore
-    shutil.which = fake_which  # type: ignore
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        runpy.run_path(str(SCRIPT))
+        with patch("subprocess.check_call", side_effect=fake_call), patch(
+            "shutil.which", side_effect=fake_which
+        ):
+            runpy.run_path(str(SCRIPT), run_name="__main__")
     finally:
         os.chdir(cwd)
-        subprocess.check_call = orig_call  # type: ignore
-        shutil.which = orig_which  # type: ignore
     return calls
 
 

--- a/tests/stubs/streamlit.py
+++ b/tests/stubs/streamlit.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 import importlib.util
 from types import ModuleType, SimpleNamespace
-from typing import Any, Protocol, Sequence
+from typing import Any, Protocol, Sequence, cast
 
 from ._registry import install_stub_module
 
 
 class SessionState(dict[str, Any]):
-    __getattr__ = dict.get  # type: ignore[assignment]
-    __setattr__ = dict.__setitem__  # type: ignore[assignment]
+    def __getattr__(self, name: str) -> Any:
+        return self.get(name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        self[name] = value
 
 
 class StreamlitModule(Protocol):
@@ -84,7 +87,9 @@ class _StreamlitModule(ModuleType):
 if importlib.util.find_spec("streamlit") is None:
     streamlit: StreamlitModule = install_stub_module("streamlit", _StreamlitModule)
 else:  # pragma: no cover
-    import streamlit as streamlit  # type: ignore  # noqa: F401
+    import streamlit as _streamlit  # noqa: F401
+
+    streamlit = cast(StreamlitModule, _streamlit)
 
 
 __all__ = ["SessionState", "StreamlitModule", "streamlit"]

--- a/tests/unit/orchestration/test_parallel_execute.py
+++ b/tests/unit/orchestration/test_parallel_execute.py
@@ -16,7 +16,7 @@ from autoresearch.orchestration.parallel import execute_parallel_query
 class DummyTracer:
     def start_as_current_span(self, name: str):
         class Span:
-            def __enter__(self) -> Span:  # type: ignore[name-defined]
+            def __enter__(self) -> "Span":
                 return self
 
             def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - no cleanup

--- a/tests/unit/test_metrics_helpers.py
+++ b/tests/unit/test_metrics_helpers.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
+from types import SimpleNamespace
 
 from autoresearch.orchestration import metrics
-from types import SimpleNamespace
 
 
 def test_mean_last_nonzero() -> None:
@@ -15,9 +16,12 @@ def test_mean_last_nonzero() -> None:
 
 def test_temporary_metrics_restores_state(tmp_path: Path) -> None:
     # Provide histogram with internal counters required by reset_metrics
-    metrics.KUZU_QUERY_TIME = SimpleNamespace(  # type: ignore[attr-defined]
-        _sum=SimpleNamespace(set=lambda x: None, get=lambda: 0.0),
-        _count=SimpleNamespace(set=lambda x: None, get=lambda: 0.0),
+    metrics.KUZU_QUERY_TIME = cast(
+        Any,
+        SimpleNamespace(
+            _sum=SimpleNamespace(set=lambda x: None, get=lambda: 0.0),
+            _count=SimpleNamespace(set=lambda x: None, get=lambda: 0.0),
+        ),
     )
     metrics.reset_metrics()
     metrics.QUERY_COUNTER.inc()

--- a/tests/unit/test_monitor_cli.py
+++ b/tests/unit/test_monitor_cli.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List
 
-import psutil  # type: ignore
+import psutil
 from typer.testing import CliRunner
 import typer
 
@@ -152,11 +152,11 @@ def test_storage_teardown_handles_missing_config(monkeypatch):
     bare_config = type("BareConfig", (), {})()
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: bare_config)
     ConfigLoader.reset_instance()
-    storage._cached_config = None  # type: ignore[attr-defined]
+    setattr(storage, "_cached_config", None)
 
     cfg = storage._get_config()
     assert isinstance(cfg, StorageConfig)
-    assert storage._cached_config is cfg  # type: ignore[attr-defined]
+    assert getattr(storage, "_cached_config") is cfg
 
     storage.teardown(remove_db=True)
-    assert storage._cached_config is None  # type: ignore[attr-defined]
+    assert getattr(storage, "_cached_config") is None

--- a/tests/unit/test_node_health_monitor_property.py
+++ b/tests/unit/test_node_health_monitor_property.py
@@ -1,19 +1,10 @@
-from pathlib import Path
-import importlib.util
+from types import MethodType
 
 from hypothesis import given, strategies as st
 from prometheus_client import CollectorRegistry
 import pytest
 
-spec = importlib.util.spec_from_file_location(
-    "node_health",
-    Path(__file__).resolve().parents[2] / "src" / "autoresearch" / "monitor" / "node_health.py",
-)
-if spec is None or spec.loader is None:
-    raise RuntimeError("Unable to load node_health module")
-module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(module)
-NodeHealthMonitor = module.NodeHealthMonitor  # type: ignore[attr-defined]
+from autoresearch.monitor.node_health import NodeHealthMonitor
 
 
 pytestmark = [pytest.mark.requires_distributed, pytest.mark.redis]
@@ -24,11 +15,13 @@ def test_check_once_updates_gauges(redis_up: bool, ray_up: bool) -> None:
     """Property-based test for gauge updates in NodeHealthMonitor."""
     registry = CollectorRegistry()
     monitor = NodeHealthMonitor(port=None, registry=registry)
-    monitor._check_redis = lambda: redis_up  # type: ignore[method-assign]
-    monitor._check_ray = lambda: ray_up  # type: ignore[method-assign]
+    monitor._check_redis = MethodType(lambda self: redis_up, monitor)
+    monitor._check_ray = MethodType(lambda self: ray_up, monitor)
 
     monitor.check_once()
 
-    assert monitor.redis_gauge._value.get() == int(redis_up)
-    assert monitor.ray_gauge._value.get() == int(ray_up)
-    assert monitor.health_gauge._value.get() == int(redis_up and ray_up)
+    assert registry.get_sample_value("autoresearch_redis_up") == int(redis_up)
+    assert registry.get_sample_value("autoresearch_ray_up") == int(ray_up)
+    assert registry.get_sample_value("autoresearch_node_health") == int(
+        redis_up and ray_up
+    )

--- a/tests/unit/test_resource_monitor_start.py
+++ b/tests/unit/test_resource_monitor_start.py
@@ -13,8 +13,8 @@ def test_gauge_reuse_resets_value() -> None:
     registry = CollectorRegistry()
     gauge = resource_monitor._gauge("test_gauge", "desc", registry)
     gauge.set(5)
-    gauge2 = resource_monitor._gauge("test_gauge", "desc", registry)
-    assert gauge2._value.get() == 0  # type: ignore[attr-defined]
+    resource_monitor._gauge("test_gauge", "desc", registry)
+    assert registry.get_sample_value("test_gauge") == 0
 
 
 def test_resource_monitor_records_stats(monkeypatch) -> None:

--- a/tests/unit/test_search_http_session.py
+++ b/tests/unit/test_search_http_session.py
@@ -1,4 +1,6 @@
 import pytest
+import requests
+
 from autoresearch.search.http import (
     close_http_session,
     get_http_session,
@@ -6,8 +8,9 @@ from autoresearch.search.http import (
 )
 
 
-class DummySession:
+class DummySession(requests.Session):
     def __init__(self) -> None:
+        super().__init__()
         self.closed = False
 
     def close(self) -> None:  # pragma: no cover - simple close
@@ -29,7 +32,7 @@ def test_http_session_management(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # Inject custom session and ensure it is returned
     custom = DummySession()
-    set_http_session(custom)  # type: ignore[arg-type]
+    set_http_session(custom)
     assert get_http_session() is custom
 
     # Closing should reset global session
@@ -44,7 +47,7 @@ def test_set_http_session_registers_atexit(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr("autoresearch.search.http.atexit.register", lambda func: calls.append(func))
     close_http_session()
     custom = DummySession()
-    set_http_session(custom)  # type: ignore[arg-type]
+    set_http_session(custom)
     assert get_http_session() is custom
     assert calls == [close_http_session]
     close_http_session()


### PR DESCRIPTION
## Summary
- extend `task verify` to run mypy on the test suites and document the new gate
- replace unused `type: ignore` directives in tests and stubs with typed helpers and registry lookups
- update simulation scripts and fixtures to restore type safety when swapping storage hooks

## Testing
- uv run --extra dev-minimal --extra test mypy tests/unit tests/integration
- uv run pytest tests/unit/test_monitor_cli.py -q
- uv run pytest tests/integration/test_upgrade_path.py -m slow -q
- uv run pytest tests/integration/storage/test_simulation_benchmarks.py -q
- uv run pytest tests/unit/orchestration/test_parallel_execute.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d575fd6cec8333b620a8a041daff2b