### PR TITLE
Add budget-aware routing metrics and search cache controls

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,9 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
 ## September 26, 2025
+- Wired budget-aware routing metrics into the orchestrator so dashboards can
+  surface per-role latency percentiles and token spend; added shared retrieval
+  cache and parallelisation toggles to stabilise search cost benchmarks.
 - Logged the Deep Research Enhancement Initiative and five-phase execution plan
   across ROADMAP.md and the new Deep Research Upgrade Plan so the alpha release
   workstream can stage adaptive gating, audits, GraphRAG, evaluation harnesses,

--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -77,6 +77,14 @@ class SearchConfig(BaseModel):
     local_git: LocalGitConfig = Field(default_factory=LocalGitConfig)
     max_workers: int = Field(default=4, ge=1)
     http_pool_size: int = Field(default=10, ge=1)
+    shared_retrieval_cache: bool = Field(
+        default=True,
+        description="Share in-memory retrieval caches across Search instances.",
+    )
+    parallel_backends: bool = Field(
+        default=True,
+        description="Execute HTTP backends concurrently when enabled.",
+    )
 
     _normalize_ranking_weights = model_validator(mode="after")(normalize_ranking_weights)
 

--- a/src/autoresearch/orchestration/execution.py
+++ b/src/autoresearch/orchestration/execution.py
@@ -274,6 +274,17 @@ def _execute_agent(
             agent = _get_agent(agent_name, agent_factory)
             if not _check_agent_can_execute(agent, agent_name, state, config):
                 return
+            role_attr = getattr(agent, "role", None)
+            role_name = (
+                role_attr.value
+                if hasattr(role_attr, "value")
+                else str(role_attr) if role_attr is not None else agent_name
+            )
+            try:
+                model_name = agent.get_model(config)
+            except Exception:  # pragma: no cover - defensive guard
+                model_name = getattr(config, "default_model", "")
+            metrics.begin_agent_turn(agent_name, role_name, model_name)
             _deliver_messages(agent_name, state, config)
             _log_agent_execution(agent_name, state, loop)
             _call_agent_start_callback(agent_name, state, callbacks)

--- a/src/autoresearch/token_budget.py
+++ b/src/autoresearch/token_budget.py
@@ -1,6 +1,51 @@
-"""Token budget utilities."""
+"""Token budget utilities and budget-aware routing helpers."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
+from typing import Mapping
+
+from .logging_utils import get_logger
+
+log = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ModelBudget:
+    """Cost and latency metadata used when ranking model candidates."""
+
+    name: str
+    prompt_cost_per_1k: float
+    completion_cost_per_1k: float
+    latency_ms: float | None = None
+    max_tokens: int | None = None
+
+
+@dataclass(frozen=True)
+class RoleUsageSnapshot:
+    """Aggregate token and latency statistics for an agent role."""
+
+    role: str
+    call_count: int
+    total_prompt_tokens: int
+    total_completion_tokens: int
+    avg_prompt_tokens: float
+    avg_completion_tokens: float
+    avg_latency_ms: float | None
+    model_counts: Mapping[str, int]
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    """Decision returned by :func:`select_model_for_role`."""
+
+    role: str
+    model: str
+    estimated_cost: float
+    estimated_latency_ms: float | None
+    meets_budget: bool
+    rationale: str
 
 
 def round_with_margin(usage: float, margin: float) -> int:
@@ -15,3 +60,125 @@ def round_with_margin(usage: float, margin: float) -> int:
     """
     scaled = Decimal(str(usage)) * (Decimal("1") + Decimal(str(margin)))
     return int(scaled.to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def _estimate_call_cost(snapshot: RoleUsageSnapshot, budget: ModelBudget) -> float:
+    """Return the estimated per-call cost for ``budget`` given ``snapshot``.
+
+    Args:
+        snapshot: Aggregated usage metrics for the role.
+        budget: Model cost profile.
+
+    Returns:
+        Estimated monetary cost for a single invocation.
+    """
+
+    prompt_tokens = snapshot.avg_prompt_tokens
+    completion_tokens = snapshot.avg_completion_tokens
+    prompt_component = (prompt_tokens / 1000.0) * budget.prompt_cost_per_1k
+    completion_component = (completion_tokens / 1000.0) * budget.completion_cost_per_1k
+    return prompt_component + completion_component
+
+
+def select_model_for_role(
+    snapshot: RoleUsageSnapshot,
+    candidates: Mapping[str, ModelBudget],
+    *,
+    default_model: str,
+    cost_budget: float | None = None,
+    latency_budget_ms: float | None = None,
+) -> RoutingDecision:
+    """Return the most appropriate model for ``snapshot.role``.
+
+    The ranking process balances latency and token cost. Models that violate
+    explicit ``cost_budget`` or ``latency_budget_ms`` constraints are
+    deprioritised but can still win when no candidate satisfies both limits.
+
+    Args:
+        snapshot: Usage statistics for a specific role.
+        candidates: Mapping of model name to budget metadata.
+        default_model: Fallback model when no candidate improves upon it.
+        cost_budget: Optional per-call cost ceiling. ``None`` disables the
+            constraint.
+        latency_budget_ms: Optional latency ceiling in milliseconds. ``None``
+            disables the constraint.
+
+    Returns:
+        A :class:`RoutingDecision` describing the chosen model and rationale.
+    """
+
+    if not candidates:
+        log.debug("No candidate models provided; retaining default %s", default_model)
+        return RoutingDecision(
+            role=snapshot.role,
+            model=default_model,
+            estimated_cost=0.0,
+            estimated_latency_ms=snapshot.avg_latency_ms,
+            meets_budget=True,
+            rationale="No candidates supplied",
+        )
+
+    def _score(budget: ModelBudget) -> tuple[bool, float, float]:
+        cost = _estimate_call_cost(snapshot, budget)
+        latency = budget.latency_ms if budget.latency_ms is not None else (
+            snapshot.avg_latency_ms or 0.0
+        )
+        within_cost = cost_budget is None or cost <= cost_budget
+        within_latency = latency_budget_ms is None or (
+            latency is not None and latency <= latency_budget_ms
+        )
+        hard_fail = not within_cost or not within_latency
+        # Prefer lower cost and latency; normalise by using the raw values.
+        return hard_fail, cost, latency or float("inf")
+
+    ranked = sorted(candidates.values(), key=_score)
+    chosen = ranked[0]
+    estimated_cost = _estimate_call_cost(snapshot, chosen)
+    estimated_latency = (
+        chosen.latency_ms if chosen.latency_ms is not None else snapshot.avg_latency_ms
+    )
+    meets_budget = True
+    reasons: list[str] = []
+
+    if cost_budget is not None:
+        if estimated_cost <= cost_budget:
+            reasons.append(f"cost {estimated_cost:.4f} within {cost_budget:.4f}")
+        else:
+            reasons.append(
+                f"cost {estimated_cost:.4f} exceeds {cost_budget:.4f}"  # pragma: no cover - text only
+            )
+            meets_budget = False
+    else:
+        reasons.append(f"cost {estimated_cost:.4f} (no ceiling)")
+
+    if latency_budget_ms is not None:
+        if estimated_latency is not None and estimated_latency <= latency_budget_ms:
+            reasons.append(
+                f"latency {estimated_latency:.1f}ms within {latency_budget_ms:.1f}ms"
+            )
+        else:
+            reasons.append(
+                f"latency {estimated_latency if estimated_latency is not None else float('nan'):.1f}ms exceeds {latency_budget_ms:.1f}ms"
+            )
+            meets_budget = False
+    else:
+        reasons.append(
+            f"latency {estimated_latency:.1f}ms (no ceiling)"
+            if estimated_latency is not None
+            else "latency unknown"
+        )
+
+    rationale = "; ".join(reasons)
+
+    if chosen.max_tokens is not None and snapshot.avg_prompt_tokens > chosen.max_tokens:
+        meets_budget = False
+        rationale += f"; prompt average {snapshot.avg_prompt_tokens:.1f} exceeds cap {chosen.max_tokens}"
+
+    return RoutingDecision(
+        role=snapshot.role,
+        model=chosen.name,
+        estimated_cost=estimated_cost,
+        estimated_latency_ms=estimated_latency,
+        meets_budget=meets_budget,
+        rationale=rationale,
+    )

--- a/tests/performance/test_budget_routing.py
+++ b/tests/performance/test_budget_routing.py
@@ -1,0 +1,53 @@
+"""Performance-focused tests for budget-aware routing heuristics."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoresearch.orchestration.metrics import OrchestrationMetrics
+from autoresearch.token_budget import ModelBudget
+
+
+def test_role_snapshot_and_model_selection_prefers_budget() -> None:
+    """Verify role snapshots drive budget-aware routing decisions."""
+
+    metrics = OrchestrationMetrics()
+
+    # Simulate two turns for the synthesizer role.
+    metrics.begin_agent_turn("Synthesizer", "Synthesizer", "fast-large")
+    metrics.record_tokens("Synthesizer", 120, 60)
+    metrics.record_agent_timing("Synthesizer", 1.2)
+
+    metrics.begin_agent_turn("Synthesizer", "Synthesizer", "fast-large")
+    metrics.record_tokens("Synthesizer", 100, 50)
+    metrics.record_agent_timing("Synthesizer", 0.9)
+
+    snapshot = metrics.get_role_usage_snapshot("Synthesizer")
+    assert snapshot.call_count == 2
+    assert pytest.approx(snapshot.avg_prompt_tokens, rel=1e-6) == 110.0
+    assert pytest.approx(snapshot.avg_completion_tokens, rel=1e-6) == 55.0
+
+    decisions = metrics.select_model_for_role(
+        "Synthesizer",
+        {
+            "fast-large": ModelBudget(
+                name="fast-large",
+                prompt_cost_per_1k=0.6,
+                completion_cost_per_1k=0.6,
+                latency_ms=520.0,
+            ),
+            "budget-small": ModelBudget(
+                name="budget-small",
+                prompt_cost_per_1k=0.08,
+                completion_cost_per_1k=0.08,
+                latency_ms=900.0,
+            ),
+        },
+        default_model="fast-large",
+        cost_budget=0.05,
+        latency_budget_ms=1500.0,
+    )
+
+    assert decisions.model == "budget-small"
+    assert decisions.meets_budget is True
+    assert "cost" in decisions.rationale

--- a/tests/performance/test_search_controls.py
+++ b/tests/performance/test_search_controls.py
@@ -1,0 +1,97 @@
+"""Performance regressions for search caching and parallel toggles."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Dict, List
+
+import pytest
+
+from autoresearch.cache import SearchCache
+from autoresearch.search.core import Search
+
+
+def _make_runtime_config(*, shared: bool, parallel: bool) -> SimpleNamespace:
+    """Return a minimal runtime config satisfying the search protocol."""
+
+    search = SimpleNamespace(
+        backends=["stub"],
+        embedding_backends=[],
+        hybrid_query=False,
+        use_semantic_similarity=False,
+        use_bm25=False,
+        use_source_credibility=False,
+        bm25_weight=0.0,
+        semantic_similarity_weight=0.0,
+        source_credibility_weight=0.0,
+        max_workers=2,
+        shared_retrieval_cache=shared,
+        parallel_backends=parallel,
+        context_aware=SimpleNamespace(enabled=False, use_topic_modeling=False),
+        local_file=SimpleNamespace(path="", file_types=["txt"]),
+        local_git=SimpleNamespace(repo_path="", branches=["main"], history_depth=10),
+    )
+    return SimpleNamespace(search=search)
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_cache() -> None:
+    """Ensure shared caches do not leak across test cases."""
+
+    Search._clear_shared_caches()
+
+
+def test_shared_retrieval_cache_reuses_backend(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Shared in-memory caches avoid repeated backend execution."""
+
+    calls: List[str] = []
+
+    def stub_backend(query: str, limit: int) -> List[Dict[str, str]]:
+        calls.append(query)
+        return [{"title": query, "url": f"https://example.com/{len(calls)}"}]
+
+    config = _make_runtime_config(shared=True, parallel=True)
+    monkeypatch.setattr("autoresearch.search.core.get_config", lambda: config)
+    cache = SearchCache(str(tmp_path / "cache.json"))
+    search = Search(cache=cache)
+
+    with search.temporary_state() as temp:
+        temp.backends = {"stub": stub_backend}
+        temp.embedding_backends = {}
+        temp.cache.clear()
+
+        temp.external_lookup("dialectics", max_results=3)
+        assert len(calls) == 1
+
+        temp.cache.clear()
+        temp.external_lookup("dialectics", max_results=3)
+        assert len(calls) == 1, "shared cache should prevent a second backend call"
+
+
+def test_parallel_toggle_disables_threadpool(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Disabling parallel backends avoids ThreadPoolExecutor usage."""
+
+    calls: List[str] = []
+
+    def stub_backend(query: str, limit: int) -> List[Dict[str, str]]:
+        calls.append(query)
+        return [{"title": query, "url": "https://example.com"}]
+
+    config = _make_runtime_config(shared=True, parallel=False)
+    monkeypatch.setattr("autoresearch.search.core.get_config", lambda: config)
+
+    def _failing_executor(*args, **kwargs):
+        raise AssertionError("ThreadPoolExecutor should not be constructed when parallelism is disabled")
+
+    monkeypatch.setattr("autoresearch.search.core.ThreadPoolExecutor", _failing_executor)
+
+    cache = SearchCache(str(tmp_path / "cache2.json"))
+    search = Search(cache=cache)
+
+    with search.temporary_state() as temp:
+        temp.backends = {"stub": stub_backend}
+        temp.embedding_backends = {}
+        temp.cache.clear()
+        temp.external_lookup("budget", max_results=2)
+
+    assert calls == ["budget"]


### PR DESCRIPTION
## Summary
- introduce budget-aware routing helpers in the token budget module and capture per-role usage snapshots in orchestration metrics
- add shared retrieval cache and parallelism toggles to the search core along with documentation and status updates
- add performance regression tests covering routing heuristics and shared cache controls

## Testing
- uv run task verify *(fails: flake8 reports pre-existing lint violations in legacy tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d706ca973083339b5360185c8e13ce