### PR TITLE
Add AUTO reasoning mode gating and surface scout policy controls

### DIFF
--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -39,6 +39,11 @@ Broader integration and performance coverage remains outstanding, but the
 release gate now has reproducible verification and targeted coverage evidence
 for the regressions that halted the prior alpha sweep.
 
+An AUTO reasoning mode landed with a scout-stage synthesizer pass and a gated
+escalation to dialectical debate. The same change exposed `gate_policy_enabled`
+and the associated thresholds/overrides through the CLI and Streamlit UI so
+operators can tune debate exits without editing TOML by hand.
+
 [verify-log-pass]:
   ../baseline/logs/task-verify-20250925T022717Z.log
 [bm25-normalization]:

--- a/docs/specs/orchestration.md
+++ b/docs/specs/orchestration.md
@@ -27,6 +27,23 @@ loops, the budget is divided by `max(1, l)` then clamped to `[q + buffer,
 q * factor]`. The lower bound guarantees enough tokens for the query plus a
 margin while the upper bound scales with input size and prevents overruns.
 
+### Auto reasoning gate
+
+`ReasoningMode.AUTO` begins with a single Synthesizer pass to produce a scout
+answer. The orchestrator records the cycle metrics, evaluates the scout gate
+policy, and either returns the direct answer or escalates to full debate with
+`ReasoningMode.DIALECTICAL`. When debate proceeds the scout metadata is carried
+into the new query state so downstream agents can reference the heuristics.
+
+Operators can tune the gate policy through configuration or the CLI/UI:
+
+- `core.gate_policy_enabled` toggles the policy entirely.
+- `core.gate_retrieval_overlap_threshold`,
+  `core.gate_nli_conflict_threshold`, and
+  `core.gate_complexity_threshold` adjust exit heuristics.
+- `core.gate_user_overrides` accepts JSON overrides to force exit/debate or
+  pin specific heuristic scores.
+
 ## Invariants
 
 ### Parallel merge

--- a/src/autoresearch/orchestration/reasoning.py
+++ b/src/autoresearch/orchestration/reasoning.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 class ReasoningMode(str, Enum):
     """Supported reasoning modes."""
 
+    AUTO = "auto"
     DIRECT = "direct"
     DIALECTICAL = "dialectical"
     CHAIN_OF_THOUGHT = "chain-of-thought"

--- a/tests/behavior/features/reasoning_mode.feature
+++ b/tests/behavior/features/reasoning_mode.feature
@@ -24,6 +24,24 @@ Feature: Reasoning Mode Selection
     And the agent groups should be "Synthesizer"
     And the agents executed should be "Synthesizer"
 
+  Scenario: Auto mode exits after the scout pass
+    Given reasoning mode is "auto"
+    And gate policy forces exit
+    When I run the orchestrator on query "mode test"
+    Then the loops used should be 1
+    And the reasoning mode selected should be "auto"
+    And the agent groups should be "Synthesizer; Contrarian; FactChecker"
+    And the agents executed should be "Synthesizer"
+
+  Scenario: Auto mode escalates to debate
+    Given reasoning mode is "auto"
+    And gate policy forces debate
+    When I run the orchestrator on query "mode test"
+    Then the loops used should be 2
+    And the reasoning mode selected should be "auto"
+    And the agent groups should be "Synthesizer; Contrarian; FactChecker"
+    And the agents executed should be "Synthesizer, Contrarian, FactChecker"
+
   Scenario: Chain-of-thought mode loops Synthesizer
     Given reasoning mode is "chain-of-thought"
     When I run the orchestrator on query "mode test"

--- a/tests/unit/orchestration/test_orchestrator_auto_mode.py
+++ b/tests/unit/orchestration/test_orchestrator_auto_mode.py
@@ -1,0 +1,121 @@
+from typing import Any, Dict, List
+
+import pytest
+
+from autoresearch.agents.registry import AgentFactory
+from autoresearch.config.models import ConfigModel
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils, ScoutGateDecision
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.reasoning import ReasoningMode
+
+
+class DummySynthesizer:
+    """Minimal synthesizer stub for AUTO mode tests."""
+
+    def __init__(self) -> None:
+        self.calls: List[int] = []
+
+    def can_execute(self, state, config) -> bool:  # noqa: ANN001 - signature mirrors agent API
+        return True
+
+    def execute(self, state, config) -> Dict[str, Any]:  # noqa: ANN001 - signature mirrors agent API
+        self.calls.append(state.cycle)
+        return {
+            "results": {"final_answer": "scout"},
+            "claims": [{"type": "synthesis", "content": "scout"}],
+        }
+
+
+def _decision(should_debate: bool, loops: int) -> ScoutGateDecision:
+    return ScoutGateDecision(
+        should_debate=should_debate,
+        target_loops=loops,
+        heuristics={"retrieval_overlap": 0.2, "nli_conflict": 0.1, "complexity": 0.1},
+        thresholds={"retrieval_overlap": 0.6, "nli_conflict": 0.3, "complexity": 0.5},
+        reason="test",  # pragma: no cover - metadata only
+        tokens_saved=0,
+    )
+
+
+def test_auto_mode_returns_direct_answer_when_gate_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AUTO mode should return the scout answer when the gate exits early."""
+
+    config = ConfigModel(reasoning_mode=ReasoningMode.AUTO, loops=2)
+    orchestrator = Orchestrator()
+    synth = DummySynthesizer()
+
+    monkeypatch.setattr(AgentFactory, "get", lambda name, llm_adapter=None: synth)
+
+    def fake_gate(**kwargs):  # noqa: ANN001 - matches evaluate_scout_gate_policy kwargs
+        decision = _decision(False, 1)
+        kwargs["state"].metadata["scout_gate"] = decision.__dict__
+        return decision
+
+    monkeypatch.setattr(OrchestrationUtils, "evaluate_scout_gate_policy", fake_gate)
+    monkeypatch.setattr(
+        OrchestrationUtils,
+        "execute_cycle",
+        lambda *args, **kwargs: pytest.fail("execute_cycle should not run when gate exits"),
+    )
+
+    response = orchestrator.run_query("auto exit", config)
+
+    assert response.answer == "scout"
+    assert synth.calls == [0]
+    assert config.reasoning_mode == ReasoningMode.AUTO
+    auto_meta = response.metrics.get("auto_mode", {})
+    assert auto_meta.get("outcome") == "direct_exit"
+    assert auto_meta.get("scout_answer") == "scout"
+
+
+def test_auto_mode_escalates_to_debate_when_gate_requires_loops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AUTO mode should escalate to debate when the gate requests it."""
+
+    config = ConfigModel(reasoning_mode=ReasoningMode.AUTO, loops=3)
+    orchestrator = Orchestrator()
+    synth = DummySynthesizer()
+
+    monkeypatch.setattr(AgentFactory, "get", lambda name, llm_adapter=None: synth)
+
+    decision = _decision(True, 3)
+
+    def fake_gate(**kwargs):  # noqa: ANN001 - matches evaluate_scout_gate_policy kwargs
+        kwargs["state"].metadata["scout_gate"] = decision.__dict__
+        return decision
+
+    monkeypatch.setattr(OrchestrationUtils, "evaluate_scout_gate_policy", fake_gate)
+
+    loop_calls: List[int] = []
+
+    def fake_cycle(
+        loop: int,
+        loops: int,
+        agents,
+        primus_index: int,
+        max_errors: int,
+        state,
+        config_obj,
+        metrics,
+        callbacks_map,
+        agent_factory,
+        storage_manager,
+        tracer,
+        cb_manager,
+    ) -> int:
+        loop_calls.append(loop)
+        state.results["final_answer"] = f"debate-{loop}"
+        return primus_index
+
+    monkeypatch.setattr(OrchestrationUtils, "execute_cycle", fake_cycle)
+
+    response = orchestrator.run_query("auto debate", config)
+
+    assert synth.calls == [0]
+    assert loop_calls == list(range(decision.target_loops))
+    assert response.answer == f"debate-{loop_calls[-1]}"
+    assert config.reasoning_mode == ReasoningMode.AUTO
+    auto_meta = response.metrics.get("auto_mode", {})
+    assert auto_meta.get("outcome") == "escalated"
+    assert auto_meta.get("scout_answer") == "scout"


### PR DESCRIPTION
## Summary
- add an AUTO reasoning branch that performs a scout synthesizer pass before debating and updates orchestrator logic accordingly
- surface scout gate configuration (enable flag, thresholds, overrides) through the CLI, Streamlit UI, and documentation
- exercise AUTO mode with new unit coverage and behavior scenarios, and document the release implications

## Testing
- `uv run --extra test pytest tests/unit/orchestration/test_orchestrator_auto_mode.py tests/behavior -m reasoning_modes`
- `uv run --extra dev-minimal --extra test mypy --strict src/autoresearch/orchestration` *(fails: missing optional stubs such as pydantic, matplotlib, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68d836f716348333b7b4e07098faa5eb