### PR TITLE
Deduplicate DuckDB VSS embedding lookups

### DIFF
--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -127,6 +127,12 @@ TestPyPI dry run. Pass `EXTRAS="gpu"` when GPU wheels are staged.
   【F:src/autoresearch/search/core.py†L705-L760】
   【F:src/autoresearch/orchestration/parallel.py†L145-L182】
   【F:tests/stubs/numpy.py†L12-L81】
+- [x] Removed duplicate DuckDB embedding lookups in the VSS path by reusing
+  storage vector hits and caching backend payloads; the updated
+  `tests/unit/test_core_modules_additional.py::test_search_stub_backend`
+  asserts the single-call flow across legacy and vector modes.
+  【F:src/autoresearch/search/core.py†L1698-L1950】
+  【F:tests/unit/test_core_modules_additional.py†L15-L180】
 - [x] `uv run --extra build python -m build` succeeded out of band and archived
   `baseline/logs/python-build-20250925T001554Z.log`, so packaging is ready to
   resume once verify and coverage pass.


### PR DESCRIPTION
## Summary
- avoid redundant DuckDB vector lookups by memoizing StorageManager.has_vss() and reusing storage-provided embeddings when VSS is available
- extend the search stub regression to assert the single-call behaviour for both legacy and VSS modes
- document the regression fix in the alpha readiness checklist

## Testing
- `uv run --extra test pytest tests/unit/test_core_modules_additional.py::test_search_stub_backend`
- `uv run task release:alpha -- step=unit` *(fails: task alias not defined in Taskfile)*
- `uv run task unit` *(fails: existing unit suite regressions unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d81d92edc083339dade183519a74aa