### PR TITLE
Refine distributed broker typing

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -21,9 +21,11 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 ## September 30, 2025
 - `task check` now runs `uv run mypy src` without excluding distributed
   modules so regressions surface during fast feedback sweeps.【F:Taskfile.yml†L69-L82】
-- Distributed brokers and executors gained a shared `MessageQueueProtocol` and
-  a typed Ray shim; the docs explain the new constraint for local runs without
-  Ray.【F:src/autoresearch/distributed/broker.py†L52-L178】【F:src/autoresearch/distributed/_ray.py†L15-L144】【F:docs/algorithms/distributed.md†L32-L36】【F:docs/message_brokers.md†L7-L17】
+- Distributed brokers and executors publish validated `BrokerMessage` payloads
+  and reuse the typed Ray shim; the docs explain the new constraint for local
+  runs without Ray.【F:src/autoresearch/distributed/broker.py†L52-L190】【F:src/autoresearch/distributed/_ray.py†L15-L144】【F:docs/algorithms/distributed.md†L32-L36】【F:docs/message_brokers.md†L7-L17】
+- Unit tests now assert agent result messages, cycle callbacks, and claim
+  persistence payloads so the stricter typing stays exercised in CI.【F:tests/unit/test_distributed_executors.py†L1-L225】
 
 ## September 28, 2025
 - Codex setup now installs Go Task into `.venv/bin`, Taskfile exposes

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -74,7 +74,7 @@ tasks:
             {{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}}
       - task check-env EXTRAS="{{.EXTRAS}}"
       - uv run flake8 src
-      - uv run mypy src
+      - uv run mypy src # distributed modules included; no exclude flag
       - task lint-specs
       - task check-release-metadata
       - uv run python scripts/check_spec_tests.py

--- a/docs/algorithms/distributed.md
+++ b/docs/algorithms/distributed.md
@@ -30,10 +30,11 @@ The regression now runs without an `xfail` guard, and
 standard coverage for the distributed executors module.
 
 All brokers now expose a shared `MessageQueueProtocol` so coordinators can
-interact with queues without falling back to `Any`. The Ray executor loads a
-typed shim that falls back to a synchronous stub when the optional dependency
-is unavailable, keeping strict mypy coverage without expanding
-`type: ignore` usage.
+interact with queues without falling back to `Any`. Queue payloads are
+validated against a `BrokerMessage` typed-dict union so serialization bugs fail
+fast. The Ray executor loads a typed shim that falls back to a synchronous stub
+when the optional dependency is unavailable, keeping strict mypy coverage
+without expanding `type: ignore` usage.
 
 ## References
 - [code](../../src/autoresearch/distributed/)

--- a/docs/message_brokers.md
+++ b/docs/message_brokers.md
@@ -12,9 +12,11 @@ services. Lightweight alternatives include:
 
 Ray-backed brokers now wrap the runtime queue behind a shared
 `MessageQueueProtocol`, letting the storage coordinator and result aggregator
-share logic with Redis and in-memory brokers. When Ray is not installed the
-typed shim falls back to a synchronous stub so local testing and strict mypy
-checks stay aligned without additional `type: ignore` directives.
+share logic with Redis and in-memory brokers.
+Queue payloads are validated via the `BrokerMessage` typed-dict union, and when
+Ray is not installed the typed shim falls back to a synchronous stub so local
+testing and strict mypy checks
+stay aligned without additional `type: ignore` directives.
 
 ## Redis
 

--- a/src/autoresearch/distributed/_ray.py
+++ b/src/autoresearch/distributed/_ray.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib
 from dataclasses import dataclass
-from typing import Any, Callable, Generic, Protocol, Sequence, TypeVar, cast
+from typing import Any, Callable, Generic, Mapping, Protocol, Sequence, TypeVar, cast
 
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
@@ -50,7 +50,7 @@ class RayLike(Protocol):
 class RayQueueProtocol(Protocol):
     """Minimal queue interface used by :class:`RayBroker`."""
 
-    def put(self, item: dict[str, Any]) -> None:
+    def put(self, item: Mapping[str, Any]) -> None:
         ...
 
     def get(self, *, block: bool = True, timeout: float | None = None) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- add BrokerMessage typed-dict unions for distributed brokers and validate queue payloads
- update coordinators/executors to use typed broker messages and stop sentinels while keeping ray stubs in sync
- extend distributed executor unit tests plus docs/status to document the stricter typing policy

## Testing
- uv run mypy src/autoresearch/distributed
- uv run pytest tests/unit/test_distributed_executors.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d8ace198008333bf805d7a97276b0f