### PR TITLE
Attach knowledge graph summary to responses and surface export hints

### DIFF
--- a/src/autoresearch/ui/provenance.py
+++ b/src/autoresearch/ui/provenance.py
@@ -99,4 +99,12 @@ def section_toggle_defaults(payload: DepthPayload) -> Dict[str, Dict[str, bool]]
             "value": sections.get("reasoning", False)
             or sections.get("react_traces", False),
         },
+        "knowledge_graph": {
+            "available": sections.get("knowledge_graph", False),
+            "value": sections.get("knowledge_graph", False),
+        },
+        "graph_exports": {
+            "available": sections.get("graph_exports", False),
+            "value": sections.get("graph_exports", False),
+        },
     }

--- a/tests/ui/test_provenance_helpers.py
+++ b/tests/ui/test_provenance_helpers.py
@@ -58,3 +58,5 @@ def test_section_toggle_defaults_reflect_payload_sections(sample_payload) -> Non
     assert toggles["key_findings"]["value"] is True
     assert toggles["claim_audits"]["available"] is True
     assert toggles["full_trace"]["available"] is True
+    assert toggles["knowledge_graph"]["available"] is False
+    assert toggles["graph_exports"]["available"] is False


### PR DESCRIPTION
## Summary
- attach the latest knowledge graph summary to `QueryResponse` metadata so downstream formatters can read entity counts, contradiction signals, and export availability
- expand depth-aware formatting to render a knowledge graph section with optional export guidance, and surface CLI/Streamlit shortcuts when graph data is present
- update UI toggle helpers and regression tests to cover the new knowledge graph output behaviour

## Testing
- `uv run pytest tests/unit/test_output_format.py tests/ui/test_provenance_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68d75031a69883339ae85cf161f5010a