### PR TITLE
Prevent duplicate embedding lookups when storage hydrates results

### DIFF
--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -1879,6 +1879,10 @@ class Search:
                 results_by_backend[name].extend(docs)
             else:
                 results_by_backend[name] = docs
+        if storage_results:
+            pending_embedding_backends.difference_update(
+                name for name in storage_results if name in pending_embedding_backends
+            )
         if storage_results.get("storage"):
             results_by_backend.pop("duckdb", None)
             pending_embedding_backends.discard("duckdb")


### PR DESCRIPTION
## Summary
- stop pending embedding backends from re-triggering embedding lookups when storage lookups already satisfied them
- extend the search stub backend test to verify single-pass embedding semantics for legacy and VSS paths

## Testing
- `uv run pytest tests/unit/test_core_modules_additional.py::test_search_stub_backend -vv`


------
https://chatgpt.com/codex/tasks/task_e_68d77f4ce6c48333b35270f0a7fe61a4