### PR TITLE
Clean Streamlit GUI test imports and archive logs

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,5 +1,13 @@
 # Autoresearch Project - Task Progress
 
+As of **2025-09-29** at 01:07 UTC the unused `os` import in
+`tests/integration/test_streamlit_gui.py` is gone, the pandas fallback stub
+remains, and targeted lint plus UI regression runs are green. Fresh logs at
+`baseline/logs/flake8-20250929T010657Z.log` and
+`baseline/logs/pytest-streamlit-20250929T010704Z.log` capture the clean
+`flake8` exit and the expected Streamlit skip banner under the `.[test]`
+extra.
+
 As of **2025-09-29** at 00:08 UTC we reran `uv run task release:alpha` after
 closing out the deep research phase tracking below. Extras synced before
 `uv run flake8 src tests` reported the unused `os` import in

--- a/baseline/logs/flake8-20250929T010657Z.log
+++ b/baseline/logs/flake8-20250929T010657Z.log
@@ -1,0 +1,4 @@
+Command: uv run --extra dev-minimal --extra test flake8 src tests
+Timestamp (UTC): 20250929T010657Z
+
+Status: success

--- a/baseline/logs/pytest-streamlit-20250929T010704Z.log
+++ b/baseline/logs/pytest-streamlit-20250929T010704Z.log
@@ -1,0 +1,6 @@
+Command: uv run --extra test pytest tests/integration/test_streamlit_gui.py -q
+Timestamp (UTC): 20250929T010704Z
+
+
+1 skipped in 0.26s
+Status: success

--- a/tests/integration/test_streamlit_gui.py
+++ b/tests/integration/test_streamlit_gui.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace


### PR DESCRIPTION
## Summary
- drop the unused `os` import from the Streamlit GUI regression test while preserving the pandas stub
- archive the latest lint and targeted Streamlit test logs and reference them from `TASK_PROGRESS.md`

## Testing
- uv run --extra dev-minimal --extra test flake8 src tests
- uv run --extra test pytest tests/integration/test_streamlit_gui.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d9db58d9b883339f482bf41aae9600