### PR TITLE
Add strict typing stubs for third-party dependencies

### DIFF
--- a/docs/dev/third_party_stub_audit.md
+++ b/docs/dev/third_party_stub_audit.md
@@ -1,0 +1,57 @@
+# Third-Party Stub Audit (Strict Mypy)
+
+This note records the third-party import failures observed under
+``mypy --strict`` and the shims introduced to unblock strict type checking.
+It also captures the questions asked while validating that each shim mirrors
+runtime behaviour.
+
+- `pydantic`: Strict runs previously failed with ``Class cannot subclass
+  "BaseModel"`` across models, agents, and API payloads because the package
+  resolves to ``Any`` when site packages are hidden.【5cc994†L1-L44】
+  【e50fee†L1-L93】
+- `fastapi`/`starlette`: Middleware classes raised ``BaseHTTPMiddleware``
+  subtype errors and request handlers became untyped because the framework
+  resolved to ``Any`` without local type information.【5cc994†L1-L44】
+- `requests`: HTTP helpers inside `search`, `llm`, and `test_tools` relied on
+  ``requests`` but strict mode treated it as untyped, silencing parameter
+  checks for ``Session`` usage.【085b5d†L1-L23】
+- `psutil`/`pynvml`: Resource monitors imported these modules with unused
+  ``type: ignore`` markers to placate missing stubs, preventing strict runs
+  from validating CPU and GPU metric helpers.【5cc994†L1-L44】
+- `spacy`, `sentence_transformers`, `bertopic`, `pdfminer.layout`,
+  `fastembed.text`, and `owlrl` were guarded behind ``type: ignore`` comments
+  despite local fallbacks, leaving context-aware search paths unchecked.
+
+## Shim design and validation prompts
+
+- For `pydantic` we asked whether ``BaseModel`` instances in the project call
+  ``model_dump``, ``model_dump_json``, and ``model_validate`` in the same ways
+  the real library allows. A runtime smoke check confirmed those methods and
+  attribute shapes (`model_fields`, `model_fields_set`) behave as assumed, so
+  the stub exposes the same signatures.【953c8b†L1-L32】
+- We confirmed `ValidationError.errors()` returns a list of dicts that surface
+  validation problems, matching our stub's structure.【92cc72†L1-L10】
+- For `fastapi` and `starlette` the key question was whether middleware and
+  router decorators need more than constructor signatures. Inspecting
+  `routing.create_app` showed we only rely on ``add_middleware``,
+  ``include_router``, and basic request state attributes, which the stub now
+  mirrors.【5dc50d†L1-L52】【aaf952†L1-L120】
+- `requests` usage centres on ``Session.get/post``, ``HTTPAdapter``, and
+  ``Response.json``. The stub captures those call sites so strict checking can
+  validate the surrounding retry logic.【085b5d†L1-L23】
+- For `psutil` we verified that call sites only read ``cpu_percent``,
+  ``virtual_memory().percent``, and ``Process().memory_info().rss``, allowing a
+  compact stub that preserves those attributes while keeping optional fallbacks
+  intact.【81b965†L49-L66】【800ff7†L108-L120】
+- Optional NLP extras (`spacy`, `sentence_transformers`, `bertopic`) were
+  stubbed with the minimal constructors and methods used when available, while
+  still allowing the runtime guards to fall back when the packages are absent.
+
+## Targeted strict checks
+
+Running ``mypy --strict`` with ``MYPYPATH=tests/stubs`` on modules previously
+blocked by third-party imports now succeeds when intrinsic issues are absent.
+For example, `agents.feedback`—which only depended on `pydantic`—passes under
+strict mode once its dictionary type annotation was tightened.【64b61d†L1-L2】
+Modules such as `api.middleware` still report pre-existing missing annotations,
+indicating the remaining work is unrelated to third-party typing gaps.

--- a/src/autoresearch/agents/feedback.py
+++ b/src/autoresearch/agents/feedback.py
@@ -1,5 +1,6 @@
+from typing import Any, Optional
+
 from pydantic import BaseModel
-from typing import Optional
 
 
 class FeedbackEvent(BaseModel):
@@ -9,4 +10,4 @@ class FeedbackEvent(BaseModel):
     target: str
     content: str
     cycle: int
-    metadata: Optional[dict] = None
+    metadata: Optional[dict[str, Any]] = None

--- a/src/autoresearch/distributed/executors.py
+++ b/src/autoresearch/distributed/executors.py
@@ -21,7 +21,7 @@ from .coordinator import (
 )
 
 try:  # pragma: no cover - optional dependency
-    import ray  # type: ignore
+    import ray
 except Exception:  # pragma: no cover - missing or faulty install
     import types
 

--- a/src/autoresearch/extensions.py
+++ b/src/autoresearch/extensions.py
@@ -79,7 +79,7 @@ class VSSExtensionLoader:
 
         def _is_duckdb_error(err: Exception) -> bool:
             try:
-                import duckdb  # type: ignore[import-not-found]
+                import duckdb
             except ImportError:  # pragma: no cover - optional dependency
                 return False
             return isinstance(err, duckdb.Error)
@@ -240,7 +240,7 @@ class VSSExtensionLoader:
             bool: True if the package provided the extension, else False.
         """
         try:
-            import duckdb_extension_vss as vss  # type: ignore[import-not-found]
+            import duckdb_extension_vss as vss
 
             if hasattr(vss, "load"):
                 vss.load(conn)  # type: ignore[attr-defined]

--- a/src/autoresearch/kg_reasoning.py
+++ b/src/autoresearch/kg_reasoning.py
@@ -13,7 +13,7 @@ import warnings
 import rdflib
 
 try:  # pragma: no cover - optional dependency
-    import owlrl  # type: ignore
+    import owlrl
 except Exception:  # pragma: no cover - fallback for offline tests
     class _DeductiveClosure:
         def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/src/autoresearch/monitor/__init__.py
+++ b/src/autoresearch/monitor/__init__.py
@@ -64,7 +64,7 @@ def _collect_system_metrics() -> Dict[str, Any]:
         else:
             metrics.update(SystemMonitor.collect())
 
-        import psutil  # type: ignore
+        import psutil
 
         mem = psutil.virtual_memory()
         proc = psutil.Process()

--- a/src/autoresearch/monitor/system_monitor.py
+++ b/src/autoresearch/monitor/system_monitor.py
@@ -4,7 +4,7 @@ import threading
 import time
 from typing import Dict, Optional
 
-import psutil  # type: ignore
+import psutil
 from prometheus_client import REGISTRY, CollectorRegistry, Gauge
 
 

--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -119,7 +119,7 @@ def temporary_metrics() -> Iterator[None]:
 def _get_system_usage() -> tuple[float, float, float, float]:  # noqa: E302
     """Return CPU, memory, GPU utilization, and GPU memory in MB."""
     try:
-        import psutil  # type: ignore
+        import psutil
 
         cpu = psutil.cpu_percent(interval=None)
         mem_mb = psutil.Process().memory_info().rss / (1024 * 1024)
@@ -127,7 +127,7 @@ def _get_system_usage() -> tuple[float, float, float, float]:  # noqa: E302
         gpu_util = 0.0
         gpu_mem = 0.0
         try:
-            import pynvml  # type: ignore
+            import pynvml
 
             pynvml.nvmlInit()
             count = pynvml.nvmlDeviceGetCount()

--- a/src/autoresearch/orchestration/utils.py
+++ b/src/autoresearch/orchestration/utils.py
@@ -8,7 +8,7 @@ from ..models import QueryResponse
 def get_memory_usage() -> float:
     """Get current memory usage in MB."""
     try:
-        import psutil  # type: ignore
+        import psutil
 
         process = psutil.Process()
         memory_info = process.memory_info()

--- a/src/autoresearch/resource_monitor.py
+++ b/src/autoresearch/resource_monitor.py
@@ -100,7 +100,7 @@ def _get_gpu_stats() -> tuple[float, float]:
     """Return average GPU utilization and memory usage in MB."""
 
     try:  # pragma: no cover - optional dependency
-        import pynvml  # type: ignore
+        import pynvml
     except ModuleNotFoundError as exc:
         _log_gpu_dependency_missing("pynvml", exc)
     except Exception as exc:  # pragma: no cover - defensive
@@ -137,7 +137,7 @@ def _get_gpu_stats() -> tuple[float, float]:
 
         output = ""
         try:
-            import psutil  # type: ignore
+            import psutil
 
             proc = psutil.Popen(
                 cmd,
@@ -183,7 +183,7 @@ def _get_gpu_stats() -> tuple[float, float]:
 def _get_usage() -> tuple[float, float]:
     """Return CPU percent and memory usage in MB."""
     try:
-        import psutil  # type: ignore
+        import psutil
 
         cpu = psutil.cpu_percent(interval=None)
         mem = psutil.Process().memory_info().rss / (1024 * 1024)

--- a/src/autoresearch/search/context.py
+++ b/src/autoresearch/search/context.py
@@ -31,8 +31,8 @@ def _try_import_spacy() -> bool:
     if not get_config().search.context_aware.enabled:
         return False
     try:  # pragma: no cover - optional dependency
-        import spacy as spacy_mod  # type: ignore
-        import spacy.cli  # type: ignore
+        import spacy as spacy_mod
+        import spacy.cli
 
         spacy = spacy_mod
         SPACY_AVAILABLE = True
@@ -50,7 +50,7 @@ def _try_import_bertopic() -> bool:
     if not get_config().search.context_aware.enabled:
         return False
     try:  # pragma: no cover - optional dependency
-        from bertopic import BERTopic as BERTopic_cls  # type: ignore
+        from bertopic import BERTopic as BERTopic_cls
 
         BERTopic = BERTopic_cls
         BERTOPIC_AVAILABLE = True
@@ -111,9 +111,9 @@ def _try_import_sentence_transformers() -> bool:
         if resolved is None:
             # Fallback to sentence-transformers if available
             try:
-                from sentence_transformers import SentenceTransformer as ST  # type: ignore
+                from sentence_transformers import SentenceTransformer as ST
 
-                resolved = ST  # type: ignore[assignment]
+                resolved = ST
             except Exception:
                 resolved = None
         if resolved is None:

--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -152,9 +152,9 @@ def _try_import_sentence_transformers() -> bool:
         if resolved is None:
             # Fallback to sentence-transformers if available
             try:
-                from sentence_transformers import SentenceTransformer as ST  # type: ignore
+                from sentence_transformers import SentenceTransformer as ST
 
-                resolved = ST  # type: ignore[assignment]
+                resolved = ST
             except Exception:
                 resolved = None
         if resolved is None:
@@ -172,7 +172,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type checking only
         from fastembed import OnnxTextEmbedding as SentenceTransformerType
     except (ImportError, ModuleNotFoundError, AttributeError):
         try:
-            from fastembed.text import OnnxTextEmbedding as SentenceTransformerType  # type: ignore[attr-defined]
+            from fastembed.text import OnnxTextEmbedding as SentenceTransformerType
         except (ImportError, ModuleNotFoundError, AttributeError):
             from fastembed import TextEmbedding as SentenceTransformerType
 else:  # pragma: no cover - runtime fallback

--- a/src/autoresearch/search/parsers.py
+++ b/src/autoresearch/search/parsers.py
@@ -134,7 +134,7 @@ def extract_pdf_text(path: str | Path) -> str:
     pdfminer_extract = _load_pdfminer()
     laparams = None
     try:  # pragma: no cover - optional tuning exercised in tests
-        from pdfminer.layout import LAParams  # type: ignore
+        from pdfminer.layout import LAParams
 
         laparams = LAParams(word_margin=0.1, char_margin=2.0, line_margin=0.5)
     except Exception:  # pragma: no cover - fallback when layout module missing

--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -114,7 +114,7 @@ _MIN_DETERMINISTIC_SURVIVORS = 2
 def _process_ram_mb() -> float:
     """Return the process resident set size in megabytes."""
     try:
-        import psutil  # type: ignore[import-untyped]
+        import psutil
 
         mem = psutil.Process(os.getpid()).memory_info().rss
         return float(mem) / (1024**2)

--- a/src/autoresearch/storage_backends.py
+++ b/src/autoresearch/storage_backends.py
@@ -969,7 +969,7 @@ class KuzuStorageBackend:
 
     def setup(self, db_path: str | None = None) -> None:
         try:
-            import kuzu  # type: ignore
+            import kuzu
         except Exception as e:  # pragma: no cover - optional dependency
             raise StorageError("Failed to initialize Kuzu", cause=e)
 

--- a/src/autoresearch/test_tools.py
+++ b/src/autoresearch/test_tools.py
@@ -5,7 +5,7 @@ to send test requests to these interfaces and verify the responses.
 """
 
 import json
-import requests  # type: ignore[import-untyped]
+import requests
 from typing import Dict, Any, List, Optional
 import time
 

--- a/tests/stubs/bertopic/__init__.pyi
+++ b/tests/stubs/bertopic/__init__.pyi
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+
+class BERTopic:
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def fit_transform(
+        self, documents: Sequence[str]
+    ) -> tuple[list[int], list[Any]]: ...
+
+    def transform(
+        self, documents: Sequence[str]
+    ) -> tuple[list[int], list[Any]]: ...
+
+
+__all__ = ["BERTopic"]

--- a/tests/stubs/fastapi/__init__.pyi
+++ b/tests/stubs/fastapi/__init__.pyi
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Awaitable, Callable, Mapping, Sequence, TypeVar
+
+from .responses import Response
+
+T_Callable = TypeVar("T_Callable", bound=Callable[..., Any])
+
+
+class _Client:
+    host: str
+
+    def __init__(self, host: str) -> None: ...
+
+
+class Request:
+    app: "FastAPI"
+    client: _Client | None
+    state: SimpleNamespace
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+
+RequestResponseEndpoint = Callable[[Request], Awaitable[Response]]
+
+
+def Depends(dependency: Callable[..., Awaitable[Any]] | Callable[..., Any]) -> Any: ...
+
+
+class HTTPException(Exception):
+    status_code: int
+    detail: Any
+    headers: Mapping[str, str] | None
+
+    def __init__(
+        self,
+        status_code: int,
+        *,
+        detail: Any = ...,
+        headers: Mapping[str, str] | None = ...,
+    ) -> None: ...
+
+
+class APIRouter:
+    routes: list[Any]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def add_api_route(
+        self,
+        path: str,
+        endpoint: Callable[..., Any],
+        *,
+        methods: Sequence[str] | None = ...,
+        **kwargs: Any,
+    ) -> None: ...
+
+    def include_router(self, router: "APIRouter", *args: Any, **kwargs: Any) -> None: ...
+
+    def get(
+        self, path: str, *args: Any, **kwargs: Any
+    ) -> Callable[[T_Callable], T_Callable]: ...
+
+    def post(
+        self, path: str, *args: Any, **kwargs: Any
+    ) -> Callable[[T_Callable], T_Callable]: ...
+
+    def delete(
+        self, path: str, *args: Any, **kwargs: Any
+    ) -> Callable[[T_Callable], T_Callable]: ...
+
+
+class FastAPI:
+    router: APIRouter
+    routes: list[Any]
+    state: SimpleNamespace
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def add_middleware(
+        self, middleware_class: type[Any], *args: Any, **kwargs: Any
+    ) -> None: ...
+
+    def include_router(self, router: APIRouter, *args: Any, **kwargs: Any) -> None: ...
+
+    def add_exception_handler(
+        self,
+        exc_class: type[BaseException],
+        handler: Callable[[Request, Exception], Response | Any],
+    ) -> None: ...
+
+
+__all__ = [
+    "APIRouter",
+    "Depends",
+    "FastAPI",
+    "HTTPException",
+    "Request",
+    "RequestResponseEndpoint",
+]

--- a/tests/stubs/fastapi/openapi/docs.pyi
+++ b/tests/stubs/fastapi/openapi/docs.pyi
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..responses import Response
+
+
+def get_swagger_ui_html(*args: Any, **kwargs: Any) -> Response: ...
+
+__all__ = ["get_swagger_ui_html"]

--- a/tests/stubs/fastapi/openapi/utils.pyi
+++ b/tests/stubs/fastapi/openapi/utils.pyi
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_openapi(*, title: str, version: str, description: str, routes: Any) -> dict[str, Any]: ...
+
+__all__ = ["get_openapi"]

--- a/tests/stubs/fastapi/responses.pyi
+++ b/tests/stubs/fastapi/responses.pyi
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+class Response:
+    status_code: int
+    media_type: str | None
+
+    def __init__(self, content: Any = ..., *, status_code: int = 200, media_type: str | None = None, headers: dict[str, str] | None = None) -> None: ...
+
+
+class PlainTextResponse(Response):
+    ...
+
+
+class JSONResponse(Response):
+    ...
+
+
+class StreamingResponse(Response):
+    def __init__(
+        self,
+        content: Iterable[Any] | Any,
+        *,
+        status_code: int = 200,
+        media_type: str | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None: ...
+
+
+__all__ = [
+    "JSONResponse",
+    "PlainTextResponse",
+    "Response",
+    "StreamingResponse",
+]

--- a/tests/stubs/fastembed/text.pyi
+++ b/tests/stubs/fastembed/text.pyi
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
+from . import OnnxTextEmbedding
+
+__all__ = ["OnnxTextEmbedding"]

--- a/tests/stubs/owlrl/__init__.pyi
+++ b/tests/stubs/owlrl/__init__.pyi
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+OWLRL_Semantics: object
+RDFS_Semantics: object
+
+
+class DeductiveClosure:
+    def __init__(self, semantics: object, *args: Any, **kwargs: Any) -> None: ...
+
+    def expand(self, graph: Any) -> None: ...
+
+
+__all__ = ["DeductiveClosure", "OWLRL_Semantics", "RDFS_Semantics"]

--- a/tests/stubs/pdfminer/layout.pyi
+++ b/tests/stubs/pdfminer/layout.pyi
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class LAParams:
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+
+__all__ = ["LAParams"]

--- a/tests/stubs/psutil/__init__.pyi
+++ b/tests/stubs/psutil/__init__.pyi
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class _MemoryInfo:
+    rss: int
+
+
+class _VirtualMemory:
+    percent: float
+    available: int
+
+
+class Process:
+    def __init__(self, pid: int | None = None) -> None: ...
+
+    def memory_info(self) -> _MemoryInfo: ...
+
+
+class Popen:
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def communicate(self, timeout: float | None = None) -> tuple[str, str]: ...
+
+    def wait(self, timeout: float | None = None) -> int: ...
+
+
+def cpu_percent(interval: float | None = ...) -> float: ...
+
+
+def virtual_memory() -> _VirtualMemory: ...
+
+
+__all__ = ["Popen", "Process", "cpu_percent", "virtual_memory"]

--- a/tests/stubs/pydantic/__init__.pyi
+++ b/tests/stubs/pydantic/__init__.pyi
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, Callable, ClassVar, Mapping, TypeVar
+
+T_BaseModel = TypeVar("T_BaseModel", bound="BaseModel")
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class BaseModel:
+    model_config: ClassVar[dict[str, Any]]
+    model_fields: ClassVar[Mapping[str, Any]]
+    model_fields_set: set[str]
+
+    def __init__(self, /, **data: Any) -> None: ...
+
+    @classmethod
+    def model_validate(cls: type[T_BaseModel], obj: Any, /) -> T_BaseModel: ...
+
+    @classmethod
+    def model_validate_json(cls: type[T_BaseModel], json_data: str, /) -> T_BaseModel: ...
+
+    def model_dump(
+        self,
+        *,
+        mode: str | None = ...,
+        by_alias: bool | None = ...,
+        include: Any | None = ...,
+        exclude: Any | None = ...,
+        exclude_none: bool | None = ...,
+        round_trip: bool | None = ...,
+    ) -> dict[str, Any]: ...
+
+    def model_dump_json(
+        self,
+        *,
+        indent: int | None = ...,
+        by_alias: bool | None = ...,
+        include: Any | None = ...,
+        exclude: Any | None = ...,
+    ) -> str: ...
+
+    def model_copy(
+        self: T_BaseModel,
+        *,
+        update: Mapping[str, Any] | None = ...,
+        deep: bool | None = ...,
+    ) -> T_BaseModel: ...
+
+
+class ValidationError(Exception):
+    def errors(self) -> list[dict[str, Any]]: ...
+
+
+def Field(*args: Any, **kwargs: Any) -> Any: ...
+
+
+def PrivateAttr(*, default: Any = ..., default_factory: Callable[[], Any] | None = ...) -> Any: ...
+
+
+def field_validator(*_fields: str, **_kwargs: Any) -> Callable[[F], F]: ...
+
+
+def model_validator(*_fields: str, **_kwargs: Any) -> Callable[[F], F]: ...
+
+
+ConfigDict = dict[str, Any]
+
+__all__ = [
+    "BaseModel",
+    "ConfigDict",
+    "Field",
+    "PrivateAttr",
+    "ValidationError",
+    "field_validator",
+    "model_validator",
+]

--- a/tests/stubs/pydantic_settings/__init__.pyi
+++ b/tests/stubs/pydantic_settings/__init__.pyi
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
+SettingsConfigDict = dict[str, Any]
+
+__all__ = ["SettingsConfigDict"]

--- a/tests/stubs/pynvml.pyi
+++ b/tests/stubs/pynvml.pyi
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+
+class _Utilization:
+    gpu: float
+
+
+class _MemoryInfo:
+    used: float
+
+
+def nvmlInit() -> None: ...
+
+
+def nvmlShutdown() -> None: ...
+
+
+def nvmlDeviceGetCount() -> int: ...
+
+
+def nvmlDeviceGetHandleByIndex(index: int) -> object: ...
+
+
+def nvmlDeviceGetUtilizationRates(handle: object) -> _Utilization: ...
+
+
+def nvmlDeviceGetMemoryInfo(handle: object) -> _MemoryInfo: ...
+
+
+__all__ = [
+    "nvmlDeviceGetCount",
+    "nvmlDeviceGetHandleByIndex",
+    "nvmlDeviceGetMemoryInfo",
+    "nvmlDeviceGetUtilizationRates",
+    "nvmlInit",
+    "nvmlShutdown",
+]

--- a/tests/stubs/requests/__init__.pyi
+++ b/tests/stubs/requests/__init__.pyi
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .adapters import HTTPAdapter
+from . import exceptions
+
+
+class Response:
+    status_code: int
+    text: str
+
+    def __init__(self, *, status_code: int = 200, text: str = "", content: Any = ...) -> None: ...
+
+    def json(self, **kwargs: Any) -> Any: ...
+
+    def raise_for_status(self) -> None: ...
+
+
+class Session:
+    def __init__(self) -> None: ...
+
+    def get(self, url: str, *args: Any, **kwargs: Any) -> Response: ...
+
+    def post(self, url: str, *args: Any, **kwargs: Any) -> Response: ...
+
+    def request(self, method: str, url: str, *args: Any, **kwargs: Any) -> Response: ...
+
+    def close(self) -> None: ...
+
+    def mount(self, prefix: str, adapter: HTTPAdapter) -> None: ...
+
+    @property
+    def headers(self) -> Mapping[str, str]: ...
+
+
+def get(url: str, *args: Any, **kwargs: Any) -> Response: ...
+
+
+def post(url: str, *args: Any, **kwargs: Any) -> Response: ...
+
+
+def request(method: str, url: str, *args: Any, **kwargs: Any) -> Response: ...
+
+
+RequestException = exceptions.RequestException
+Timeout = exceptions.Timeout
+
+__all__ = [
+    "HTTPAdapter",
+    "RequestException",
+    "Response",
+    "Session",
+    "Timeout",
+    "exceptions",
+    "get",
+    "post",
+    "request",
+]

--- a/tests/stubs/requests/adapters.pyi
+++ b/tests/stubs/requests/adapters.pyi
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class HTTPAdapter:
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+
+__all__ = ["HTTPAdapter"]

--- a/tests/stubs/requests/exceptions.pyi
+++ b/tests/stubs/requests/exceptions.pyi
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+class RequestException(Exception):
+    ...
+
+
+class Timeout(RequestException):
+    ...
+
+
+__all__ = ["RequestException", "Timeout"]

--- a/tests/stubs/sentence_transformers/__init__.pyi
+++ b/tests/stubs/sentence_transformers/__init__.pyi
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+
+class SentenceTransformer:
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def encode(
+        self, sentences: Sequence[str] | str, *args: Any, **kwargs: Any
+    ) -> Any: ...
+
+    def embed(
+        self, sentences: Sequence[str] | str, *args: Any, **kwargs: Any
+    ) -> Any: ...
+
+
+__all__ = ["SentenceTransformer"]

--- a/tests/stubs/spacy/__init__.pyi
+++ b/tests/stubs/spacy/__init__.pyi
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any
+
+from . import cli
+from .language import Language
+
+
+def load(model: str, *args: Any, **kwargs: Any) -> Language: ...
+
+
+__all__ = ["Language", "cli", "load"]

--- a/tests/stubs/spacy/cli/__init__.pyi
+++ b/tests/stubs/spacy/cli/__init__.pyi
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def download(model: str, *args: Any, **kwargs: Any) -> None: ...
+
+__all__ = ["download"]

--- a/tests/stubs/spacy/language/__init__.pyi
+++ b/tests/stubs/spacy/language/__init__.pyi
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Iterable, Iterator, Protocol
+
+
+class Span(Protocol):
+    text: str
+    label_: str
+
+
+class Doc(Protocol):
+    ents: Iterable[Span]
+
+
+class Language:
+    def __call__(self, text: str) -> Doc: ...
+
+    def pipe(self, texts: Iterable[str]) -> Iterator[Doc]: ...

--- a/tests/stubs/starlette/middleware/base.pyi
+++ b/tests/stubs/starlette/middleware/base.pyi
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable
+
+from ...fastapi import Request
+from ...fastapi import RequestResponseEndpoint
+from ...fastapi.responses import Response
+
+
+class BaseHTTPMiddleware:
+    app: Any
+
+    def __init__(self, app: Any, *args: Any, **kwargs: Any) -> None: ...
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response: ...
+
+    async def __call__(self, scope: Any, receive: Callable[..., Awaitable[Any]], send: Callable[..., Awaitable[Any]]) -> None: ...
+
+
+__all__ = ["BaseHTTPMiddleware", "RequestResponseEndpoint"]


### PR DESCRIPTION
## Summary
- add .pyi stubs under tests/stubs for pydantic, fastapi/starlette, requests, psutil/pynvml, and optional NLP libraries to unblock strict mypy
- remove no-longer-needed `type: ignore` markers on third-party imports and tighten agent feedback metadata typing
- document the stub audit and validation reasoning in docs/dev/third_party_stub_audit.md

## Testing
- MYPYPATH=tests/stubs uv run --extra dev-minimal --extra test mypy --strict src/autoresearch/agents/feedback.py --follow-imports=skip
- MYPYPATH=tests/stubs uv run --extra dev-minimal --extra test mypy --strict src/autoresearch/test_tools.py --follow-imports=skip
- MYPYPATH=tests/stubs uv run --extra dev-minimal --extra test mypy --strict src/autoresearch/search/context.py --follow-imports=skip


------
https://chatgpt.com/codex/tasks/task_e_68d5b58fbaec833381dcaf75129c3a5d