### PR TITLE
Integrate session graph metadata into search context

### DIFF
--- a/src/autoresearch/kg_reasoning.py
+++ b/src/autoresearch/kg_reasoning.py
@@ -40,7 +40,7 @@ except Exception:  # pragma: no cover - fallback for offline tests
 
 from .config import ConfigLoader
 from .errors import StorageError
-from .knowledge import (  # noqa: F401
+from .knowledge.graph import (  # noqa: F401
     GraphContradiction,
     GraphEntity,
     GraphExtractionSummary,

--- a/src/autoresearch/knowledge/__init__.py
+++ b/src/autoresearch/knowledge/__init__.py
@@ -14,10 +14,13 @@ from .graph import (
     SessionGraphPipeline,
 )
 
+KnowledgeGraphPipeline = SessionGraphPipeline
+
 __all__ = [
     "GraphContradiction",
     "GraphEntity",
     "GraphExtractionSummary",
     "GraphRelation",
     "SessionGraphPipeline",
+    "KnowledgeGraphPipeline",
 ]

--- a/src/autoresearch/search/context.py
+++ b/src/autoresearch/search/context.py
@@ -1,15 +1,26 @@
 from __future__ import annotations
 
+import copy
 import importlib
 import os
 import threading
 import time
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Mapping, Sequence, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Sequence,
+    cast,
+)
 
 from ..config.loader import get_config
-from ..knowledge import SessionGraphPipeline
 from ..logging_utils import get_logger
 
 # Keep a reference to the original get_config to detect monkeypatching in tests
@@ -146,6 +157,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type checking only
     from bertopic import BERTopic as BERTopicType
     from spacy.language import Language
 
+    from ..knowledge.graph import SessionGraphPipeline
     from ..orchestration.state import QueryState
 
 log = get_logger(__name__)
@@ -162,12 +174,19 @@ class SearchContext:
 
     _instance = None
     _lock = threading.Lock()
+    _graph_pipeline_lock: ClassVar[threading.Lock] = threading.Lock()
+    _graph_pipeline_factory: ClassVar[
+        Callable[[], "SessionGraphPipeline"] | None
+    ] = None
+    _graph_pipeline_singleton: ClassVar["SessionGraphPipeline" | None] = None
 
     @classmethod
     def reset_instance(cls) -> None:
         """Reset the singleton instance."""
         with cls._lock:
             cls._instance = None
+        with cls._graph_pipeline_lock:
+            cls._graph_pipeline_singleton = None
 
     @classmethod
     def new_for_tests(cls) -> "SearchContext":
@@ -193,18 +212,67 @@ class SearchContext:
                 cls._instance = SearchContext()
             return cls._instance
 
-    def __init__(self) -> None:
+    def __init__(self, *, graph_pipeline: "SessionGraphPipeline" | None = None) -> None:
         self.search_history: List[Dict[str, Any]] = []
         self.entities: defaultdict[str, int] = defaultdict(int)
         self.topic_model: BERTopicType | None = None
         self.dictionary: dict[str, int] | None = None
         self.nlp: Language | None = None
-        self.graph_pipeline: SessionGraphPipeline = SessionGraphPipeline()
+        self._graph_pipeline_override: "SessionGraphPipeline" | None = graph_pipeline
         self._graph_summary: dict[str, Any] = {}
+        self._graph_stage_metadata: dict[str, Any] = {}
         self._scout_metadata: dict[str, Any] = {}
         self._scout_lock = threading.Lock()
         if get_config().search.context_aware.enabled:
             self._initialize_nlp()
+
+    @property
+    def graph_pipeline(self) -> "SessionGraphPipeline":
+        """Return the lazily constructed session graph pipeline singleton."""
+
+        if self._graph_pipeline_override is not None:
+            return self._graph_pipeline_override
+        cls = type(self)
+        pipeline = cls._graph_pipeline_singleton
+        if pipeline is not None:
+            return pipeline
+        with cls._graph_pipeline_lock:
+            pipeline = cls._graph_pipeline_singleton
+            if pipeline is None:
+                factory = cls._graph_pipeline_factory or self._default_graph_pipeline_factory
+                pipeline = factory()
+                cls._graph_pipeline_singleton = pipeline
+        return pipeline
+
+    @classmethod
+    def configure_graph_pipeline(
+        cls,
+        *,
+        factory: Callable[[], "SessionGraphPipeline"] | None = None,
+        pipeline: "SessionGraphPipeline" | None = None,
+    ) -> None:
+        """Configure or replace the lazy graph pipeline singleton."""
+
+        with cls._graph_pipeline_lock:
+            if factory is not None:
+                cls._graph_pipeline_factory = factory
+                cls._graph_pipeline_singleton = None
+            if pipeline is not None:
+                cls._graph_pipeline_singleton = pipeline
+            if factory is None and pipeline is None:
+                cls._graph_pipeline_factory = None
+                cls._graph_pipeline_singleton = None
+
+    @staticmethod
+    def _default_graph_pipeline_factory() -> "SessionGraphPipeline":
+        from ..knowledge.graph import SessionGraphPipeline as _SessionGraphPipeline
+
+        return _SessionGraphPipeline()
+
+    def set_graph_pipeline(self, pipeline: "SessionGraphPipeline" | None) -> None:
+        """Override the graph pipeline for the current instance."""
+
+        self._graph_pipeline_override = pipeline
 
     def _initialize_nlp(self) -> None:
         if not get_config().search.context_aware.enabled:
@@ -247,9 +315,15 @@ class SearchContext:
             self._extract_entities(result.get("title", ""))
             self._extract_entities(result.get("snippet", ""))
 
-        summary = self.graph_pipeline.ingest(query, results)
-        self._graph_summary = summary.to_dict()
-        self._store_scout_complexity(self._graph_summary)
+        pipeline = self.graph_pipeline
+        start = time.perf_counter()
+        summary = pipeline.ingest(query, results)
+        ingestion_seconds = max(0.0, time.perf_counter() - start)
+        summary_payload = summary.to_dict()
+        summary_payload["ingestion_seconds"] = ingestion_seconds
+        self._graph_summary = summary_payload
+        self._store_graph_metadata(summary_payload)
+        self._store_scout_complexity(summary_payload)
 
     def _extract_entities(self, text: str) -> None:
         """Update entity frequency counts from text.
@@ -354,8 +428,27 @@ class SearchContext:
         cfg = get_config()
         context_cfg = getattr(cfg.search, "context_aware", None)
         weight = float(getattr(context_cfg, "graph_contradiction_weight", 0.0))
+        stage_meta = self._graph_stage_metadata.get("contradictions", {})
+        stored_weight = float(stage_meta.get("weight", -1.0)) if stage_meta else -1.0
+        if not stage_meta or stored_weight != weight:
+            summary = self.get_graph_summary()
+            if summary:
+                summary["contradiction_weight"] = weight
+                self._store_graph_metadata(summary)
+                stage_meta = self._graph_stage_metadata.get("contradictions", {})
+        if stage_meta:
+            return float(stage_meta.get("weighted_score", 0.0))
         base_score = self.graph_pipeline.get_contradiction_score()
-        return float(base_score * weight)
+        weighted = float(base_score * weight)
+        self._graph_stage_metadata = {
+            "contradictions": {
+                "raw_score": float(base_score),
+                "weighted_score": weighted,
+                "weight": weight,
+                "items": [],
+            }
+        }
+        return weighted
 
     def graph_neighbors(
         self, label: str, *, direction: str = "out", limit: int = 5
@@ -374,6 +467,44 @@ class SearchContext:
         """
 
         return self.graph_pipeline.neighbors(label, direction=direction, limit=limit)
+
+    def get_graph_neighbors_for_nodes(
+        self,
+        nodes: Sequence[str],
+        *,
+        direction: str = "both",
+        limit: int = 5,
+    ) -> dict[str, list[dict[str, str]]]:
+        """Return neighbour relations for the provided entity labels.
+
+        Args:
+            nodes: Iterable of entity labels that should be inspected.
+            direction: Edge direction passed through to
+                :meth:`SessionGraphPipeline.neighbors`.
+            limit: Maximum neighbour count per entity.
+
+        Returns:
+            Mapping from the original entity label to neighbouring relation
+            payloads. Labels with no neighbours are omitted from the result.
+        """
+
+        neighbors: dict[str, list[dict[str, str]]] = {}
+        seen: set[str] = set()
+        pipeline = self.graph_pipeline
+        for label in nodes:
+            if not isinstance(label, str):
+                continue
+            trimmed = label.strip()
+            if not trimmed:
+                continue
+            key = trimmed.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            payload = pipeline.neighbors(trimmed, direction=direction, limit=limit)
+            if payload:
+                neighbors[trimmed] = payload
+        return neighbors
 
     def graph_paths(
         self, source: str, target: str, *, max_depth: int = 3, limit: int = 5
@@ -475,6 +606,8 @@ class SearchContext:
             ]
         if "complexity" in meta:
             cloned["complexity"] = dict(meta.get("complexity", {}))
+        if "graph" in meta:
+            cloned["graph"] = copy.deepcopy(meta.get("graph", {}))
         return cloned
 
     def apply_scout_metadata(self, state: "QueryState") -> bool:
@@ -499,6 +632,19 @@ class SearchContext:
         if complexity and "scout_complexity_features" not in state.metadata:
             state.metadata["scout_complexity_features"] = complexity
             updated = True
+
+        graph_payload = metadata.get("graph")
+        if graph_payload:
+            scout_stage = state.metadata.setdefault("scout_stage", {})
+            existing_graph = scout_stage.get("graph")
+            if existing_graph != graph_payload:
+                scout_stage["graph"] = graph_payload
+                updated = True
+        elif "scout_stage" in state.metadata:
+            scout_stage = state.metadata.get("scout_stage")
+            if isinstance(scout_stage, dict) and "graph" in scout_stage:
+                scout_stage.pop("graph", None)
+                updated = True
 
         return updated
 
@@ -567,7 +713,7 @@ class SearchContext:
             return
         with self._scout_lock:
             if not self._scout_metadata:
-                return
+                self._scout_metadata = {"complexity": {}}
             complexity = dict(self._scout_metadata.get("complexity", {}))
             contradictions = summary.get("contradictions")
             if isinstance(contradictions, Sequence):
@@ -579,3 +725,121 @@ class SearchContext:
             if hop_lengths:
                 complexity["hops"] = float(max(hop_lengths))
             self._scout_metadata["complexity"] = complexity
+
+    def _store_graph_metadata(self, summary: Mapping[str, Any]) -> None:
+        """Persist planner-oriented graph metadata derived from ``summary``."""
+
+        metadata = self._build_graph_metadata(summary)
+        self._graph_stage_metadata = metadata
+        if not metadata:
+            return
+        with self._scout_lock:
+            if not self._scout_metadata:
+                self._scout_metadata = {"graph": copy.deepcopy(metadata)}
+            else:
+                self._scout_metadata["graph"] = copy.deepcopy(metadata)
+
+    def _build_graph_metadata(self, summary: Mapping[str, Any]) -> dict[str, Any]:
+        if not summary:
+            return {}
+
+        cfg = get_config()
+        context_cfg = getattr(cfg.search, "context_aware", None)
+        weight = float(getattr(context_cfg, "graph_contradiction_weight", 0.0))
+
+        raw_score = float(summary.get("contradiction_score", 0.0) or 0.0)
+        weighted_score = float(raw_score * weight)
+
+        contradictions_raw = summary.get("contradictions") or []
+        contradiction_items: list[dict[str, Any]] = []
+        nodes_for_neighbors: list[str] = []
+        if isinstance(contradictions_raw, Sequence):
+            for item in contradictions_raw:
+                if not isinstance(item, Mapping):
+                    continue
+                subject = str(item.get("subject", "")) if item.get("subject") else ""
+                predicate = str(item.get("predicate", "")) if item.get("predicate") else ""
+                objects_value = item.get("objects", [])
+                objects: list[str]
+                if isinstance(objects_value, Sequence):
+                    objects = [str(obj) for obj in objects_value if isinstance(obj, str)]
+                else:
+                    objects = []
+                contradiction_items.append(
+                    {
+                        "subject": subject,
+                        "predicate": predicate,
+                        "objects": objects,
+                    }
+                )
+                if subject:
+                    nodes_for_neighbors.append(subject)
+                nodes_for_neighbors.extend(objects)
+
+        provenance_records = summary.get("provenance") or []
+        if isinstance(provenance_records, Sequence):
+            for record in provenance_records:
+                if not isinstance(record, Mapping):
+                    continue
+                subject = record.get("subject")
+                obj = record.get("object")
+                if isinstance(subject, str):
+                    nodes_for_neighbors.append(subject)
+                if isinstance(obj, str):
+                    nodes_for_neighbors.append(obj)
+
+        neighbors = self.get_graph_neighbors_for_nodes(nodes_for_neighbors, direction="both")
+
+        paths_raw = summary.get("multi_hop_paths") or []
+        paths: list[list[str]] = []
+        if isinstance(paths_raw, Sequence):
+            for path in paths_raw:
+                if isinstance(path, Sequence):
+                    serialised = [str(node) for node in path]
+                    if serialised:
+                        paths.append(serialised)
+
+        ingestion_seconds = float(summary.get("ingestion_seconds", 0.0) or 0.0)
+        storage_latency = summary.get("storage_latency") or {}
+        latency_payload: dict[str, float] = {}
+        if isinstance(storage_latency, Mapping):
+            for key, value in storage_latency.items():
+                try:
+                    latency_payload[str(key)] = float(value)
+                except (TypeError, ValueError):
+                    continue
+
+        entity_count = summary.get("entity_count", 0)
+        relation_count = summary.get("relation_count", 0)
+        try:
+            entity_count_float = float(entity_count)
+        except (TypeError, ValueError):
+            entity_count_float = 0.0
+        try:
+            relation_count_float = float(relation_count)
+        except (TypeError, ValueError):
+            relation_count_float = 0.0
+
+        metadata: dict[str, Any] = {
+            "contradictions": {
+                "raw_score": raw_score,
+                "weighted_score": weighted_score,
+                "weight": weight,
+                "items": contradiction_items,
+            },
+            "ingestion": {
+                "seconds": ingestion_seconds,
+                "storage_latency": latency_payload,
+                "entity_count": entity_count_float,
+                "relation_count": relation_count_float,
+            },
+            "paths": paths,
+        }
+        if neighbors:
+            metadata["neighbors"] = neighbors
+        return metadata
+
+    def get_graph_stage_metadata(self) -> dict[str, Any]:
+        """Return a defensive copy of the planner-oriented graph metadata."""
+
+        return copy.deepcopy(self._graph_stage_metadata)

--- a/tests/integration/test_graph_rag.py
+++ b/tests/integration/test_graph_rag.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from autoresearch.orchestration.state import QueryState
+from autoresearch.search.context import SearchContext
+from autoresearch.storage import StorageManager
+
+
+def _reset_storage() -> None:
+    StorageManager.teardown(remove_db=True)
+    StorageManager.setup(db_path=":memory:")
+
+
+def test_graph_rag_neighbors_metadata() -> None:
+    """Search context should expose planner-ready graph metadata."""
+
+    _reset_storage()
+    with SearchContext.temporary_instance() as context:
+        query = "How are Marie Curie and Pierre Curie related to Paris?"
+        results = [
+            {
+                "title": "Marie Curie biography",
+                "snippet": "Marie Curie discovered polonium with Pierre Curie.",
+                "url": "https://example.org/curie",
+            },
+            {
+                "title": "Pierre Curie",
+                "snippet": "Pierre Curie was born in Paris and collaborated with Marie Curie.",
+                "url": "https://example.org/pierre",
+            },
+        ]
+
+        context.add_to_history(query, results)
+
+        neighbors = context.get_graph_neighbors_for_nodes(
+            ["Marie Curie", "Pierre Curie", "Paris"], direction="both", limit=5
+        )
+        assert "Marie Curie" in neighbors
+        assert any(
+            edge.get("target") == "Pierre Curie" for edge in neighbors["Marie Curie"]
+        )
+        assert "Pierre Curie" in neighbors
+
+        stage_meta = context.get_graph_stage_metadata()
+        ingestion = stage_meta.get("ingestion", {})
+        assert ingestion.get("seconds", 0.0) >= 0.0
+        assert ingestion.get("relation_count", 0.0) >= 2
+        assert stage_meta.get("paths"), "Graph metadata should include multi-hop paths"
+
+        state = QueryState(query=query)
+        assert context.apply_scout_metadata(state)
+        scout_stage = state.metadata.get("scout_stage", {})
+        graph_meta = scout_stage.get("graph")
+        assert graph_meta, "Graph metadata should be persisted for planner use"
+        assert graph_meta.get("neighbors"), "Planner metadata should include neighbors"
+        assert graph_meta.get("paths"), "Planner metadata should include paths"
+        assert graph_meta.get("ingestion", {}).get("entity_count", 0.0) >= 2
+    StorageManager.teardown(remove_db=True)


### PR DESCRIPTION
## Summary
- lazy-load the session graph pipeline in `SearchContext`, capture ingestion latency, and surface planner-ready graph metadata through new helpers and scout-stage wiring
- add a `KnowledgeGraphPipeline` compatibility alias while updating `kg_reasoning` imports to avoid circular references
- expand integration coverage for graph metadata and add a new Graph RAG test exercising neighbor and path payloads

## Testing
- `uv run --extra test pytest tests/integration/test_knowledge_graph_pipeline.py tests/integration/test_graph_rag.py`


------
https://chatgpt.com/codex/tasks/task_e_68d99540e54c8333a605b75de2d59897