### PR TITLE
Add budget-aware routing and search cache controls

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,8 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
 ## September 26, 2025
+- Integrated budget-aware model routing, shared retrieval cache namespaces, and
+  telemetry updates that surface cost savings alongside latency percentiles.
 - Logged the Deep Research Enhancement Initiative and five-phase execution plan
   across ROADMAP.md and the new Deep Research Upgrade Plan so the alpha release
   workstream can stage adaptive gating, audits, GraphRAG, evaluation harnesses,

--- a/src/autoresearch/orchestration/execution.py
+++ b/src/autoresearch/orchestration/execution.py
@@ -271,6 +271,7 @@ def _execute_agent(
         return
     for attempt in range(retries):
         try:
+            metrics.apply_model_routing(agent_name, config)
             agent = _get_agent(agent_name, agent_factory)
             if not _check_agent_can_execute(agent, agent_name, state, config):
                 return

--- a/src/autoresearch/token_budget.py
+++ b/src/autoresearch/token_budget.py
@@ -1,17 +1,210 @@
-"""Token budget utilities."""
+"""Token budget utilities and budget-aware model routing helpers."""
 
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
+from typing import Iterable, Mapping, Sequence
+
+log = logging.getLogger(__name__)
 
 
 def round_with_margin(usage: float, margin: float) -> int:
-    """Return ``usage * (1 + margin)`` rounded half up.
+    """Return ``usage * (1 + margin)`` rounded half up."""
 
-    Args:
-        usage: Baseline token usage.
-        margin: Additional fractional margin to apply.
-
-    Returns:
-        int: Rounded token budget.
-    """
     scaled = Decimal(str(usage)) * (Decimal("1") + Decimal(str(margin)))
     return int(scaled.to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def _percentile(values: Sequence[float], fraction: float) -> float:
+    """Return the percentile for ``values`` at ``fraction`` in ``[0, 1]``."""
+
+    if not values:
+        return 0.0
+    if fraction <= 0:
+        return float(min(values))
+    if fraction >= 1:
+        return float(max(values))
+    ordered = sorted(values)
+    index = (len(ordered) - 1) * fraction
+    lower = math.floor(index)
+    upper = math.ceil(index)
+    if lower == upper:
+        return float(ordered[int(index)])
+    lower_val = float(ordered[lower])
+    upper_val = float(ordered[upper])
+    return lower_val + (upper_val - lower_val) * (index - lower)
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    """Cost and latency profile for a single model option."""
+
+    prompt_cost_per_1k: float
+    completion_cost_per_1k: float
+    latency_p95_ms: float
+    quality_rank: int = 0
+
+    def cost_per_token(self) -> float:
+        """Return blended cost per token across prompt and completion."""
+
+        return (self.prompt_cost_per_1k + self.completion_cost_per_1k) / 1000.0
+
+
+@dataclass(frozen=True)
+class AgentUsageStats:
+    """Aggregate token and latency usage for an agent role."""
+
+    avg_prompt_tokens: float
+    avg_completion_tokens: float
+    p95_latency_ms: float
+    call_count: int
+
+    @property
+    def avg_total_tokens(self) -> float:
+        """Return the average total tokens consumed per invocation."""
+
+        return self.avg_prompt_tokens + self.avg_completion_tokens
+
+    def estimated_cost(self, profile: ModelProfile) -> float:
+        """Estimate currency cost using ``profile`` per-token pricing."""
+
+        prompt_cost = (self.avg_prompt_tokens / 1000.0) * profile.prompt_cost_per_1k
+        completion_cost = (
+            self.avg_completion_tokens / 1000.0
+        ) * profile.completion_cost_per_1k
+        return prompt_cost + completion_cost
+
+    @classmethod
+    def from_samples(
+        cls,
+        token_samples: Sequence[tuple[int, int]],
+        latencies_ms: Sequence[float],
+    ) -> "AgentUsageStats" | None:
+        """Build usage statistics from raw token and latency samples."""
+
+        if not token_samples:
+            return None
+        prompt = sum(sample[0] for sample in token_samples) / len(token_samples)
+        completion = sum(sample[1] for sample in token_samples) / len(token_samples)
+        latency = _percentile(latencies_ms, 0.95) if latencies_ms else 0.0
+        return cls(prompt, completion, latency, len(token_samples))
+
+
+class BudgetRouter:
+    """Select an appropriate model when token budgets become constrained."""
+
+    def __init__(
+        self,
+        profiles: Mapping[str, ModelProfile],
+        *,
+        default_model: str,
+        pressure_ratio: float,
+        default_latency_slo_ms: float,
+    ) -> None:
+        self._profiles = dict(profiles)
+        self._default_model = default_model
+        self._pressure_ratio = max(0.0, min(pressure_ratio, 1.0))
+        self._default_latency_slo_ms = max(default_latency_slo_ms, 0.0)
+
+    def _candidate_names(self, allowed: Sequence[str] | None) -> list[str]:
+        if allowed:
+            return [name for name in allowed if name in self._profiles]
+        return list(self._profiles.keys())
+
+    def _choose_preferred(
+        self,
+        candidates: Sequence[str],
+        preferred: Sequence[str] | None,
+    ) -> str | None:
+        if not candidates:
+            return None
+        if preferred:
+            for name in preferred:
+                if name in candidates:
+                    return name
+        return max(
+            candidates,
+            key=lambda name: (
+                self._profiles[name].quality_rank,
+                -self._profiles[name].cost_per_token(),
+            ),
+        )
+
+    def select_model(
+        self,
+        agent_name: str,
+        usage: AgentUsageStats | None,
+        *,
+        agent_budget_tokens: float | None,
+        agent_latency_slo_ms: float | None,
+        allowed_models: Sequence[str] | None,
+        preferred_models: Sequence[str] | None,
+        current_model: str,
+    ) -> str | None:
+        """Return a model name honouring token and latency constraints."""
+
+        candidates = self._candidate_names(allowed_models)
+        if not candidates:
+            return None
+
+        latency_cap = (
+            agent_latency_slo_ms
+            if agent_latency_slo_ms is not None
+            else self._default_latency_slo_ms
+        )
+        latency_constrained = [
+            name
+            for name in candidates
+            if self._profiles[name].latency_p95_ms <= latency_cap
+        ]
+        if not latency_constrained:
+            latency_constrained = list(candidates)
+
+        baseline = self._choose_preferred(latency_constrained, preferred_models)
+        if usage is None or agent_budget_tokens is None:
+            return baseline
+
+        expected_tokens = max(usage.avg_total_tokens, 0.0)
+        if expected_tokens <= 0:
+            return baseline
+        budget_threshold = agent_budget_tokens * self._pressure_ratio
+        if budget_threshold <= 0:
+            budget_threshold = agent_budget_tokens
+
+        if expected_tokens <= budget_threshold:
+            return baseline
+
+        cheapest = min(
+            latency_constrained,
+            key=lambda name: self._profiles[name].cost_per_token(),
+        )
+
+        if cheapest == baseline or cheapest == current_model:
+            return cheapest
+
+        baseline_profile = self._profiles.get(baseline or current_model)
+        cheapest_profile = self._profiles[cheapest]
+        before_cost = usage.estimated_cost(baseline_profile) if baseline_profile else None
+        after_cost = usage.estimated_cost(cheapest_profile)
+        log.info(
+            "Budget router selecting cost-efficient model",
+            extra={
+                "agent": agent_name,
+                "selected_model": cheapest,
+                "previous_model": baseline or current_model,
+                "avg_tokens": expected_tokens,
+                "budget_tokens": agent_budget_tokens,
+                "cost_before": before_cost,
+                "cost_after": after_cost,
+            },
+        )
+        return cheapest
+
+    def iter_profiles(self) -> Iterable[tuple[str, ModelProfile]]:
+        """Return an iterator over configured model profiles."""
+
+        return self._profiles.items()
+

--- a/tests/performance/test_budget_router.py
+++ b/tests/performance/test_budget_router.py
@@ -1,0 +1,78 @@
+"""Performance-oriented tests for budget-aware model routing heuristics."""
+
+from __future__ import annotations
+
+from autoresearch.config.models import (
+    AgentConfig,
+    ConfigModel,
+    ModelRouteProfile,
+    ModelRoutingConfig,
+)
+from autoresearch.orchestration.metrics import OrchestrationMetrics
+
+
+def _make_base_config() -> ConfigModel:
+    config = ConfigModel()
+    config.default_model = "premium"
+    config.token_budget = 4000
+    config.agents = ["Synthesizer", "Contrarian"]
+    config.model_routing = ModelRoutingConfig(
+        enabled=True,
+        budget_pressure_ratio=0.8,
+        default_latency_slo_ms=1500.0,
+        model_profiles={
+            "premium": ModelRouteProfile(
+                prompt_cost_per_1k=5.0,
+                completion_cost_per_1k=5.0,
+                latency_p95_ms=900.0,
+                quality_rank=10,
+            ),
+            "efficient": ModelRouteProfile(
+                prompt_cost_per_1k=1.5,
+                completion_cost_per_1k=1.5,
+                latency_p95_ms=1000.0,
+                quality_rank=5,
+            ),
+        },
+    )
+    return config
+
+
+def test_budget_router_prefers_cost_efficient_model_when_budget_constrained() -> None:
+    """High token consumption forces the router onto a cheaper profile."""
+
+    config = _make_base_config()
+    config.agent_config["Synthesizer"] = AgentConfig(
+        preferred_models=["premium", "efficient"],
+        token_share=0.5,
+        latency_slo_ms=1200.0,
+    )
+
+    metrics = OrchestrationMetrics()
+    metrics.record_tokens("Synthesizer", tokens_in=1800, tokens_out=900)
+    metrics.record_agent_timing("Synthesizer", duration=0.8)
+
+    selected = metrics.apply_model_routing("Synthesizer", config)
+
+    assert selected == "efficient"
+    assert config.agent_config["Synthesizer"].model == "efficient"
+
+
+def test_budget_router_retains_preferred_model_when_within_budget() -> None:
+    """Low token usage leaves the preferred premium profile in place."""
+
+    config = _make_base_config()
+    config.agent_config["Contrarian"] = AgentConfig(
+        preferred_models=["premium", "efficient"],
+        token_share=0.5,
+        latency_slo_ms=1200.0,
+    )
+
+    metrics = OrchestrationMetrics()
+    metrics.record_tokens("Contrarian", tokens_in=200, tokens_out=150)
+    metrics.record_agent_timing("Contrarian", duration=0.4)
+
+    selected = metrics.apply_model_routing("Contrarian", config)
+
+    assert selected == "premium"
+    assert config.agent_config["Contrarian"].model == "premium"

--- a/tests/performance/test_search_parallel_controls.py
+++ b/tests/performance/test_search_parallel_controls.py
@@ -1,0 +1,82 @@
+"""Performance regression tests for search parallelisation controls."""
+
+from __future__ import annotations
+
+import time
+from typing import Dict, List
+
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel
+from autoresearch.search.core import Search
+
+
+def _configure_search(parallel_enabled: bool, parallel_prefetch: int = 0) -> ConfigModel:
+    config = ConfigModel()
+    config.search.backends = ["slow", "fast"]
+    config.search.parallel_enabled = parallel_enabled
+    config.search.parallel_prefetch = parallel_prefetch
+    config.search.shared_cache = False
+    config.search.cache_namespace = "test"
+    return config
+
+
+def test_external_lookup_runs_sequentially_when_parallel_disabled() -> None:
+    """Disabling parallel execution should process backends sequentially."""
+
+    config = _configure_search(parallel_enabled=False)
+    order: List[str] = []
+
+    with ConfigLoader.temporary_instance(search_paths=[]) as loader:
+        loader._config = config
+        search = Search()
+
+        def slow_backend(query: str, max_results: int) -> List[Dict[str, str]]:
+            order.append("slow")
+            time.sleep(0.05)
+            return [{"title": "slow", "url": ""}]
+
+        def fast_backend(query: str, max_results: int) -> List[Dict[str, str]]:
+            order.append("fast")
+            time.sleep(0.05)
+            return [{"title": "fast", "url": ""}]
+
+        search.backends = {"slow": slow_backend, "fast": fast_backend}
+
+        start = time.perf_counter()
+        search.external_lookup("query", max_results=1)
+        elapsed = time.perf_counter() - start
+        search.reset()
+
+    assert order == ["slow", "fast"]
+    assert elapsed >= 0.09
+
+
+def test_external_lookup_fans_out_when_parallel_enabled() -> None:
+    """Parallel lookups should overlap backend latency to reduce wall time."""
+
+    config = _configure_search(parallel_enabled=True, parallel_prefetch=0)
+    order: List[str] = []
+
+    with ConfigLoader.temporary_instance(search_paths=[]) as loader:
+        loader._config = config
+        search = Search()
+
+        def slow_backend(query: str, max_results: int) -> List[Dict[str, str]]:
+            order.append("slow")
+            time.sleep(0.05)
+            return [{"title": "slow", "url": ""}]
+
+        def fast_backend(query: str, max_results: int) -> List[Dict[str, str]]:
+            order.append("fast")
+            time.sleep(0.05)
+            return [{"title": "fast", "url": ""}]
+
+        search.backends = {"slow": slow_backend, "fast": fast_backend}
+
+        start = time.perf_counter()
+        search.external_lookup("query", max_results=1)
+        elapsed = time.perf_counter() - start
+        search.reset()
+
+    assert set(order) == {"slow", "fast"}
+    assert elapsed < 0.09


### PR DESCRIPTION
## Summary
- add cost-aware routing utilities and runtime metrics that log per-agent token and latency usage and update agent model selections when budgets tighten
- extend the configuration and search stack with shared cache namespaces plus parallelisation toggles, updating the documentation and status log accordingly
- add performance regression tests covering budget-aware routing decisions and search parallel fan-out controls

## Testing
- `uv run task verify` *(fails: flake8 reports pre-existing lint issues in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d7118ed73483339c653eb460e8e782