### PR TITLE
Add provenance tracking to claim audits

### DIFF
--- a/src/autoresearch/agents/mixins.py
+++ b/src/autoresearch/agents/mixins.py
@@ -72,6 +72,7 @@ class ClaimGeneratorMixin:
         instability_flag: bool | None = None,
         sample_size: int | None = None,
         notes: str | None = None,
+        provenance: Mapping[str, Any] | None = None,
     ) -> ClaimPayload:
         """Create a claim with the given content and type.
 
@@ -92,6 +93,8 @@ class ClaimGeneratorMixin:
             sample_size: Number of snippets contributing to the entailment
                 estimate.
             notes: Optional reviewer notes to attach to the audit payload.
+            provenance: Optional structured provenance metadata describing
+                retrieval queries, retry counts, or evidence identifiers.
 
         Returns:
             A dictionary representing the claim.
@@ -131,6 +134,7 @@ class ClaimGeneratorMixin:
                     variance=entailment_variance,
                     instability=instability_flag,
                     sample_size=sample_size,
+                    provenance=provenance,
                 )
             except TypeError as exc:
                 raise TypeError("verification_sources must contain mappings") from exc

--- a/src/autoresearch/models.py
+++ b/src/autoresearch/models.py
@@ -75,9 +75,10 @@ class QueryResponse(BaseModel):
         reasoning: Ordered reasoning steps exchanged between agents.
         metrics: Execution metrics describing latency, token usage, etc.
         claim_audits: Verification metadata for each evaluated claim. Each
-            entry is a mapping containing ``claim_id``, ``status``,
-            ``entailment_score``, ``entailment_variance``, ``instability_flag``,
-            ``sample_size``, ``sources``, ``notes``, and ``created_at``.
+            entry mirrors :class:`~autoresearch.storage.ClaimAuditRecord` and
+            includes ``claim_id``, ``status``, ``entailment_score``,
+            ``entailment_variance``, ``instability_flag``, ``sample_size``,
+            ``sources``, ``provenance``, ``notes``, and ``created_at``.
     """
 
     query: Optional[str] = Field(
@@ -89,7 +90,7 @@ class QueryResponse(BaseModel):
     metrics: Dict[str, Any]
     claim_audits: List[Dict[str, Any]] = Field(
         default_factory=list,
-        description="FEVER-style verification metadata for individual claims",
+        description="FEVER-style verification metadata with provenance for individual claims",
     )
     task_graph: Optional[Dict[str, Any]] = Field(
         default=None,

--- a/tests/unit/test_agents_dialectical.py
+++ b/tests/unit/test_agents_dialectical.py
@@ -1,0 +1,111 @@
+"""Unit tests covering dialectical agents' claim audit provenance."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from autoresearch.agents.dialectical.fact_checker import FactChecker
+from autoresearch.agents.dialectical.synthesizer import SynthesizerAgent
+from autoresearch.config.models import ConfigModel
+from autoresearch.llm.adapters import LLMAdapter
+from autoresearch.orchestration.reasoning import ReasoningMode
+from autoresearch.orchestration.state import QueryState
+
+
+class _DummyAdapter(LLMAdapter):
+    """Minimal adapter stub that returns deterministic completions."""
+
+    available_models = ["mock-model"]
+
+    def generate(self, prompt: str, model: str | None = None, **_: Any) -> str:
+        return "analysis"
+
+    def validate_model(self, model: str | None) -> str:
+        return model or self.available_models[0]
+
+
+@pytest.fixture()
+def adapter() -> _DummyAdapter:
+    return _DummyAdapter()
+
+
+def test_fact_checker_audit_provenance(adapter: _DummyAdapter, monkeypatch: pytest.MonkeyPatch) -> None:
+    """FactChecker should emit provenance-rich audits with stable source ids."""
+
+    def fake_lookup(*args: Any, **_: Any):
+        if len(args) == 1:
+            query = args[0]
+        else:
+            query = args[1]
+        assert query  # query should always be provided
+        return [
+            {
+                "title": "Evidence",
+                "url": "https://example.com/evidence",
+                "snippet": "Solar energy reduces emissions.",
+            }
+        ]
+
+    monkeypatch.setattr(
+        "autoresearch.agents.dialectical.fact_checker.Search.external_lookup",
+        fake_lookup,
+    )
+
+    state = QueryState(
+        query="solar energy benefits",
+        claims=[{"id": "claim-1", "content": "Solar energy reduces emissions."}],
+    )
+    cfg = ConfigModel.model_construct()
+    agent = FactChecker(name="FactChecker", llm_adapter=adapter)
+
+    with patch.object(FactChecker, "get_model", return_value="mock-model"):
+        result = agent.execute(state, cfg)
+
+    assert result["claim_audits"], "claim audits should be emitted"
+    audit = result["claim_audits"][0]
+    assert audit["provenance"]["retrieval"]["base_query"] == "solar energy benefits"
+    assert audit["provenance"]["evidence"]["best_source_id"]
+    assert audit["provenance"]["retrieval"]["events"], "retrieval events should be logged"
+    for source in result["sources"]:
+        assert "source_id" in source
+
+    claim_audit = result["claims"][0]["audit"]
+    assert claim_audit["provenance"]["evidence"]["top_source_ids"], (
+        "top source ids should be tracked"
+    )
+    per_claim = claim_audit["provenance"]["backoff"]["per_claim"]
+    assert per_claim["claim-1"]["retry_count"] == 0
+
+
+def test_synthesizer_support_audit_provenance(adapter: _DummyAdapter) -> None:
+    """Synthesizer support audits should thread provenance into payloads."""
+
+    state = QueryState(
+        query="climate mitigation",
+        claims=[
+            {"id": "claim-1", "type": "thesis", "content": "Solar energy reduces emissions."},
+            {"id": "claim-2", "type": "antithesis", "content": "Wind energy is renewable."},
+        ],
+        cycle=1,
+    )
+    cfg = ConfigModel.model_construct(reasoning_mode=ReasoningMode.DIALECTICAL)
+    agent = SynthesizerAgent(name="Synthesizer", llm_adapter=adapter)
+
+    with patch.object(SynthesizerAgent, "get_model", return_value="mock-model"):
+        result = agent.execute(state, cfg)
+
+    audits = {audit["claim_id"]: audit for audit in result["claim_audits"]}
+    support_audit = audits["claim-1"]
+    assert support_audit["provenance"]["retrieval"]["mode"] == "hypothesis_vs_claim"
+    assert support_audit["provenance"]["evidence"]["source_ids"], (
+        "support source ids should be present"
+    )
+
+    claim = result["claims"][0]
+    summary_audit = audits[claim["id"]]
+    support_ids = summary_audit["provenance"]["evidence"]["support_audit_ids"]
+    assert support_ids, "summary audit should reference support audits"
+    assert audits["claim-1"]["audit_id"] in support_ids

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,0 +1,33 @@
+"""Regression tests for storage claim audit provenance."""
+
+from __future__ import annotations
+
+from autoresearch import storage
+from autoresearch.storage import ClaimAuditRecord
+
+
+def test_record_claim_audit_persists_provenance_round_trip(tmp_path) -> None:
+    """Claim audit provenance should survive storage round-trips."""
+
+    db_path = tmp_path / "audits.duckdb"
+    storage.teardown(remove_db=True)
+    ctx = storage.initialize_storage(str(db_path))
+    try:
+        provenance = {
+            "retrieval": {"base_query": "test", "events": []},
+            "backoff": {"retry_count": 1},
+            "evidence": {"best_source_id": "src-abc"},
+        }
+        record = ClaimAuditRecord.from_score(
+            "claim-x",
+            0.75,
+            sources=[{"title": "Traceable", "snippet": "Claim x"}],
+            provenance=provenance,
+        )
+        storage.StorageManager.record_claim_audit(record)
+
+        round_tripped = storage.StorageManager.list_claim_audits("claim-x")
+        assert len(round_tripped) == 1
+        assert round_tripped[0].provenance == provenance
+    finally:
+        storage.teardown(remove_db=True, context=ctx)


### PR DESCRIPTION
## Summary
- extend `ClaimAuditRecord` and associated storage logic with provenance metadata and stable source identifiers
- update FactChecker and Synthesizer agents to populate provenance fields and expose hashed source ids
- add regression tests for agent audits and DuckDB persistence to ensure provenance survives round trips

## Testing
- `uv run --extra test pytest tests/unit/test_agents_dialectical.py -k audit`
- `uv run --extra test pytest tests/unit/test_storage.py -k claim_audit`


------
https://chatgpt.com/codex/tasks/task_e_68d778e91d0c8333933ddc0f70c90657