### PR TITLE
Explicitly set mypy strictness toggles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,8 +243,11 @@ markers = [
 ]
 
 [tool.mypy]
+# Typing strictness guidelines: see docs/dev/typing-strictness.md
 python_version = "3.12"
 strict = true
+warn_unused_configs = true
+no_implicit_optional = true
 
 [tool.flake8]
 max-line-length = 100


### PR DESCRIPTION
## Summary
- document the mypy configuration with a pointer to docs/dev/typing-strictness.md
- explicitly enable warn_unused_configs and no_implicit_optional alongside strict mode

## Testing
- uv run mypy --strict --show-config *(fails: option unsupported in bundled mypy 1.18.2)*
- uv run python - <<'PY' from mypy.main import process_options ... *(confirms warn_unused_configs=True and implicit_optional=False)*

------
https://chatgpt.com/codex/tasks/task_e_68d948173c0c8333ab72c18ef8b2aea6