### PR TITLE
Add depth-aware output controls and provenance visualisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,3 +262,22 @@ Run `uv run --extra docs mkdocs build` directly if you skip Go Task, and use
 CLI output uses Markdown headings and plain-text lists so screen readers can
 navigate sections. Help messages avoid color-only cues and respect the
 `NO_COLOR` environment variable for ANSI-free output.
+
+## Depth-aware output and provenance
+
+The `search` command exposes a `--depth` option that controls how much detail
+is returned for each run. Depth presets range from `tldr` (TL;DR plus the full
+answer) through `concise`, `standard`, and `trace`. Higher levels progressively
+include key findings, verification tables, and the raw response payload:
+
+```bash
+autoresearch search "What is agentic search?" --depth concise
+autoresearch search "Explain prompt reflection" --depth trace --output json
+```
+
+Streamlit mirrors the same depth levels through a radio selector above the
+results panel. Adjusting the selector toggles TL;DR summaries, key findings,
+claim tables, GraphRAG artefacts, and agent traces without re-running the
+query. Provenance notes underneath each section highlight when data is hidden
+or truncated, making it explicit when a deeper depth is required for audit
+workflows.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -51,6 +51,29 @@ Run a search from the command line:
 autoresearch search "What is quantum computing?"
 ```
 
+### Controlling output depth
+
+The `search` command accepts a `--depth` flag so you can tune how much detail
+is printed. Depth presets include:
+
+- `tldr` – TL;DR summary plus the final answer.
+- `concise` – adds key findings and a short citation roll-up.
+- `standard` – includes claim audit tables and expanded metrics.
+- `trace` – exposes the full reasoning trace and raw response payload.
+
+For example:
+
+```bash
+autoresearch search "What is agentic search?" --depth concise
+autoresearch search "Explain prompt reflection" --depth trace --output json
+```
+
+When using the Streamlit UI, a radio selector above the results mirrors the
+same depth levels. Switching depth refreshes the TL;DR, key findings, claim
+audits, and GraphRAG artefacts without re-running the query. Each panel shows a
+provenance note when information is truncated so you know when to increase the
+depth for audit work.
+
 ## API authentication
 
 To access the HTTP API, configure keys and roles:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 minversion = 6.0
 addopts = -m 'not slow and not pending'
-testpaths = tests/unit tests/integration tests/behavior tests/behavior/features
+testpaths = tests/unit tests/integration tests/behavior tests/behavior/features tests/cli tests/ui
 bdd_features_base_dir = tests/behavior/features
 norecursedirs =
     .git

--- a/src/autoresearch/evidence/__init__.py
+++ b/src/autoresearch/evidence/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Iterable, List, Sequence
+from typing import Iterable, List
 
 from ..storage import ClaimAuditStatus
 

--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -11,7 +11,12 @@ from typing import Any, Optional
 import typer
 from rich.console import Console
 
-from ..cli_helpers import handle_command_not_found, parse_agent_groups
+from ..cli_helpers import (
+    handle_command_not_found,
+    parse_agent_groups,
+    depth_option_callback,
+    depth_help_text,
+)
 from ..cli_utils import (
     Verbosity,
     console,
@@ -38,6 +43,7 @@ from ..errors import StorageError
 from ..logging_utils import configure_logging
 from ..mcp_interface import create_server
 from ..monitor import monitor_app
+from ..output_format import OutputDepth
 
 app = typer.Typer(
     help=(
@@ -204,6 +210,12 @@ def search(
     query: str = typer.Argument(..., help="Natural-language query to process"),
     output: Optional[str] = typer.Option(
         None, "-o", "--output", help="Output format: json|markdown|plain"
+    ),
+    depth: Optional[OutputDepth] = typer.Option(
+        None,
+        "--depth",
+        help=f"Depth of detail in CLI output ({depth_help_text()})",
+        callback=depth_option_callback,
     ),
     interactive: bool = typer.Option(
         False,
@@ -434,7 +446,7 @@ def search(
         # Show a success message before the results
         print_success("Query processed successfully")
 
-        OutputFormatter.format(result, fmt)
+        OutputFormatter.format(result, fmt, depth=depth)
         if visualize:
             OutputFormatter.format(result, "graph")
             visualize_metrics_cli(result.metrics)
@@ -486,7 +498,7 @@ def search(
             if os.getenv("PYTEST_CURRENT_TEST")
             else ("json" if not sys.stdout.isatty() else "markdown")
         )
-        OutputFormatter.format(error_result, fmt)
+        OutputFormatter.format(error_result, fmt, depth=depth)
 
 
 # Add monitoring subcommands

--- a/src/autoresearch/storage.py
+++ b/src/autoresearch/storage.py
@@ -211,7 +211,6 @@ class ClaimAuditRecord:
         )
 
 
-
 def _process_ram_mb() -> float:
     """Return the process resident set size in megabytes."""
     try:

--- a/src/autoresearch/ui/provenance.py
+++ b/src/autoresearch/ui/provenance.py
@@ -1,0 +1,54 @@
+"""Utilities for presenting depth-aware provenance details in UIs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping
+
+from ..output_format import DepthPayload, OutputDepth
+
+
+def generate_socratic_prompts(
+    payload: DepthPayload, max_prompts: int = 3
+) -> List[str]:
+    """Derive Socratic follow-up prompts from a depth payload."""
+
+    prompts: List[str] = []
+    if payload.key_findings:
+        prompts.append(
+            f"Which assumptions support the claim '{payload.key_findings[0]}'?"
+        )
+    if payload.citations:
+        prompts.append(
+            "If the top citation were unreliable, how would the conclusion change?"
+        )
+    if payload.claim_audits:
+        first_claim = payload.claim_audits[0].get("claim_id", "the leading claim")
+        prompts.append(
+            f"What additional evidence would strengthen verification of {first_claim}?"
+        )
+    prompts.append(
+        "Which counterexamples could challenge the TL;DR and should be investigated?"
+    )
+    unique_prompts = []
+    for prompt in prompts:
+        if prompt not in unique_prompts:
+            unique_prompts.append(prompt)
+    return unique_prompts[:max_prompts]
+
+
+def extract_graphrag_artifacts(metrics: Mapping[str, Any]) -> Dict[str, Any]:
+    """Filter metric entries that describe GraphRAG provenance artefacts."""
+
+    artifacts: Dict[str, Any] = {}
+    for key, value in metrics.items():
+        key_lower = str(key).lower()
+        if any(token in key_lower for token in ("graphrag", "graph_rag", "graphviz")):
+            artifacts[key] = value
+        elif "graph" in key_lower and isinstance(value, (dict, list)):
+            artifacts[key] = value
+    return artifacts
+
+
+def depth_sequence() -> List[OutputDepth]:
+    """Return the ordered depth options for UI widgets."""
+    return [OutputDepth.TLDR, OutputDepth.CONCISE, OutputDepth.STANDARD, OutputDepth.TRACE]

--- a/tests/cli/test_search_depth.py
+++ b/tests/cli/test_search_depth.py
@@ -1,0 +1,91 @@
+import pytest
+from typer.testing import CliRunner
+
+from autoresearch.main.app import app as cli_app
+from autoresearch.models import QueryResponse
+
+pytestmark = pytest.mark.integration
+
+
+class DummyProgress:
+    def __enter__(self) -> "DummyProgress":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def add_task(self, *args: object, **kwargs: object) -> int:
+        return 0
+
+    def update(self, *args: object, **kwargs: object) -> None:
+        return None
+
+
+class DummyPrompt:
+    @staticmethod
+    def ask(*args: object, **kwargs: object) -> str:
+        return ""
+
+
+@pytest.fixture
+def cli_environment(monkeypatch: pytest.MonkeyPatch) -> QueryResponse:
+    from autoresearch.config.models import ConfigModel
+
+    dummy_response = QueryResponse(
+        query="depth test",
+        answer="An extended answer about adaptive depth rendering.",
+        citations=["Source A", "Source B"],
+        reasoning=["Initial reasoning", "Follow-up check"],
+        metrics={"tokens": 42, "latency_ms": 12},
+        claim_audits=[
+            {
+                "claim_id": "1",
+                "status": "supported",
+                "entailment_score": 0.92,
+                "sources": [{"title": "Whitepaper"}],
+            }
+        ],
+    )
+
+    class DummyOrchestrator:
+        def __init__(self) -> None:  # pragma: no cover - interface shim
+            return None
+
+        def run_query(self, *args: object, **kwargs: object) -> QueryResponse:
+            return dummy_response
+
+    class DummyStorage:
+        @staticmethod
+        def setup() -> None:  # pragma: no cover - interface shim
+            return None
+
+        @staticmethod
+        def load_ontology(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
+            return None
+
+    monkeypatch.setattr("autoresearch.main.app.Orchestrator", DummyOrchestrator)
+    monkeypatch.setattr("autoresearch.main.app.StorageManager", DummyStorage)
+    monkeypatch.setattr(
+        "autoresearch.main.app._config_loader.load_config",
+        lambda: ConfigModel(),
+    )
+    monkeypatch.setattr("autoresearch.main.app.Progress", DummyProgress)
+    monkeypatch.setattr("autoresearch.main.app.Prompt", DummyPrompt)
+    return dummy_response
+
+
+def test_cli_depth_tldr(cli_runner: CliRunner, cli_environment: QueryResponse) -> None:
+    result = cli_runner.invoke(cli_app, ["search", "depth test", "--depth", "tldr"])
+    assert result.exit_code == 0
+    assert "# TL;DR" in result.stdout
+    assert "Key findings are hidden" in result.stdout
+
+
+def test_cli_depth_trace_json(cli_runner: CliRunner, cli_environment: QueryResponse) -> None:
+    result = cli_runner.invoke(
+        cli_app,
+        ["search", "depth test", "--depth", "trace", "--output", "json"],
+    )
+    assert result.exit_code == 0
+    assert '"raw_response"' in result.stdout
+    assert '"key_findings"' in result.stdout

--- a/tests/ui/test_provenance_helpers.py
+++ b/tests/ui/test_provenance_helpers.py
@@ -1,0 +1,44 @@
+import pytest
+
+from autoresearch.models import QueryResponse
+from autoresearch.output_format import DepthPayload, build_depth_payload, OutputDepth
+from autoresearch.ui.provenance import (
+    extract_graphrag_artifacts,
+    generate_socratic_prompts,
+)
+
+pytestmark = pytest.mark.requires_ui
+
+
+@pytest.fixture
+def sample_payload() -> DepthPayload:
+    return build_depth_payload(
+        QueryResponse(
+            query="ui test",
+            answer="Summary of the research findings.",
+            citations=["Doc A"],
+            reasoning=["Agent gathered documents", "Agents synthesised answer"],
+            metrics={"tokens": 88, "graphrag_edges": [1, 2, 3]},
+            claim_audits=[
+                {
+                    "claim_id": "alpha",
+                    "status": "supported",
+                    "entailment_score": 0.88,
+                    "sources": [{"title": "Paper"}],
+                }
+            ],
+        ),
+        OutputDepth.STANDARD,
+    )
+
+
+def test_generate_socratic_prompts_highlight_claims(sample_payload) -> None:
+    prompts = generate_socratic_prompts(sample_payload)
+    assert prompts
+    assert any("claim" in prompt.lower() for prompt in prompts)
+
+
+def test_extract_graphrag_artifacts_filters_non_graph_metrics(sample_payload) -> None:
+    artifacts = extract_graphrag_artifacts(sample_payload.metrics)
+    assert "graphrag_edges" in artifacts
+    assert "tokens" not in artifacts


### PR DESCRIPTION
## Summary
- add depth-aware payload planning, TL;DR rendering, and template plumbing to the shared formatter and CLI utilities
- introduce Streamlit depth toggles, Socratic prompts, and provenance helpers that surface claim audits and GraphRAG artefacts
- refresh documentation plus CLI/UI regression tests to explain and validate the new depth controls

## Testing
- `uv run task check` *(fails: mypy cannot resolve many optional dependencies without broader extras or stub packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d7116485c08333b08ec23e999eb0cf