### PR TITLE
Capture VSS vector counts and refresh release notes

### DIFF
--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -151,14 +151,14 @@ TestPyPI dry run. Pass `EXTRAS="gpu"` when GPU wheels are staged.
   【F:src/autoresearch/search/core.py†L705-L760】
   【F:src/autoresearch/orchestration/parallel.py†L145-L182】
   【F:tests/stubs/numpy.py†L12-L81】
-- [x] Revalidated the DuckDB vector path now emits four embedding-related
-  events (two compute calls and two lookups) while the legacy path stays at
-  the direct-only pair. The refreshed
+- [x] Revalidated the DuckDB vector path now emits two search-phase instance
+  lookups plus the direct-only pair (four calls total) while the legacy branch
+  stays capped at the direct pair. The refreshed
   `tests/unit/test_core_modules_additional.py::test_search_stub_backend`
-  captures the breakdown and the stubbed reproduction log shows the
-  deterministic counts for the vector flow.
-  【F:tests/unit/test_core_modules_additional.py†L15-L210】
-  【3335ae†L1-L7】
+  snapshots the counts through `vector_search_counts_log`, and the reproduction
+  log confirms the deterministic four-event breakdown for the vector flow.
+  【F:tests/unit/test_core_modules_additional.py†L18-L379】
+  【22e0d1†L1-L11】
 - [x] `uv run --extra build python -m build` succeeded out of band and archived
   `baseline/logs/python-build-20250925T001554Z.log`, so packaging is ready to
   resume once verify and coverage pass.

--- a/issues/archive/prepare-first-alpha-release.md
+++ b/issues/archive/prepare-first-alpha-release.md
@@ -85,10 +85,10 @@ alpha tag. 【6c5abf†L1-L1】【16543c†L1-L1】【84bbfd†L1-L4】【5b4d9e
   `uv run task verify` sweep and targeted coverage rerun, citing the BM25
   normalization, parallel payload, and numpy stub fixes that cleared the
   regressions. The same plan entry now notes the four-call VSS evidence
-  captured by the refreshed stubbed search regression and its reproduction
+  captured by the refreshed stubbed search regression and the reproduction
   log so reviewers can track the deterministic vector search counts.
-  【F:tests/unit/test_core_modules_additional.py†L15-L210】
-  【3335ae†L1-L7】
+  【F:tests/unit/test_core_modules_additional.py†L18-L379】
+  【22e0d1†L1-L11】
   Supporting links:
   - [docs/release_plan.md][plan-status]
   - [STATUS.md][status-sept25]


### PR DESCRIPTION
## Summary
- track vector-search lookup and compute counts from the stubbed search fixture and assert the four-call path in the regression test
- note the new deterministic vector counts in the alpha prerequisite checklist and archived release issue with updated citations

## Testing
- `uv run --extra test pytest tests/unit/test_core_modules_additional.py::test_search_stub_backend -vv`
- `uv run task release:alpha`


------
https://chatgpt.com/codex/tasks/task_e_68d8a9db9aa48333a5d4f4bd44a515df