### PR TITLE
Add routing decision telemetry and search cache controls

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -21,6 +21,9 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 ## September 26, 2025
 - Integrated budget-aware model routing, shared retrieval cache namespaces, and
   telemetry updates that surface cost savings alongside latency percentiles.
+- Instrumented the orchestration summary with `agent_latency_p95_ms`,
+  `agent_avg_tokens`, `model_routing_decisions`, and `model_routing_cost_savings`
+  so dashboards can plot budget impact without reprocessing raw samples.
 - Logged the Deep Research Enhancement Initiative and five-phase execution plan
   across ROADMAP.md and the new Deep Research Upgrade Plan so the alpha release
   workstream can stage adaptive gating, audits, GraphRAG, evaluation harnesses,

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -27,7 +27,7 @@ Running `autoresearch monitor resources` will therefore include ``GPU %`` and
 
 ## Budget-Aware Model Routing
 
-The orchestration layer now records per-agent token and latency samples so the
+The orchestration layer records per-agent token and latency samples so the
 model router can steer high-usage roles toward cost-efficient backends without
 violating service-level objectives. The router consults:
 
@@ -37,10 +37,10 @@ violating service-level objectives. The router consults:
 
 When an agent consumes more than 80% of its allocated share of the global token
 budget, the router downgrades to a cheaper profile that still satisfies the
-agent's latency SLO. The decision is logged with before/after cost estimates so
-operators can audit the savings. You can visualise the routing behaviour by
-exporting the new `agent_token_samples` and `agent_timings` series via
-`metrics.get_summary()` or the Prometheus counters exposed by the API gateway.
+agent's latency SLO. Every evaluation emits a `Budget router evaluated` log
+record with the rolling token averages, percentile latency, and projected cost
+delta so operators can audit the savings. When the orchestrator applies the
+recommendation it emits an `Applied budget-aware model routing` event.
 
 ## Telemetry Dashboards
 
@@ -48,15 +48,32 @@ The metrics payload now includes latency percentiles per agent role alongside
 aggregate cost estimates derived from the routing profiles. Dashboards should
 plot the following series to track performance regressions:
 
-- `agent_latency_p95_ms`: 95th-percentile latency per agent, surfaced through
-  the orchestration summary payload.
-- `agent_avg_tokens`: moving-average token consumption emitted as
-  ``avg_tokens_per_call`` in the orchestration logs.
-- `model_routing_cost_savings`: difference between the baseline and routed cost
-  stored in the log event `Budget router selecting cost-efficient model`.
+- `agent_latency_p95_ms`: 95th-percentile latency per agent surfaced through the
+  orchestration summary payload.
+- `agent_avg_tokens`: moving-average token consumption stored alongside the
+  latency summary for dashboards and structured logs.
+- `model_routing_decisions`: structured records of each routing evaluation,
+  including the baseline and selected models.
+- `model_routing_cost_savings`: cumulative difference between baseline and
+  routed cost estimates derived from the logged decisions.
 
 These signals make it easy to confirm that cost savings materialise without
 raising the latency envelope for latency-sensitive agents.
+
+## Retrieval Cache and Parallel Controls
+
+Search now respects two new knobs in `config.search`:
+
+- `shared_cache` and `cache_namespace` decide whether search instances share a
+  TinyDB cache or work from a private file. Namespacing allows concurrent runs
+  to avoid collisions while still reusing expensive retrievals when desired.
+- `parallel_enabled` and `parallel_prefetch` control backend fan-out. Disabling
+  parallelism forces sequential execution, while prefetching allows a subset of
+  backends to warm their caches before the remaining requests run in a thread
+  pool.
+
+Combine these toggles to simulate customer environments, cap concurrency, or
+quarantine experiments without reconfiguring global state.
 
 ## Distributed Coordination Benchmarks
 

--- a/src/autoresearch/token_budget.py
+++ b/src/autoresearch/token_budget.py
@@ -6,7 +6,7 @@ import logging
 import math
 from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
-from typing import Iterable, Mapping, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 log = logging.getLogger(__name__)
 
@@ -93,6 +93,65 @@ class AgentUsageStats:
         return cls(prompt, completion, latency, len(token_samples))
 
 
+@dataclass(frozen=True)
+class RoutingDecision:
+    """Result of evaluating budget-aware routing for an agent."""
+
+    agent: str
+    selected_model: str | None
+    previous_model: str
+    reason: str
+    usage: AgentUsageStats | None
+    budget_tokens: float | None
+    latency_cap_ms: float
+    latency_slo_ms: float | None
+    cost_before: float | None
+    cost_after: float | None
+    pressure_ratio: float
+
+    def cost_savings(self) -> float | None:
+        """Return the estimated currency saved by routing decisions."""
+
+        if self.cost_before is None or self.cost_after is None:
+            return None
+        return self.cost_before - self.cost_after
+
+    def as_log_extra(self) -> dict[str, Any]:
+        """Return a flattened payload suitable for structured logging."""
+
+        payload: dict[str, Any] = {
+            "agent": self.agent,
+            "selected_model": self.selected_model,
+            "previous_model": self.previous_model,
+            "reason": self.reason,
+            "budget_tokens": self.budget_tokens,
+            "latency_cap_ms": self.latency_cap_ms,
+            "latency_slo_ms": self.latency_slo_ms,
+            "cost_before": self.cost_before,
+            "cost_after": self.cost_after,
+            "cost_savings": self.cost_savings(),
+            "pressure_ratio": self.pressure_ratio,
+        }
+        if self.usage is not None:
+            payload.update(
+                {
+                    "avg_prompt_tokens": self.usage.avg_prompt_tokens,
+                    "avg_completion_tokens": self.usage.avg_completion_tokens,
+                    "avg_total_tokens": self.usage.avg_total_tokens,
+                    "latency_p95_ms": self.usage.p95_latency_ms,
+                    "call_count": self.usage.call_count,
+                }
+            )
+        return payload
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable representation of the decision."""
+
+        data = self.as_log_extra()
+        data.pop("pressure_ratio", None)
+        return data
+
+
 class BudgetRouter:
     """Select an appropriate model when token budgets become constrained."""
 
@@ -133,6 +192,112 @@ class BudgetRouter:
             ),
         )
 
+    def select_model_decision(
+        self,
+        agent_name: str,
+        usage: AgentUsageStats | None,
+        *,
+        agent_budget_tokens: float | None,
+        agent_latency_slo_ms: float | None,
+        allowed_models: Sequence[str] | None,
+        preferred_models: Sequence[str] | None,
+        current_model: str,
+    ) -> RoutingDecision:
+        """Return routing metadata honouring token and latency constraints."""
+
+        candidates = self._candidate_names(allowed_models)
+        latency_cap = (
+            agent_latency_slo_ms
+            if agent_latency_slo_ms is not None
+            else self._default_latency_slo_ms
+        )
+        if not candidates:
+            decision = RoutingDecision(
+                agent=agent_name,
+                selected_model=None,
+                previous_model=current_model,
+                reason="no_candidates",
+                usage=usage,
+                budget_tokens=agent_budget_tokens,
+                latency_cap_ms=latency_cap,
+                latency_slo_ms=agent_latency_slo_ms,
+                cost_before=None,
+                cost_after=None,
+                pressure_ratio=self._pressure_ratio,
+            )
+            log.info("Budget router evaluated", extra=decision.as_log_extra())
+            return decision
+
+        latency_constrained = [
+            name
+            for name in candidates
+            if self._profiles[name].latency_p95_ms <= latency_cap
+        ]
+        if not latency_constrained:
+            latency_constrained = list(candidates)
+
+        baseline = self._choose_preferred(latency_constrained, preferred_models)
+        if baseline is None:
+            baseline = (
+                current_model
+                if current_model in latency_constrained
+                else latency_constrained[0]
+            )
+
+        reason = "preferred"
+        selected = baseline
+        cost_before = None
+        cost_after = None
+        baseline_profile = self._profiles.get(baseline)
+        if usage is not None and baseline_profile is not None:
+            cost_before = usage.estimated_cost(baseline_profile)
+
+        if usage is None:
+            reason = "no_usage"
+        elif agent_budget_tokens is None:
+            reason = "no_budget"
+        else:
+            expected_tokens = max(usage.avg_total_tokens, 0.0)
+            if expected_tokens <= 0:
+                reason = "no_usage"
+            else:
+                budget_threshold = agent_budget_tokens * self._pressure_ratio
+                if budget_threshold <= 0:
+                    budget_threshold = agent_budget_tokens
+
+                if expected_tokens > budget_threshold:
+                    cheapest = min(
+                        latency_constrained,
+                        key=lambda name: self._profiles[name].cost_per_token(),
+                    )
+                    if cheapest != baseline:
+                        selected = cheapest
+                        reason = "budget_pressure"
+                    else:
+                        reason = "budget_pressure"
+                else:
+                    reason = "within_budget"
+
+        selected_profile = self._profiles.get(selected)
+        if usage is not None and selected_profile is not None:
+            cost_after = usage.estimated_cost(selected_profile)
+
+        decision = RoutingDecision(
+            agent=agent_name,
+            selected_model=selected,
+            previous_model=current_model,
+            reason=reason,
+            usage=usage,
+            budget_tokens=agent_budget_tokens,
+            latency_cap_ms=latency_cap,
+            latency_slo_ms=agent_latency_slo_ms,
+            cost_before=cost_before,
+            cost_after=cost_after,
+            pressure_ratio=self._pressure_ratio,
+        )
+        log.info("Budget router evaluated", extra=decision.as_log_extra())
+        return decision
+
     def select_model(
         self,
         agent_name: str,
@@ -144,64 +309,18 @@ class BudgetRouter:
         preferred_models: Sequence[str] | None,
         current_model: str,
     ) -> str | None:
-        """Return a model name honouring token and latency constraints."""
+        """Return the selected model name for compatibility callers."""
 
-        candidates = self._candidate_names(allowed_models)
-        if not candidates:
-            return None
-
-        latency_cap = (
-            agent_latency_slo_ms
-            if agent_latency_slo_ms is not None
-            else self._default_latency_slo_ms
+        decision = self.select_model_decision(
+            agent_name,
+            usage,
+            agent_budget_tokens=agent_budget_tokens,
+            agent_latency_slo_ms=agent_latency_slo_ms,
+            allowed_models=allowed_models,
+            preferred_models=preferred_models,
+            current_model=current_model,
         )
-        latency_constrained = [
-            name
-            for name in candidates
-            if self._profiles[name].latency_p95_ms <= latency_cap
-        ]
-        if not latency_constrained:
-            latency_constrained = list(candidates)
-
-        baseline = self._choose_preferred(latency_constrained, preferred_models)
-        if usage is None or agent_budget_tokens is None:
-            return baseline
-
-        expected_tokens = max(usage.avg_total_tokens, 0.0)
-        if expected_tokens <= 0:
-            return baseline
-        budget_threshold = agent_budget_tokens * self._pressure_ratio
-        if budget_threshold <= 0:
-            budget_threshold = agent_budget_tokens
-
-        if expected_tokens <= budget_threshold:
-            return baseline
-
-        cheapest = min(
-            latency_constrained,
-            key=lambda name: self._profiles[name].cost_per_token(),
-        )
-
-        if cheapest == baseline or cheapest == current_model:
-            return cheapest
-
-        baseline_profile = self._profiles.get(baseline or current_model)
-        cheapest_profile = self._profiles[cheapest]
-        before_cost = usage.estimated_cost(baseline_profile) if baseline_profile else None
-        after_cost = usage.estimated_cost(cheapest_profile)
-        log.info(
-            "Budget router selecting cost-efficient model",
-            extra={
-                "agent": agent_name,
-                "selected_model": cheapest,
-                "previous_model": baseline or current_model,
-                "avg_tokens": expected_tokens,
-                "budget_tokens": agent_budget_tokens,
-                "cost_before": before_cost,
-                "cost_after": after_cost,
-            },
-        )
-        return cheapest
+        return decision.selected_model
 
     def iter_profiles(self) -> Iterable[tuple[str, ModelProfile]]:
         """Return an iterator over configured model profiles."""

--- a/tests/performance/test_budget_router.py
+++ b/tests/performance/test_budget_router.py
@@ -76,3 +76,32 @@ def test_budget_router_retains_preferred_model_when_within_budget() -> None:
 
     assert selected == "premium"
     assert config.agent_config["Contrarian"].model == "premium"
+
+
+def test_metrics_summary_reports_cost_and_latency() -> None:
+    """Summaries expose latency, token averages, and routing savings."""
+
+    config = _make_base_config()
+    config.agent_config["Synthesizer"] = AgentConfig(
+        preferred_models=["premium", "efficient"],
+        token_share=0.5,
+        latency_slo_ms=1200.0,
+    )
+
+    metrics = OrchestrationMetrics()
+    metrics.record_tokens("Synthesizer", tokens_in=1800, tokens_out=900)
+    metrics.record_agent_timing("Synthesizer", duration=0.95)
+
+    selected = metrics.apply_model_routing("Synthesizer", config)
+    assert selected == "efficient"
+
+    summary = metrics.get_summary()
+    latency_ms = summary["agent_latency_p95_ms"]["Synthesizer"]
+    avg_tokens = summary["agent_avg_tokens"]["Synthesizer"]
+    decisions = summary["model_routing_decisions"]
+    savings = summary["model_routing_cost_savings"]
+
+    assert latency_ms >= 900.0
+    assert avg_tokens >= 2600.0
+    assert decisions[-1]["selected_model"] == "efficient"
+    assert savings["total"] > 0


### PR DESCRIPTION
## Summary
- add structured routing decisions that log token and latency usage and expose cost savings
- extend orchestration metrics summaries with agent percentile latency, average tokens, and routing cost aggregates
- document and test the search cache sharing and parallelisation controls for retrieval workloads

## Testing
- uv run task verify *(fails: repository flake8 configuration reports pre-existing lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_68d723e70f4c833380c452882426f0cf