### PR TITLE
Fix QueryState pickling and add regression tests

### DIFF
--- a/tests/unit/orchestration/test_query_state_features.py
+++ b/tests/unit/orchestration/test_query_state_features.py
@@ -1,0 +1,26 @@
+"""Regression tests for :mod:`autoresearch.orchestration.state`."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoresearch.orchestration.state import QueryState
+
+
+def test_query_state_cloudpickle_serialization_preserves_fields() -> None:
+    """`cloudpickle` round-trips retain planner metadata and claims."""
+
+    cloudpickle = pytest.importorskip("cloudpickle")
+
+    state = QueryState(query="serial")
+    state.claims.append({"id": "c1", "text": "claim"})
+    state.metadata["planner"] = {"strategy": "map"}
+    state.set_task_graph({"tasks": [{"id": "t1", "question": "Q"}], "edges": []})
+
+    payload = cloudpickle.dumps(state)
+    restored = cloudpickle.loads(payload)
+
+    assert restored.claims == state.claims
+    assert restored.metadata["planner"] == state.metadata["planner"]
+    assert restored.task_graph == state.task_graph
+

--- a/tests/unit/test_distributed_executors.py
+++ b/tests/unit/test_distributed_executors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import pickle
 import types
 from typing import Dict, Any, Type
 
@@ -80,6 +81,16 @@ def test_execute_agent_remote() -> None:
         if isinstance(msg, dict):
             assert msg["agent"] == "Dummy"
             assert msg["result"]["results"]["final_answer"] == "done"
+
+        enriched = QueryState(query="rich")
+        enriched.claims.append({"id": "c1", "text": "claim"})
+        enriched.metadata["planner"] = {"strategy": "map"}
+        enriched.set_task_graph({"tasks": [{"id": "t1", "question": "Q"}], "edges": []})
+
+        restored_state = pickle.loads(pickle.dumps(enriched))
+        assert restored_state.claims == enriched.claims
+        assert restored_state.metadata["planner"] == enriched.metadata["planner"]
+        assert restored_state.task_graph == enriched.task_graph
     finally:
         _unregister_dummy()
 


### PR DESCRIPTION
## Summary
- rebuild QueryState pickling with model_dump/model_validate to drop locks and caches while restoring the synchronization primitive explicitly
- exercise pickle round trips for QueryState in the distributed executor test to ensure claims, metadata, and planner state survive serialization
- add a cloudpickle regression test covering planner metadata and task graph preservation

## Testing
- uv run --extra test pytest tests/unit/test_distributed_executors.py tests/unit/orchestration/test_query_state_features.py
- uv run --extra dev-minimal --extra test mypy --strict src/autoresearch/orchestration/state.py tests/unit *(fails: repository-wide stub gaps outside the touched modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d811ade8a88333bda9393e69575db1