### PR TITLE
Add typing helpers for API auth behavior steps

### DIFF
--- a/tests/behavior/steps/__init__.py
+++ b/tests/behavior/steps/__init__.py
@@ -1,28 +1,43 @@
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
 """Behavior step package."""
 
-from .common_steps import (
-    app_running,
-    app_running_with_default,
-    application_running,
-    cli_app,
-)  # noqa: F401
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
-# Import step modules so pytest-bdd discovers them when running the package.
-for _mod in [
-    "distributed_execution_steps",
-    "config_cli_steps",
-    "backup_cli_steps",
-    "serve_cli_steps",
-    "completion_cli_steps",
-    "capabilities_cli_steps",
-    "api_auth_steps",
-    "api_orchestrator_integration_steps",
-    "evaluation_steps",
-]:
-    try:
-        __import__(f"tests.behavior.steps.{_mod}")
-    except Exception:  # pragma: no cover - optional imports
-        pass
+    app_running: Callable[..., None]
+    app_running_with_default: Callable[..., None]
+    application_running: Callable[..., None]
+    cli_app: Callable[..., None]
+else:
+    _common_steps = importlib.import_module(
+        "tests.behavior.steps.common_steps"
+    )
+    app_running = _common_steps.app_running
+    app_running_with_default = _common_steps.app_running_with_default
+    application_running = _common_steps.application_running
+    cli_app = _common_steps.cli_app
+
+if not TYPE_CHECKING:
+    # Import step modules so pytest-bdd discovers them when running the package.
+    for _mod in [
+        "distributed_execution_steps",
+        "config_cli_steps",
+        "backup_cli_steps",
+        "serve_cli_steps",
+        "completion_cli_steps",
+        "capabilities_cli_steps",
+        "api_auth_steps",
+        "api_orchestrator_integration_steps",
+        "evaluation_steps",
+    ]:
+        try:
+            importlib.import_module(f"tests.behavior.steps.{_mod}")
+        except Exception:  # pragma: no cover - optional imports
+            pass
 
 __all__ = [
     "app_running",

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator
-
 import pytest
+
+from tests.typing_helpers import TypedFixture
 
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel
@@ -20,7 +20,7 @@ class ConfigContext:
 
 
 @pytest.fixture()
-def config_loader(tmp_path: Path) -> Iterator[ConfigLoader]:
+def config_loader(tmp_path: Path) -> TypedFixture[ConfigLoader]:
     """Provide a ConfigLoader instance backed by a minimal config file."""
     (tmp_path / "autoresearch.toml").write_text("[core]\n")
     loader = ConfigLoader.new_for_tests()
@@ -77,7 +77,7 @@ llm_backend = "openai"
 @pytest.fixture()
 def config_context(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> Iterator[ConfigContext]:
+) -> TypedFixture[ConfigContext]:
     """Return a ConfigContext with representative config and data samples.
 
     The context writes a realistic configuration file and creates placeholder

--- a/tests/fixtures/diagnostics.py
+++ b/tests/fixtures/diagnostics.py
@@ -2,17 +2,18 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from typing import Generator
 
 from multiprocessing import resource_tracker
 
 import pytest
 
+from tests.typing_helpers import TypedFixture
+
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(autouse=True)
-def _log_resource_tracker_cache() -> Generator[None, None, None]:
+def _log_resource_tracker_cache() -> TypedFixture[None]:
     """Log resource tracker state before and after each test.
 
     The diagnostics help confirm that multiprocessing resources are removed

--- a/tests/fixtures/redis.py
+++ b/tests/fixtures/redis.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import pytest
 
+from tests.typing_helpers import TypedFixture
+
 
 @pytest.fixture()
-def redis_client(redis_service):
+def redis_client(redis_service) -> TypedFixture[object]:
     """Return a Redis client backed by the session-level service."""
     redis_service.flushdb()
     yield redis_service

--- a/tests/typing_helpers.py
+++ b/tests/typing_helpers.py
@@ -1,0 +1,66 @@
+"""Shared typing helpers for pytest fixtures and behavior tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+from typing import (
+    Any,
+    Protocol,
+    TypeAlias,
+    TypeVar,
+    cast,
+    overload,
+)
+
+from pytest_bdd import given as _given
+from pytest_bdd import scenario as _scenario
+from pytest_bdd import then as _then
+from pytest_bdd import when as _when
+
+R_co = TypeVar("R_co")
+T = TypeVar("T")
+
+TypedFixture: TypeAlias = Generator[T, None, None] | T
+
+
+class StepDecorator(Protocol[R_co]):
+    """Protocol for the decorator returned by pytest-bdd step factories."""
+
+    def __call__(self, func: Callable[..., R_co]) -> Callable[..., R_co]: ...
+
+
+class StepFactory(Protocol[R_co]):
+    """Protocol modelling pytest-bdd ``given``/``when``/``then`` factories."""
+
+    @overload
+    def __call__(self, func: Callable[..., R_co]) -> Callable[..., R_co]: ...
+
+    @overload
+    def __call__(
+        self, pattern: Any, /, *args: Any, **kwargs: Any
+    ) -> StepDecorator[R_co]: ...
+
+
+class ScenarioFactory(Protocol):
+    """Protocol for the ``pytest_bdd.scenario`` decorator factory."""
+
+    def __call__(
+        self, *args: Any, **kwargs: Any
+    ) -> StepDecorator[None]: ...
+
+
+given = cast("StepFactory[Any]", _given)
+when = cast("StepFactory[Any]", _when)
+then = cast("StepFactory[Any]", _then)
+scenario = cast(ScenarioFactory, _scenario)
+
+__all__ = [
+    "TypedFixture",
+    "StepDecorator",
+    "StepFactory",
+    "ScenarioFactory",
+    "given",
+    "when",
+    "then",
+    "scenario",
+]


### PR DESCRIPTION
## Summary
- add a reusable tests/typing_helpers module with typed fixture aliases and pytest-bdd decorator protocols
- adopt the new helpers across shared test fixtures and refactor API auth step definitions for strict typing
- update behavior step package imports to avoid strict mypy cascades while preserving runtime discovery

## Testing
- uv run mypy --strict tests/behavior/steps/api_auth_steps.py

------
https://chatgpt.com/codex/tasks/task_e_68d953478c4c83338b31e2e9d57b1dcb