### PR TITLE
Add knowledge graph reasoning pipeline and integrations

### DIFF
--- a/docs/deep_research_upgrade_plan.md
+++ b/docs/deep_research_upgrade_plan.md
@@ -31,9 +31,14 @@ keep truthfulness, verifiability, and cost discipline in balance.
    - Capture ReAct traces for transparency and replay.
    - Document interfaces for specialized agents and tool calls.
 3. **Phase 3 – Graph-Augmented Retrieval**
-   - Build session-scoped knowledge graphs using existing storage hooks.
-   - Surface contradiction checks that feed back into the gate policy.
-   - Export lightweight GraphML or JSON artifacts per session.
+   - Build session-scoped knowledge graphs by extracting entities and
+     relations from retrieval snippets and persisting them to DuckDB and
+     RDFLib via `KnowledgeGraphPipeline`.
+   - Surface contradiction checks to the scout gate through
+     `SearchContext.get_contradiction_signal()` while exposing neighbour and
+     path queries to agents for multi-hop reasoning.
+   - Export lightweight GraphML or JSON artifacts via the output formatter so
+     downstream tools can visualise graph state per session.
 4. **Phase 4 – Evaluation Harness and Layered UX**
    - Automate TruthfulQA, FEVER, and HotpotQA smoke runs with KPIs.
    - Add layered summaries, Socratic prompts, and per-claim audits to the UI.

--- a/docs/specs/kg-reasoning.md
+++ b/docs/specs/kg-reasoning.md
@@ -28,6 +28,27 @@ Helper utilities for ontology reasoning and advanced SPARQL queries.
 1. Invoke `run_ontology_reasoner`.
 2. Run the supplied SPARQL query against the updated store.
 
+### KnowledgeGraphPipeline.ingest
+1. Skip work when graph ingestion is disabled via
+   `search.context_aware.graph_pipeline_enabled`.
+2. Normalise sentences from retrieval snippets and extract candidate relations
+   using heuristics for verb phrases (`discovered`, `was born in`, etc.).
+3. Deduplicate entities with hashed identifiers and cap totals by
+   `graph_max_entities` and `graph_max_edges`.
+4. Persist entities and relations through `StorageManager` into DuckDB,
+   NetworkX, and RDFLib, emitting triples such as `urn:kg:<subject>`.
+5. Derive contradictions when identical subjects and predicates map to
+   different objects, and compute multi-hop paths via NetworkX.
+6. Cache a summary containing entity counts, relation counts, contradictions,
+   multi-hop paths, and a contradiction score for downstream consumers.
+
+### KnowledgeGraphPipeline.graph_paths
+1. Resolve entity identifiers by case-insensitive label matching.
+2. Traverse the knowledge graph as an undirected view to discover simple paths
+   between the requested endpoints, respecting the configured depth cutoff.
+3. Return paths as ordered label lists suitable for multi-hop reasoning or
+   explanation traces.
+
 ## Invariants
 
 - `register_reasoner` adds exactly one callable per name.
@@ -36,6 +57,11 @@ Helper utilities for ontology reasoning and advanced SPARQL queries.
 - `run_ontology_reasoner` skips execution when `ontology_reasoner_max_triples`
   is set and exceeded.
 - `query_with_reasoning` applies reasoning before evaluation.
+- `KnowledgeGraphPipeline.ingest` never emits more than the configured maximum
+  entities or relations per batch and always records summaries even when no
+  edges are extracted.
+- Knowledge graph contradiction scores are derived from persisted edges and
+  remain in `[0, 1]`.
 
 ## Proof Sketch
 
@@ -47,11 +73,19 @@ Helper utilities for ontology reasoning and advanced SPARQL queries.
   the original size, while reasoners typically add new triples.
 - `query_with_reasoning` simply delegates, so its guarantees follow from
   `run_ontology_reasoner`.
+- Entity hashing ensures deterministic identifiers, so duplicates collapse
+  safely before persistence.
+- Knowledge graph persistence routes through `StorageManager`, guaranteeing
+  RDFLib, DuckDB, and NetworkX remain in sync.
+- Contradiction detection groups edges by subject and predicate; multiple
+  targets increase the contradiction count and the normalised score.
 
 ## Simulation Expectations
 
 Unit tests verify plugin registration, single-invocation semantics, skipping
-when the triple cap is exceeded, and query execution after reasoning.
+when the triple cap is exceeded, and query execution after reasoning. New
+integration tests assert that ingestion yields multi-hop paths and that
+contradictions influence orchestrator heuristics.
 
 ## Traceability
 
@@ -59,6 +93,8 @@ when the triple cap is exceeded, and query execution after reasoning.
   - [src/autoresearch/kg_reasoning.py][m1]
 - Tests
   - [tests/unit/test_kg_reasoning.py][t1]
+  - [tests/integration/test_knowledge_graph_pipeline.py][t2]
 
 [m1]: ../../src/autoresearch/kg_reasoning.py
 [t1]: ../../tests/unit/test_kg_reasoning.py
+[t2]: ../../tests/integration/test_knowledge_graph_pipeline.py

--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -35,6 +35,26 @@ class ContextAwareSearchConfig(BaseModel):
     use_search_history: bool = Field(default=True)
     history_weight: float = Field(default=0.2, ge=0.0, le=1.0)
     max_history_items: int = Field(default=10, ge=1, le=100)
+    graph_pipeline_enabled: bool = Field(
+        default=True,
+        description="Enable knowledge graph construction from retrieval snippets.",
+    )
+    graph_max_entities: int = Field(
+        default=256,
+        ge=1,
+        description="Maximum number of unique entities captured per ingestion batch.",
+    )
+    graph_max_edges: int = Field(
+        default=512,
+        ge=1,
+        description="Maximum number of relations extracted per ingestion batch.",
+    )
+    graph_contradiction_weight: float = Field(
+        default=0.35,
+        ge=0.0,
+        le=1.0,
+        description="Weight applied to contradiction signals derived from the graph.",
+    )
 
 
 class LocalFileConfig(BaseModel):

--- a/src/autoresearch/kg_reasoning.py
+++ b/src/autoresearch/kg_reasoning.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 from importlib import import_module
-from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence
 
+import hashlib
 import logging
+import re
 import threading
 import time
 import warnings
+from collections import defaultdict
+import networkx as nx
 import rdflib
 
 try:  # pragma: no cover - optional dependency
@@ -46,12 +50,17 @@ from .errors import StorageError
 _REASONER_PLUGINS: Dict[str, Callable[[rdflib.Graph], None]] = {}
 
 
-def register_reasoner(name: str) -> Callable[[Callable[[rdflib.Graph], None]], Callable[[rdflib.Graph], None]]:
-    """Register a reasoning plugin under ``name``.
+def register_reasoner(
+    name: str,
+) -> Callable[[Callable[[rdflib.Graph], None]], Callable[[rdflib.Graph], None]]:
+    """Register a reasoning plugin for use in the ontology pipeline.
 
-    The returned decorator registers ``func`` as the handler for the given
-    reasoner name, allowing ``run_ontology_reasoner`` to invoke it when
-    configured.
+    Args:
+        name: Identifier under which the decorated callable is stored.
+
+    Returns:
+        A decorator that stores the wrapped callable in the global reasoner
+        registry, keyed by ``name``.
     """
 
     def decorator(func: Callable[[rdflib.Graph], None]) -> Callable[[rdflib.Graph], None]:
@@ -89,8 +98,20 @@ def _rdfs_reasoner(store: rdflib.Graph) -> None:
         )
 
 
-def run_ontology_reasoner(store: rdflib.Graph, engine: Optional[str] = None) -> None:
-    """Apply ontology reasoning over ``store`` using the configured engine."""
+def run_ontology_reasoner(
+    store: rdflib.Graph, engine: Optional[str] = None
+) -> None:
+    """Apply ontology reasoning using the configured engine.
+
+    Args:
+        store: RDF graph that should be enriched with inferred triples.
+        engine: Optional override for the reasoner name. When ``None`` the
+            value from configuration is used.
+
+    Raises:
+        StorageError: If the configured reasoner is unknown, times out, or
+            encounters an unrecoverable error during execution.
+    """
 
     storage_cfg = ConfigLoader().config.storage
     reasoner_setting = engine or getattr(storage_cfg, "ontology_reasoner", "owlrl")
@@ -186,15 +207,632 @@ def run_ontology_reasoner(store: rdflib.Graph, engine: Optional[str] = None) -> 
     )
 
 
-def query_with_reasoning(store: rdflib.Graph, query: str, engine: Optional[str] = None):
-    """Run a SPARQL query after applying ontology reasoning."""
+def query_with_reasoning(
+    store: rdflib.Graph, query: str, engine: Optional[str] = None
+):
+    """Run a SPARQL query with ontology reasoning applied first.
+
+    Args:
+        store: RDF graph to query.
+        query: SPARQL query string executed after reasoning.
+        engine: Optional override for the reasoner name.
+
+    Returns:
+        The ``rdflib`` query result produced by evaluating ``query`` on the
+        enriched ``store``.
+
+    Raises:
+        StorageError: If ontology reasoning fails before the query executes.
+    """
 
     run_ontology_reasoner(store, engine)
     return store.query(query)
+
+
+def _slugify(label: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-")
+    return cleaned or "entity"
+
+
+def _make_entity_id(label: str) -> str:
+    normalized = label.strip().lower()
+    digest = hashlib.sha1(normalized.encode("utf-8")).hexdigest()[:10]
+    return f"kg:{_slugify(label)}:{digest}"
+
+
+def _normalise_whitespace(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _sentence_split(text: str) -> list[str]:
+    tokens = re.split(r"[.!?]+\s+", text)
+    return [token.strip() for token in tokens if token.strip()]
+
+
+def _truncate_snippet(snippet: str, limit: int = 240) -> str:
+    snippet = _normalise_whitespace(snippet)
+    if len(snippet) <= limit:
+        return snippet
+    return f"{snippet[:limit - 1].rstrip()}…"
+
+
+def _clean_entity(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip(" .,;:'\"()")
+
+
+@dataclass
+class GraphEntity:
+    """Structured representation of an extracted entity."""
+
+    id: str
+    label: str
+    type: str = "entity"
+    source: str | None = None
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> dict[str, Any]:
+        payload = {
+            "id": self.id,
+            "label": self.label,
+            "type": self.type,
+            "attributes": dict(self.attributes),
+        }
+        if self.source:
+            payload["source"] = self.source
+        return payload
+
+
+@dataclass
+class GraphRelation:
+    """Structured representation of a semantic relation."""
+
+    subject_id: str
+    predicate: str
+    object_id: str
+    weight: float = 1.0
+    provenance: dict[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "subject_id": self.subject_id,
+            "predicate": self.predicate,
+            "object_id": self.object_id,
+            "weight": self.weight,
+            "provenance": dict(self.provenance),
+        }
+
+
+@dataclass(frozen=True)
+class GraphContradiction:
+    """Detected contradiction derived from knowledge graph triples."""
+
+    subject: str
+    predicate: str
+    objects: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "subject": self.subject,
+            "predicate": self.predicate,
+            "objects": list(self.objects),
+        }
+
+
+@dataclass
+class GraphExtractionSummary:
+    """Summary describing the outcome of a graph ingestion run."""
+
+    entity_count: int
+    relation_count: int
+    contradictions: list[GraphContradiction]
+    multi_hop_paths: list[list[str]]
+    query: str = ""
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entity_count": self.entity_count,
+            "relation_count": self.relation_count,
+            "contradictions": [c.to_dict() for c in self.contradictions],
+            "multi_hop_paths": [list(path) for path in self.multi_hop_paths],
+            "query": self.query,
+            "timestamp": self.timestamp,
+            "contradiction_score": self.contradiction_score,
+        }
+
+    @property
+    def contradiction_score(self) -> float:
+        if self.relation_count == 0:
+            return 0.0
+        return min(1.0, len(self.contradictions) / self.relation_count)
+
+
+class KnowledgeGraphPipeline:
+    """Extract entities and relations from retrieval snippets.
+
+    The pipeline normalises raw snippets, identifies entity and relation
+    candidates, persists them, and exposes derived metrics such as detected
+    contradictions or multi-hop paths.
+    """
+
+    def __init__(self) -> None:
+        self._entity_cache: dict[str, GraphEntity] = {}
+        self._entity_lock = threading.Lock()
+        self._summary_lock = threading.Lock()
+        self._latest_summary: dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def ingest(
+        self,
+        query: str,
+        snippets: Sequence[Mapping[str, Any]],
+    ) -> GraphExtractionSummary:
+        """Extract graph data from retrieved snippets and persist it.
+
+        Args:
+            query: Original retrieval query that produced ``snippets``.
+            snippets: Iterable of snippet payloads that include title, snippet
+                text, and optional URL metadata.
+
+        Returns:
+            A :class:`GraphExtractionSummary` describing how many entities and
+            relations were added plus any detected contradictions or
+            multi-hop paths.
+        """
+
+        cfg = ConfigLoader().config
+        context_cfg = getattr(getattr(cfg, "search", None), "context_aware", None)
+        enabled = bool(getattr(context_cfg, "enabled", False))
+        pipeline_enabled = bool(getattr(context_cfg, "graph_pipeline_enabled", enabled))
+        if not pipeline_enabled:
+            summary = GraphExtractionSummary(0, 0, [], [], query=query)
+            self._store_summary(summary)
+            return summary
+
+        max_entities = int(getattr(context_cfg, "graph_max_entities", 256))
+        max_relations = int(getattr(context_cfg, "graph_max_edges", 512))
+
+        entities: dict[str, GraphEntity] = {}
+        relations: list[GraphRelation] = []
+        triples: list[tuple[str, str, str]] = []
+        relation_keys: set[tuple[str, str, str]] = set()
+
+        for snippet in snippets:
+            if len(relations) >= max_relations:
+                break
+            text_parts = [snippet.get("title"), snippet.get("snippet"), snippet.get("content")]
+            for raw_text in text_parts:
+                text = _normalise_whitespace(raw_text or "")
+                if not text:
+                    continue
+                sentences = _sentence_split(text)
+                for sentence in sentences:
+                    extracted = self._extract_relations(sentence)
+                    for subj_label, predicate, obj_label in extracted:
+                        if not subj_label or not obj_label:
+                            continue
+                        subject = self._ensure_entity(subj_label, snippet.get("url"))
+                        obj = self._ensure_entity(obj_label, snippet.get("url"))
+                        if subject.id not in entities and len(entities) >= max_entities:
+                            continue
+                        if obj.id not in entities and len(entities) >= max_entities:
+                            continue
+                        entities[subject.id] = subject
+                        entities[obj.id] = obj
+
+                        relation_key = (subject.id, predicate, obj.id)
+                        if relation_key in relation_keys:
+                            continue
+                        relation_keys.add(relation_key)
+
+                        provenance = {
+                            "snippet": _truncate_snippet(text),
+                            "source": snippet.get("url") or snippet.get("backend"),
+                        }
+                        relation = GraphRelation(
+                            subject_id=subject.id,
+                            predicate=predicate,
+                            object_id=obj.id,
+                            provenance=provenance,
+                        )
+                        relations.append(relation)
+                        triples.append((subject.id, predicate, obj.id))
+                        if len(relations) >= max_relations:
+                            break
+                    if len(relations) >= max_relations:
+                        break
+
+        summary = GraphExtractionSummary(
+            entity_count=len(entities),
+            relation_count=len(relations),
+            contradictions=[],
+            multi_hop_paths=[],
+            query=query,
+        )
+
+        if not relations and not entities:
+            self._store_summary(summary)
+            return summary
+
+        try:
+            from .storage import StorageManager  # Local import to avoid circular dependency
+
+            StorageManager.update_knowledge_graph(
+                entities=[entity.to_payload() for entity in entities.values()],
+                relations=[relation.to_payload() for relation in relations],
+                triples=triples,
+            )
+
+            kg_graph = StorageManager.get_knowledge_graph(create=False)
+            summary.contradictions = self._detect_contradictions(kg_graph)
+            summary.multi_hop_paths = self._derive_multi_hop_paths(kg_graph)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logging.getLogger(__name__).debug(
+                "Knowledge graph ingestion failed", exc_info=exc
+            )
+
+        self._store_summary(summary)
+        return summary
+
+    def get_latest_summary(self) -> dict[str, Any]:
+        """Return the most recent ingestion summary.
+
+        Returns:
+            A shallow copy of the latest graph extraction summary payload.
+        """
+
+        with self._summary_lock:
+            return dict(self._latest_summary)
+
+    def get_contradiction_score(self) -> float:
+        """Return the current contradiction score from the summary.
+
+        Returns:
+            Normalised contradiction score in the range ``[0.0, 1.0]``.
+        """
+
+        summary = self.get_latest_summary()
+        score = summary.get("contradiction_score")
+        if isinstance(score, (int, float)):
+            return float(score)
+        return 0.0
+
+    def neighbors(
+        self,
+        entity_label: str,
+        *,
+        direction: str = "out",
+        limit: int = 5,
+    ) -> list[dict[str, str]]:
+        """Return neighbouring entities linked to ``entity_label``.
+
+        Args:
+            entity_label: Canonical label of the entity to search for.
+            direction: Restrict traversal to ``"out"``, ``"in"``, or
+                ``"both"`` directions.
+            limit: Maximum number of neighbours returned.
+
+        Returns:
+            A list of neighbour records describing adjacent entities and the
+            predicates connecting them.
+        """
+
+        try:
+            from .storage import StorageManager
+
+            graph = StorageManager.get_knowledge_graph(create=False)
+        except Exception:
+            return []
+        if graph is None:
+            return []
+
+        matches = self._find_nodes_by_label(graph, entity_label)
+        results: list[dict[str, str]] = []
+        for node in matches:
+            if direction == "in":
+                iterator = graph.in_edges(node, keys=True, data=True)
+            elif direction == "both":
+                iterator = list(graph.out_edges(node, keys=True, data=True)) + list(
+                    graph.in_edges(node, keys=True, data=True)
+                )
+            else:
+                iterator = graph.out_edges(node, keys=True, data=True)
+            for source, target, key, data in iterator:
+                predicate = data.get("predicate") or key
+                other = target if source == node else source
+                label = graph.nodes[other].get("label", other)
+                results.append({
+                    "subject": graph.nodes[source].get("label", source),
+                    "predicate": predicate,
+                    "object": graph.nodes[target].get("label", target),
+                    "direction": "out" if source == node else "in",
+                    "target": label,
+                })
+                if len(results) >= limit:
+                    return results
+        return results
+
+    def find_paths(
+        self,
+        source_label: str,
+        target_label: str,
+        *,
+        max_depth: int = 3,
+        limit: int = 5,
+    ) -> list[list[str]]:
+        """Return simple paths between two entity labels.
+
+        Args:
+            source_label: Label of the starting entity.
+            target_label: Label of the destination entity.
+            max_depth: Maximum traversal depth when searching for paths.
+            limit: Maximum number of distinct paths to return.
+
+        Returns:
+            A list of paths where each path is represented as ordered labels
+            traversed from source to target.
+        """
+
+        try:
+            from .storage import StorageManager
+
+            graph = StorageManager.get_knowledge_graph(create=False)
+        except Exception:
+            return []
+        if graph is None:
+            return []
+
+        sources = self._find_nodes_by_label(graph, source_label)
+        targets = self._find_nodes_by_label(graph, target_label)
+        if not sources or not targets:
+            return []
+
+        undirected = graph.to_undirected(as_view=True)
+        label_lookup = {node: graph.nodes[node].get("label", node) for node in graph.nodes}
+        paths: list[list[str]] = []
+        for source in sources:
+            for target in targets:
+                if source == target:
+                    continue
+                try:
+                    iterator = nx.all_simple_paths(undirected, source, target, cutoff=max_depth)
+                except Exception:
+                    continue
+                for path in iterator:
+                    if len(path) < 2:
+                        continue
+                    labelled = [label_lookup.get(node, str(node)) for node in path]
+                    if labelled not in paths:
+                        paths.append(labelled)
+                    if len(paths) >= limit:
+                        return paths
+        return paths
+
+    def export_artifacts(self) -> dict[str, str]:
+        """Return GraphML and JSON artefacts for downstream consumers.
+
+        Returns:
+            Mapping of artifact format to serialised string content.
+        """
+
+        try:
+            from .storage import StorageManager
+
+            graphml = StorageManager.export_knowledge_graph_graphml()
+            graph_json = StorageManager.export_knowledge_graph_json()
+        except Exception:  # pragma: no cover - optional storage errors
+            graphml = ""
+            graph_json = "{}"
+        return {"graphml": graphml, "graph_json": graph_json}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _store_summary(self, summary: GraphExtractionSummary) -> None:
+        with self._summary_lock:
+            self._latest_summary = summary.to_dict()
+
+    def _ensure_entity(self, label: str, source: Optional[str]) -> GraphEntity:
+        key = label.strip().lower()
+        with self._entity_lock:
+            entity = self._entity_cache.get(key)
+            if entity is None:
+                entity = GraphEntity(
+                    id=_make_entity_id(label),
+                    label=label,
+                    source=source,
+                )
+                self._entity_cache[key] = entity
+            elif source and not entity.source:
+                entity.source = source
+        return entity
+
+    def _extract_relations(self, sentence: str) -> list[tuple[str, str, str]]:
+        sentence = _normalise_whitespace(sentence)
+        relations: list[tuple[str, str, str]] = []
+        if not sentence:
+            return relations
+
+        # Direct verb patterns such as "A discovered B"
+        verb_pattern = re.compile(
+            (
+                r"(?P<subj>[A-Z][A-Za-z0-9 .'-]+?)\s+"
+                r"(?P<verb>discovered|invented|created|developed|founded|built|"
+                r"wrote|directed|led|studied|isolated)\s+"
+                r"(?P<obj>[A-Za-z][A-Za-z0-9 .'-]+)"
+            ),
+            re.IGNORECASE,
+        )
+        for match in verb_pattern.finditer(sentence):
+            subj = _clean_entity(match.group("subj"))
+            obj = _clean_entity(match.group("obj"))
+            if " with " in obj.lower():
+                continue
+            verb = match.group("verb").lower().replace(" ", "_")
+            if subj and obj:
+                relations.append((subj, verb, obj))
+
+        # Collaborations "A worked with B" or "A discovered X with B"
+        collab_pattern = re.compile(
+            (
+                r"(?P<subj>[A-Z][A-Za-z0-9 .'-]+?)\s+"
+                r"(?:collaborated|worked|partnered)\s+with\s+"
+                r"(?P<obj>[A-Z][A-Za-z0-9 .'-]+)"
+            ),
+            re.IGNORECASE,
+        )
+        for match in collab_pattern.finditer(sentence):
+            subj = _clean_entity(match.group("subj"))
+            obj = _clean_entity(match.group("obj"))
+            if subj and obj:
+                relations.append((subj, "collaborated_with", obj))
+                relations.append((obj, "collaborated_with", subj))
+
+        with_pattern = re.compile(
+            (
+                r"(?P<subj>[A-Z][A-Za-z0-9 .'-]+?)\s+"
+                r"(?P<verb>discovered|invented|created|developed|built|wrote)\s+"
+                r"(?P<object>[A-Za-z][A-Za-z0-9 .'-]+?)(?=\s+with\s+)\s+with\s+"
+                r"(?P<partner>[A-Z][A-Za-z0-9 .'-]+)"
+            ),
+            re.IGNORECASE,
+        )
+        for match in with_pattern.finditer(sentence):
+            subj = _clean_entity(match.group("subj"))
+            obj = _clean_entity(match.group("object"))
+            partner = _clean_entity(match.group("partner"))
+            verb = match.group("verb").lower().replace(" ", "_")
+            if subj and obj:
+                relations.append((subj, verb, obj))
+            if subj and partner:
+                relations.append((subj, "collaborated_with", partner))
+            if partner and subj:
+                relations.append((partner, "collaborated_with", subj))
+
+        born_pattern = re.compile(
+            (
+                r"(?P<subj>[A-Z][A-Za-z0-9 .'-]+?)\s+"
+                r"(?:was|is)\s+born\s+in\s+(?P<obj>[A-Z][A-Za-z0-9 .'-]+)"
+            ),
+            re.IGNORECASE,
+        )
+        for match in born_pattern.finditer(sentence):
+            subj = _clean_entity(match.group("subj"))
+            obj = _clean_entity(match.group("obj"))
+            if subj and obj:
+                relations.append((subj, "born_in", obj))
+
+        role_pattern = re.compile(
+            (
+                r"(?P<subj>[A-Z][A-Za-z0-9 .'-]+?)\s+"
+                r"(?:is|was)\s+(?:an?\s+)?(?P<role>[A-Za-z\s]+?)\s+"
+                r"(?P<prep>of|in|at|for)\s+(?P<obj>[A-Z][A-Za-z0-9 .'-]+)"
+            ),
+            re.IGNORECASE,
+        )
+        for match in role_pattern.finditer(sentence):
+            subj = _clean_entity(match.group("subj"))
+            obj = _clean_entity(match.group("obj"))
+            role = match.group("role").strip().replace(" ", "_").lower()
+            prep = match.group("prep").lower()
+            predicate = f"{role}_{prep}" if role else f"related_{prep}"
+            if subj and obj:
+                relations.append((subj, predicate, obj))
+
+        married_pattern = re.compile(
+            (
+                r"(?P<subj>[A-Z][A-Za-z0-9 .'-]+?)\s+"
+                r"(?:married|marry)\s+(?P<obj>[A-Z][A-Za-z0-9 .'-]+)"
+            ),
+            re.IGNORECASE,
+        )
+        for match in married_pattern.finditer(sentence):
+            subj = _clean_entity(match.group("subj"))
+            obj = _clean_entity(match.group("obj"))
+            if subj and obj:
+                relations.append((subj, "married", obj))
+                relations.append((obj, "married", subj))
+
+        return relations
+
+    def _detect_contradictions(self, graph: Any) -> list[GraphContradiction]:
+        if graph is None:
+            try:
+                from .storage import StorageManager
+
+                graph = StorageManager.get_knowledge_graph(create=False)
+            except Exception:
+                return []
+        if graph is None:
+            return []
+
+        buckets: dict[tuple[str, str], set[str]] = defaultdict(set)
+        label_lookup = {node: graph.nodes[node].get("label", node) for node in graph.nodes}
+        for subj, obj, key, data in graph.edges(keys=True, data=True):
+            predicate = data.get("predicate") or key
+            subj_label = label_lookup.get(subj, str(subj))
+            obj_label = label_lookup.get(obj, str(obj))
+            buckets[(subj_label, predicate)].add(obj_label)
+
+        contradictions: list[GraphContradiction] = []
+        for (subject, predicate), objects in buckets.items():
+            if len(objects) > 1:
+                contradictions.append(
+                    GraphContradiction(
+                        subject=subject,
+                        predicate=predicate,
+                        objects=tuple(sorted(objects)),
+                    )
+                )
+        return contradictions
+
+    def _derive_multi_hop_paths(self, graph: Any) -> list[list[str]]:
+        if graph is None:
+            try:
+                from .storage import StorageManager
+
+                graph = StorageManager.get_knowledge_graph(create=False)
+            except Exception:
+                return []
+        if graph is None:
+            return []
+        undirected = graph.to_undirected(as_view=True)
+        label_lookup = {node: graph.nodes[node].get("label", node) for node in graph.nodes}
+        paths: list[list[str]] = []
+        for source in graph.nodes:
+            for target in graph.nodes:
+                if source == target:
+                    continue
+                try:
+                    for path in nx.all_simple_paths(undirected, source, target, cutoff=3):
+                        if len(path) < 3:
+                            continue
+                        labelled = [label_lookup.get(node, str(node)) for node in path]
+                        if labelled not in paths:
+                            paths.append(labelled)
+                        if len(paths) >= 5:
+                            return paths
+                except Exception:
+                    continue
+        return paths
+
+    def _find_nodes_by_label(self, graph: Any, label: str) -> list[str]:
+        normalized = label.strip().lower()
+        matches = []
+        for node, attrs in graph.nodes(data=True):
+            node_label = str(attrs.get("label", node)).strip().lower()
+            if node_label == normalized:
+                matches.append(node)
+        return matches
 
 
 __all__ = [
     "run_ontology_reasoner",
     "query_with_reasoning",
     "register_reasoner",
+    "KnowledgeGraphPipeline",
 ]

--- a/src/autoresearch/orchestration/orchestration_utils.py
+++ b/src/autoresearch/orchestration/orchestration_utils.py
@@ -13,6 +13,7 @@ from statistics import mean
 from typing import Iterable, Sequence
 
 from ..config.models import ConfigModel
+from ..search.context import SearchContext
 from .budgeting import _apply_adaptive_token_budget
 from .error_handling import (
     _apply_recovery_strategy,
@@ -189,6 +190,12 @@ class ScoutGatePolicy:
                         values.append(float(item))
                     except (TypeError, ValueError):
                         continue
+        try:
+            graph_signal = SearchContext.get_instance().get_contradiction_signal()
+        except Exception:
+            graph_signal = 0.0
+        if graph_signal:
+            values.append(float(graph_signal))
         if values:
             return float(mean(values))
         return 0.0

--- a/src/autoresearch/output_format.py
+++ b/src/autoresearch/output_format.py
@@ -15,6 +15,7 @@ from .models import QueryResponse
 from .errors import ValidationError as AutoresearchValidationError
 from .config import ConfigLoader
 from .logging_utils import get_logger
+from .storage import StorageManager
 
 log = get_logger(__name__)
 
@@ -964,6 +965,10 @@ class OutputFormatter:
             template = TemplateRegistry.get(template_name)
             extra = _template_variables_from_payload(payload)
             return template.render(response, extra=extra)
+        if fmt == "graphml":
+            return StorageManager.export_knowledge_graph_graphml()
+        if fmt in {"graph-json", "graphjson"}:
+            return StorageManager.export_knowledge_graph_json()
         if fmt == "graph":
             raise ValueError(
                 "Graph format cannot be rendered to a string; use format() instead."
@@ -1003,6 +1008,16 @@ class OutputFormatter:
                 metrics_node.add(f"{k}: {v}")
 
             Console(file=sys.stdout, force_terminal=False, color_system=None).print(tree)
+            return
+        if fmt == "graphml":
+            graphml = StorageManager.export_knowledge_graph_graphml()
+            sys.stdout.write(graphml + ("\n" if graphml and not graphml.endswith("\n") else ""))
+            return
+        if fmt in {"graph-json", "graphjson"}:
+            graph_json = StorageManager.export_knowledge_graph_json()
+            if graph_json and not graph_json.endswith("\n"):
+                graph_json += "\n"
+            sys.stdout.write(graph_json)
             return
 
         try:

--- a/tests/integration/test_knowledge_graph_pipeline.py
+++ b/tests/integration/test_knowledge_graph_pipeline.py
@@ -1,0 +1,74 @@
+"""Integration tests validating knowledge graph construction."""
+
+from __future__ import annotations
+
+from autoresearch.search.context import SearchContext
+from autoresearch.storage import StorageManager
+
+
+def _reset_storage() -> None:
+    StorageManager.teardown(remove_db=True)
+    StorageManager.setup(db_path=":memory:")
+
+
+def test_knowledge_graph_multi_hop_paths() -> None:
+    """Knowledge graph should surface multi-hop paths for multi-entity queries."""
+
+    _reset_storage()
+    with SearchContext.temporary_instance() as context:
+        query = "Where was Marie Curie's collaborator born?"
+        results = [
+            {
+                "title": "Marie Curie biography",
+                "snippet": "Marie Curie discovered polonium with Pierre Curie.",
+                "url": "https://example.org/curie",
+            },
+            {
+                "title": "Pierre Curie",
+                "snippet": "Pierre Curie was born in Paris.",
+                "url": "https://example.org/pierre",
+            },
+        ]
+
+        context.add_to_history(query, results)
+
+        paths = context.graph_paths("Marie Curie", "Paris", max_depth=3)
+        assert paths, "Expected at least one multi-hop path"
+        flattened = {node for path in paths for node in path}
+        assert {"Marie Curie", "Pierre Curie", "Paris"}.issubset(flattened)
+
+        summary = context.get_graph_summary()
+        assert summary["relation_count"] >= 2
+        assert any(
+            len(path) >= 3 and path[0] == "Marie Curie" and path[-1] == "Paris"
+            for path in paths
+        )
+    StorageManager.teardown(remove_db=True)
+
+
+def test_knowledge_graph_contradiction_signal() -> None:
+    """Contradictory relations should influence the contradiction signal."""
+
+    _reset_storage()
+    with SearchContext.temporary_instance() as context:
+        query = "What city is Gotham the capital of?"
+        results = [
+            {
+                "title": "Gotham in Arkham",
+                "snippet": "Gotham is the capital of Arkham.",
+                "url": "https://example.org/arkham",
+            },
+            {
+                "title": "Gotham in Blüdhaven",
+                "snippet": "Gotham is the capital of Bludhaven.",
+                "url": "https://example.org/bludhaven",
+            },
+        ]
+
+        context.add_to_history(query, results)
+
+        signal = context.get_contradiction_signal()
+        assert signal > 0.0
+        summary = context.get_graph_summary()
+        assert summary["contradictions"], "Expected contradiction entries in summary"
+    StorageManager.teardown(remove_db=True)


### PR DESCRIPTION
## Summary
- implement a knowledge-graph construction pipeline with contradiction detection, multi-hop discovery, and storage integration
- expose graph queries and exports through the search context, storage manager, and output formatter with updated defaults
- document the workflow and add HotpotQA-style integration tests for multi-hop answers

## Testing
- task verify EXTRAS="dev-minimal test" *(fails: legacy flake8 errors in untouched modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d719e566248333a8ace7ca560d331f