### PR TITLE
Add knowledge graph heuristics to gate policy and planner prompts

### DIFF
--- a/docs/search_backends.md
+++ b/docs/search_backends.md
@@ -72,3 +72,29 @@ produced:
 | bm25    | 1.00      | 1.00   | 1.93              |
 | semantic| 0.50      | 1.00   | 1.99              |
 | hybrid  | 0.75      | 1.00   | 2.20              |
+
+## Knowledge graph conditioning
+
+Context-aware search can enrich the planner and gate policy with knowledge graph
+signals. Configure these options in the `[search.context_aware]` section:
+
+```toml
+[search.context_aware]
+graph_signal_weight = 0.2
+planner_graph_conditioning = true
+```
+
+- `graph_signal_weight` scales supportive similarity signals derived from the
+  knowledge graph.
+- `planner_graph_conditioning` injects contradictions, neighbour snippets, and
+  provenance sources into planner prompts when enabled.
+
+Gate policy thresholds live at the top level of the configuration:
+
+```toml
+gate_graph_contradiction_threshold = 0.25
+gate_graph_similarity_threshold = 0.0
+```
+
+Tuning these values lets you balance how strongly graph contradictions or sparse
+similarity encourage a multi-agent debate.

--- a/src/autoresearch/agents/prompts.py
+++ b/src/autoresearch/agents/prompts.py
@@ -117,6 +117,8 @@ Guidelines:
 6. Anticipate potential challenges or limitations and how to address them
 7. Suggest criteria for evaluating the quality and relevance of information
 8. Create a structured outline with clear sections and subsections
+9. When knowledge graph context is provided, incorporate contradictions, neighbour paths,
+   and provenance cues into the plan
 
 Your research plan should be comprehensive, well-organized, and provide a clear roadmap for conducting thorough research on the topic.
 """,

--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -55,6 +55,19 @@ class ContextAwareSearchConfig(BaseModel):
         le=1.0,
         description="Weight applied to contradiction signals derived from the graph.",
     )
+    graph_signal_weight: float = Field(
+        default=0.2,
+        ge=0.0,
+        le=1.0,
+        description="Weight applied to supportive similarity signals derived from the graph.",
+    )
+    planner_graph_conditioning: bool = Field(
+        default=False,
+        description=(
+            "Inject knowledge graph contradictions, neighbours, and provenance into planner "
+            "prompts when true."
+        ),
+    )
 
 
 class LocalFileConfig(BaseModel):
@@ -400,6 +413,22 @@ class ConfigModel(BaseModel):
         ge=0.0,
         le=1.0,
         description="Minimum retrieval confidence required to skip debate",
+    )
+    gate_graph_contradiction_threshold: float = Field(
+        default=0.25,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Weighted contradiction score from the knowledge graph that triggers debate."
+        ),
+    )
+    gate_graph_similarity_threshold: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Minimum weighted graph similarity signal required to skip multi-loop debate."
+        ),
     )
     gate_user_overrides: Dict[str, Any] = Field(
         default_factory=dict,

--- a/src/autoresearch/orchestration/metrics.py
+++ b/src/autoresearch/orchestration/metrics.py
@@ -426,6 +426,7 @@ class OrchestrationMetrics:
             "coverage": decision.telemetry.get("coverage"),
             "contradiction_total": decision.telemetry.get("contradiction_total"),
             "contradiction_samples": decision.telemetry.get("contradiction_samples"),
+            "graph": decision.telemetry.get("graph"),
         }
         self.gate_events.append(event)
 

--- a/tests/helpers/config.py
+++ b/tests/helpers/config.py
@@ -23,6 +23,8 @@ class ContextAwareSearchConfigDump(TypedDict):
     expansion_factor: float
     use_search_history: bool
     max_history_items: int
+    graph_signal_weight: float
+    planner_graph_conditioning: bool
 
 
 class SearchConfigDump(TypedDict):
@@ -39,6 +41,8 @@ class ConfigModelDump(TypedDict):
     adaptive_max_factor: int
     adaptive_min_buffer: int
     search: SearchConfigDump
+    gate_graph_contradiction_threshold: float
+    gate_graph_similarity_threshold: float
 
 
 ContextOverrideValue = bool | float | int
@@ -53,6 +57,8 @@ class ContextAwareSearchConfigStub:
     expansion_factor: float = 0.3
     use_search_history: bool = True
     max_history_items: int = 10
+    graph_signal_weight: float = 0.2
+    planner_graph_conditioning: bool = False
 
 
 @dataclass(slots=True)
@@ -73,6 +79,8 @@ class ConfigModelStub:
     adaptive_max_factor: int = 20
     adaptive_min_buffer: int = 10
     search: SearchConfigStub = field(default_factory=SearchConfigStub)
+    gate_graph_contradiction_threshold: float = 0.25
+    gate_graph_similarity_threshold: float = 0.0
 
     def model_dump(self) -> ConfigModelDump:
         """Return a dictionary representation mirroring ``BaseModel``."""
@@ -95,8 +103,18 @@ class ConfigModelStub:
                     "max_history_items": (
                         self.search.context_aware.max_history_items
                     ),
+                    "graph_signal_weight": (
+                        self.search.context_aware.graph_signal_weight
+                    ),
+                    "planner_graph_conditioning": (
+                        self.search.context_aware.planner_graph_conditioning
+                    ),
                 },
             },
+            "gate_graph_contradiction_threshold": (
+                self.gate_graph_contradiction_threshold
+            ),
+            "gate_graph_similarity_threshold": self.gate_graph_similarity_threshold,
         }
 
 

--- a/tests/unit/test_planner_prompt_builder.py
+++ b/tests/unit/test_planner_prompt_builder.py
@@ -1,0 +1,59 @@
+from autoresearch.agents.specialized.planner import PlannerPromptBuilder
+
+
+def test_planner_prompt_builder_injects_graph_context() -> None:
+    """Graph context is summarised in the planner prompt when provided."""
+
+    graph_context = {
+        "contradictions": {
+            "weighted_score": 0.28,
+            "raw_score": 0.8,
+            "items": [
+                {
+                    "subject": "Policy A",
+                    "predicate": "conflicts_with",
+                    "objects": ["Policy B"],
+                }
+            ],
+        },
+        "similarity": {"weighted_score": 0.1, "raw_score": 0.2},
+        "neighbors": {
+            "Policy A": [
+                {
+                    "predicate": "relates_to",
+                    "target": "Policy C",
+                    "direction": "out",
+                }
+            ]
+        },
+        "paths": [["Policy A", "Policy B", "Policy C"]],
+        "sources": ["https://example.com/policy-a"],
+        "provenance": [{"source": "https://example.com/policy-a"}],
+    }
+
+    prompt = PlannerPromptBuilder(
+        base_prompt="Planner base",
+        query="Policy impact",
+        graph_context=graph_context,
+    ).build()
+
+    assert "Knowledge graph signals:" in prompt
+    assert "Graph similarity support: 0.10 (raw 0.20)" in prompt
+    assert "Contradiction score: 0.28 (raw 0.80)" in prompt
+    assert "Policy A --conflicts_with--> Policy B" in prompt
+    assert "Representative neighbours" in prompt
+    assert "Policy A → (relates_to) Policy C" in prompt
+    assert "Multi-hop paths" in prompt
+    assert "Policy A → Policy B → Policy C" in prompt
+    assert "Provenance sources: https://example.com/policy-a" in prompt
+
+
+def test_planner_prompt_builder_without_graph_context() -> None:
+    """No graph summary is included when graph context is absent."""
+
+    prompt = PlannerPromptBuilder(
+        base_prompt="Planner base",
+        query="Policy impact",
+    ).build()
+
+    assert "Knowledge graph signals:" not in prompt


### PR DESCRIPTION
## Summary
- add context-aware configuration for graph signal weighting, planner conditioning, and gate thresholds while documenting the new keys
- extend `ScoutGatePolicy` to consume knowledge graph contradiction and similarity signals with updated telemetry, overrides, and unit coverage
- enrich the planner prompt builder and template to surface knowledge graph context when enabled, with new dedicated tests

## Testing
- `uv run --extra test pytest tests/unit/test_planner_prompt_builder.py tests/unit/orchestration/test_gate_policy.py`
- `uv run task check` *(fails: mypy reports numerous missing stubs and pre-existing typing issues in optional components)*

------
https://chatgpt.com/codex/tasks/task_e_68d99dedd2b08333b699f4d3bac2a063