### PR TITLE
feat: add depth-aware toggles and provenance summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,13 @@ autoresearch search "Explain prompt reflection" --depth trace --output json
 ```
 
 Streamlit mirrors the same depth levels through a radio selector above the
-results panel. Adjusting the selector toggles TL;DR summaries, key findings,
-claim tables, GraphRAG artefacts, and agent traces without re-running the
-query. Provenance notes underneath each section highlight when data is hidden
-or truncated, making it explicit when a deeper depth is required for audit
-workflows.
+results panel and augments them with four toggles: **Show TL;DR**, **Show key
+findings**, **Show claim table**, and **Show full trace**. The toggles reset when
+depth changes so that newly available evidence appears automatically while
+letting reviewers silence sections on demand. A dedicated Provenance panel
+summarises claim audit statuses and renders GraphRAG artefacts, while section
+notes continue to explain when information is truncated or hidden.
+
+CLI help text now lists which headline sections are enabled at each depth, and
+JSON output includes a `sections` map so integrations can confirm what data was
+emitted before post-processing.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,36 @@
+# User Guide
+
+This guide highlights the most important controls for navigating Autoresearch
+outputs.
+
+## Depth controls
+
+Autoresearch responses are organised by depth levels that determine how much
+context is displayed. Depth can be selected from the CLI with `--depth` or via
+the Streamlit radio group. Each depth level now advertises the sections it
+unlocks—TL;DR summaries, key findings, claim tables, and the full reasoning
+trace. The CLI `--help` output lists these combinations, and JSON exports
+include a `sections` map so that downstream tools can enforce depth-aware
+policies.
+
+The Streamlit app mirrors these options with four toggles:
+**Show TL;DR**, **Show key findings**, **Show claim table**, and **Show full
+trace**. Toggle defaults are bound to the current depth so that moving to deeper
+views surfaces more context without retaining stale preferences.
+
+## Provenance verification
+
+Claim verification is surfaced through the dedicated Provenance panel. Claim
+statuses are summarised in natural order (supported, needs review, unsupported)
+and the detailed table remains available when the claim table toggle is active.
+GraphRAG artifacts are also exposed in the Provenance panel to verify that graph
+reasoning supplied the cited evidence. When running at lower depths the panel
+explains which artefacts are hidden and how to reveal them.
+
+## Socratic prompts and traces
+
+Socratic prompts adapt to the visible findings and claims, encouraging users to
+question evidence and explore follow-up angles. The full trace toggle governs
+both reasoning steps and ReAct event visualisations, making it simple to switch
+between quick summaries and full audit trails. Trace downloads retain the depth
+selection so exported Markdown or JSON matches the on-screen view.

--- a/src/autoresearch/ui/provenance.py
+++ b/src/autoresearch/ui/provenance.py
@@ -52,3 +52,51 @@ def extract_graphrag_artifacts(metrics: Mapping[str, Any]) -> Dict[str, Any]:
 def depth_sequence() -> List[OutputDepth]:
     """Return the ordered depth options for UI widgets."""
     return [OutputDepth.TLDR, OutputDepth.CONCISE, OutputDepth.STANDARD, OutputDepth.TRACE]
+
+
+def audit_status_rollup(claim_audits: List[Mapping[str, Any]]) -> Dict[str, int]:
+    """Summarise claim audit statuses for quick provenance overviews."""
+
+    if not claim_audits:
+        return {}
+
+    counts: Dict[str, int] = {}
+    for audit in claim_audits:
+        status = str(audit.get("status", "unknown")).lower()
+        counts[status] = counts.get(status, 0) + 1
+
+    ordered: Dict[str, int] = {}
+    for key in ("supported", "needs_review", "unsupported"):
+        value = counts.pop(key, 0)
+        if value:
+            ordered[key] = value
+    for key in sorted(counts):
+        if counts[key]:
+            ordered[key] = counts[key]
+    return ordered
+
+
+def section_toggle_defaults(payload: DepthPayload) -> Dict[str, Dict[str, bool]]:
+    """Return toggle availability and defaults for depth-aware sections."""
+
+    sections = payload.sections
+    return {
+        "tldr": {
+            "available": sections.get("tldr", True),
+            "value": sections.get("tldr", True),
+        },
+        "key_findings": {
+            "available": sections.get("key_findings", False),
+            "value": sections.get("key_findings", False),
+        },
+        "claim_audits": {
+            "available": sections.get("claim_audits", False),
+            "value": sections.get("claim_audits", False),
+        },
+        "full_trace": {
+            "available": sections.get("reasoning", False)
+            or sections.get("react_traces", False),
+            "value": sections.get("reasoning", False)
+            or sections.get("react_traces", False),
+        },
+    }

--- a/tests/cli/test_search_depth.py
+++ b/tests/cli/test_search_depth.py
@@ -1,6 +1,9 @@
+import json
+
 import pytest
 from typer.testing import CliRunner
 
+from autoresearch.cli_helpers import depth_help_text
 from autoresearch.main.app import app as cli_app
 from autoresearch.models import QueryResponse
 
@@ -87,5 +90,14 @@ def test_cli_depth_trace_json(cli_runner: CliRunner, cli_environment: QueryRespo
         ["search", "depth test", "--depth", "trace", "--output", "json"],
     )
     assert result.exit_code == 0
-    assert '"raw_response"' in result.stdout
-    assert '"key_findings"' in result.stdout
+    data = json.loads(result.stdout)
+    assert "raw_response" in data
+    assert data["sections"]["full_trace"] is True
+    assert data["sections"]["claim_audits"] is True
+
+
+def test_depth_help_text_includes_feature_matrix() -> None:
+    text = depth_help_text()
+    assert "includes TL;DR" in text
+    assert "claim table" in text
+    assert "full trace" in text

--- a/tests/ui/test_provenance_helpers.py
+++ b/tests/ui/test_provenance_helpers.py
@@ -3,8 +3,10 @@ import pytest
 from autoresearch.models import QueryResponse
 from autoresearch.output_format import DepthPayload, build_depth_payload, OutputDepth
 from autoresearch.ui.provenance import (
+    audit_status_rollup,
     extract_graphrag_artifacts,
     generate_socratic_prompts,
+    section_toggle_defaults,
 )
 
 pytestmark = pytest.mark.requires_ui
@@ -42,3 +44,17 @@ def test_extract_graphrag_artifacts_filters_non_graph_metrics(sample_payload) ->
     artifacts = extract_graphrag_artifacts(sample_payload.metrics)
     assert "graphrag_edges" in artifacts
     assert "tokens" not in artifacts
+
+
+def test_audit_status_rollup_orders_known_statuses(sample_payload) -> None:
+    counts = audit_status_rollup(sample_payload.claim_audits)
+    assert list(counts.keys())[0] == "supported"
+    assert counts["supported"] == 1
+
+
+def test_section_toggle_defaults_reflect_payload_sections(sample_payload) -> None:
+    toggles = section_toggle_defaults(sample_payload)
+    assert toggles["tldr"]["available"] is True
+    assert toggles["key_findings"]["value"] is True
+    assert toggles["claim_audits"]["available"] is True
+    assert toggles["full_trace"]["available"] is True


### PR DESCRIPTION
## Summary
- extend the depth planner to expose TL;DR, claim tables, reasoning traces, and feature flags in CLI and JSON output
- add Streamlit toggles, provenance rollups, and GraphRAG artifact panels seeded by the new depth metadata
- refresh user documentation and regression tests to cover depth controls and provenance verification

## Testing
- task check *(fails: task not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d723e2c8b88333a43b3c4cc93bb976