### PR TITLE
Track gate outcomes in evaluation metrics

### DIFF
--- a/src/autoresearch/cli_utils.py
+++ b/src/autoresearch/cli_utils.py
@@ -240,6 +240,14 @@ def _format_tokens(summary: "EvaluationSummary") -> str:
     return "/".join(parts)
 
 
+def _format_percentage(value: Optional[float], precision: int = 1) -> str:
+    """Format a ratio as a percentage string."""
+
+    if value is None:
+        return "—"
+    return f"{value * 100:.{precision}f}%"
+
+
 def render_evaluation_summary(
     summaries: Sequence["EvaluationSummary"],
 ) -> None:
@@ -252,6 +260,8 @@ def render_evaluation_summary(
     table.add_column("Contradiction rate")
     table.add_column("Avg latency (s)")
     table.add_column("Avg tokens in/out/total")
+    table.add_column("Avg loops")
+    table.add_column("% gated exits")
     table.add_column("Run ID")
     table.add_column("Artifacts")
 
@@ -271,6 +281,8 @@ def render_evaluation_summary(
             _format_optional(summary.contradiction_rate),
             _format_optional(summary.avg_latency_seconds),
             _format_tokens(summary),
+            _format_optional(summary.avg_cycles_completed, precision=1),
+            _format_percentage(summary.gate_exit_rate),
             summary.run_id,
             "
 ".join(artifacts) if artifacts else "—",


### PR DESCRIPTION
## Summary
- capture gate events, loop counts, and aggregated gate outcomes in the evaluation harness
- persist the new gate telemetry to DuckDB/Parquet artifacts and surface it via EvaluationSummary
- extend the CLI summary table and regression tests to cover average loops and gated exit percentages

## Testing
- uv run --extra test pytest tests/evaluation/test_harness.py

------
https://chatgpt.com/codex/tasks/task_e_68d75346f9ac8333b480ed2449ea519e