### PR TITLE
Fix CLI percentage formatting and restore Task runs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -26,6 +26,17 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   Ray.【F:src/autoresearch/distributed/broker.py†L52-L178】【F:src/autoresearch/distributed/_ray.py†L15-L144】【F:docs/algorithms/distributed.md†L32-L36】【F:docs/message_brokers.md†L7-L17】
 
 ## September 28, 2025
+- Codex setup now installs Go Task into `.venv/bin`, Taskfile exposes
+  higher-level targets again, and the 03:10 UTC rerun reaches the substantive
+  failures: `uv run task verify` halts in `flake8` on long-standing style
+  violations while `uv run task coverage` fails in the scout gate policy test
+  after syncing every optional extra. The logs live at
+  `baseline/logs/task-verify-20250928T031021Z.log` and
+  `baseline/logs/task-coverage-20250928T031031Z.log` for reference.
+  【F:scripts/codex_setup.sh†L1-L66】【F:Taskfile.yml†L1-L136】
+  【F:baseline/logs/task-verify-20250928T031021Z.log†L1-L68】
+  【F:baseline/logs/task-coverage-20250928T031031Z.log†L1-L120】
+  【F:baseline/logs/task-coverage-20250928T031031Z.log†L200-L280】
 - The new CLI formatter fix still leaves `uv run task verify` and `uv run task
   coverage` blocked because the Go Task CLI only exposes the bootstrap tasks;
   both commands return "Task \"verify\" does not exist" / "Task \"coverage\"

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,5 +1,17 @@
 # Autoresearch Project - Task Progress
 
+As of **2025-09-28** at 03:10 UTC `scripts/codex_setup.sh` ensures Go Task
+installs into `.venv/bin`, Taskfile once again exposes the `verify` and
+`coverage` targets, and fresh sweeps reach the substantive failures instead of
+exiting early. `uv run task verify` now stops in `flake8`, which reports the
+pre-existing style violations across orchestration, storage, and benchmark
+modules, while `uv run task coverage` completes the extras sync and fails in
+`tests/unit/orchestration/test_gate_policy.py::test_scout_gate_reduces_loops_when_signals_low`
+after the scout gate keeps the debate loop enabled. The new logs,
+`baseline/logs/task-verify-20250928T031021Z.log` and
+`baseline/logs/task-coverage-20250928T031031Z.log`, capture the upgraded
+pipeline progression.【F:scripts/codex_setup.sh†L1-L66】【F:Taskfile.yml†L1-L136】【F:baseline/logs/task-verify-20250928T031021Z.log†L1-L68】【F:baseline/logs/task-coverage-20250928T031031Z.log†L1-L120】【F:baseline/logs/task-coverage-20250928T031031Z.log†L200-L280】
+
 As of **2025-09-28** at 01:10 UTC fresh `uv run task verify` and
 `uv run task coverage` attempts immediately exit because the Go Task CLI only
 lists the eight bootstrap targets (`behavior`, `check`, `check-env`,

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -100,29 +100,29 @@ tasks:
     desc: "Run BDD (behavior) tests with uv"
 
 
-evaluation:truthfulqa:
-  cmds:
-    - |
-        uv run autoresearch evaluate run truthfulqa{{if .LIMIT}} --limit {{.LIMIT}}{{end}}{{if .DRY_RUN}} --dry-run{{end}}
-  desc: "Run the curated TruthfulQA evaluation harness"
+  evaluation:truthfulqa:
+    cmds:
+      - |
+          uv run autoresearch evaluate run truthfulqa{{if .LIMIT}} --limit {{.LIMIT}}{{end}}{{if .DRY_RUN}} --dry-run{{end}}
+    desc: "Run the curated TruthfulQA evaluation harness"
 
-evaluation:fever:
-  cmds:
-    - |
-        uv run autoresearch evaluate run fever{{if .LIMIT}} --limit {{.LIMIT}}{{end}}{{if .DRY_RUN}} --dry-run{{end}}
-  desc: "Run the curated FEVER evaluation harness"
+  evaluation:fever:
+    cmds:
+      - |
+          uv run autoresearch evaluate run fever{{if .LIMIT}} --limit {{.LIMIT}}{{end}}{{if .DRY_RUN}} --dry-run{{end}}
+    desc: "Run the curated FEVER evaluation harness"
 
-evaluation:hotpotqa:
-  cmds:
-    - |
-        uv run autoresearch evaluate run hotpotqa{{if .LIMIT}} --limit {{.LIMIT}}{{end}}{{if .DRY_RUN}} --dry-run{{end}}
-  desc: "Run the curated HotpotQA evaluation harness"
+  evaluation:hotpotqa:
+    cmds:
+      - |
+          uv run autoresearch evaluate run hotpotqa{{if .LIMIT}} --limit {{.LIMIT}}{{end}}{{if .DRY_RUN}} --dry-run{{end}}
+    desc: "Run the curated HotpotQA evaluation harness"
 
-evaluation:all:
-  cmds:
-    - |
-        uv run autoresearch evaluate run all{{if .LIMIT}} --limit {{.LIMIT}}{{end}}{{if .DRY_RUN}} --dry-run{{end}}
-  desc: "Run all curated truthfulness evaluation harnesses"
+  evaluation:all:
+    cmds:
+      - |
+          uv run autoresearch evaluate run all{{if .LIMIT}} --limit {{.LIMIT}}{{end}}{{if .DRY_RUN}} --dry-run{{end}}
+    desc: "Run all curated truthfulness evaluation harnesses"
 
 
 

--- a/baseline/logs/task-coverage-20250928T031031Z.log
+++ b/baseline/logs/task-coverage-20250928T031031Z.log
@@ -1,0 +1,327 @@
+task: [coverage] echo "[coverage] syncing dependencies"
+[coverage] syncing dependencies
+task: [coverage] uv sync \
+   --extra dev-minimal --extra test --extra nlp --extra ui --extra vss --extra git --extra distributed --extra analysis --extra llm --extra parsers --extra gpu \
+  
+
+Resolved 328 packages in 7ms
+Downloading nvidia-cusparselt-cu12 (273.9MiB)
+Downloading nvidia-nvjitlink-cu12 (37.4MiB)
+Downloading nvidia-cusparse-cu12 (274.9MiB)
+Downloading language-data (5.1MiB)
+Downloading scipy (34.0MiB)
+Downloading hf-xet (3.0MiB)
+Downloading nvidia-cufft-cu12 (184.2MiB)
+Downloading triton (148.4MiB)
+Downloading nvidia-cublas-cu12 (566.8MiB)
+Downloading nvidia-cuda-nvrtc-cu12 (84.0MiB)
+Downloading nvidia-cudnn-cu12 (674.0MiB)
+Downloading nvidia-curand-cu12 (60.7MiB)
+Downloading numba (3.3MiB)
+Downloading nvidia-nccl-cu12 (307.4MiB)
+Downloading spacy (32.4MiB)
+Downloading duckdb-extension-vss (15.7MiB)
+Downloading nvidia-cusolver-cu12 (255.1MiB)
+Downloading polars (37.9MiB)
+Downloading streamlit (9.6MiB)
+Downloading torch (846.8MiB)
+Downloading blis (11.1MiB)
+Downloading llvmlite (53.7MiB)
+Downloading ray (66.9MiB)
+Downloading pandas (11.4MiB)
+Downloading pydeck (6.6MiB)
+Downloading nvidia-cuda-cupti-cu12 (9.8MiB)
+Downloading transformers (11.1MiB)
+Downloading thinc (4.1MiB)
+Downloading nvidia-cufile-cu12 (1.1MiB)
+Downloading sympy (6.0MiB)
+Downloading pillow (6.3MiB)
+Downloading plotly (9.3MiB)
+Downloading litellm (8.7MiB)
+Downloading srsly (1.1MiB)
+Downloading onnxruntime (16.5MiB)
+Downloading pyarrow (40.8MiB)
+Downloading scikit-learn (9.0MiB)
+Downloading tokenizers (3.1MiB)
+Downloading marisa-trie (1.2MiB)
+ Downloading nvidia-cufile-cu12
+ Downloading marisa-trie
+ Downloading hf-xet
+ Downloading tokenizers
+ Downloading srsly
+   Building madoka==0.7.1
+   Building hdbscan==0.8.40
+ Downloading pydeck
+ Downloading pillow
+ Downloading thinc
+ Downloading nvidia-cuda-cupti-cu12
+ Downloading blis
+ Downloading duckdb-extension-vss
+ Downloading streamlit
+ Downloading nvidia-nvjitlink-cu12
+ Downloading numba
+ Downloading onnxruntime
+ Downloading polars
+ Downloading language-data
+ Downloading scikit-learn
+ Downloading llvmlite
+ Downloading nvidia-curand-cu12
+ Downloading litellm
+ Downloading pyarrow
+ Downloading sympy
+ Downloading nvidia-cuda-nvrtc-cu12
+ Downloading pandas
+ Downloading spacy
+ Downloading plotly
+ Downloading transformers
+ Downloading scipy
+      Built madoka==0.7.1
+ Downloading triton
+ Downloading ray
+ Downloading nvidia-cufft-cu12
+ Downloading nvidia-cusolver-cu12
+ Downloading nvidia-cusparselt-cu12
+ Downloading nvidia-cusparse-cu12
+ Downloading nvidia-nccl-cu12
+ Downloading nvidia-cublas-cu12
+ Downloading nvidia-cudnn-cu12
+ Downloading torch
+      Built hdbscan==0.8.40
+Prepared 103 packages in 2m 12s
+Installed 103 packages in 374ms
+ + alembic==1.16.5
+ + altair==5.5.0
+ + asyncer==0.0.8
+ + backoff==2.2.1
+ + bertopic==0.17.3
+ + blinker==1.9.0
+ + blis==1.3.0
+ + catalogue==2.0.10
+ + cloudpathlib==0.22.0
+ + cloudpickle==3.1.1
+ + coloredlogs==15.0.1
+ + colorlog==6.9.0
+ + confection==0.1.5
+ + cymem==2.0.11
+ + diskcache==5.6.3
+ + dspy==3.0.3
+ + dspy-ai==3.0.3
+ + duckdb-extension-vss==1.3.2
+ + fastembed==0.7.3
+ + fastuuid==0.13.5
+ + filelock==3.19.1
+ + flatbuffers==25.9.23
+ + fsspec==2025.9.0
+ + gepa==0.0.7
+ + gitdb==4.0.12
+ + gitpython==3.1.45
+ + hdbscan==0.8.40
+ + hf-xet==1.1.10
+ + httpx-ws==0.8.0
+ + huggingface-hub==0.35.1
+ + humanfriendly==10.0
+ + jinja2==3.1.6
+ + joblib==1.5.2
+ + json-repair==0.51.0
+ + langcodes==3.5.0
+ + language-data==1.3.0
+ + litellm==1.77.4
+ + llvmlite==0.45.0
+ + lmstudio==1.5.0
+ + madoka==0.7.1
+ + magicattr==0.1.6
+ + marisa-trie==1.3.1
+ + mmh3==5.2.0
+ + mpmath==1.3.0
+ + msgpack==1.1.1
+ + msgspec==0.19.0
+ + murmurhash==1.0.13
+ + narwhals==2.5.0
+ + numba==0.62.0
+ + nvidia-cublas-cu12==12.8.4.1
+ + nvidia-cuda-cupti-cu12==12.8.90
+ + nvidia-cuda-nvrtc-cu12==12.8.93
+ + nvidia-cuda-runtime-cu12==12.8.90
+ + nvidia-cudnn-cu12==9.10.2.21
+ + nvidia-cufft-cu12==11.3.3.83
+ + nvidia-cufile-cu12==1.13.1.3
+ + nvidia-curand-cu12==10.3.9.90
+ + nvidia-cusolver-cu12==11.7.3.90
+ + nvidia-cusparse-cu12==12.5.8.93
+ + nvidia-cusparselt-cu12==0.7.1
+ + nvidia-nccl-cu12==2.27.3
+ + nvidia-nvjitlink-cu12==12.8.93
+ + nvidia-nvtx-cu12==12.8.90
+ + onnxruntime==1.23.0
+ + optuna==4.5.0
+ + pandas==2.3.2
+ + pillow==11.3.0
+ + plotly==6.3.0
+ + polars==1.33.1
+ + pondpond==1.4.1
+ + preshed==3.0.10
+ + py-rust-stemmers==0.1.5
+ + pyarrow==21.0.0
+ + pydeck==0.9.1
+ + pynndescent==0.5.13
+ + pytz==2025.2
+ + ray==2.49.2
+ + safetensors==0.6.2
+ + scikit-learn==1.7.2
+ + scipy==1.16.2
+ + sentence-transformers==5.1.1
+ + smart-open==7.3.1
+ + smmap==5.0.2
+ + spacy==3.8.7
+ + spacy-legacy==3.0.12
+ + spacy-loggers==1.0.5
+ + srsly==2.5.1
+ + streamlit==1.50.0
+ + sympy==1.14.0
+ + thinc==8.3.6
+ + threadpoolctl==3.6.0
+ + tokenizers==0.22.1
+ + toml==0.10.2
+ + torch==2.8.0
+ + tornado==6.5.2
+ + transformers==4.56.2
+ + triton==3.4.0
+ + tzdata==2025.2
+ + umap-learn==0.5.9.post2
+ + wasabi==1.1.3
+ + watchdog==6.0.0
+ + weasel==0.4.1
+ + wsproto==1.2.0
+task: [coverage] echo "[coverage] erasing previous data"
+[coverage] erasing previous data
+task: [coverage] uv run coverage erase
+task: [coverage] echo "[coverage] running unit tests"
+[coverage] running unit tests
+task: [coverage] uv run pytest -vv --maxfail=1 --durations=10 -x tests/unit -m 'not slow' \
+  --cov=src --cov-report=term-missing --cov-append
+
+===================================================== test session starts ======================================================
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /workspace/autoresearch/.venv/bin/python3
+cachedir: .pytest_cache
+hypothesis profile 'default'
+benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+rootdir: /workspace/autoresearch
+configfile: pytest.ini
+plugins: hypothesis-6.140.2, bdd-8.1.0, httpx-0.35.0, anyio-4.11.0, benchmark-5.1.0, cov-7.0.0, langsmith-0.4.31
+collecting ... collected 1015 items / 25 deselected / 990 selected
+
+tests/unit/distributed/test_coordination_properties.py::test_election_converges_to_minimum PASSED                        [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_election_requires_identifier PASSED                         [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_election_accepts_strings PASSED                             [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent PASSED                     [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_message_processing_returns_copy PASSED                      [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_module_exports_helpers PASSED                               [  0%]
+tests/unit/evidence/test_stability_utils.py::test_aggregate_entailment_scores_stable PASSED                              [  0%]
+tests/unit/evidence/test_stability_utils.py::test_aggregate_entailment_scores_unstable PASSED                            [  0%]
+tests/unit/evidence/test_stability_utils.py::test_sample_paraphrases_returns_unique_variants PASSED                      [  0%]
+tests/unit/orchestration/test_budgeting_algorithm.py::test_budget_scaled_by_loops_and_limits PASSED                      [  1%]
+tests/unit/orchestration/test_budgeting_algorithm.py::test_budget_minimum_buffer_applied PASSED                          [  1%]
+tests/unit/orchestration/test_budgeting_algorithm.py::test_budget_unchanged_within_bounds PASSED                         [  1%]
+tests/unit/orchestration/test_circuit_breaker_determinism.py::test_circuit_breaker_determinism_and_recovery PASSED       [  1%]
+tests/unit/orchestration/test_circuit_breaker_thresholds.py::test_circuit_breaker_threshold_and_recovery PASSED          [  1%]
+tests/unit/orchestration/test_gate_policy.py::test_scout_gate_reduces_loops_when_signals_low FAILED                      [  1%]
+
+=========================================================== FAILURES ===========================================================
+________________________________________ test_scout_gate_reduces_loops_when_signals_low ________________________________________
+
+    def test_scout_gate_reduces_loops_when_signals_low() -> None:
+        """High overlap and low conflict skip debate and estimate token savings."""
+    
+        config = _make_config(token_budget=120, loops=3)
+        state = QueryState(query="What is the capital of France?", primus_index=0, coalitions={})
+        metrics = OrchestrationMetrics()
+    
+        by_backend = {
+            "duckduckgo": [
+                {
+                    "url": "https://example.com/paris",
+                    "title": "Paris - Wikipedia",
+                    "snippet": "What is the capital of France? It is Paris, the capital of France.",
+                },
+                {
+                    "url": "https://example.com/history",
+                    "title": "History of Paris",
+                    "snippet": "Paris has long served as France's capital city.",
+                },
+            ],
+            "serper": [
+                {
+                    "url": "https://example.com/paris",
+                    "title": "Paris - Wikipedia",
+                    "snippet": "Paris, the capital city of France, sits on the Seine river.",
+                },
+                {
+                    "url": "https://example.com/overview",
+                    "title": "France Overview",
+                    "snippet": "France designates Paris as its capital and largest city.",
+                },
+            ],
+        }
+        ranked = [dict(doc) for docs in by_backend.values() for doc in docs]
+    
+        with SearchContext.temporary_instance() as context:
+            context.record_scout_observation(state.query, ranked, by_backend=by_backend)
+            decision = OrchestrationUtils.evaluate_scout_gate_policy(
+                query=state.query,
+                config=config,
+                state=state,
+                loops=config.loops,
+                metrics=metrics,
+            )
+    
+        assert isinstance(decision, ScoutGateDecision)
+>       assert decision.should_debate is False
+E       AssertionError: assert True is False
+E        +  where True = ScoutGateDecision(should_debate=True, target_loops=3, heuristics={'retrieval_overlap': 0.3333333333333333, 'nli_conflict': 0.5305059523809524, 'complexity': 0.04300000000000001}, thresholds={'retrieval_overlap': 0.6, 'nli_conflict': 0.3, 'complexity': 0.5}, reason='policy_enabled', tokens_saved=0).should_debate
+
+/workspace/autoresearch/tests/unit/orchestration/test_gate_policy.py:69: AssertionError
+----------------------------------------------------- Captured stderr call -----------------------------------------------------
+{"text": "2025-09-28 03:14:28.488 | INFO     | autoresearch.logging_utils:emit:113 - No configuration file found; using defaults\n", "record": {"elapsed": {"repr": "0:00:36.389903", "seconds": 36.389903}, "exception": null, "extra": {}, "file": {"name": "logging_utils.py", "path": "/workspace/autoresearch/src/autoresearch/logging_utils.py"}, "function": "emit", "level": {"icon": "ℹ️", "name": "INFO", "no": 20}, "line": 113, "message": "No configuration file found; using defaults", "module": "logging_utils", "name": "autoresearch.logging_utils", "process": {"id": 5920, "name": "MainProcess"}, "thread": {"id": 140213277989760, "name": "MainThread"}, "time": {"repr": "2025-09-28 03:14:28.488911+00:00", "timestamp": 1759029268.488911}}}
+{"text": "2025-09-28 03:14:28.490 | WARNING  | autoresearch.logging_utils:emit:113 - {\"event\": \"spaCy model 'en_core_web_sm' not found. Set AUTORESEARCH_AUTO_DOWNLOAD_SPACY_MODEL=true to download automatically.\", \"timestamp\": \"2025-09-28T03:14:28.490524Z\"}\n", "record": {"elapsed": {"repr": "0:00:36.391670", "seconds": 36.39167}, "exception": null, "extra": {}, "file": {"name": "logging_utils.py", "path": "/workspace/autoresearch/src/autoresearch/logging_utils.py"}, "function": "emit", "level": {"icon": "⚠️", "name": "WARNING", "no": 30}, "line": 113, "message": "{\"event\": \"spaCy model 'en_core_web_sm' not found. Set AUTORESEARCH_AUTO_DOWNLOAD_SPACY_MODEL=true to download automatically.\", \"timestamp\": \"2025-09-28T03:14:28.490524Z\"}", "module": "logging_utils", "name": "autoresearch.logging_utils", "process": {"id": 5920, "name": "MainProcess"}, "thread": {"id": 140213277989760, "name": "MainThread"}, "time": {"repr": "2025-09-28 03:14:28.490678+00:00", "timestamp": 1759029268.490678}}}
+------------------------------------------------------ Captured log call -------------------------------------------------------
+INFO     autoresearch.config.loader:loader.py:186 No configuration file found; using defaults
+WARNING  autoresearch.search.context:context.py:227 {"event": "spaCy model 'en_core_web_sm' not found. Set AUTORESEARCH_AUTO_DOWNLOAD_SPACY_MODEL=true to download automatically.", "timestamp": "2025-09-28T03:14:28.490524Z"}
+--------------------------------------------------- Captured stderr teardown ---------------------------------------------------
+{"text": "2025-09-28 03:14:28.524 | INFO     | autoresearch.logging_utils:emit:113 - No configuration file found; using defaults\n", "record": {"elapsed": {"repr": "0:00:36.425346", "seconds": 36.425346}, "exception": null, "extra": {}, "file": {"name": "logging_utils.py", "path": "/workspace/autoresearch/src/autoresearch/logging_utils.py"}, "function": "emit", "level": {"icon": "ℹ️", "name": "INFO", "no": 20}, "line": 113, "message": "No configuration file found; using defaults", "module": "logging_utils", "name": "autoresearch.logging_utils", "process": {"id": 5920, "name": "MainProcess"}, "thread": {"id": 140213277989760, "name": "MainThread"}, "time": {"repr": "2025-09-28 03:14:28.524354+00:00", "timestamp": 1759029268.524354}}}
+---------------------------------------------------- Captured log teardown -----------------------------------------------------
+INFO     autoresearch.config.loader:loader.py:186 No configuration file found; using defaults
+======================================================= warnings summary =======================================================
+.venv/lib/python3.12/site-packages/hdbscan/plots.py:448
+  /workspace/autoresearch/.venv/lib/python3.12/site-packages/hdbscan/plots.py:448: SyntaxWarning: invalid escape sequence '\l'
+    axis.set_ylabel('$\lambda$ value')
+
+.venv/lib/python3.12/site-packages/hdbscan/robust_single_linkage_.py:175
+  /workspace/autoresearch/.venv/lib/python3.12/site-packages/hdbscan/robust_single_linkage_.py:175: SyntaxWarning: invalid escape sequence '\{'
+    $max \{ core_k(a), core_k(b), 1/\alpha d(a,b) \}$.
+
+.venv/lib/python3.12/site-packages/spacy/cli/_util.py:23
+  /workspace/autoresearch/.venv/lib/python3.12/site-packages/spacy/cli/_util.py:23: DeprecationWarning: Importing 'parser.split_arg_string' is deprecated, it will only be available in 'shell_completion' in Click 9.0.
+    from click.parser import split_arg_string
+
+.venv/lib/python3.12/site-packages/weasel/util/config.py:8
+  /workspace/autoresearch/.venv/lib/python3.12/site-packages/weasel/util/config.py:8: DeprecationWarning: Importing 'parser.split_arg_string' is deprecated, it will only be available in 'shell_completion' in Click 9.0.
+    from click.parser import split_arg_string
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+===================================================== slowest 10 durations =====================================================
+5.22s call     tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent
+1.56s call     tests/unit/distributed/test_coordination_properties.py::test_election_converges_to_minimum
+0.02s teardown tests/unit/distributed/test_coordination_properties.py::test_election_accepts_strings
+0.02s teardown tests/unit/orchestration/test_gate_policy.py::test_scout_gate_reduces_loops_when_signals_low
+0.02s setup    tests/unit/distributed/test_coordination_properties.py::test_election_converges_to_minimum
+0.02s setup    tests/unit/evidence/test_stability_utils.py::test_sample_paraphrases_returns_unique_variants
+0.02s setup    tests/unit/orchestration/test_gate_policy.py::test_scout_gate_reduces_loops_when_signals_low
+0.02s setup    tests/unit/distributed/test_coordination_properties.py::test_module_exports_helpers
+0.02s teardown tests/unit/distributed/test_coordination_properties.py::test_election_converges_to_minimum
+0.02s teardown tests/unit/evidence/test_stability_utils.py::test_aggregate_entailment_scores_unstable
+=================================================== short test summary info ====================================================
+FAILED tests/unit/orchestration/test_gate_policy.py::test_scout_gate_reduces_loops_when_signals_low - AssertionError: assert True is False
+ +  where True = ScoutGateDecision(should_debate=True, target_loops=3, heuristics={'retrieval_overlap': 0.3333333333333333, 'nli_conflict': 0.5305059523809524, 'complexity': 0.04300000000000001}, thresholds={'retrieval_overlap': 0.6, 'nli_conflict': 0.3, 'complexity': 0.5}, reason='policy_enabled', tokens_saved=0).should_debate
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+=================================== 1 failed, 14 passed, 25 deselected, 4 warnings in 17.85s ===================================
+task: Failed to run task "coverage": exit status 1

--- a/baseline/logs/task-verify-20250928T031021Z.log
+++ b/baseline/logs/task-verify-20250928T031021Z.log
@@ -1,0 +1,71 @@
+task: [verify] set -eu
+extras="dev-minimal test"
+export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-600}"
+uv sync \
+  --python-platform x86_64-manylinux_2_28 \
+  $(printf ' --extra %s' $extras) \
+  
+
+Resolved 328 packages in 7ms
+Audited 173 packages in 0.37ms
+task: [verify] task check-env EXTRAS="dev-minimal test"
+task: [check-env] task --version
+3.45.4
+task: [check-env] uv run python scripts/check_env.py
+Verifying extras: dev-minimal, test
+Python 3.12.10
+Go Task 3.45.4
+uv 0.7.22
+a2a-sdk 0.3.7
+black 25.9.0
+duckdb 1.3.2
+fakeredis 2.31.3
+flake8 7.3.0
+freezegun 1.5.5
+hypothesis 6.140.2
+mypy 1.18.2
+networkx 3.5
+owlrl 7.1.4
+pdfminer-six 20250506
+psutil 7.1.0
+pytest 8.4.2
+pytest-bdd 8.1.0
+pytest-benchmark 5.1.0
+pytest-cov 7.0.0
+pytest-httpx 0.35.0
+python-docx 1.2.0
+redis 6.4.0
+responses 0.25.8
+tomli-w 1.2.0
+types-psutil 7.0.0.20250822
+uvicorn 0.37.0
+task: [verify] uv run flake8 src tests
+src/autoresearch/distributed/_ray.py:145:1: W391 blank line at end of file
+src/autoresearch/orchestration/orchestrator.py:316:19: E131 continuation line unaligned for hanging indent
+src/autoresearch/orchestration/orchestrator.py:317:19: E131 continuation line unaligned for hanging indent
+src/autoresearch/orchestration/state.py:7:1: F401 'typing.cast' imported but unused
+src/autoresearch/orchestration/task_graph.py:6:1: F401 'typing.MutableMapping' imported but unused
+tests/benchmark/test_token_memory.py:14:1: E402 module level import not at top of file
+tests/conftest.py:23:1: E402 module level import not at top of file
+tests/conftest.py:24:1: E402 module level import not at top of file
+tests/conftest.py:25:1: E402 module level import not at top of file
+tests/conftest.py:333:9: E306 expected 1 blank line before a nested definition, found 0
+tests/conftest.py:343:1: W293 blank line contains whitespace
+tests/integration/test_cli_progress.py:41:5: E306 expected 1 blank line before a nested definition, found 0
+tests/integration/test_relevance_ranking_integration.py:3:1: F811 redefinition of unused 'csv' from line 1
+tests/integration/test_relevance_ranking_integration.py:4:1: F811 redefinition of unused 'Path' from line 2
+tests/integration/test_upgrade_path.py:3:1: F401 'subprocess' imported but unused
+tests/integration/test_upgrade_path.py:5:1: F401 'shutil' imported but unused
+tests/targeted/test_gpu_parsers.py:4:1: F811 redefinition of unused 'sys' from line 3
+tests/targeted/test_http_session.py:3:1: F401 'sys' imported but unused
+tests/unit/distributed/test_coordination_properties.py:7:1: F811 redefinition of unused 'sys' from line 5
+tests/unit/evidence/test_stability_utils.py:37:1: W391 blank line at end of file
+tests/unit/orchestration/test_query_state_features.py:26:1: W391 blank line at end of file
+tests/unit/test_duckdb_storage_backend_concurrency.py:4:1: F811 redefinition of unused 'threading' from line 1
+tests/unit/test_duckdb_storage_backend_concurrency.py:6:1: F811 redefinition of unused 'MagicMock' from line 2
+tests/unit/test_duckdb_storage_backend_concurrency.py:6:1: F811 redefinition of unused 'patch' from line 2
+tests/unit/test_storage_eviction.py:164:21: E117 over-indented
+tests/unit/test_streamlit_ui.py:53:5: E306 expected 1 blank line before a nested definition, found 0
+tests/unit/test_visualization.py:3:1: F811 redefinition of unused 'sys' from line 1
+tests/unit/test_visualization.py:4:1: F811 redefinition of unused 'ModuleType' from line 2
+task: Failed to run task "verify": exit status 1

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -18,14 +18,24 @@ STATUS.md, ROADMAP.md, and CHANGELOG.md for aligned progress. Phase 3
 
 ## Status
 
-The **September 28, 2025 at 01:10 UTC** rerun attempt shows `uv run task
-verify` and `uv run task coverage` immediately exiting with "Task \"verify\"
-does not exist" / "Task \"coverage\" does not exist" because the Go Task CLI
-only exposes the bootstrap targets in the current shell. The failure banners
-are archived at
-`baseline/logs/task-verify-20250928T011001Z.log` and
-`baseline/logs/task-coverage-20250928T011012Z.log` so we can follow up on the
-Taskfile layout before the next verification sweep.【F:baseline/logs/task-verify-20250928T011001Z.log†L1-L13】【F:baseline/logs/task-coverage-20250928T011012Z.log†L1-L13】
+The **September 28, 2025 at 03:10 UTC** rerun uses the updated Codex bootstrap
+to install Go Task in `.venv/bin` and the repaired Taskfile targets, so
+`uv run task verify` now reaches `flake8` before failing on the existing style
+regressions while `uv run task coverage` completes the extras sync and then
+fails in `tests/unit/orchestration/test_gate_policy.py::test_scout_gate_reduces_loops_when_signals_low`.
+The new evidence lives at
+`baseline/logs/task-verify-20250928T031021Z.log` and
+`baseline/logs/task-coverage-20250928T031031Z.log`.
+【F:scripts/codex_setup.sh†L1-L66】【F:Taskfile.yml†L1-L136】
+【F:baseline/logs/task-verify-20250928T031021Z.log†L1-L68】
+【F:baseline/logs/task-coverage-20250928T031031Z.log†L1-L120】
+【F:baseline/logs/task-coverage-20250928T031031Z.log†L200-L280】
+
+The earlier **September 28, 2025 at 01:10 UTC** attempt still records the
+"Task \"verify\" does not exist" / "Task \"coverage\" does not exist" failure
+from before the Taskfile repair; those logs remain archived for comparison.
+【F:baseline/logs/task-verify-20250928T011001Z.log†L1-L13】
+【F:baseline/logs/task-coverage-20250928T011012Z.log†L1-L13】
 
 `uv run task verify` succeeded on **September 25, 2025 at 02:27:17 Z**
 after we normalized BM25 scores, remapped parallel aggregator payloads into

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -33,12 +33,14 @@ if [[ "$(uname -s)" != "Linux" ]]; then
     exit 1
 fi
 
-SCRIPT_DIR="$(dirname "$0")"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/setup_common.sh"
 
 # Ensure Go Task is available before platform-specific setup
 "$SCRIPT_DIR/bootstrap.sh"
-ensure_venv_bin_on_path "$PWD/.venv/bin"
+VENV_BIN="$PWD/.venv/bin"
+ensure_venv_bin_on_path "$VENV_BIN"
+export PATH="$VENV_BIN:$PATH"
 if ! task --version >/dev/null 2>&1; then
     echo "Go Task installation failed. See docs/installation.md for manual steps." >&2
     exit 1

--- a/src/autoresearch/cli_utils.py
+++ b/src/autoresearch/cli_utils.py
@@ -71,6 +71,7 @@ def attach_cli_hooks(
     setattr(target, "_cli_visualize", visualize)
     setattr(target, "_cli_visualize_query", visualize_query)
 
+
 def set_verbosity(level: Verbosity) -> None:
     """Set the global verbosity level.
 
@@ -285,8 +286,10 @@ def _format_percentage(value: Optional[float], precision: int = 1) -> str:
         return "—"
 
     percent_value = value * 100
-    format_spec = f".{precision}f"
-    return f"{percent_value:{format_spec}}%"
+    formatted = f"{percent_value:.{precision}f}"
+    if formatted.startswith("-0") and percent_value == 0:
+        formatted = formatted.replace("-0", "0", 1)
+    return f"{formatted}%"
 
 
 def render_evaluation_summary(
@@ -410,6 +413,7 @@ def visualize_query_cli(
         from .orchestration.orchestrator import Orchestrator
         from .monitor import _collect_system_metrics, _render_metrics
         from .output_format import OutputFormatter
+
         # Lazy import for interactive prompts
         from . import Prompt
 
@@ -451,6 +455,7 @@ def visualize_query_cli(
 
         try:
             from .visualization import save_knowledge_graph
+
             save_knowledge_graph(result, output_path, layout=layout)
             print_success(f"Graph written to {output_path}")
         except Exception as e:  # pragma: no cover - optional dependency

--- a/tests/unit/test_additional_coverage.py
+++ b/tests/unit/test_additional_coverage.py
@@ -133,9 +133,7 @@ def test_streamlit_metrics(monkeypatch):
     assert fake_st.session_state["agent_performance"]["A"]["executions"] == 1
     fake_psutil = types.SimpleNamespace(
         cpu_percent=lambda interval=None: 10.0,
-        virtual_memory=lambda: types.SimpleNamespace(
-            percent=20.0, used=1024**3, total=2 * 1024**3
-        ),
+        virtual_memory=lambda: types.SimpleNamespace(percent=20.0, used=1024**3, total=2 * 1024**3),
         Process=lambda pid=None: types.SimpleNamespace(
             memory_info=lambda: types.SimpleNamespace(rss=50 * 1024**2)
         ),
@@ -214,6 +212,12 @@ def test_render_evaluation_summary_joins_artifacts(monkeypatch):
         ]
     )
     assert artifacts_cell == expected
+
+
+def test_format_percentage_variants():
+    assert cli_utils._format_percentage(None) == "—"
+    assert cli_utils._format_percentage(0.1234, precision=1) == "12.3%"
+    assert cli_utils._format_percentage(-0.0, precision=1) == "0.0%"
 
 
 def test_cli_utils_format_helpers_importable():


### PR DESCRIPTION
## Summary
- ensure the Codex bootstrap installs Go Task into `.venv/bin` and fix the Taskfile evaluation namespace so the `verify` and `coverage` targets resolve again
- harden `_format_percentage` to avoid negative zero and add a regression test in the fast coverage suite
- record the latest verify/coverage attempts and update STATUS, TASK_PROGRESS, and the release plan with the new log locations

## Testing
- `uv run pytest tests/unit/test_additional_coverage.py -k format_percentage -q`


------
https://chatgpt.com/codex/tasks/task_e_68d8a4fc090083339d9f4cc75c5ca677