### PR TITLE
Add role-aware model routing policies and telemetry

### DIFF
--- a/docs/deep_research_upgrade_plan.md
+++ b/docs/deep_research_upgrade_plan.md
@@ -58,6 +58,11 @@ keep truthfulness, verifiability, and cost discipline in balance.
    - Assign models per role with budget-aware fallbacks.
    - Monitor token, latency, and accuracy metrics for regressions.
    - Publish tuning guides for operators.
+   - Persist routing decisions, overrides, and the active strategy via
+     `persist_model_routing_metrics` so dashboards can chart savings without
+     replaying runs. Initial simulations report roughly two currency units of
+     savings for the `cost_saver` policy while still logging gate-driven
+     escalations to premium models.【F:tests/performance/test_budget_router.py†L103-L152】
 
 ## Cross-Cutting Requirements
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -56,9 +56,38 @@ plot the following series to track performance regressions:
   including the baseline and selected models.
 - `model_routing_cost_savings`: cumulative difference between baseline and
   routed cost estimates derived from the logged decisions.
+- `model_routing_overrides`: the gate and planner escalation requests that
+  forced more capable models into the debate.
+- `model_routing_strategy`: the active routing profile (for example,
+  `balanced`, `cost_saver`, or `premium`) recorded with each run.
 
 These signals make it easy to confirm that cost savings materialise without
 raising the latency envelope for latency-sensitive agents.
+
+The `OrchestrationMetrics.persist_model_routing_metrics` helper appends these
+series as JSON Lines to ``AUTORESEARCH_ROUTING_METRICS`` (defaulting to
+``tests/integration/baselines/model_routing.json``). Dashboards can tail this
+file to display the chosen strategy, overrides, latency percentiles, and cost
+deltas without re-running orchestrations.
+
+## Role-Aware Routing Policies
+
+`config.model_routing.role_policies` maps each agent to preferred and allowed
+models, a token share or explicit budget, and a `confidence_threshold` that
+triggers escalations. When the scout gate or planner reports confidence below
+this threshold, the orchestrator registers a routing override that prioritises
+the policy's `escalation_model` and records the override in telemetry. This
+ensures expensive models are only invoked when evidence coverage looks weak or
+the planner produces low-confidence plans.
+
+## Routing Strategy Comparisons
+
+`EvaluationHarness.compare_routing_strategies` summarises accuracy, latency,
+token usage, and cost deltas between a baseline configuration and alternative
+model routing strategies. The helper accepts two sets of
+`EvaluationSummary` results and returns the difference in key metrics so teams
+can quantify the trade-offs between aggressive cost-saving strategies and
+premium accuracy-focused profiles before rolling them out broadly.
 
 ## Retrieval Cache and Parallel Controls
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -219,6 +219,11 @@ is fully attributable.
 - Each task encodes model preferences, tool requirements, and evidence exit
   criteria so cheaper models can handle low-risk work. The coordinator records
   actual routing decisions for evaluation.
+- Routing configuration exposes per-role policies with preferred and allowed
+  models, reserved token budgets, and `confidence_threshold` settings. When the
+  scout gate or planner reports confidence below this threshold the orchestrator
+  registers an override that escalates to the policy's `escalation_model` and
+  logs the decision for downstream audits.
 - Planner outputs persist in the query state for observability and debugging.
 - ``QueryState`` records the canonical task graph along with coordinator
   metadata. ``TaskCoordinator`` serialises every ReAct step (thought, action,
@@ -248,6 +253,10 @@ is fully attributable.
   config signatures.
 - Support A/B comparisons between gate policies, model routings, retrieval
   strategies, and GraphRAG enablement flags.
+- Persist the active routing strategy and override events so dashboards can
+  visualise escalation frequency. Provide `EvaluationHarness.compare_routing_
+  strategies` to contrast accuracy, latency, token usage, and cost savings
+  across routing configurations.
 - Highlight runs where accuracy drops more than 5% or the contradiction rate
   exceeds 0.10 so gate and routing policies can be reviewed alongside telemetry
   snapshots keyed by the config signature.

--- a/src/autoresearch/orchestration/execution.py
+++ b/src/autoresearch/orchestration/execution.py
@@ -274,7 +274,7 @@ def _execute_agent(
         return
     for attempt in range(retries):
         try:
-            metrics.apply_model_routing(agent_name, config)
+            metrics.apply_model_routing(agent_name, config, state)
             agent = _get_agent(agent_name, agent_factory)
             if not _check_agent_can_execute(agent, agent_name, state, config):
                 return

--- a/src/autoresearch/orchestration/model_routing.py
+++ b/src/autoresearch/orchestration/model_routing.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+"""Utilities for applying role-aware model routing policies."""
+
+from dataclasses import dataclass, field
+import time
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence
+
+from ..config.models import AgentConfig, ConfigModel, ModelRoutingConfig
+from ..logging_utils import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .metrics import OrchestrationMetrics
+
+
+log = get_logger(__name__)
+
+
+@dataclass
+class RoutingOverrideRequest:
+    """Explicit override applied by the gate, planner, or user."""
+
+    agent: str
+    requested_model: str | None
+    source: str
+    reason: str
+    confidence: float | None = None
+    threshold: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation of the override."""
+
+        payload = {
+            "agent": self.agent,
+            "requested_model": self.requested_model,
+            "source": self.source,
+            "reason": self.reason,
+            "created_at": self.created_at,
+        }
+        if self.confidence is not None:
+            payload["confidence"] = self.confidence
+        if self.threshold is not None:
+            payload["threshold"] = self.threshold
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+    def as_log_extra(self) -> dict[str, Any]:
+        """Return structured logging metadata."""
+
+        extra = self.to_dict()
+        extra["kind"] = "routing_override"
+        return extra
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> list["RoutingOverrideRequest"]:
+        """Build override requests from a serialisable mapping."""
+
+        if not isinstance(payload, Mapping):
+            return []
+        agents: list[str] = []
+        agent = payload.get("agent")
+        if agent:
+            agents = [str(agent)]
+        else:
+            agents_raw = payload.get("agents")
+            if isinstance(agents_raw, Sequence) and not isinstance(agents_raw, (str, bytes)):
+                agents = [str(item) for item in agents_raw if str(item).strip()]
+        model_map = payload.get("model_map")
+        if not agents:
+            return []
+        requested_model = payload.get("model")
+        confidence = payload.get("confidence")
+        threshold = payload.get("threshold")
+        metadata_raw = payload.get("metadata")
+        heuristics_raw = payload.get("heuristics")
+        metadata: dict[str, Any] = {}
+        if isinstance(metadata_raw, Mapping):
+            metadata.update({str(k): v for k, v in metadata_raw.items()})
+        if isinstance(heuristics_raw, Mapping):
+            metadata.setdefault("heuristics", dict(heuristics_raw))
+        reason = str(payload.get("reason") or "override").strip() or "override"
+        source = str(payload.get("source") or "unknown").strip() or "unknown"
+        requests: list[RoutingOverrideRequest] = []
+        for name in agents:
+            model = requested_model
+            if isinstance(model_map, Mapping):
+                mapped = model_map.get(name)
+                if mapped:
+                    model = mapped
+            try:
+                confidence_val = float(confidence) if confidence is not None else None
+            except (TypeError, ValueError):  # pragma: no cover - defensive guard
+                confidence_val = None
+            try:
+                threshold_val = float(threshold) if threshold is not None else None
+            except (TypeError, ValueError):  # pragma: no cover - defensive guard
+                threshold_val = None
+            requests.append(
+                cls(
+                    agent=str(name),
+                    requested_model=str(model) if model else None,
+                    source=source,
+                    reason=reason,
+                    confidence=confidence_val,
+                    threshold=threshold_val,
+                    metadata=dict(metadata),
+                )
+            )
+        return requests
+
+
+@dataclass
+class AgentRoutingDirectives:
+    """Resolved routing configuration for a specific agent."""
+
+    allowed_models: list[str] | None
+    preferred_models: list[str] | None
+    latency_slo_ms: float | None
+    token_share: float | None
+    budget_tokens: float | None
+    policy_name: str | None
+    strategy_name: str | None
+    override: RoutingOverrideRequest | None
+    default_model: str
+
+
+def _clamp_token_share(value: float | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return max(0.0, min(float(value), 1.0))
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        return None
+
+
+def _normalize_models(models: Iterable[str] | None) -> list[str]:
+    if not models:
+        return []
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for model in models:
+        key = str(model).strip()
+        if key and key not in seen:
+            seen.add(key)
+            ordered.append(key)
+    return ordered
+
+
+def _latest_override(
+    agent_name: str,
+    overrides: Sequence[RoutingOverrideRequest],
+) -> RoutingOverrideRequest | None:
+    lowered = agent_name.lower()
+    for override in reversed(list(overrides)):
+        if override.agent.lower() == lowered:
+            return override
+    return None
+
+
+def resolve_agent_directives(
+    agent_name: str,
+    config: ConfigModel,
+    routing_cfg: ModelRoutingConfig,
+    agent_cfg: AgentConfig | None,
+    overrides: Sequence[RoutingOverrideRequest],
+) -> AgentRoutingDirectives:
+    """Merge routing configuration, role policy, and overrides."""
+
+    policy_key, policy = routing_cfg.policy_for(agent_name)
+    preferred = None
+    allowed = None
+    latency_slo = None
+    token_share = None
+    budget_tokens = None
+    if policy:
+        preferred = _normalize_models(policy.preferred_models)
+        allowed = _normalize_models(policy.allowed_models)
+        latency_slo = policy.latency_slo_ms
+        token_share = policy.token_share
+        budget_tokens = float(policy.token_budget) if policy.token_budget is not None else None
+    if agent_cfg:
+        if agent_cfg.preferred_models:
+            preferred = _normalize_models(agent_cfg.preferred_models)
+        if agent_cfg.allowed_models:
+            allowed = _normalize_models(agent_cfg.allowed_models)
+        if agent_cfg.latency_slo_ms is not None:
+            latency_slo = agent_cfg.latency_slo_ms
+        if agent_cfg.token_share is not None:
+            token_share = agent_cfg.token_share
+    preferred = preferred or None
+    allowed = allowed or None
+    latency_slo = latency_slo if latency_slo is not None else None
+    token_share = _clamp_token_share(token_share)
+    override = _latest_override(agent_name, overrides)
+    if override and override.requested_model:
+        override_model = override.requested_model
+        preferred = [override_model] + [
+            model for model in (preferred or []) if model != override_model
+        ]
+        if allowed is None:
+            allowed = [override_model]
+        elif override_model not in allowed:
+            allowed = [override_model, *[m for m in allowed if m != override_model]]
+    default_model = (
+        (policy.default_model if policy and policy.default_model else None)
+        or config.default_model
+    )
+    return AgentRoutingDirectives(
+        allowed_models=allowed,
+        preferred_models=preferred,
+        latency_slo_ms=latency_slo,
+        token_share=token_share,
+        budget_tokens=budget_tokens,
+        policy_name=policy_key,
+        strategy_name=routing_cfg.strategy_name,
+        override=override,
+        default_model=default_model,
+    )
+
+
+def evaluate_gate_confidence_escalations(
+    config: ConfigModel,
+    metrics: "OrchestrationMetrics",
+    heuristics: Mapping[str, float],
+    *,
+    source: str = "scout_gate",
+) -> list[RoutingOverrideRequest]:
+    """Escalate routing when gate confidence drops below policy thresholds."""
+
+    routing_cfg = getattr(config, "model_routing", None)
+    if not routing_cfg or not routing_cfg.enabled or not routing_cfg.role_policies:
+        return []
+    confidence = heuristics.get("retrieval_confidence")
+    if confidence is None:
+        return []
+    overrides: list[RoutingOverrideRequest] = []
+    for agent_name, policy in routing_cfg.role_policies.items():
+        threshold = getattr(policy, "confidence_threshold", None)
+        if threshold is None:
+            continue
+        if confidence < threshold:
+            target_model = policy.escalation_model or policy.default_model
+            reason = policy.escalation_reason or "low_confidence"
+            override = metrics.request_model_escalation(
+                agent_name,
+                model=target_model,
+                source=source,
+                reason=reason,
+                confidence=confidence,
+                threshold=threshold,
+                metadata={"heuristics": dict(heuristics)},
+            )
+            overrides.append(override)
+    return overrides
+
+
+def ingest_state_overrides(payload: Any) -> list[RoutingOverrideRequest]:
+    """Convert planner/state-provided overrides into request objects."""
+
+    requests: list[RoutingOverrideRequest] = []
+    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes)):
+        for entry in payload:
+            if isinstance(entry, Mapping):
+                requests.extend(RoutingOverrideRequest.from_payload(entry))
+    return requests

--- a/src/autoresearch/orchestration/orchestration_utils.py
+++ b/src/autoresearch/orchestration/orchestration_utils.py
@@ -37,6 +37,7 @@ from .execution import (
     _rotate_list,
 )
 from .metrics import OrchestrationMetrics
+from .model_routing import evaluate_gate_confidence_escalations
 from .state import QueryState
 from .token_utils import _capture_token_usage, _execute_with_adapter
 from .utils import calculate_result_confidence, get_memory_usage
@@ -222,6 +223,12 @@ class ScoutGatePolicy:
         }
         if graph_telemetry:
             telemetry["graph"] = graph_telemetry
+
+        evaluate_gate_confidence_escalations(
+            config=self.config,
+            metrics=metrics,
+            heuristics=heuristics,
+        )
 
         decision = ScoutGateDecision(
             should_debate=should_debate,

--- a/src/autoresearch/token_budget.py
+++ b/src/autoresearch/token_budget.py
@@ -108,6 +108,7 @@ class RoutingDecision:
     cost_before: float | None
     cost_after: float | None
     pressure_ratio: float
+    metadata: dict[str, Any] | None = None
 
     def cost_savings(self) -> float | None:
         """Return the estimated currency saved by routing decisions."""
@@ -132,6 +133,8 @@ class RoutingDecision:
             "cost_savings": self.cost_savings(),
             "pressure_ratio": self.pressure_ratio,
         }
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
         if self.usage is not None:
             payload.update(
                 {


### PR DESCRIPTION
## Summary
- implement role-specific routing directives that combine policy, state overrides, and gate/planner escalations
- persist routing strategies, overrides, and cost metrics via orchestration telemetry and evaluation exports
- document tuning guidance, savings, and new evaluation comparisons for routing strategies

## Testing
- `uv run --extra test pytest tests/performance/test_budget_router.py tests/evaluation/test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_68d9c3d8be108333be6b3fdd64200ed5