### PR TITLE
Enable mypy strict bundle baseline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,10 +242,8 @@ markers = [
 
 [tool.mypy]
 python_version = "3.12"
-ignore_missing_imports = true
-disable_error_code = ["import-untyped"]
 no_site_packages = true
-check_untyped_defs = true
+strict = true
 
 [tool.flake8]
 max-line-length = 100


### PR DESCRIPTION
## Summary
- switch the mypy configuration to use the strict option while keeping the project-specific python_version and no_site_packages settings

## Testing
- `uv run --extra dev-minimal --extra test mypy src tests`
- `task check`


------
https://chatgpt.com/codex/tasks/task_e_68d5c95aeb908333b5ef54d0d65b0040