### PR TITLE
Enhance scout gate policy telemetry and audit provenance

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -32,6 +32,11 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   from the pinned path.【F:baseline/logs/task-verify-20250930T174512Z.log†L6-L13】【F:baseline/logs/task-coverage-20250930T181947Z.log†L3-L11】
 
 ## September 28, 2025
+- Captured back-to-back `uv run task verify` sweeps after the scout gate
+  updates: the baseline run resolves dependencies in 6 ms before the existing
+  strict mypy wall, and the post-fix run resolves in 9 ms with the same legacy
+  typing failures and no token metrics emitted to compare.【57e095†L1-L11】
+  【dae05e†L1-L13】【373e47†L1-L100】
 - Captured the first strict-typing `uv run task verify` after enabling
   repo-wide `strict = true`; the 16:17 UTC sweep hits mypy and reports missing
   stubs plus 230 errors across storage, orchestration, and API modules, so the

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -174,17 +174,20 @@ is fully attributable.
   supporting snippets for later audits.
 - **Gate policy:** Decide between early exit and dialectical debate using the
   scout signals, policy-sensitive topic detection, contradiction cues from
-  GraphRAG, and budget guards. Escalate when uncertainty exceeds configured
+  GraphRAG, coverage gaps derived from prior audits, retrieval confidence
+  metrics, and budget guards. Escalate when uncertainty exceeds configured
   thresholds or when the user forces debate.
 - **Debate stage:** Limit cycles adaptively; ensure the fact checker audits all
   claims before synthesis and citation formatting. Persist thesis/antithesis
   turns and fact-checker verdicts for replay.
-- **Telemetry:** Record gate inputs, overrides, and outcomes so policies can be
-  tuned with offline evaluation.
+- **Telemetry:** Record gate inputs, rationales, overrides, and outcomes so
+  policies can be tuned with offline evaluation.
 - **Configuration:** Operators can tune `gate_policy_enabled`,
   `gate_retrieval_overlap_threshold`, `gate_nli_conflict_threshold`,
-  `gate_complexity_threshold`, `gate_graph_contradiction_threshold`, and
-  `gate_user_overrides` to align the scout policy with domain needs.
+  `gate_complexity_threshold`, `gate_coverage_gap_threshold`,
+  `gate_retrieval_confidence_threshold`,
+  `gate_graph_contradiction_threshold`, and `gate_user_overrides` to align the
+  scout policy with domain needs.
 
 ## 10. Evidence Pipeline 2.0
 
@@ -194,7 +197,9 @@ is fully attributable.
 - Score claim support with entailment checks and a self-checking ensemble for
   instability detection. Flag conflicting snippets for contrarian review.
 - Emit per-claim audit records (`supported`, `weak`, `disputed`) containing
-  sources, quotes, entailment scores, reviewer notes, and stability deltas.
+  sources, quotes, entailment scores, reviewer notes, stability deltas, and a
+  provenance map with retrieval, backoff, and evidence namespaces so CLI, JSON,
+  and UI surfaces stay consistent.
 - Block synthesis on unsupported claims; require hedging or removal before
   completion. Persist audit metadata so clients can render detailed tables.
 

--- a/src/autoresearch/agents/dialectical/synthesizer.py
+++ b/src/autoresearch/agents/dialectical/synthesizer.py
@@ -202,6 +202,15 @@ class SynthesizerAgent(Agent):
             },
         }
 
+        metadata["audit_provenance_synthesizer"] = {
+            "summary": dict(audit_kwargs.get("provenance", {})),
+            "supporting_audits": [
+                dict(audit.get("provenance", {}))
+                for audit in support_audits
+                if isinstance(audit, Mapping) and audit.get("provenance")
+            ],
+        }
+
         return metadata, audit_kwargs, support_audits
 
     @staticmethod

--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -389,6 +389,18 @@ class ConfigModel(BaseModel):
         le=1.0,
         description="Complexity score that escalates to full debate",
     )
+    gate_coverage_gap_threshold: float = Field(
+        default=0.25,
+        ge=0.0,
+        le=1.0,
+        description="Maximum uncovered-claim share before debate escalates",
+    )
+    gate_retrieval_confidence_threshold: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="Minimum retrieval confidence required to skip debate",
+    )
     gate_user_overrides: Dict[str, Any] = Field(
         default_factory=dict,
         description="Optional overrides for gate policy decisions and signals",

--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -422,6 +422,10 @@ class OrchestrationMetrics:
             "thresholds": decision.thresholds,
             "reason": decision.reason,
             "tokens_saved_estimate": decision.tokens_saved,
+            "rationales": decision.rationales,
+            "coverage": decision.telemetry.get("coverage"),
+            "contradiction_total": decision.telemetry.get("contradiction_total"),
+            "contradiction_samples": decision.telemetry.get("contradiction_samples"),
         }
         self.gate_events.append(event)
 

--- a/tests/cli/test_search_depth.py
+++ b/tests/cli/test_search_depth.py
@@ -1,40 +1,17 @@
 import json
 
 import pytest
-from typer.testing import CliRunner
 
 from autoresearch.cli_helpers import depth_help_text
-from autoresearch.main.app import app as cli_app
 from autoresearch.models import QueryResponse
+from autoresearch.output_format import OutputDepth, OutputFormatter
 
 pytestmark = pytest.mark.integration
 
 
-class DummyProgress:
-    def __enter__(self) -> "DummyProgress":
-        return self
-
-    def __exit__(self, *exc: object) -> bool:
-        return False
-
-    def add_task(self, *args: object, **kwargs: object) -> int:
-        return 0
-
-    def update(self, *args: object, **kwargs: object) -> None:
-        return None
-
-
-class DummyPrompt:
-    @staticmethod
-    def ask(*args: object, **kwargs: object) -> str:
-        return ""
-
-
 @pytest.fixture
-def cli_environment(monkeypatch: pytest.MonkeyPatch) -> QueryResponse:
-    from autoresearch.config.models import ConfigModel
-
-    dummy_response = QueryResponse(
+def response_payload() -> QueryResponse:
+    return QueryResponse(
         query="depth test",
         answer="An extended answer about adaptive depth rendering.",
         citations=["Source A", "Source B"],
@@ -45,55 +22,34 @@ def cli_environment(monkeypatch: pytest.MonkeyPatch) -> QueryResponse:
                 "claim_id": "1",
                 "status": "supported",
                 "entailment_score": 0.92,
-                "sources": [{"title": "Whitepaper"}],
+                "sources": [{"title": "Whitepaper", "source_id": "src-1"}],
+                "provenance": {
+                    "retrieval": {"base_query": "depth test"},
+                    "backoff": {"retry_count": 0},
+                    "evidence": {"best_source_id": "src-1"},
+                },
             }
         ],
     )
 
-    class DummyOrchestrator:
-        def __init__(self) -> None:  # pragma: no cover - interface shim
-            return None
 
-        def run_query(self, *args: object, **kwargs: object) -> QueryResponse:
-            return dummy_response
-
-    class DummyStorage:
-        @staticmethod
-        def setup() -> None:  # pragma: no cover - interface shim
-            return None
-
-        @staticmethod
-        def load_ontology(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
-            return None
-
-    monkeypatch.setattr("autoresearch.main.app.Orchestrator", DummyOrchestrator)
-    monkeypatch.setattr("autoresearch.main.app.StorageManager", DummyStorage)
-    monkeypatch.setattr(
-        "autoresearch.main.app._config_loader.load_config",
-        lambda: ConfigModel(),
-    )
-    monkeypatch.setattr("autoresearch.main.app.Progress", DummyProgress)
-    monkeypatch.setattr("autoresearch.main.app.Prompt", DummyPrompt)
-    return dummy_response
+def test_cli_depth_tldr(response_payload: QueryResponse) -> None:
+    output = OutputFormatter.render(response_payload, "markdown", OutputDepth.TLDR)
+    assert "# TL;DR" in output
+    assert "Key findings are hidden" in output
 
 
-def test_cli_depth_tldr(cli_runner: CliRunner, cli_environment: QueryResponse) -> None:
-    result = cli_runner.invoke(cli_app, ["search", "depth test", "--depth", "tldr"])
-    assert result.exit_code == 0
-    assert "# TL;DR" in result.stdout
-    assert "Key findings are hidden" in result.stdout
-
-
-def test_cli_depth_trace_json(cli_runner: CliRunner, cli_environment: QueryResponse) -> None:
-    result = cli_runner.invoke(
-        cli_app,
-        ["search", "depth test", "--depth", "trace", "--output", "json"],
-    )
-    assert result.exit_code == 0
-    data = json.loads(result.stdout)
-    assert "raw_response" in data
+def test_cli_depth_trace_json(response_payload: QueryResponse) -> None:
+    output = OutputFormatter.render(response_payload, "json", OutputDepth.TRACE)
+    data = json.loads(output)
     assert data["sections"]["full_trace"] is True
     assert data["sections"]["claim_audits"] is True
+
+
+def test_cli_preserves_claim_audits(response_payload: QueryResponse) -> None:
+    output = OutputFormatter.render(response_payload, "json", OutputDepth.TRACE)
+    payload = json.loads(output)
+    assert payload["claim_audits"] == response_payload.claim_audits
 
 
 def test_depth_help_text_includes_feature_matrix() -> None:


### PR DESCRIPTION
## Summary
- expand the scout gate policy with coverage-gap and retrieval-confidence heuristics, structured rationales, persisted scout-stage metadata, and richer telemetry for downstream overrides
- attach audit provenance metadata to synthesizer and fact-checker results, refresh documentation and Streamlit UI panels to describe the extended gate signals, and update STATUS with the latest verify logs
- migrate CLI depth tests to formatter-focused coverage so claim audits round-trip in JSON output and broaden gate-policy unit tests for new override scenarios

## Testing
- uv run pytest tests/unit/orchestration/test_gate_policy.py
- uv run pytest tests/cli/test_search_depth.py
- uv run task verify *(fails: strict mypy baseline remains outstanding)*

------
https://chatgpt.com/codex/tasks/task_e_68d960c7ba44833387f5a73081e90b3b