### PR TITLE
Add stability aggregation to claim audits

### DIFF
--- a/src/autoresearch/agents/dialectical/fact_checker.py
+++ b/src/autoresearch/agents/dialectical/fact_checker.py
@@ -1,16 +1,23 @@
 """FactChecker agent verifies claims against external sources."""
 
-from typing import Dict, Any
+from typing import Any, Dict, Iterable, Mapping
 
 from ...agents.base import Agent, AgentRole
 from ...config import ConfigModel
-from ...evidence import classify_entailment, expand_retrieval_queries, score_entailment
+from ...evidence import (
+    aggregate_entailment_scores,
+    EntailmentBreakdown,
+    classify_entailment,
+    expand_retrieval_queries,
+    sample_paraphrases,
+    score_entailment,
+)
 from ...orchestration.phases import DialoguePhase
 from ...orchestration.reasoning import ReasoningMode
 from ...orchestration.state import QueryState
 from ...logging_utils import get_logger
 from ...search import Search
-from ...storage import ClaimAuditRecord
+from ...storage import ClaimAuditRecord, ClaimAuditStatus
 
 log = get_logger(__name__)
 
@@ -32,12 +39,33 @@ class FactChecker(Agent):
             config, "max_results_per_query", 5
         )  # Default to 5 if not specified
         raw_sources = Search.external_lookup(state.query, max_results=max_results)
-        sources = []
-        for s in raw_sources:
-            s = dict(s)
-            s["checked_claims"] = [c["id"] for c in state.claims]
-            s["agent"] = self.name
-            sources.append(s)
+        sources: list[Dict[str, Any]] = []
+        seen_sources: set[tuple[str | None, str | None, str | None]] = set()
+
+        def _source_key(source: Mapping[str, Any]) -> tuple[str | None, str | None, str | None]:
+            snippet = source.get("snippet") or source.get("content") or ""
+            key = (
+                source.get("url"),
+                source.get("title"),
+                snippet[:200] if isinstance(snippet, str) else None,
+            )
+            return key
+
+        def _register_sources(candidates: Iterable[Mapping[str, Any]]) -> list[Dict[str, Any]]:
+            registered: list[Dict[str, Any]] = []
+            for candidate in candidates:
+                enriched = dict(candidate)
+                enriched["checked_claims"] = [c["id"] for c in state.claims]
+                enriched["agent"] = self.name
+                key = _source_key(enriched)
+                if key in seen_sources:
+                    continue
+                seen_sources.add(key)
+                sources.append(enriched)
+                registered.append(enriched)
+            return registered
+
+        _register_sources(raw_sources)
 
         query_variations: list[str] = []
         for claim in state.claims:
@@ -50,20 +78,66 @@ class FactChecker(Agent):
         claim_audits: list[dict[str, Any]] = []
         top_sources: list[Dict[str, Any]] = []
         for claim in state.claims:
-            best_score = 0.0
+            claim_text = str(claim.get("content", "")).strip()
+            if not claim_text:
+                continue
+
+            breakdowns: list[EntailmentBreakdown] = []
+            best_score = -1.0
             best_source: Dict[str, Any] | None = None
-            for source in sources:
+
+            def _evaluate(source: Mapping[str, Any]) -> None:
+                nonlocal best_score, best_source
                 snippet = source.get("snippet") or source.get("content") or ""
-                breakdown = score_entailment(claim.get("content", ""), snippet)
+                if not isinstance(snippet, str) or not snippet.strip():
+                    return
+                breakdown = score_entailment(claim_text, snippet)
+                breakdowns.append(breakdown)
                 if breakdown.score > best_score:
                     best_score = breakdown.score
-                    best_source = source
-            status = classify_entailment(best_score)
+                    best_source = dict(source)
+
+            for source in sources:
+                _evaluate(source)
+
+            aggregate = aggregate_entailment_scores(breakdowns)
+            if aggregate.disagreement:
+                for paraphrase in sample_paraphrases(claim_text, max_samples=2):
+                    new_candidates = Search.external_lookup(
+                        paraphrase, max_results=max_results
+                    )
+                    registered = _register_sources(new_candidates)
+                    for source in registered:
+                        _evaluate(source)
+                    aggregate = aggregate_entailment_scores(breakdowns)
+                    if not aggregate.disagreement or aggregate.sample_size >= max_results * 2:
+                        break
+
+            score_value = aggregate.mean if aggregate.sample_size else None
+            status = classify_entailment(score_value or 0.0)
+            if aggregate.disagreement or aggregate.sample_size == 0:
+                status = ClaimAuditStatus.NEEDS_REVIEW
+
+            note: str | None = None
+            if aggregate.sample_size:
+                note = (
+                    f"Self-check over {aggregate.sample_size} snippet(s); "
+                    f"variance={aggregate.variance:.3f}."
+                )
+                if aggregate.disagreement:
+                    note += " Disagreement detected; manual review recommended."
+            else:
+                note = "No retrieval snippets matched the claim."
+
             record = ClaimAuditRecord.from_score(
                 claim["id"],
-                best_score,
+                score_value,
                 sources=[best_source] if best_source else None,
+                notes=note,
                 status=status,
+                variance=aggregate.variance if aggregate.sample_size else None,
+                instability=aggregate.disagreement if aggregate.sample_size else None,
+                sample_size=aggregate.sample_size or None,
             )
             audit_payload = record.to_payload()
             claim_audits.append(audit_payload)
@@ -76,12 +150,52 @@ class FactChecker(Agent):
         verification = adapter.generate(prompt, model=model)
 
         # Create and return the result
+        valid_scores = [
+            audit.get("entailment_score")
+            for audit in claim_audits
+            if audit.get("entailment_score") is not None
+        ]
         aggregate_score = (
-            sum(audit.get("entailment_score", 0.0) for audit in claim_audits) / len(claim_audits)
-            if claim_audits
-            else 0.0
+            sum(valid_scores) / len(valid_scores) if valid_scores else None
         )
-        aggregate_status = classify_entailment(aggregate_score)
+        aggregate_status = classify_entailment(aggregate_score or 0.0)
+
+        variance_values = [
+            audit.get("entailment_variance")
+            for audit in claim_audits
+            if audit.get("entailment_variance") is not None
+        ]
+        aggregate_variance = (
+            sum(variance_values) / len(variance_values) if variance_values else None
+        )
+        total_samples = sum(int(audit.get("sample_size") or 0) for audit in claim_audits)
+        instability_flags = [
+            audit.get("instability_flag")
+            for audit in claim_audits
+            if audit.get("instability_flag") is not None
+        ]
+        instability_state: bool | None
+        if instability_flags:
+            instability_state = any(bool(flag) for flag in instability_flags)
+        elif claim_audits:
+            instability_state = False
+        else:
+            instability_state = None
+
+        if instability_state or not valid_scores:
+            aggregate_status = ClaimAuditStatus.NEEDS_REVIEW
+
+        summary_note: str | None = None
+        if claim_audits:
+            if total_samples:
+                summary_note = f"Aggregated over {total_samples} snippet(s)."
+                if aggregate_variance is not None:
+                    summary_note += f" Mean variance={aggregate_variance:.3f}."
+            else:
+                summary_note = "No snippet-level audits were available."
+            if instability_state:
+                summary_note = (summary_note or "") + " Instability detected across claims."
+
         claim = self.create_claim(
             verification,
             "verification",
@@ -89,6 +203,10 @@ class FactChecker(Agent):
             verification_status=aggregate_status,
             verification_sources=top_sources,
             entailment_score=aggregate_score,
+            entailment_variance=aggregate_variance,
+            instability_flag=instability_state,
+            sample_size=total_samples or None,
+            notes=summary_note,
         )
         return self.create_result(
             claims=[claim],

--- a/src/autoresearch/agents/mixins.py
+++ b/src/autoresearch/agents/mixins.py
@@ -68,6 +68,9 @@ class ClaimGeneratorMixin:
         verification_status: ClaimAuditStatus | str | None = None,
         verification_sources: Optional[Sequence[SourcePayload]] = None,
         entailment_score: float | None = None,
+        entailment_variance: float | None = None,
+        instability_flag: bool | None = None,
+        sample_size: int | None = None,
         notes: str | None = None,
     ) -> ClaimPayload:
         """Create a claim with the given content and type.
@@ -82,6 +85,12 @@ class ClaimGeneratorMixin:
             verification_sources: Evidence payloads that informed the
                 verification decision.
             entailment_score: Normalised entailment score in ``[0, 1]``.
+            entailment_variance: Sample variance of entailment scores where
+                available.
+            instability_flag: Boolean indicator that the self-check disagreed
+                with retrieved snippets.
+            sample_size: Number of snippets contributing to the entailment
+                estimate.
             notes: Optional reviewer notes to attach to the audit payload.
 
         Returns:
@@ -102,7 +111,15 @@ class ClaimGeneratorMixin:
             )
         elif any(
             value is not None
-            for value in (verification_status, verification_sources, entailment_score)
+            for value in (
+                verification_status,
+                verification_sources,
+                entailment_score,
+                entailment_variance,
+                instability_flag,
+                sample_size,
+                notes,
+            )
         ):
             try:
                 record = ClaimAuditRecord.from_score(
@@ -111,6 +128,9 @@ class ClaimGeneratorMixin:
                     sources=verification_sources,
                     notes=notes,
                     status=verification_status,
+                    variance=entailment_variance,
+                    instability=instability_flag,
+                    sample_size=sample_size,
                 )
             except TypeError as exc:
                 raise TypeError("verification_sources must contain mappings") from exc

--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -11,7 +11,7 @@ from pydantic import (
 )
 from pydantic_settings import SettingsConfigDict
 
-from ..orchestration import ReasoningMode
+from ..orchestration.reasoning import ReasoningMode
 from .validators import (
     normalize_ranking_weights,
     validate_eviction_policy,

--- a/src/autoresearch/models.py
+++ b/src/autoresearch/models.py
@@ -76,7 +76,8 @@ class QueryResponse(BaseModel):
         metrics: Execution metrics describing latency, token usage, etc.
         claim_audits: Verification metadata for each evaluated claim. Each
             entry is a mapping containing ``claim_id``, ``status``,
-            ``entailment_score``, ``sources``, ``notes``, and ``created_at``.
+            ``entailment_score``, ``entailment_variance``, ``instability_flag``,
+            ``sample_size``, ``sources``, ``notes``, and ``created_at``.
     """
 
     query: Optional[str] = Field(

--- a/src/autoresearch/orchestration/__init__.py
+++ b/src/autoresearch/orchestration/__init__.py
@@ -1,6 +1,7 @@
 """Orchestration module for agent coordination."""
 
-from .coordinator import TaskCoordinator, TaskStatus
+from importlib import import_module
+
 from .reasoning import ChainOfThoughtStrategy, ReasoningMode, ReasoningStrategy
 
 __all__ = [
@@ -10,3 +11,14 @@ __all__ = [
     "TaskCoordinator",
     "TaskStatus",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Lazily import coordinator symbols to avoid circular imports."""
+
+    if name in {"TaskCoordinator", "TaskStatus"}:
+        module = import_module(".coordinator", __name__)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/integration/test_claim_audits_stability.py
+++ b/tests/integration/test_claim_audits_stability.py
@@ -1,0 +1,31 @@
+"""Integration tests for claim audit stability metadata."""
+
+import pytest
+
+from autoresearch.storage import ClaimAuditRecord
+from autoresearch.storage_backends import DuckDBStorageBackend
+
+
+def test_duckdb_persists_stability_metadata() -> None:
+    """Persisting and retrieving claim audits should round-trip stability fields."""
+
+    backend = DuckDBStorageBackend()
+    backend.setup(db_path=":memory:", skip_migrations=False)
+    try:
+        record = ClaimAuditRecord.from_score(
+            "claim-123",
+            0.8,
+            variance=0.02,
+            instability=False,
+            sample_size=5,
+        )
+        backend.persist_claim_audit(record.to_payload())
+
+        audits = backend.list_claim_audits("claim-123")
+        assert audits, "Expected persisted audit to be retrievable"
+        stored = audits[0]
+        assert stored["entailment_variance"] == pytest.approx(0.02)
+        assert stored["instability_flag"] is False
+        assert stored["sample_size"] == 5
+    finally:
+        backend.close()

--- a/tests/unit/evidence/test_stability_utils.py
+++ b/tests/unit/evidence/test_stability_utils.py
@@ -1,0 +1,37 @@
+"""Unit tests for evidence stability utilities."""
+
+import pytest
+
+from autoresearch.evidence import (
+    aggregate_entailment_scores,
+    sample_paraphrases,
+)
+
+
+def test_aggregate_entailment_scores_stable() -> None:
+    """Consistent scores should yield a stable aggregate."""
+
+    aggregate = aggregate_entailment_scores([0.7, 0.72, 0.68])
+    assert aggregate.sample_size == 3
+    assert aggregate.disagreement is False
+    assert aggregate.mean == pytest.approx(0.7, abs=1e-2)
+    assert aggregate.variance < 0.005
+
+
+def test_aggregate_entailment_scores_unstable() -> None:
+    """Divergent scores should trigger the disagreement flag."""
+
+    aggregate = aggregate_entailment_scores([0.1, 0.9])
+    assert aggregate.sample_size == 2
+    assert aggregate.disagreement is True
+    assert aggregate.variance > 0.25
+
+
+def test_sample_paraphrases_returns_unique_variants() -> None:
+    """Paraphrase sampler should provide diverse, normalised variants."""
+
+    variants = sample_paraphrases("Vaccines reduce hospitalisations.", max_samples=4)
+    assert variants  # at least one variant
+    assert len(set(variant.lower() for variant in variants)) == len(variants)
+    assert any(variant.endswith("?") for variant in variants)
+


### PR DESCRIPTION
## Summary
- add paraphrase sampling and entailment aggregation helpers for evidence stability analysis
- surface stability-aware retries in the FactChecker and Synthesizer agents and persist variance/instability metadata
- update storage/output layers for the new audit fields and add regression plus integration coverage

## Testing
- `uv run --extra test pytest tests/unit/evidence/test_stability_utils.py tests/integration/test_claim_audits_stability.py`


------
https://chatgpt.com/codex/tasks/task_e_68d74078b8f48333b7617e07f3fd819a