### PR TITLE
test: update hybridmethod stubs for search backend unit tests

### DIFF
--- a/tests/unit/test_search_backends_unit.py
+++ b/tests/unit/test_search_backends_unit.py
@@ -23,8 +23,16 @@ def _make_hybrid_stub(
     """
 
     def _stub(subject, *args, **kwargs):
-        binding = "class" if subject is Search else "instance"
-        calls.append({"binding": binding, "args": args, "kwargs": kwargs})
+        is_class = isinstance(subject, type) and issubclass(subject, Search)
+        binding = "class" if is_class else "instance"
+        calls.append(
+            {
+                "binding": binding,
+                "subject": subject,
+                "args": args,
+                "kwargs": kwargs,
+            }
+        )
         if responder is not None:
             return responder(subject, args, kwargs)
         return default


### PR DESCRIPTION
## Summary
- ensure the search backend unit test uses a hybridmethod-aware stub that records call context

## Testing
- `uv run --extra test pytest tests/unit/test_search_backends_unit.py::test_register_backend_and_lookup -q`
- `uv run --extra test pytest tests/unit/test_core_modules_additional.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d6c01650048333b86441a6cc759b87