### PR TITLE
Fix evaluation summary artifact join handling

### DIFF
--- a/src/autoresearch/cli_utils.py
+++ b/src/autoresearch/cli_utils.py
@@ -274,6 +274,8 @@ def render_evaluation_summary(
         if summary.summary_parquet:
             artifacts.append(f"summary: {summary.summary_parquet}")
 
+        artifact_display = ", ".join(artifacts) if artifacts else "—"
+
         table.add_row(
             summary.dataset,
             _format_optional(summary.accuracy),
@@ -284,7 +286,7 @@ def render_evaluation_summary(
             _format_optional(summary.avg_cycles_completed, precision=1),
             _format_percentage(summary.gate_exit_rate),
             summary.run_id,
-            ", ".join(artifacts) if artifacts else "—",
+            artifact_display,
         )
 
     console.print(table)

--- a/tests/unit/test_additional_coverage.py
+++ b/tests/unit/test_additional_coverage.py
@@ -205,9 +205,11 @@ def test_render_evaluation_summary_joins_artifacts(monkeypatch):
 
     assert created_tables
     artifacts_cell = created_tables[0].rows[0][-1]
-    assert (
-        artifacts_cell
-        == "duckdb: artifacts/run.duckdb, "
-        "examples: artifacts/examples.parquet, "
-        "summary: artifacts/summary.parquet"
+    expected = ", ".join(
+        [
+            "duckdb: artifacts/run.duckdb",
+            "examples: artifacts/examples.parquet",
+            "summary: artifacts/summary.parquet",
+        ]
     )
+    assert artifacts_cell == expected


### PR DESCRIPTION
## Summary
- compute the evaluation artifact display string via an explicit join before rendering the table row
- extend the regression test to assert the artifact column contains the joined DuckDB, example, and summary paths

## Testing
- uv run mypy src *(fails: numerous missing third-party typing stubs such as pydantic, matplotlib, and fastapi)*
- uv run task coverage *(fails: `task` CLI reports that the `coverage` task is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d77f383b5483338fea9ade4a5d60c6