### PR TITLE
feat: add claim audits and evidence utilities

### DIFF
--- a/docs/quickstart_guides.md
+++ b/docs/quickstart_guides.md
@@ -140,7 +140,10 @@ This will start the Streamlit server and open the GUI in your default web browse
 
 2. **View results:**
    - The answer will appear in the "Answer" tab
-   - Click on other tabs to view reasoning, citations, and the knowledge graph
+   - Click on other tabs to view reasoning, citations, claim audits, metrics,
+     and the knowledge graph. The **Claim Audits** tab surfaces FEVER-style
+     status badges (supported, unsupported, needs review) together with the
+     top evidence snippet and entailment score for each claim.
 
 3. **Export results:**
    - Click the "Export" button

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -49,7 +49,13 @@
   - By default (TTY), output is readable Markdown or plaintext, with clear sections for thesis, antithesis, synthesis, and citations.
   - If `--output json` or output is piped, output is schema-validated JSON.
   - User can override with `--output` flag.
-- Output: Schema-validated JSON with `answer`, `citations`, `reasoning`, `metrics` (for automation); Markdown/pretty text for humans.
+- Output: Schema-validated JSON with `answer`, `citations`, `reasoning`,
+  `metrics`, and `claim_audits` (for automation); Markdown/pretty text for
+  humans.
+- `claim_audits` is a FEVER-style array of verification records containing a
+  `claim_id`, `status` (`supported`, `unsupported`, `needs_review`),
+  `entailment_score`, `sources`, optional reviewer `notes`, and a
+  `created_at` timestamp.
 
 ## 5. Reasoning Modes
 

--- a/src/autoresearch/agents/dialectical/fact_checker.py
+++ b/src/autoresearch/agents/dialectical/fact_checker.py
@@ -4,11 +4,13 @@ from typing import Dict, Any
 
 from ...agents.base import Agent, AgentRole
 from ...config import ConfigModel
+from ...evidence import classify_entailment, expand_retrieval_queries, score_entailment
 from ...orchestration.phases import DialoguePhase
 from ...orchestration.reasoning import ReasoningMode
 from ...orchestration.state import QueryState
 from ...logging_utils import get_logger
 from ...search import Search
+from ...storage import ClaimAuditRecord
 
 log = get_logger(__name__)
 
@@ -37,21 +39,67 @@ class FactChecker(Agent):
             s["agent"] = self.name
             sources.append(s)
 
+        query_variations: list[str] = []
+        for claim in state.claims:
+            query_variations.extend(
+                expand_retrieval_queries(
+                    claim.get("content", ""), base_query=state.query, max_variations=2
+                )
+            )
+
+        claim_audits: list[dict[str, Any]] = []
+        top_sources: list[Dict[str, Any]] = []
+        for claim in state.claims:
+            best_score = 0.0
+            best_source: Dict[str, Any] | None = None
+            for source in sources:
+                snippet = source.get("snippet") or source.get("content") or ""
+                breakdown = score_entailment(claim.get("content", ""), snippet)
+                if breakdown.score > best_score:
+                    best_score = breakdown.score
+                    best_source = source
+            status = classify_entailment(best_score)
+            record = ClaimAuditRecord(
+                claim_id=claim["id"],
+                status=status,
+                entailment_score=best_score,
+                sources=[best_source] if best_source else [],
+            )
+            audit_payload = record.to_payload()
+            claim_audits.append(audit_payload)
+            if best_source and best_source not in top_sources:
+                top_sources.append(best_source)
+
         # Generate verification using the prompt template
         claims_text = "\n".join(c.get("content", "") for c in state.claims)
         prompt = self.generate_prompt("fact_checker.verification", claims=claims_text)
         verification = adapter.generate(prompt, model=model)
 
         # Create and return the result
-        claim = self.create_claim(verification, "verification")
+        aggregate_score = (
+            sum(audit.get("entailment_score", 0.0) for audit in claim_audits) / len(claim_audits)
+            if claim_audits
+            else 0.0
+        )
+        aggregate_status = classify_entailment(aggregate_score)
+        claim = self.create_claim(
+            verification,
+            "verification",
+            metadata={"query_variations": query_variations},
+            verification_status=aggregate_status,
+            verification_sources=top_sources,
+            entailment_score=aggregate_score,
+        )
         return self.create_result(
             claims=[claim],
             metadata={
                 "phase": DialoguePhase.VERIFICATION,
                 "source_count": len(sources),
+                "query_variations": query_variations,
             },
             results={"verification": verification},
             sources=sources,
+            claim_audits=claim_audits,
         )
 
     def can_execute(self, state: QueryState, config: ConfigModel) -> bool:

--- a/src/autoresearch/evidence/__init__.py
+++ b/src/autoresearch/evidence/__init__.py
@@ -1,0 +1,142 @@
+"""Utilities for evidence retrieval expansion and entailment scoring."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from ..storage import ClaimAuditStatus
+
+_STOPWORDS = {
+    "the",
+    "a",
+    "an",
+    "of",
+    "and",
+    "in",
+    "to",
+    "for",
+    "on",
+    "at",
+    "by",
+    "is",
+    "are",
+    "was",
+    "were",
+    "be",
+    "with",
+    "from",
+    "that",
+    "this",
+}
+
+_NEGATION_TERMS = {"no", "not", "never", "without", "none", "neither"}
+
+
+@dataclass(frozen=True)
+class EntailmentBreakdown:
+    """Structured insight returned by :func:`score_entailment`."""
+
+    score: float
+    overlap_ratio: float
+    support_ratio: float
+    overlapping_terms: List[str]
+
+
+def expand_retrieval_queries(
+    claim: str,
+    *,
+    base_query: str | None = None,
+    max_variations: int = 5,
+) -> List[str]:
+    """Generate lightweight retrieval queries for a claim."""
+
+    cleaned = claim.strip()
+    if not cleaned:
+        return []
+
+    variations: list[str] = []
+    candidates = [cleaned]
+    if base_query:
+        candidates.append(f"{base_query.strip()} {cleaned}")
+
+    keywords = _extract_keywords(cleaned)
+    if keywords:
+        candidates.append(" ".join(keywords))
+
+    candidates.extend(
+        [
+            f"evidence supporting {cleaned}",
+            f"evidence contradicting {cleaned}",
+        ]
+    )
+
+    for candidate in candidates:
+        normalised = " ".join(candidate.split())
+        if normalised and normalised.lower() not in {c.lower() for c in variations}:
+            variations.append(normalised)
+        if len(variations) >= max_variations:
+            break
+
+    return variations
+
+
+def score_entailment(claim: str, evidence: str) -> EntailmentBreakdown:
+    """Return a lightweight lexical entailment estimate."""
+
+    claim_tokens = _tokenize(claim)
+    evidence_tokens = _tokenize(evidence)
+    if not claim_tokens or not evidence_tokens:
+        return EntailmentBreakdown(0.0, 0.0, 0.0, [])
+
+    claim_counts = _frequency_vector(claim_tokens)
+    evidence_counts = _frequency_vector(evidence_tokens)
+
+    overlap = sum(min(claim_counts[token], evidence_counts.get(token, 0)) for token in claim_counts)
+    overlap_ratio = overlap / max(sum(claim_counts.values()), 1)
+    support_ratio = overlap / max(sum(evidence_counts.values()), 1)
+
+    score = (overlap_ratio + support_ratio) / 2
+
+    claim_negated = bool(_NEGATION_TERMS.intersection(claim_counts))
+    evidence_negated = bool(_NEGATION_TERMS.intersection(evidence_counts))
+    if claim_negated != evidence_negated and score > 0:
+        score *= 0.6
+    elif claim_negated and evidence_negated:
+        score = min(1.0, score + 0.1)
+
+    overlapping_terms = sorted({token for token in claim_counts if token in evidence_counts})
+    score = max(0.0, min(1.0, score))
+
+    return EntailmentBreakdown(score, overlap_ratio, support_ratio, overlapping_terms)
+
+
+def classify_entailment(score: float) -> ClaimAuditStatus:
+    """Map an entailment score to a :class:`ClaimAuditStatus`."""
+
+    return ClaimAuditStatus.from_entailment(score)
+
+
+def _tokenize(text: str) -> List[str]:
+    return [token for token in re.findall(r"[a-z0-9']+", text.lower()) if token not in _STOPWORDS]
+
+
+def _frequency_vector(tokens: Iterable[str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for token in tokens:
+        counts[token] = counts.get(token, 0) + 1
+    return counts
+
+
+def _extract_keywords(text: str) -> List[str]:
+    tokens = _tokenize(text)
+    return tokens[:8]
+
+
+__all__ = [
+    "EntailmentBreakdown",
+    "classify_entailment",
+    "expand_retrieval_queries",
+    "score_entailment",
+]

--- a/src/autoresearch/models.py
+++ b/src/autoresearch/models.py
@@ -61,25 +61,35 @@ class QueryRequest(BaseModel):
 
 
 class QueryResponse(BaseModel):
-    """
-    Represents a structured response to a user query.
+    """Structured response returned by the orchestration system.
 
-    This class defines the standard format for responses returned by the orchestration system.
-    It includes the final answer, supporting citations, reasoning steps, and execution metrics.
+    The response captures the synthesized answer along with traceability
+    artefacts that downstream clients can audit. Claim verification metadata
+    is represented by the ``claim_audits`` field which mirrors the
+    :class:`~autoresearch.storage.ClaimAuditRecord` payload structure.
 
     Attributes:
-        query (Optional[str]): The original query that produced this response.
-        answer (str): The final answer to the user's query.
-        citations (List[Any]): A list of citations or sources that support the answer.
-        reasoning (List[Any]): A list of reasoning steps or explanations that led to the answer.
-        metrics (Dict[str, Any]): Performance and execution metrics for the query processing.
+        query: The original query that produced this response, if available.
+        answer: The final answer synthesized by the agent cohort.
+        citations: References surfaced during retrieval.
+        reasoning: Ordered reasoning steps exchanged between agents.
+        metrics: Execution metrics describing latency, token usage, etc.
+        claim_audits: Verification metadata for each evaluated claim. Each
+            entry is a mapping containing ``claim_id``, ``status``,
+            ``entailment_score``, ``sources``, ``notes``, and ``created_at``.
     """
 
-    query: Optional[str] = Field(None, description="The original query that produced this response")
+    query: Optional[str] = Field(
+        None, description="The original query that produced this response"
+    )
     answer: str
     citations: List[Any]
     reasoning: List[Any]
     metrics: Dict[str, Any]
+    claim_audits: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="FEVER-style verification metadata for individual claims",
+    )
 
 
 class BatchQueryRequest(BaseModel):

--- a/tests/evidence/test_fever_regression.py
+++ b/tests/evidence/test_fever_regression.py
@@ -1,0 +1,84 @@
+"""Regression tests for claim evidence utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from autoresearch.agents.mixins import ClaimGeneratorMixin
+from autoresearch.evidence import (
+    classify_entailment,
+    expand_retrieval_queries,
+    score_entailment,
+)
+from autoresearch.storage import ClaimAuditRecord, ClaimAuditStatus
+
+
+@dataclass
+class _MixinHarness(ClaimGeneratorMixin):
+    """Minimal harness to expose mixin behaviour in tests."""
+
+
+def test_expand_retrieval_queries_generates_contextual_variations() -> None:
+    claim = "The Eiffel Tower is located in Paris."
+    expansions = expand_retrieval_queries(
+        claim, base_query="France landmarks", max_variations=4
+    )
+    assert expansions
+    assert expansions[0] == claim
+    assert any("supporting" in variant for variant in expansions)
+
+
+def test_entailment_scoring_supported_claim() -> None:
+    claim = "The Eiffel Tower is in Paris."
+    evidence = "Paris is home to the famous Eiffel Tower landmark."
+    breakdown = score_entailment(claim, evidence)
+    assert breakdown.score > 0.6
+    status = classify_entailment(breakdown.score)
+    assert status == ClaimAuditStatus.SUPPORTED
+    record = ClaimAuditRecord(
+        claim_id="claim-1",
+        status=status,
+        entailment_score=breakdown.score,
+        sources=[{"snippet": evidence}],
+    )
+    payload = record.to_payload()
+    recovered = ClaimAuditRecord.from_payload(payload)
+    assert recovered.status == status
+    assert recovered.entailment_score == record.entailment_score
+
+
+def test_entailment_scoring_unsupported_claim() -> None:
+    claim = "The Eiffel Tower is in Paris."
+    evidence = "The Statue of Liberty stands in New York Harbor."
+    breakdown = score_entailment(claim, evidence)
+    assert breakdown.score < 0.3
+    status = classify_entailment(breakdown.score)
+    assert status == ClaimAuditStatus.UNSUPPORTED
+
+
+def test_claim_generator_attaches_audit_metadata() -> None:
+    harness = _MixinHarness()
+    record = ClaimAuditRecord(
+        claim_id="placeholder",
+        status=ClaimAuditStatus.NEEDS_REVIEW,
+        entailment_score=0.4,
+    )
+    claim = harness.create_claim(
+        "Paris hosts the Eiffel Tower.",
+        "thesis",
+        audit=record,
+    )
+    assert "audit" in claim
+    assert claim["audit"]["claim_id"] == claim["id"]
+    assert claim["audit"]["status"] == ClaimAuditStatus.NEEDS_REVIEW.value
+
+    claim2 = harness.create_claim(
+        "The Louvre is in Paris.",
+        "thesis",
+        verification_status="supported",
+        verification_sources=[{"title": "Museums in Paris"}],
+        entailment_score=0.72,
+    )
+    assert claim2["audit"]["status"] == ClaimAuditStatus.SUPPORTED.value
+    assert claim2["audit"]["entailment_score"] == 0.72
+    assert claim2["audit"]["sources"][0]["title"] == "Museums in Paris"


### PR DESCRIPTION
## Summary
- add a claim audit model with DuckDB persistence, output formatting, and Streamlit rendering
- provide retrieval-expansion and lexical entailment helpers for agents and integrate them into the FactChecker
- document the expanded response schema and back the evidence pipeline with FEVER-style regression tests

## Testing
- `uv run pytest tests/evidence/test_fever_regression.py`


------
https://chatgpt.com/codex/tasks/task_e_68d706a032688333a90edbcb0b60c361