### PR TITLE
Refine adapter typings and kuzu results

### DIFF
--- a/src/autoresearch/__init__.py
+++ b/src/autoresearch/__init__.py
@@ -68,7 +68,7 @@ _DISTRIBUTED_ATTRS = {
 }
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> object:
     """Lazily import distributed features on first access."""
     if name in _DISTRIBUTED_ATTRS:
         try:  # pragma: no cover - optional distributed extras

--- a/src/autoresearch/a2a_interface.py
+++ b/src/autoresearch/a2a_interface.py
@@ -320,7 +320,7 @@ class A2AInterface:
             # Return error response
             return error_data
 
-    def _handle_get_capabilities(self) -> Any:
+    def _handle_get_capabilities(self) -> Dict[str, Any]:
         """Handle a get_capabilities command.
 
         Returns:
@@ -329,7 +329,7 @@ class A2AInterface:
         capabilities = capabilities_endpoint()
         return capabilities
 
-    def _handle_get_config(self) -> Any:
+    def _handle_get_config(self) -> Dict[str, Any]:
         """Handle a get_config command.
 
         Returns:
@@ -338,7 +338,7 @@ class A2AInterface:
         config = get_config()
         return config.model_dump(mode="json")
 
-    def _handle_set_config(self, args: Dict[str, Any]) -> Any:
+    def _handle_set_config(self, args: Dict[str, Any]) -> Dict[str, Any]:
         """Handle a set_config command.
 
         Args:

--- a/src/autoresearch/distributed/broker.py
+++ b/src/autoresearch/distributed/broker.py
@@ -13,15 +13,15 @@ class _CountingQueue:
     """Wrap ``multiprocessing.Queue`` with a reliable ``empty`` check."""
 
     def __init__(self) -> None:
-        self._queue: multiprocessing.Queue[Any] = multiprocessing.Queue()
+        self._queue: multiprocessing.Queue[dict[str, Any]] = multiprocessing.Queue()
         self._size = multiprocessing.Value("i", 0)
 
-    def put(self, item: Any) -> None:
+    def put(self, item: dict[str, Any]) -> None:
         self._queue.put(item)
         with self._size.get_lock():
             self._size.value += 1
 
-    def get(self) -> Any:
+    def get(self) -> dict[str, Any]:
         item = self._queue.get()
         with self._size.get_lock():
             self._size.value -= 1

--- a/src/autoresearch/storage_backends.py
+++ b/src/autoresearch/storage_backends.py
@@ -993,11 +993,13 @@ class KuzuStorageBackend:
             self._conn.close()
             self._conn = None
 
-    def execute(self, query: str, params: dict[str, Any] | None = None) -> Any:
+    def execute(
+        self, query: str, params: dict[str, Any] | None = None
+    ) -> "kuzu.QueryResult":
         if self._conn is None:
             raise StorageError("Kuzu connection not initialized")
         start = time.time()
-        result = self._conn.execute(query, params or {})
+        result: "kuzu.QueryResult" = self._conn.execute(query, params or {})
         KUZU_QUERY_COUNTER.inc()
         KUZU_QUERY_TIME.observe(time.time() - start)
         return result


### PR DESCRIPTION
## Summary
- narrow the Kuzu storage execute method to return the concrete QueryResult type
- introduce an adapter protocol so orchestration token utilities avoid Any leakage
- tighten ancillary annotations in distributed broker, a2a interface, search hybridmethod, and package init

## Testing
- `uv run --extra dev-minimal --extra test mypy --strict src` *(fails: repository currently has extensive pre-existing strict mypy violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c4ea3f9483338c8953088b7aedfa