### PR TITLE
Improve orchestration typing and git storage semantics

### DIFF
--- a/src/autoresearch/orchestration/execution.py
+++ b/src/autoresearch/orchestration/execution.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from itertools import chain, islice
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Sequence, TypeVar
 
 import rdflib
 
@@ -26,6 +26,8 @@ from .token_utils import _capture_token_usage as capture_token_usage
 from .token_utils import _execute_with_adapter as execute_with_adapter
 
 log = get_logger(__name__)
+
+T = TypeVar("T")
 
 
 def _get_agent(agent_name: str, agent_factory: type[AgentFactory]) -> Any:
@@ -285,7 +287,7 @@ def _execute_agent(
             break
 
 
-def _rotate_list(items: List[Any], start_idx: int) -> List[Any]:
+def _rotate_list(items: Sequence[T], start_idx: int) -> List[T]:
     """Rotate ``items`` so ``start_idx`` becomes the first element.
 
     This implementation avoids creating multiple intermediate lists by using
@@ -306,7 +308,7 @@ def _rotate_list(items: List[Any], start_idx: int) -> List[Any]:
 def _execute_cycle(
     loop: int,
     loops: int,
-    agents: List[List[str]],
+    agents: Sequence[Sequence[str]],
     primus_index: int,
     max_errors: int,
     state: QueryState,
@@ -376,7 +378,7 @@ def _execute_cycle(
 async def _execute_cycle_async(
     loop: int,
     loops: int,
-    agents: List[List[str]],
+    agents: Sequence[Sequence[str]],
     primus_index: int,
     max_errors: int,
     state: QueryState,

--- a/src/autoresearch/orchestration/orchestrator.py
+++ b/src/autoresearch/orchestration/orchestrator.py
@@ -9,7 +9,7 @@ is exercised by unit and integration tests under ``tests/``.
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Sequence
 
 import rdflib
 
@@ -386,13 +386,14 @@ class Orchestrator:
     def run_parallel_query(
         query: str,
         config: ConfigModel,
-        agent_groups: List[List[str]],
+        agent_groups: Sequence[Sequence[str]],
         timeout: int = 300,
     ) -> QueryResponse:
         """Run multiple parallel agent groups and synthesize results."""
         from . import parallel
 
-        return parallel.execute_parallel_query(query, config, agent_groups, timeout)
+        normalized_groups = [list(group) for group in agent_groups]
+        return parallel.execute_parallel_query(query, config, normalized_groups, timeout)
 
     @staticmethod
     def infer_relations() -> None:

--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -51,6 +51,7 @@ from typing import (
     Protocol,
     Sequence,
     Tuple,
+    TypedDict,
     cast,
 )
 from weakref import WeakSet
@@ -431,6 +432,18 @@ class ExternalLookupResult:
 
     def __getitem__(self, index: int) -> Dict[str, Any]:
         return self.results[index]
+
+
+class LocalGitResult(TypedDict, total=False):
+    """Typed mapping describing entries produced by ``_local_git_backend``."""
+
+    title: str
+    url: str
+    snippet: str
+    commit: str
+    author: str
+    date: str
+    diff: str
 
 
 # Scores are bucketed on a 10^-6 grid before lexicographic tie-breaking. This scale
@@ -2034,7 +2047,7 @@ def _local_file_backend(query: str, max_results: int = 5) -> List[Dict[str, Any]
 
 
 @Search.register_backend("local_git")
-def _local_git_backend(query: str, max_results: int = 5) -> List[Dict[str, Any]]:
+def _local_git_backend(query: str, max_results: int = 5) -> List[LocalGitResult]:
     """Search a local Git repository's files and commit messages."""
 
     cfg = _get_runtime_config()
@@ -2057,7 +2070,7 @@ def _local_git_backend(query: str, max_results: int = 5) -> List[Dict[str, Any]]
     repo = Repo(repo_path)
     head_hash = repo.head.commit.hexsha
 
-    results: List[Dict[str, str]] = []
+    results: List[LocalGitResult] = []
 
     # Search working tree files using ripgrep/Python scanning
     rg_path = shutil.which("rg")

--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -240,9 +240,10 @@ def setup(
         cfg = _get_config()
         fingerprint = _fingerprint_config(cfg)
 
+        backend = ctx.db_backend
         backend_ready = (
-            ctx.db_backend is not None
-            and ctx.db_backend.get_connection() is not None
+            backend is not None
+            and backend.get_connection() is not None
             and ctx.rdf_store is not None
         )
 
@@ -311,9 +312,10 @@ def initialize_storage(
     ctx = context or st.context
 
     with st.lock:
+        backend = ctx.db_backend
         backend_ready = (
-            ctx.db_backend is not None
-            and ctx.db_backend.get_connection() is not None
+            backend is not None
+            and backend.get_connection() is not None
             and ctx.rdf_store is not None
         )
         if not backend_ready:


### PR DESCRIPTION
## Summary
- allow parallel orchestration helpers to accept any sequence of agent groups and normalise them for execution
- tighten orchestration execution utilities to operate on sequences without mutating caller-owned collections
- add a typed LocalGitResult mapping and guard DuckDB backend references through local variables for clearer optional handling

## Testing
- `uv run --extra test pytest   tests/unit/test_orchestrator_parallel_deterministic.py   tests/unit/test_orchestrator_parallel_property.py   tests/unit/test_orchestrator_proofs.py   tests/unit/orchestration/test_parallel_execute.py`
- `uv run --extra test pytest tests/unit/test_storage_persistence.py`
- `uv run --extra test pytest tests/unit/test_local_git_backend.py`
- `uv run --extra test pytest tests/unit/test_search_backends_unit.py`


------
https://chatgpt.com/codex/tasks/task_e_68d57ae76e60833385ae6cad119411e7