### PR TITLE
Add typed helper protocols across logging, storage, and CLI helpers

### DIFF
--- a/src/autoresearch/cli_utils.py
+++ b/src/autoresearch/cli_utils.py
@@ -3,12 +3,14 @@
 This module provides utilities for consistent formatting of CLI output
 with accessibility in mind. It includes functions for formatting messages
 with both color and text-based alternatives, as well as symbolic indicators.
+``attach_cli_hooks`` offers a typed helper for exposing test hooks on Typer
+applications without reaching into private attributes directly.
 """
 
 import os
 import sys
 from enum import Enum
-from typing import Any, Iterable, Mapping, Optional, Sequence, TYPE_CHECKING, cast
+from typing import Any, Callable, Iterable, Mapping, Optional, Sequence, TYPE_CHECKING, cast
 from rich.console import Console
 from rich.table import Table
 import rdflib
@@ -45,6 +47,29 @@ console = Console()
 
 if TYPE_CHECKING:
     from .evaluation import EvaluationSummary
+    import typer
+
+
+def attach_cli_hooks(
+    app: "typer.Typer",
+    visualize: Callable[..., Any],
+    visualize_query: Callable[..., Any],
+    *,
+    name: str,
+) -> None:
+    """Expose monkeypatch hooks on ``app`` using typed attribute assignment.
+
+    Args:
+        app: The Typer application to mutate.
+        visualize: Callable assigned to ``_cli_visualize`` for tests.
+        visualize_query: Callable assigned to ``_cli_visualize_query``.
+        name: Public name exposed to ``CliRunner``.
+    """
+
+    target = cast(object, app)
+    setattr(target, "name", name)
+    setattr(target, "_cli_visualize", visualize)
+    setattr(target, "_cli_visualize_query", visualize_query)
 
 def set_verbosity(level: Verbosity) -> None:
     """Set the global verbosity level.

--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -19,6 +19,7 @@ from ..cli_helpers import (
 )
 from ..cli_utils import (
     Verbosity,
+    attach_cli_hooks,
     console,
     format_success,
     get_verbosity,
@@ -58,14 +59,13 @@ app = typer.Typer(
     pretty_exceptions_enable=False,
     # Disable pretty exceptions to handle them ourselves
 )
-# ``typer.Typer`` doesn't set ``name`` attribute on the object itself.
-# ``click.testing.CliRunner`` expects a ``name`` attribute when invoking the
-# application. Expose it explicitly so tests can run the CLI via ``CliRunner``.
-app.name = "autoresearch"  # type: ignore[attr-defined]
-# Expose private attributes for tests to monkeypatch CLI helper functions
-# (tests refer to autoresearch.main.app._cli_visualize and _cli_visualize_query)
-app._cli_visualize = _cli_visualize  # type: ignore[attr-defined]
-app._cli_visualize_query = _cli_visualize_query  # type: ignore[attr-defined]
+# Provide test hooks without mutating private Typer attributes directly.
+attach_cli_hooks(
+    app,
+    visualize=_cli_visualize,
+    visualize_query=_cli_visualize_query,
+    name="autoresearch",
+)
 # Expose a patchable orchestrator handle for tests, defaulting to the real class
 try:
     _orchestrator_module = importlib.import_module("autoresearch.orchestration.orchestrator")

--- a/src/autoresearch/streamlit_ui.py
+++ b/src/autoresearch/streamlit_ui.py
@@ -1,7 +1,20 @@
-"""Helper functions for the Streamlit user interface."""
+"""Streamlit UI helpers with typed modal wrappers for strict mypy support."""
+
 from __future__ import annotations
 
+from typing import Any, Callable, ContextManager, cast
+
 import streamlit as st
+
+
+def open_modal(title: str, **kwargs: Any) -> ContextManager[Any]:
+    """Return a typed context manager for ``st.modal`` when available."""
+
+    modal = getattr(st, "modal", None)
+    if modal is None:
+        raise AttributeError("Streamlit does not expose modal support")
+    modal_func = cast(Callable[..., ContextManager[Any]], modal)
+    return modal_func(title, **kwargs)
 
 
 def apply_accessibility_settings() -> None:
@@ -58,7 +71,7 @@ def display_guided_tour() -> None:
     if "show_tour" not in st.session_state:
         st.session_state.show_tour = True
     if st.session_state.show_tour:
-        with st.modal("Welcome to Autoresearch", key="guided_tour", aria_modal=True):  # type: ignore[attr-defined]
+        with open_modal("Welcome to Autoresearch", key="guided_tour", aria_modal=True):
             st.markdown(
                 """
                 <div role="dialog" aria-label="Onboarding Tour" aria-modal="true">

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,0 +1,21 @@
+"""Unit tests for CLI utility helpers."""
+
+import typer
+
+from autoresearch.cli_utils import attach_cli_hooks
+
+
+def test_attach_cli_hooks_exposes_attributes() -> None:
+    app = typer.Typer()
+
+    def visualize() -> None:  # pragma: no cover - simple stub
+        return None
+
+    def visualize_query() -> None:  # pragma: no cover - simple stub
+        return None
+
+    attach_cli_hooks(app, visualize=visualize, visualize_query=visualize_query, name="demo")
+
+    assert getattr(app, "name") == "demo"
+    assert getattr(app, "_cli_visualize") is visualize
+    assert getattr(app, "_cli_visualize_query") is visualize_query


### PR DESCRIPTION
## Summary
- introduce Loguru handler protocols, Prometheus metric wrappers, and typed Redis queue accessors to eliminate private attribute type ignores
- replace storage delegate shortcuts with a `StorageDelegateProtocol` and add typed helpers for Typer and Streamlit integrations
- add unit tests covering the new logging handler guard and CLI hook attachment helper

## Testing
- `uv run --extra dev-minimal --extra test mypy --strict src tests` *(fails: repository-wide missing stubs and untyped fixtures in existing suites)*
- `uv run --extra test pytest tests/unit/test_logging_utils.py tests/unit/test_cli_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68d82b31ab1883339bd5eaf54e831f1e