### PR TITLE
Refresh typing strictness documentation

### DIFF
--- a/docs/dev/typing-strictness.md
+++ b/docs/dev/typing-strictness.md
@@ -2,65 +2,85 @@
 
 ## Configuration audit
 
-- `[tool.mypy]` in [pyproject.toml](../../pyproject.toml) enables
-  `ignore_missing_imports = true`, which hides missing stub coverage for
-  third-party dependencies rather than surfacing actionable failures.
-- The same section disables the `import-untyped` error code, so imports from
-  modules without type information quietly become `Any` and propagate through
-  the code base. Restoring this diagnostic is required for meaningful strict
-  gating.
-- `check_untyped_defs = true` is already active, which means re-enabling the
-  hidden diagnostics will mostly affect external modules and call sites instead
-  of local function bodies.
+- `[tool.mypy]` in [pyproject.toml](../../pyproject.toml) now enables
+  `strict = true`, activating the full strict preset for every checked module.
+- `warn_unused_configs = true` is set explicitly, so unused sections or typoed
+  options fail fast instead of silently drifting out of sync with tooling.
+- `no_implicit_optional = true` requires all optional parameters to be written
+  as `Optional[T] | None`, which keeps orchestration helpers and behaviour
+  steps honest about nullable values.
+- `mypy_path = ["typings"]` ensures vendored stubs (for example
+  [typings/rdflib](../../typings/rdflib/__init__.pyi)) are discovered alongside
+  newly added helper shims.
+- There are no `ignore_missing_imports` toggles or per-package allowlists, so
+  missing stubs for optional extras surface directly in strict runs.
 
-## Strict run snapshot (2025-09-25 UTC)
+## Strict run snapshot (2025-09-28 16:08 UTC)
 
-- Command: `uv run --extra dev-minimal --extra test mypy --strict src tests`.
-- Result: 4,129 errors reported across 531 files (693 checked). The majority
-  originate from test suites and helper fixtures, but several core packages
-  also fail strict checks.
+- Command: `uv run mypy --strict src tests`.
+- Result: 4,122 errors across 511 files (740 checked). Tests dominate the
+  totals, but strict diagnostics also flag newer orchestration helpers and
+  monitoring utilities.
 - Dominant categories observed:
-  - Missing function annotations, especially in unit and behaviour tests such
-    as [tests/unit/test_ui_save_config.py](../../tests/unit/test_ui_save_config.py)
-    and [tests/behavior/steps/api_auth_steps.py](../../tests/behavior/steps/api_auth_steps.py).
-  - Untyped decorators (e.g., pytest, behave) that force functions into
-    untyped mode, preventing downstream type inference.
-  - `Any` leakage from external dependencies, notably `pydantic.BaseModel`
-    usages in [src/autoresearch/models.py](../../src/autoresearch/models.py)
-    and related agent/message models.
-  - Unused `# type: ignore` directives and `no-any-return` violations in
-    orchestration helpers such as
-    [src/autoresearch/orchestration/utils.py](../../src/autoresearch/orchestration/utils.py)
-    and [src/autoresearch/orchestration/token_utils.py](../../src/autoresearch/orchestration/token_utils.py).
-  - Attribute export issues surfaced by strict namespace checking, for example
-    references to `AgentFactory` from
-    [src/autoresearch/orchestration/orchestrator.py](../../src/autoresearch/orchestration/orchestrator.py)
-    that are not present in `__all__`.
+  - Missing annotations in orchestrator helpers and behaviour steps, notably
+    [tests/unit/test_orchestrator_helpers.py]
+    (../../tests/unit/test_orchestrator_helpers.py) and
+    [tests/behavior/steps/api_async_query_steps.py]
+    (../../tests/behavior/steps/api_async_query_steps.py), plus related
+    fixtures that wrap refactored helper modules.
+  - Third-party stub gaps for optional extras (`streamlit`, `ray`, `networkx`,
+    `matplotlib`, `duckdb_extension_vss`, `spacy.cli`) despite the vendored
+    stubs path, highlighting where additional packages or shim updates are
+    still required.
+  - HTTP and cache helpers returning `Any` or using incorrect attributes in
+    [src/autoresearch/cache.py](../../src/autoresearch/cache.py),
+    [src/autoresearch/monitor/system_monitor.py]
+    (../../src/autoresearch/monitor/system_monitor.py), and
+    [src/autoresearch/llm/pool.py](../../src/autoresearch/llm/pool.py).
+  - Graph-backed storage modules such as
+    [src/autoresearch/storage_backends.py]
+    (../../src/autoresearch/storage_backends.py) and
+    [src/autoresearch/storage.py](../../src/autoresearch/storage.py) where
+    strict rdflib typing uncovers attribute and return-type mismatches surfaced
+    by the new helpers.
+- Exclusions: none. The strict preset applies globally, and remaining
+  suppressions must be justified inline.
 
 ## Representative modules and triage notes
 
-- **Tests (unit, integration, behaviour)** – Thousands of errors driven by
-  missing annotations and untyped pytest/behave decorators. Adding helper
-  type aliases and pytest fixtures with explicit return signatures should
-  resolve large portions quickly once a consistent convention is agreed upon.
-- **Pydantic models** – Every subclass of `BaseModel` is currently typed as
-  `Any` because the disabled `import-untyped` diagnostic masks the missing
-  stubs. Installing or vendoring Pydantic v1 stubs (or upgrading to a version
-  that ships them) is a prerequisite before enabling strict gating on these
-  modules.
-- **Orchestration utilities** – Several functions return `Any` or rely on
-  unchecked dictionaries. These appear more involved because they require
-  defining protocol objects and refining return types without breaking
-  runtime behaviour.
-- **Distributed executors and scripts** – Queue and callable generics lack
-  type parameters, and some scripts attempt to monkey-patch methods, which
-  strict mypy rejects outright. These likely demand bespoke refactors or
-  opt-in `type: ignore[misc]` justifications.
+- **Tests (unit, integration, behaviour)** – Thousands of missing annotations
+  across orchestrator, API, and CLI suites (see
+  [tests/integration/test_monitor_metrics.py]
+  (../../tests/integration/test_monitor_metrics.py) and
+  [tests/behavior/steps/agent_orchestration_steps.py]
+  (../../tests/behavior/steps/agent_orchestration_steps.py)).
+  Establishing shared fixtures and helper protocols for the refactored
+  behaviour steps will eliminate large swaths of `no-untyped-def` noise.
+- **Optional extras and vendored stubs** – Import errors for `streamlit`,
+  `ray`, `duckdb_extension_vss`, and `matplotlib` show where additional stub
+  packages or expanded files under `typings/` are still required so that
+  orchestration helpers and UI modules type-check.
+- **Core orchestration utilities** – Recent helper refactors in
+  [src/autoresearch/orchestration/utils.py]
+  (../../src/autoresearch/orchestration/utils.py),
+  [src/autoresearch/orchestration/orchestrator.py]
+  (../../src/autoresearch/orchestration/orchestrator.py), and
+  [src/autoresearch/orchestration/token_utils.py]
+  (../../src/autoresearch/orchestration/token_utils.py) surface `Any` returns,
+  redundant casts, and TypedDict misuse that ripple into behaviour-step
+  assertions.
+- **Monitoring and API layers** – Modules such as
+  [src/autoresearch/monitor/metrics.py]
+  (../../src/autoresearch/monitor/metrics.py) and
+  [src/autoresearch/api/auth.py](../../src/autoresearch/api/auth.py) require
+  concrete protocol definitions for Starlette/FastAPI integration, aligning
+  them with the orchestrator helpers relied on by the new behaviour suites.
 
 ## TYPE_CHECKING usage review
 
 - Files like
-  [src/autoresearch/storage_backends.py](../../src/autoresearch/storage_backends.py)
+  [src/autoresearch/storage_backends.py]
+  (../../src/autoresearch/storage_backends.py)
   gate heavy optional imports (e.g., `kuzu`) behind `if TYPE_CHECKING:` blocks.
   This pattern aligns with the preferred approach—runtime availability remains
   optional while type checkers benefit from the annotations. New strict work
@@ -68,16 +88,15 @@
 
 ## Suggested sequencing towards strict gating
 
-1. Restore `import-untyped` diagnostics and audit third-party dependencies for
-   missing stubs. Prioritize high-impact packages (Pydantic, DuckDB, rdflib).
-2. Establish annotation helpers for pytest/behave fixtures, then roll strict
-   mode across `tests/` to prevent regression once coverage improves.
-3. Address orchestration utilities and token management helpers by defining
-   shared typed interfaces, reducing `Any` returns, and trimming unused
-   `type: ignore` directives.
-4. Treat complex scripts and distributed components last; evaluate whether the
-   functionality should be fully typed, partially ignored with justification,
-   or relocated under optional strict modules.
-5. Once the above areas stabilize, enable `mypy --strict` in CI, potentially
-   with an allowlist that temporarily excludes still-problematic modules while
-   the backlog burns down.
+1. Harden shared pytest and behave helpers so orchestrator, API, and CLI tests
+   pick up consistent typed fixtures, shrinking the strict error surface.
+2. Extend vendored stubs (or add dependencies) for high-noise extras such as
+   `streamlit`, `ray`, `networkx`, and `duckdb_extension_vss`, mirroring the
+   new helper modules they exercise.
+3. Refine orchestration and storage helpers—introduce typed protocols for
+   cache, HTTP, and rdflib adapters to replace `Any` flows and redundant casts.
+4. Tackle monitoring and FastAPI integrations next, ensuring ASGI request and
+   response wrappers expose the attributes the behaviour steps assert on.
+5. When the above areas stabilize, wire `uv run mypy --strict src tests` into
+   CI without excludes, treating any future suppressions as temporary and
+   documented inline.


### PR DESCRIPTION
## Summary
- reran `uv run mypy --strict src tests` and captured the updated error counts, timestamp, and remaining suppressions
- documented the explicit `strict`, `warn_unused_configs`, and `no_implicit_optional` flags plus the vendored stub path
- refreshed representative module notes to match the current orchestration helpers and behaviour step suites

## Testing
- `uv run mypy --strict src tests` *(fails: 4,122 errors remain under strict mode)*

------
https://chatgpt.com/codex/tasks/task_e_68d95d40d16c83339d2b349baf51923b