### PR TITLE
feat: capture planner telemetry and scheduler snapshots

### DIFF
--- a/tests/behavior/features/reasoning_mode.feature
+++ b/tests/behavior/features/reasoning_mode.feature
@@ -136,3 +136,4 @@ Feature: Reasoning Mode Selection
     When I simulate a PRDV planner flow
     Then the planner react log should capture normalization warnings
     And the coordinator trace metadata should include unlock events
+    And the telemetry snapshot should include scheduler context

--- a/tests/unit/orchestration/test_query_state_features.py
+++ b/tests/unit/orchestration/test_query_state_features.py
@@ -15,7 +15,21 @@ def test_query_state_cloudpickle_serialization_preserves_fields() -> None:
     state = QueryState(query="serial")
     state.claims.append({"id": "c1", "text": "claim"})
     state.metadata["planner"] = {"strategy": "map"}
-    state.set_task_graph({"tasks": [{"id": "t1", "question": "Q"}], "edges": []})
+    state.set_task_graph(
+        {
+            "objectives": ["Persist graph"],
+            "tasks": [
+                {
+                    "id": "t1",
+                    "question": "Q",
+                    "tool_affinity": {"search": 0.4},
+                    "exit_criteria": ["complete"],
+                    "explanation": "baseline",
+                }
+            ],
+            "edges": [],
+        }
+    )
 
     payload = cloudpickle.dumps(state)
     restored = cloudpickle.loads(payload)
@@ -23,3 +37,4 @@ def test_query_state_cloudpickle_serialization_preserves_fields() -> None:
     assert restored.claims == state.claims
     assert restored.metadata["planner"] == state.metadata["planner"]
     assert restored.task_graph == state.task_graph
+    assert restored.metadata["planner"]["telemetry"] == state.metadata["planner"]["telemetry"]

--- a/tests/unit/orchestration/test_task_coordinator.py
+++ b/tests/unit/orchestration/test_task_coordinator.py
@@ -78,7 +78,12 @@ def test_task_coordinator_schedules_dependencies(state_with_graph: QueryState) -
         "t1",
         "t2",
     ]
-    assert (
-        state_with_graph.metadata["coordinator"]["ordering_strategy"]
-        == "depth_affinity"
-    )
+    coordinator_meta = state_with_graph.metadata["coordinator"]
+    assert coordinator_meta["ordering_strategy"] == "readiness_affinity"
+    assert coordinator_meta["decisions"], "scheduler decisions should be captured"
+    decision_snapshot = coordinator_meta["decisions"][-1]
+    assert decision_snapshot["task_id"] == "t2"
+    scheduler_meta = trace["metadata"]["scheduler"]
+    assert scheduler_meta["selected"]["id"] == "t2"
+    assert scheduler_meta["selected"]["status"] == TaskStatus.RUNNING.value
+    assert scheduler_meta["candidates"][0]["ready"] is True


### PR DESCRIPTION
## Summary
- enforce typed JSON outputs from the planner via a new prompt builder and normalization updates
- add TaskGraphNode snapshots plus readiness-aware scheduling and telemetry logging in the coordinator
- persist planner/coordinator telemetry through QueryState and extend tests, docs, and behaviour scenarios

## Testing
- `uv run task verify`
- `uv run task coverage`


------
https://chatgpt.com/codex/tasks/task_e_68d96e53dff08333acb593a82297ab12