### PR TITLE
Add strict mypy helper task to verify pipeline

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,6 +59,10 @@ tasks:
     cmds:
       - uv run python scripts/check_release_metadata.py
     desc: "Validate release version and date alignment"
+  mypy:strict-suite:
+    cmds:
+      - uv run mypy --strict src tests
+    desc: "Run mypy in strict mode across src and tests"
   check:
     vars:
       EXTRAS: "{{.EXTRAS | default \"\"}}"
@@ -366,6 +370,7 @@ tasks:
       - uv run flake8 src tests
       - uv run mypy src
       - uv run mypy tests/unit tests/integration
+      - task: mypy:strict-suite
       - task lint-specs
       - task check-release-metadata
       - uv run python scripts/check_spec_tests.py


### PR DESCRIPTION
## Summary
- add a mypy:strict-suite helper task that runs strict type checking across src and tests
- invoke the strict helper from the verify pipeline after existing mypy checks

## Testing
- uv run task --list

------
https://chatgpt.com/codex/tasks/task_e_68d94c9a0f3c83338b416bf5e4c4b528