### PR TITLE
Add layered evaluation metrics exports and depth UX sync

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -23,6 +23,12 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   sweep complete linting, typing, and every unit, integration, and behavior
   suite while streaming the VSS loaders that previously blocked the gate.
   【F:baseline/logs/task-verify-20250930T174512Z.log†L1-L23】
+- Layered evaluation exports now persist planner depth, routing deltas, and CSV
+  twins alongside the Parquet files. The CLI depth help mirrors the Streamlit
+  toggles for knowledge graphs and graph exports, while the Streamlit claim
+  table adds per-claim detail toggles and Socratic prompt hints. The CSV schema
+  lives at `baseline/evaluation/metrics_schema.csv` for downstream diffing.
+  【F:src/autoresearch/cli_utils.py†L288-L323】【F:src/autoresearch/streamlit_app.py†L208-L244】【F:src/autoresearch/evaluation/harness.py†L63-L286】【F:baseline/evaluation/metrics_schema.csv†L1-L20】
 - `task coverage` succeeds again at 92.4 % statement coverage and records the
   CLI remediation banner so future release sweeps can rely on the Task
   entrypoints instead of `uv` wrappers.【F:baseline/logs/task-coverage-20250930T181947Z.log†L1-L21】

--- a/baseline/evaluation/metrics_schema.csv
+++ b/baseline/evaluation/metrics_schema.csv
@@ -1,0 +1,22 @@
+field,description
+run_id,Unique identifier combining dataset name timestamp and nonce
+config_signature,First 16 hex characters of the orchestrator config SHA-256 digest
+dataset,Lowercase dataset identifier (truthfulqa fever hotpotqa)
+total_examples,Number of prompts processed in the run
+accuracy,Share of correct answers across processed examples
+citation_coverage,Share of answers containing at least one citation
+contradiction_rate,Share of claim audits marked unsupported or refuted
+avg_planner_depth,Average planner dependency depth measured from the task graph
+avg_routing_delta,Average model routing cost savings reported per example
+total_routing_delta,Sum of routing cost savings across the run
+avg_routing_decisions,Average number of routing decisions taken per example
+avg_latency_seconds,Average wall-clock latency in seconds
+avg_tokens_input,Average prompt tokens consumed per example
+avg_tokens_output,Average completion tokens emitted per example
+avg_tokens_total,Average total tokens consumed per example
+avg_cycles_completed,Average number of orchestration cycles completed
+gate_debate_rate,Fraction of gated examples that escalated into debate
+gate_exit_rate,Fraction of gated examples that exited without debate
+gated_example_ratio,Share of examples that triggered the gate policy
+summary_path,Path to the summary parquet or csv artifact for the run
+examples_path,Path to the per-example parquet or csv artifact for the run

--- a/docs/deep_research_upgrade_plan.md
+++ b/docs/deep_research_upgrade_plan.md
@@ -50,9 +50,10 @@ keep truthfulness, verifiability, and cost discipline in balance.
      so downstream tools can visualise graph state per session.
 4. **Phase 4 – Evaluation Harness and Layered UX**
    - Automate TruthfulQA, FEVER, and HotpotQA smoke runs with KPIs.
-   - Add layered summaries, Socratic prompts, and per-claim audits to the
-     UI.
-   - Ensure CLI and GUI share consistent depth controls.
+   - Add layered summaries, Socratic prompts, per-claim audit toggles, and
+     claim badge guidance to the UI.
+   - Ensure CLI and GUI share consistent depth controls and expose the same
+     planner depth and routing metrics in CSV/Parquet exports.
 5. **Phase 5 – Cost-Aware Model Routing**
    - Assign models per role with budget-aware fallbacks.
    - Monitor token, latency, and accuracy metrics for regressions.

--- a/docs/output_formats.md
+++ b/docs/output_formats.md
@@ -16,6 +16,26 @@ Every format exposes the same core artifacts:
   run.
 - **Claim audits** – FEVER-style verification records with provenance maps.
 
+## Layered UX and exports
+
+Depth controls in the CLI (`--depth`) and Streamlit share the same sequence of
+levels—TL;DR, Concise, Standard, and Trace. Each level now publishes its enabled
+sections so operators know when TL;DR summaries, key findings, claim tables,
+knowledge graph panels, and graph exports are available. The Streamlit radio
+syncs with these options and surfaces toggle switches for each section.
+
+Claim audits gain dedicated toggles per row. Selecting **Show details for
+claim** reveals the audit JSON, top sources, and analyst notes. Badges mirror
+the CLI table: green (supported), amber (needs review), and red (unsupported).
+The Socratic prompt expander reuses the same depth payload to recommend
+follow-up questions grounded in the visible findings, citations, and claim
+statuses.
+
+Evaluation runs export the enriched metrics as Parquet and CSV pairs. The CSVs
+include the config signature, citation coverage, contradiction rate, average
+planner depth, routing deltas, and average routing decision count so telemetry
+pipelines can diff regressions without re-opening the database files.
+
 ### Markdown
 
 The default Markdown renderer highlights the TL;DR, answer, citations, and claim

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -8,29 +8,37 @@ outputs.
 Autoresearch responses are organised by depth levels that determine how much
 context is displayed. Depth can be selected from the CLI with `--depth` or via
 the Streamlit radio group. Each depth level now advertises the sections it
-unlocks—TL;DR summaries, key findings, claim tables, and the full reasoning
-trace. The CLI `--help` output lists these combinations, and JSON exports
-include a `sections` map so that downstream tools can enforce depth-aware
-policies.
+unlocks—TL;DR summaries, key findings, claim tables, the knowledge graph, graph
+export links, and the full reasoning trace. The CLI `--help` output lists these
+combinations, and JSON exports include a `sections` map so that downstream tools
+can enforce depth-aware policies.
 
-The Streamlit app mirrors these options with four toggles:
-**Show TL;DR**, **Show key findings**, **Show claim table**, and **Show full
-trace**. Toggle defaults are bound to the current depth so that moving to deeper
-views surfaces more context without retaining stale preferences.
+The Streamlit app mirrors these options with toggle switches for every layer:
+**Show TL;DR**, **Show key findings**, **Show claim table**, **Show full
+trace**, **Show knowledge graph**, and **Enable graph exports**. Toggle defaults
+are bound to the current depth so that moving to deeper views surfaces more
+context without retaining stale preferences.
 
 ## Provenance verification
 
 Claim verification is surfaced through the dedicated Provenance panel. Claim
 statuses are summarised in natural order (supported, needs review, unsupported)
 and the detailed table remains available when the claim table toggle is active.
-GraphRAG artifacts are also exposed in the Provenance panel to verify that graph
-reasoning supplied the cited evidence. When running at lower depths the panel
-explains which artefacts are hidden and how to reveal them.
+Each row exposes a **Show details for claim** toggle that reveals the full audit
+payload, top sources, and analyst notes. Badges reuse the CLI legend—green for
+supported, amber for needs review, red for unsupported—so the table, CLI, and
+CSV exports convey the same meaning. GraphRAG artifacts are also exposed in the
+Provenance panel to verify that graph reasoning supplied the cited evidence. At
+lower depths the panel explains which artefacts are hidden and how to reveal
+them.
 
 ## Socratic prompts and traces
 
-Socratic prompts adapt to the visible findings and claims, encouraging users to
-question evidence and explore follow-up angles. The full trace toggle governs
-both reasoning steps and ReAct event visualisations, making it simple to switch
-between quick summaries and full audit trails. Trace downloads retain the depth
-selection so exported Markdown or JSON matches the on-screen view.
+Socratic prompts adapt to the visible findings, citations, gate telemetry, and
+claims, encouraging users to question evidence and explore follow-up angles.
+The per-claim detail toggles pipe the same payload into the Socratic expander,
+so prompts reference the selected claim ID and supporting evidence. The full
+trace toggle governs both reasoning steps and ReAct event visualisations, making
+it simple to switch between quick summaries and full audit trails. Trace
+downloads retain the depth selection so exported Markdown or JSON matches the
+on-screen view.

--- a/src/autoresearch/cli_evaluation.py
+++ b/src/autoresearch/cli_evaluation.py
@@ -22,7 +22,7 @@ from .evaluation import EvaluationHarness, available_datasets
 evaluation_app = typer.Typer(
     help=(
         "Run curated TruthfulQA, FEVER, and HotpotQA subsets and persist telemetry "
-        "metrics for longitudinal tracking."
+        "metrics for longitudinal tracking, including Parquet and CSV exports."
     )
 )
 
@@ -106,6 +106,10 @@ def run_suite(
             artifact_paths.add(summary.example_parquet)
         if summary.summary_parquet:
             artifact_paths.add(summary.summary_parquet)
+        if summary.example_csv:
+            artifact_paths.add(summary.example_csv)
+        if summary.summary_csv:
+            artifact_paths.add(summary.summary_csv)
 
     if artifact_paths:
         print_info("Artifacts:")

--- a/src/autoresearch/cli_helpers.py
+++ b/src/autoresearch/cli_helpers.py
@@ -17,6 +17,7 @@ from .output_format import (
     get_depth_aliases,
     normalize_depth,
 )
+from .ui.provenance import depth_sequence
 
 from .cli_utils import (
     print_error,
@@ -126,9 +127,11 @@ def depth_help_text() -> str:
         "key_findings": "key findings",
         "claim_audits": "claim table",
         "full_trace": "full trace",
+        "knowledge_graph": "knowledge graph",
+        "graph_exports": "graph exports",
     }
     parts: List[str] = []
-    for depth in OutputDepth:
+    for depth in depth_sequence():
         desc = descriptions[depth]
         enabled = [
             label

--- a/src/autoresearch/output_format.py
+++ b/src/autoresearch/output_format.py
@@ -266,6 +266,8 @@ def describe_depth_features() -> Dict[OutputDepth, Dict[str, bool]]:
             "key_findings": plan.include_key_findings,
             "claim_audits": plan.include_claims,
             "full_trace": plan.include_reasoning and plan.include_react_traces,
+            "knowledge_graph": plan.include_knowledge_graph,
+            "graph_exports": plan.include_graph_exports,
         }
     return features
 

--- a/src/autoresearch/streamlit_app.py
+++ b/src/autoresearch/streamlit_app.py
@@ -2117,6 +2117,37 @@ def display_results(result: QueryResponse) -> None:
                     f"<tbody>{''.join(rows)}</tbody></table>"
                 )
                 st.markdown(table_html, unsafe_allow_html=True)
+                st.markdown("### Claim details", unsafe_allow_html=True)
+                for index, audit in enumerate(payload.claim_audits):
+                    claim_id = str(audit.get("claim_id") or index + 1)
+                    toggle_key = f"ui_claim_details_{claim_id}_{index}"
+                    default_state = st.session_state.get(toggle_key, False)
+                    show_details = toggle_widget(
+                        f"Show details for claim {claim_id}",
+                        key=toggle_key,
+                        value=default_state,
+                        help="Reveal full provenance, notes, and Socratic follow-ups.",
+                    )
+                    if show_details:
+                        status_label = str(audit.get("status", "unknown")).replace("_", " ").title()
+                        entailment_score = audit.get("entailment_score")
+                        entailment_display = (
+                            "—" if entailment_score is None else f"{entailment_score:.2f}"
+                        )
+                        st.markdown(f"- **Status:** {status_label}")
+                        st.markdown(f"- **Entailment:** {entailment_display}")
+                        if audit.get("notes"):
+                            st.markdown(f"- **Notes:** {audit['notes']}")
+                        sources = audit.get("sources") or []
+                        if sources:
+                            st.markdown("- **Sources:**")
+                            for source in sources:
+                                title = source.get("title") or source.get("url") or "Source"
+                                st.markdown(f"  - {title}")
+                        st.json(audit)
+                st.caption(
+                    "Claim badges: supported (green), needs review (amber), unsupported (red)."
+                )
             elif note := payload.notes.get("claim_audits"):
                 st.info(note)
             else:

--- a/tests/behavior/features/user_workflows.feature
+++ b/tests/behavior/features/user_workflows.feature
@@ -19,3 +19,9 @@ Feature: User workflows
     Given the Streamlit application is running
     When I run a query in the Streamlit interface
     Then the results should be displayed in a tabbed interface
+
+  Scenario: Layered UX exposes claim toggles and prompts
+    Given a layered depth payload with claim audits
+    When I derive layered UX guidance
+    Then the layered payload exposes claim toggles
+    And Socratic prompts include claim follow-ups

--- a/tests/behavior/steps/user_workflows_steps.py
+++ b/tests/behavior/steps/user_workflows_steps.py
@@ -1,5 +1,12 @@
 import pytest
-from pytest_bdd import scenario
+from pytest_bdd import given, scenario, then, when
+
+from autoresearch.models import QueryResponse
+from autoresearch.output_format import OutputDepth, OutputFormatter
+from autoresearch.ui.provenance import (
+    generate_socratic_prompts,
+    section_toggle_defaults,
+)
 
 pytest_plugins = [
     "tests.behavior.steps.common_steps",
@@ -27,3 +34,67 @@ def test_cli_workflow_invalid_backend(bdd_context):
 )
 def test_streamlit_ui_workflow() -> None:
     """Ensure the Streamlit UI renders search results."""
+
+
+@scenario(
+    "../features/user_workflows.feature",
+    "Layered UX exposes claim toggles and prompts",
+)
+def test_layered_ux_guidance() -> None:
+    """Behavior scenario verifying layered UX guidance."""
+
+
+@given("a layered depth payload with claim audits")
+def layered_payload(bdd_context) -> None:
+    """Build a standard-depth payload containing claim audits."""
+
+    response = QueryResponse(
+        answer="Autoresearch produces evidence-backed answers.\n\n- Item one",
+        citations=[{"title": "Source A"}],
+        reasoning=["Finding one", "Finding two"],
+        metrics={
+            "scout_gate": {
+                "rationales": {
+                    "coverage": {
+                        "triggered": True,
+                        "description": "coverage below policy",
+                    }
+                }
+            }
+        },
+        claim_audits=[
+            {
+                "claim_id": "C1",
+                "status": "supported",
+                "sources": [{"title": "Evidence"}],
+            }
+        ],
+    )
+    payload = OutputFormatter.plan_response_depth(response, OutputDepth.STANDARD)
+    bdd_context["depth_payload"] = payload
+
+
+@when("I derive layered UX guidance")
+def derive_guidance(bdd_context) -> None:
+    """Derive toggle defaults and Socratic prompts."""
+
+    payload = bdd_context["depth_payload"]
+    bdd_context["toggle_defaults"] = section_toggle_defaults(payload)
+    bdd_context["socratic_prompts"] = generate_socratic_prompts(payload)
+
+
+@then("the layered payload exposes claim toggles")
+def assert_claim_toggles(bdd_context) -> None:
+    """Ensure the claim table toggle is available and enabled."""
+
+    toggles = bdd_context["toggle_defaults"]
+    assert toggles["claim_audits"]["available"] is True
+    assert toggles["claim_audits"]["value"] is True
+
+
+@then("Socratic prompts include claim follow-ups")
+def assert_socratic_prompts(bdd_context) -> None:
+    """Verify generated Socratic prompts reference the claim."""
+
+    prompts = bdd_context["socratic_prompts"]
+    assert any("claim" in prompt.lower() for prompt in prompts)

--- a/tests/evaluation/test_harness.py
+++ b/tests/evaluation/test_harness.py
@@ -59,42 +59,73 @@ def test_dry_run_respects_limit_and_skips_runner(tmp_harness: EvaluationHarness)
     assert summary.gate_debate_rate is None
     assert summary.gate_exit_rate is None
     assert summary.gated_example_ratio == 0.0
+    assert summary.avg_planner_depth is None
+    assert summary.avg_routing_delta is None
+    assert summary.avg_routing_decisions is None
+    assert summary.total_routing_delta is None
+    assert summary.example_csv is None
+    assert summary.summary_csv is None
 
 
 def test_harness_persists_results_and_artifacts(tmp_harness: EvaluationHarness) -> None:
     """The harness persists DuckDB and Parquet outputs when enabled."""
 
+    call_counter = {"count": 0}
+
     def _runner(query: str, config: ConfigModel) -> QueryResponse:
-        if "breathe water" in query:
-            answer = "No, humans cannot breathe water without assistance."
-            status = "supported"
-        else:
-            answer = "Yes"
-            status = "refuted"
-        gate_should_debate = "breathe water" not in query
+        idx = call_counter["count"]
+        call_counter["count"] += 1
+        answer = (
+            "No, humans cannot breathe water without assistance."
+            if idx % 2 == 0
+            else "Evidence is inconclusive"
+        )
+        status = "supported" if idx % 2 == 0 else "unsupported"
+        gate_should_debate = idx % 2 == 0
         cycles_completed = 3 if gate_should_debate else 1
+        routing_total = 5.0 + idx
+        routing_decisions = idx + 1
+        execution_metrics = {
+            "total_duration_seconds": 1.2 + (0.3 * idx),
+            "total_tokens": {"input": 10 + idx, "output": 5 + idx, "total": 15 + 2 * idx},
+            "cycles_completed": cycles_completed,
+            "model_routing_cost_savings": {"total": routing_total},
+            "model_routing_decisions": [
+                {"agent": "synthesizer", "recommendation": "alt"}
+            ]
+            * routing_decisions,
+        }
+        gate_events = [
+            {
+                "should_debate": gate_should_debate,
+                "target_loops": cycles_completed,
+                "reason": "test_policy",
+                "tokens_saved_estimate": 42 + idx,
+                "heuristics": {"score": 0.8},
+                "thresholds": {"min_score": 0.5},
+            }
+        ]
+        task_graph = {
+            "tasks": [
+                {"id": "t1", "depends_on": []},
+                {"id": "t2", "depends_on": ["t1"]},
+                {"id": "t3", "depends_on": ["t2"]},
+            ],
+            "edges": [
+                {"source": "t1", "target": "t2"},
+                {"source": "t2", "target": "t3"},
+            ],
+        }
         return QueryResponse(
             answer=answer,
             citations=[{"source": "test"}],
             reasoning=[],
             metrics={
-                "execution_metrics": {
-                    "total_duration_seconds": 1.2,
-                    "total_tokens": {"input": 10, "output": 5, "total": 15},
-                    "cycles_completed": cycles_completed,
-                },
-                "gate_events": [
-                    {
-                        "should_debate": gate_should_debate,
-                        "target_loops": cycles_completed,
-                        "reason": "test_policy",
-                        "tokens_saved_estimate": 42,
-                        "heuristics": {"score": 0.8},
-                        "thresholds": {"min_score": 0.5},
-                    }
-                ],
+                "execution_metrics": execution_metrics,
+                "gate_events": gate_events,
             },
             claim_audits=[{"status": status}],
+            task_graph=task_graph,
         )
 
     harness = EvaluationHarness(
@@ -107,6 +138,7 @@ def test_harness_persists_results_and_artifacts(tmp_harness: EvaluationHarness) 
     summaries = harness.run(
         ["truthfulqa"],
         config=config,
+        limit=2,
         dry_run=False,
         store_duckdb=True,
         store_parquet=True,
@@ -116,48 +148,73 @@ def test_harness_persists_results_and_artifacts(tmp_harness: EvaluationHarness) 
     assert summary.accuracy is not None and pytest.approx(0.5) == summary.accuracy
     assert summary.citation_coverage == pytest.approx(1.0)
     assert summary.contradiction_rate == pytest.approx(0.5)
-    assert summary.avg_latency_seconds == pytest.approx(1.2)
-    assert summary.avg_tokens_input == pytest.approx(10.0)
-    assert summary.avg_tokens_output == pytest.approx(5.0)
-    assert summary.avg_tokens_total == pytest.approx(15.0)
+    assert summary.avg_latency_seconds == pytest.approx(1.35)
+    assert summary.avg_tokens_input == pytest.approx(10.5)
+    assert summary.avg_tokens_output == pytest.approx(5.5)
+    assert summary.avg_tokens_total == pytest.approx(16.0)
     assert summary.avg_cycles_completed == pytest.approx(2.0)
     assert summary.gate_debate_rate == pytest.approx(0.5)
     assert summary.gate_exit_rate == pytest.approx(0.5)
     assert summary.gated_example_ratio == pytest.approx(1.0)
+    assert summary.avg_planner_depth == pytest.approx(3.0)
+    assert summary.avg_routing_delta == pytest.approx(5.5)
+    assert summary.total_routing_delta == pytest.approx(11.0)
+    assert summary.avg_routing_decisions == pytest.approx(1.5)
     assert summary.duckdb_path == tmp_harness.duckdb_path
     assert summary.example_parquet and summary.example_parquet.exists()
     assert summary.summary_parquet and summary.summary_parquet.exists()
+    assert summary.example_csv and summary.example_csv.exists()
+    assert summary.summary_csv and summary.summary_csv.exists()
 
     with duckdb.connect(str(summary.duckdb_path)) as conn:
         count = conn.execute(
             "SELECT COUNT(*) FROM evaluation_results WHERE run_id = ?",
             [summary.run_id],
         ).fetchone()[0]
-        gate_rows = conn.execute(
+        example_rows = conn.execute(
             """
-            SELECT cycles_completed, gate_should_debate, gate_events
+            SELECT cycles_completed, gate_should_debate, planner_depth,
+                   routing_delta, routing_decision_count
             FROM evaluation_results
             WHERE run_id = ?
+            ORDER BY example_id
             """,
             [summary.run_id],
         ).fetchall()
         summary_row = conn.execute(
             """
-            SELECT gate_exit_rate, gate_debate_rate, avg_cycles_completed, gated_example_ratio
+            SELECT gate_exit_rate, gate_debate_rate, avg_cycles_completed,
+                   gated_example_ratio, avg_planner_depth, avg_routing_delta,
+                   total_routing_delta, avg_routing_decisions
             FROM evaluation_run_summary
             WHERE run_id = ?
             """,
             [summary.run_id],
         ).fetchone()
     assert count == summary.total_examples
-    assert gate_rows
-    assert {row[1] for row in gate_rows} == {True, False}
-    for row in gate_rows:
-        assert row[0] in {1, 3}
-        assert row[2] is not None
+    assert example_rows
+    assert {row[1] for row in example_rows} == {True, False}
+    for cycles, _debate, depth, routing_delta, routing_count in example_rows:
+        assert cycles in {1, 3}
+        assert depth == pytest.approx(3.0)
+        assert routing_delta in {5.0, 6.0}
+        assert routing_count in {1, 2}
     assert summary_row is not None
-    gate_exit_rate, gate_debate_rate, avg_cycles_completed, gated_ratio = summary_row
+    (
+        gate_exit_rate,
+        gate_debate_rate,
+        avg_cycles_completed,
+        gated_ratio,
+        avg_depth,
+        avg_routing,
+        total_routing,
+        avg_routing_decisions,
+    ) = summary_row
     assert gate_exit_rate == pytest.approx(summary.gate_exit_rate)
     assert gate_debate_rate == pytest.approx(summary.gate_debate_rate)
     assert avg_cycles_completed == pytest.approx(summary.avg_cycles_completed)
     assert gated_ratio == pytest.approx(summary.gated_example_ratio)
+    assert avg_depth == pytest.approx(summary.avg_planner_depth)
+    assert avg_routing == pytest.approx(summary.avg_routing_delta)
+    assert total_routing == pytest.approx(summary.total_routing_delta)
+    assert avg_routing_decisions == pytest.approx(summary.avg_routing_decisions)

--- a/tests/integration/test_cli_depth_controls.py
+++ b/tests/integration/test_cli_depth_controls.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import contextlib
+import importlib
+
+from typer.testing import CliRunner
+
+from autoresearch.config.models import ConfigModel
+from autoresearch.main.app import app as cli_app, _config_loader
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.output_format import OutputDepth, OutputFormatter
+from autoresearch.cli_helpers import depth_option_callback
+
+
+def test_search_depth_help_lists_features() -> None:
+    """CLI help enumerates layered depth features."""
+
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["search", "--help"])
+    assert result.exit_code == 0
+    output = result.stdout.lower()
+    assert "knowledge graph" in output
+    assert "graph exports" in output
+    assert "claim table" in output
+
+
+def test_search_depth_flag_forwards_to_formatter(monkeypatch) -> None:
+    """`--depth` forwards the parsed value to the output formatter."""
+
+    monkeypatch.setattr(
+        type(_config_loader), "load_config", lambda self: ConfigModel()
+    )
+    monkeypatch.setattr(
+        type(_config_loader), "watching", lambda self: contextlib.nullcontext()
+    )
+    monkeypatch.setattr(type(_config_loader), "stop_watching", lambda self: None)
+    dummy_response = QueryResponse(
+        answer="ok",
+        citations=[],
+        reasoning=[],
+        metrics={},
+    )
+
+    monkeypatch.setattr(
+        Orchestrator,
+        "run_query",
+        lambda self, query, config, callbacks=None, visualize=None: dummy_response,
+    )
+
+    captured_depths: list[OutputDepth | None] = []
+
+    def fake_render(cls, result, format_type="markdown", depth=None):
+        captured_depths.append(depth)
+        return "ok"
+
+    monkeypatch.setattr(OutputFormatter, "render", classmethod(fake_render))
+    cli_module = importlib.import_module("autoresearch.main.app")
+    monkeypatch.setattr(cli_module, "print_success", lambda *_, **__: None)
+    storage_module = importlib.import_module("autoresearch.storage")
+    monkeypatch.setattr(storage_module.StorageManager, "setup", staticmethod(lambda: None))
+    cli_module.search(
+        "depth probe",
+        output=None,
+        depth=OutputDepth.TRACE,
+        interactive=False,
+        reasoning_mode=None,
+        loops=None,
+        ontology=None,
+        ontology_reasoner=None,
+        ontology_reasoning=False,
+        token_budget=None,
+        gate_policy_enabled=None,
+        gate_retrieval_overlap_threshold=None,
+        gate_nli_conflict_threshold=None,
+        gate_complexity_threshold=None,
+        gate_user_overrides=None,
+        adaptive_max_factor=None,
+        adaptive_min_buffer=None,
+        circuit_breaker_threshold=None,
+        circuit_breaker_cooldown=None,
+        agents=None,
+        parallel=False,
+        agent_groups=None,
+        primus_start=None,
+        visualize=False,
+        graphml=None,
+        graph_json=None,
+    )
+    assert captured_depths == [OutputDepth.TRACE]
+
+    captured_depths.clear()
+    cli_module.search(
+        "depth alias",
+        output=None,
+        depth=depth_option_callback("3"),
+        interactive=False,
+        reasoning_mode=None,
+        loops=None,
+        ontology=None,
+        ontology_reasoner=None,
+        ontology_reasoning=False,
+        token_budget=None,
+        gate_policy_enabled=None,
+        gate_retrieval_overlap_threshold=None,
+        gate_nli_conflict_threshold=None,
+        gate_complexity_threshold=None,
+        gate_user_overrides=None,
+        adaptive_max_factor=None,
+        adaptive_min_buffer=None,
+        circuit_breaker_threshold=None,
+        circuit_breaker_cooldown=None,
+        agents=None,
+        parallel=False,
+        agent_groups=None,
+        primus_start=None,
+        visualize=False,
+        graphml=None,
+        graph_json=None,
+    )
+    assert captured_depths == [OutputDepth.TRACE]


### PR DESCRIPTION
## Summary
- extend the truthfulness evaluation harness to record planner depth, routing deltas, config signatures, and export Parquet/CSV summaries alongside DuckDB rows
- synchronize CLI depth help, Streamlit layered toggles, and Socratic prompts while documenting the layered UX and claim badge legend
- capture the metrics schema, update status tracking, and add unit/integration/behavior coverage for the new metrics and depth routing hooks

## Testing
- `uv run --extra test pytest tests/evaluation/test_harness.py tests/integration/test_cli_depth_controls.py`


------
https://chatgpt.com/codex/tasks/task_e_68d9bbcc91a883338a30ed41d62ff0e2