### PR TITLE
Document planner telemetry integration

### DIFF
--- a/docs/deep_research_upgrade_plan.md
+++ b/docs/deep_research_upgrade_plan.md
@@ -30,6 +30,11 @@ keep truthfulness, verifiability, and cost discipline in balance.
    - Promote planner outputs into a schedulable task graph.
    - Capture ReAct traces for transparency and replay.
    - Document interfaces for specialized agents and tool calls.
+   - Refine `agents/specialized/planner.py` prompts so decomposition yields
+     typed `TaskGraph` nodes with tool affinity scores instead of spawning new
+     agents.
+   - Extend `orchestration/coordinator.py` scheduling rules to consume those
+     affinities while reusing the existing coordinator instance.
 3. **Phase 3 – Graph-Augmented Retrieval**
    - Build session-scoped knowledge graphs by extracting entities and
      relations from retrieval snippets and persisting them to DuckDB and
@@ -66,3 +71,60 @@ keep truthfulness, verifiability, and cost discipline in balance.
 
 Complete the documentation and issue updates described above, then begin Phase
 1 implementation under the new tickets while monitoring cost and accuracy.
+
+## Planner and Coordinator Implementation Map
+
+- **Socratic prompt calibration (Planner):**
+  - Question: How do we surface decomposition intent without multiplying
+    agents?
+  - Answer: Update `PlannerPromptBuilder` in
+    `agents/specialized/planner.py` to ask for explicit task objectives,
+    required tools, and exit criteria in a single ReAct-style table. Encode the
+    result as structured JSON so `TaskGraph.from_planner_output` can hydrate
+    nodes without extra adapters.
+  - Counterpoint: Could free-form language capture nuance better? No, because
+    downstream scheduling relies on typed fields; keep free-form rationale in a
+    separate `explanation` column that does not affect routing.
+- **Dialectical graph shaping (Coordinator):**
+  - Question: Should `TaskCoordinator` branch into per-tool coordinators?
+  - Answer: No. Amend `TaskCoordinator.schedule_next` in
+    `orchestration/coordinator.py` to order nodes by dependency readiness and
+    the planner-provided tool affinity score. Maintain a single coordinator and
+    augment the logic with a deterministic tie-breaker on dependency depth to
+    keep behavior reproducible.
+  - Counterpoint: Would a brand-new coordinator be simpler? Reject that
+    impulse; integrating within the current class preserves telemetry and keeps
+    regression risk bounded.
+
+## ReAct Telemetry and Test Hooks
+
+- **`QueryState.set_task_graph`:** Layer a lightweight `react_log` append that
+  stores the planner prompt, structured response, and normalization warnings so
+  subsequent `TaskCoordinator` calls can replay the reasoning chain.
+- **`TaskCoordinator.record_react_step`:** Extend the method to include task
+  node identifiers, tool affinity deltas, and downstream task unlock events in
+  each log entry. Keep the signature stable by packing additions into the
+  existing metadata dictionary.
+- **Testing impact:**
+  - Update `tests/unit/orchestration/test_task_coordinator.py` to assert the
+    new metadata keys and tie-breaker ordering.
+  - Expand `tests/unit/test_query_state_features.py` to cover `react_log`
+    persistence when the task graph is replaced.
+  - Introduce scenario coverage in
+    `tests/behavior/steps/reasoning_mode_steps.py` so multi-step runs verify the
+    planner-coordinator hand-off with ReAct telemetry enabled.
+
+## KPI Tracking for Iterative Delivery
+
+- **Multi-step task coverage:** Track the proportion of tasks with depth >1
+  that successfully log planner decomposition and coordinator execution per run
+  of `task verify`. Target ≥75% coverage before widening scope.
+- **Tool affinity accuracy:** Measure how often the selected tool matches the
+  planner's top-ranked choice. Record baselines in `STATUS.md` and aim for ≥85%
+  agreement once telemetry is wired.
+- **ReAct replay latency:** Monitor the time to reconstruct a task run from the
+  new logs. Maintain <200 ms overhead per task to avoid regressions.
+- **Telemetry completeness:** Use docstring-driven audits in
+  `orchestration/coordinator.py` to ensure every scheduled node includes a
+  `react_log` reference. Audit results quarterly and publish deltas in
+  `TASK_PROGRESS.md`.


### PR DESCRIPTION
## Summary
- expand the deep research upgrade plan with concrete planner and coordinator prompts
- outline ReAct telemetry layering for QueryState and TaskCoordinator alongside required tests
- add KPI targets to frame iterative delivery of multi-step task coverage

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d73298cda48333bc897c4114baaf4a