### PR TITLE
Add typed orchestration test helpers and vend strict stubs

### DIFF
--- a/src/autoresearch/orchestration/token_utils.py
+++ b/src/autoresearch/orchestration/token_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
-from typing import Any, Protocol, TypeGuard, cast
+from typing import Protocol, TypeGuard, cast
 
 from ..config.models import ConfigModel
 from .metrics import OrchestrationMetrics
@@ -13,7 +13,7 @@ from .types import AgentExecutionResult
 class AdapterProtocol(Protocol):
     """Structural protocol capturing the ``generate`` method used by adapters."""
 
-    def generate(self, prompt: str, model: str | None = None, **kwargs: Any) -> str:
+    def generate(self, prompt: str, model: str | None = None, **kwargs: object) -> str:
         """Generate a response for ``prompt``."""
 
 
@@ -24,7 +24,7 @@ class SupportsExecute(Protocol):
         self,
         state: QueryState,
         config: ConfigModel,
-        **kwargs: Any,
+        **kwargs: object,
     ) -> AgentExecutionResult:
         """Execute the agent with optional keyword arguments."""
 
@@ -65,7 +65,7 @@ def supports_adapter_mutation(obj: object) -> TypeGuard[SupportsExecuteWithMutat
     return callable(set_adapter) and callable(get_adapter) and callable(execute)
 
 
-def supports_adapter_setter(obj: SupportsExecute) -> TypeGuard[SupportsExecuteWithAdapterSetter]:
+def supports_adapter_setter(obj: object) -> TypeGuard[SupportsExecuteWithAdapterSetter]:
     """Return ``True`` when ``obj`` supports adapter injection via ``set_adapter``."""
 
     set_adapter = getattr(obj, "set_adapter", None)
@@ -119,7 +119,7 @@ def _capture_token_usage(
                     self.inner = inner
 
                 def generate(
-                    self, prompt: str, model: str | None = None, **kwargs: Any
+                    self, prompt: str, model: str | None = None, **kwargs: object
                 ) -> str:
                     prompt = metrics.compress_prompt_if_needed(prompt, tb)
                     return self.inner.generate(prompt, model=model, **kwargs)

--- a/src/autoresearch/orchestration/utils.py
+++ b/src/autoresearch/orchestration/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, Deque
+from typing import Deque, TypeVar
 
 from ..models import QueryResponse
 
@@ -102,7 +102,10 @@ def calculate_result_confidence(result: QueryResponse) -> float:
     return max(0.1, min(1.0, confidence))
 
 
-def enqueue_with_limit(queue: Deque[Any], item: Any, limit: int) -> bool:
+T = TypeVar("T")
+
+
+def enqueue_with_limit(queue: Deque[T], item: T, limit: int) -> bool:
     """Append an item if the queue is below a size limit.
 
     Args:

--- a/tests/integration/test_monitor_metrics.py
+++ b/tests/integration/test_monitor_metrics.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+import sys
 import time
+from collections.abc import Callable, Iterator
+from typing import cast
 
 import psutil
 import pytest
+from requests import Response as RequestsResponse
+from fastapi.testclient import TestClient
 from prometheus_client import CollectorRegistry, generate_latest
 from typer.testing import CliRunner
 
@@ -12,27 +19,53 @@ from autoresearch.models import QueryResponse
 from autoresearch.monitor.system_monitor import SystemMonitor
 from autoresearch.orchestration import metrics
 from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.types import CallbackMap
 from autoresearch.resource_monitor import ResourceMonitor
 
 
-def dummy_run_query(query, config, callbacks=None, **kwargs):
+MonitorSetup = Callable[[ConfigModel | None], ConfigModel]
+
+
+def dummy_run_query(
+    query: str,
+    config: ConfigModel,
+    callbacks: CallbackMap | None = None,
+    **_: object,
+) -> QueryResponse:
     metrics.record_query()
     return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
 
-def setup_patches(monkeypatch):
-    cfg = ConfigModel(loops=1, output_format="json")
-    cfg.api.role_permissions["anonymous"] = ["query", "metrics"]
-    cfg.api.monitoring_enabled = True
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
-    responses = iter(["test", "", "q"])
-    monkeypatch.setattr("autoresearch.main.Prompt.ask", lambda *a, **k: next(responses))
-    monkeypatch.setattr(Orchestrator, "run_query", dummy_run_query)
-    monkeypatch.setattr("autoresearch.monitor.Orchestrator", Orchestrator)
-    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+@pytest.fixture
+def monitor_cli_setup(monkeypatch: pytest.MonkeyPatch) -> MonitorSetup:
+    """Return a callable that applies CLI patches with typed state."""
+
+    def _apply(config: ConfigModel | None = None) -> ConfigModel:
+        cfg = config or ConfigModel(loops=1, output_format="json")
+        cfg.api.role_permissions.setdefault("anonymous", [])
+        cfg.api.role_permissions["anonymous"] = ["query", "metrics"]
+        cfg.api.monitoring_enabled = True
+
+        def _load_config(_: ConfigLoader) -> ConfigModel:
+            return cfg
+
+        monkeypatch.setattr(ConfigLoader, "load_config", _load_config)
+
+        responses: Iterator[str] = iter(["test", "", "q"])
+
+        def _ask(*_: object, **__: object) -> str:
+            return next(responses)
+
+        monkeypatch.setattr("autoresearch.main.Prompt.ask", _ask)
+        monkeypatch.setattr(Orchestrator, "run_query", dummy_run_query)
+        monkeypatch.setattr("autoresearch.monitor.Orchestrator", Orchestrator)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        return cfg
+
+    return _apply
 
 
-def test_sampling_frequency_formula():
+def test_sampling_frequency_formula() -> None:
     f_base = 1.0
     f_max = 5.0
     load = 0.75
@@ -41,7 +74,7 @@ def test_sampling_frequency_formula():
     assert freq == pytest.approx(2.5)
 
 
-def test_resource_threshold_formula():
+def test_resource_threshold_formula() -> None:
     samples = [40, 50, 60, 50]
     mean = sum(samples) / len(samples)
     var = sum((x - mean) ** 2 for x in samples) / (len(samples) - 1)
@@ -52,19 +85,22 @@ def test_resource_threshold_formula():
 
 
 @pytest.mark.slow
-def test_monitor_cli_increments_counter(monkeypatch, api_client):
-    setup_patches(monkeypatch)
+def test_monitor_cli_increments_counter(
+    monitor_cli_setup: MonitorSetup, api_client: TestClient
+) -> None:
+    monitor_cli_setup(None)
     runner = CliRunner()
     start = metrics.QUERY_COUNTER._value.get()
     result = runner.invoke(cli_app, ["monitor", "run"])
     assert result.exit_code == 0
     assert metrics.QUERY_COUNTER._value.get() >= start
     resp = api_client.get("/metrics")
-    assert resp.status_code == 200
-    assert "autoresearch_queries_total" in resp.text
+    response = cast(RequestsResponse, resp)
+    assert response.status_code == 200
+    assert "autoresearch_queries_total" in response.text
 
 
-def test_resource_monitor_collects_metrics():
+def test_resource_monitor_collects_metrics() -> None:
     registry = CollectorRegistry()
     monitor = ResourceMonitor(interval=0.01, registry=registry)
     monitor.start()
@@ -80,12 +116,13 @@ def test_resource_monitor_collects_metrics():
     assert monitor.token_snapshots
 
 
-def test_system_monitor_metrics_exposed(monkeypatch, api_client):
-    setup_patches(monkeypatch)
-    cfg = ConfigModel(loops=1, output_format="json")
+def test_system_monitor_metrics_exposed(
+    monitor_cli_setup: MonitorSetup,
+    monkeypatch: pytest.MonkeyPatch,
+    api_client: TestClient,
+) -> None:
+    cfg = monitor_cli_setup(ConfigModel(loops=1, output_format="json"))
     cfg.api.role_permissions["anonymous"] = ["metrics"]
-    cfg.api.monitoring_enabled = True
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     monkeypatch.setattr(psutil, "cpu_percent", lambda interval=None: 5.0)
     mem = type("m", (), {"percent": 10.0})()
     monkeypatch.setattr(psutil, "virtual_memory", lambda: mem)
@@ -96,19 +133,20 @@ def test_system_monitor_metrics_exposed(monkeypatch, api_client):
     monitor.stop()
 
     resp = api_client.get("/metrics")
-    assert resp.status_code == 200
-    assert "autoresearch_system_cpu_percent" in resp.text
-    assert "autoresearch_system_memory_percent" in resp.text
+    response = cast(RequestsResponse, resp)
+    assert response.status_code == 200
+    assert "autoresearch_system_cpu_percent" in response.text
+    assert "autoresearch_system_memory_percent" in response.text
 
 
 @pytest.mark.slow
-def test_monitor_start_cli(monkeypatch):
+def test_monitor_start_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = {}
 
-    def fake_start(self, prometheus_port=None):
+    def fake_start(self: ResourceMonitor, prometheus_port: int | None = None) -> None:
         calls["port"] = prometheus_port
 
-    def fake_stop(self):
+    def fake_stop(self: ResourceMonitor) -> None:
         calls["stop"] = True
 
     monkeypatch.setattr(ResourceMonitor, "start", fake_start)
@@ -138,7 +176,7 @@ def test_monitor_start_cli(monkeypatch):
     assert calls["sys_stop"]
 
 
-def test_monitor_resources_cli(monkeypatch):
+def test_monitor_resources_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         metrics,
         "_get_system_usage",
@@ -152,10 +190,13 @@ def test_monitor_resources_cli(monkeypatch):
     assert "GPU MB" in out
 
 
-def test_metrics_requires_api_key(monkeypatch, api_client):
+def test_metrics_requires_api_key(
+    monkeypatch: pytest.MonkeyPatch, api_client: TestClient
+) -> None:
     cfg = ConfigModel(api=APIConfig(api_key="secret", monitoring_enabled=True))
     cfg.api.role_permissions["user"] = ["metrics"]
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     resp = api_client.get("/metrics")
-    assert resp.status_code == 401
-    assert resp.headers["WWW-Authenticate"] == "API-Key"
+    response = cast(RequestsResponse, resp)
+    assert response.status_code == 401
+    assert response.headers["WWW-Authenticate"] == "API-Key"

--- a/tests/typing_helpers.py
+++ b/tests/typing_helpers.py
@@ -17,6 +17,11 @@ from pytest_bdd import scenario as _scenario
 from pytest_bdd import then as _then
 from pytest_bdd import when as _when
 
+from autoresearch.config.models import ConfigModel
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.state import QueryState
+from autoresearch.orchestration.types import AgentExecutionResult, CallbackMap
+
 R_co = TypeVar("R_co")
 T = TypeVar("T")
 
@@ -49,6 +54,38 @@ class ScenarioFactory(Protocol):
     ) -> StepDecorator[None]: ...
 
 
+class AgentTestProtocol(Protocol):
+    """Protocol capturing the agent surface used within tests."""
+
+    def can_execute(self, state: QueryState, config: ConfigModel) -> bool: ...
+
+    def execute(
+        self,
+        state: QueryState,
+        config: ConfigModel,
+        **kwargs: object,
+    ) -> AgentExecutionResult: ...
+
+
+class AgentFactoryProtocol(Protocol):
+    """Protocol for factories that resolve agent instances by name."""
+
+    @staticmethod
+    def get(name: str) -> AgentTestProtocol: ...
+
+
+class QueryRunner(Protocol):
+    """Protocol mirroring :meth:`Orchestrator.run_query` call semantics."""
+
+    def __call__(
+        self,
+        query: str,
+        config: ConfigModel,
+        callbacks: CallbackMap | None = None,
+        **kwargs: object,
+    ) -> QueryResponse: ...
+
+
 given = cast("StepFactory[Any]", _given)
 when = cast("StepFactory[Any]", _when)
 then = cast("StepFactory[Any]", _then)
@@ -59,6 +96,9 @@ __all__ = [
     "StepDecorator",
     "StepFactory",
     "ScenarioFactory",
+    "AgentTestProtocol",
+    "AgentFactoryProtocol",
+    "QueryRunner",
     "given",
     "when",
     "then",

--- a/tests/unit/orchestration/test_utils_confidence.py
+++ b/tests/unit/orchestration/test_utils_confidence.py
@@ -7,7 +7,7 @@ from autoresearch.orchestration.utils import MetricsSnapshot, TokenUsageSnapshot
 
 
 def build_response(**overrides: object) -> QueryResponse:
-    base = {
+    base: dict[str, object] = {
         "answer": "result",
         "citations": [],
         "reasoning": [],

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -1,58 +1,75 @@
+from __future__ import annotations
+
+from typing import cast
+
 import pytest
 from unittest.mock import MagicMock
 
+from autoresearch.agents.registry import AgentFactory
 from autoresearch.config.models import ConfigModel
 from autoresearch.errors import NotFoundError, StorageError
 from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.orchestration.state import QueryState
+from tests.typing_helpers import AgentFactoryProtocol, AgentTestProtocol
 
 
 class DummyAgent:
-    def can_execute(self, state, config):
+    """Simple agent used to validate OrchestrationUtils helpers."""
+
+    def can_execute(self, state: QueryState, config: ConfigModel) -> bool:
         return True
 
-    def execute(self, state, config, **_):
+    def execute(
+        self, state: QueryState, config: ConfigModel, **_: object
+    ) -> dict[str, object]:
         return {"results": {"dummy": "ok"}}
 
 
-class DummyFactory:
+class DummyFactory(AgentFactoryProtocol):
+    """Factory that resolves the dummy agent by name."""
+
     @staticmethod
-    def get(name: str):
+    def get(name: str) -> AgentTestProtocol:
         if name == "Dummy":
             return DummyAgent()
         raise ValueError("not found")
 
 
-def test_get_agent_success():
-    agent = OrchestrationUtils.get_agent("Dummy", DummyFactory)
+def test_get_agent_success() -> None:
+    factory = cast(type[AgentFactory], DummyFactory)
+    agent = OrchestrationUtils.get_agent("Dummy", factory)
     assert isinstance(agent, DummyAgent)
 
 
-def test_get_agent_not_found():
+def test_get_agent_not_found() -> None:
+    factory = cast(type[AgentFactory], DummyFactory)
     with pytest.raises(NotFoundError) as excinfo:
-        OrchestrationUtils.get_agent("Missing", DummyFactory)
+        OrchestrationUtils.get_agent("Missing", factory)
     assert isinstance(excinfo.value.__cause__, ValueError)
 
     state = QueryState(query="q")
-    cfg = ConfigModel.model_construct(enable_agent_messages=True)
+    cfg = ConfigModel(enable_agent_messages=True)
     state.add_message({"to": "Dummy", "content": "hi"})
     OrchestrationUtils.deliver_messages("Dummy", state, cfg)
     assert "Dummy" in state.metadata.get("delivered_messages", {})
 
 
-def test_call_agent_start_callback():
+def test_call_agent_start_callback() -> None:
     state = QueryState(query="q")
-    calls = []
-    OrchestrationUtils.call_agent_start_callback(
-        "Dummy", state, {"on_agent_start": lambda a, s: calls.append(a)}
-    )
+    calls: list[str] = []
+
+    def _capture(agent_name: str, _: QueryState) -> None:
+        calls.append(agent_name)
+
+    callbacks = {"on_agent_start": _capture}
+    OrchestrationUtils.call_agent_start_callback("Dummy", state, callbacks)
     assert calls == ["Dummy"]
 
 
-def test_persist_claims_logs_storage_error(caplog):
+def test_persist_claims_logs_storage_error(caplog: pytest.LogCaptureFixture) -> None:
     storage = MagicMock()
     storage.persist_claim.side_effect = StorageError("fail")
-    result = {"claims": [{"id": "c1"}]}
+    result: dict[str, object] = {"claims": [{"id": "c1"}]}
 
     with caplog.at_level("WARNING"):
         OrchestrationUtils.persist_claims("Agent", result, storage)

--- a/typings/duckdb_extension_vss/__init__.pyi
+++ b/typings/duckdb_extension_vss/__init__.pyi
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class SupportsLoad(Protocol):
+    def load(self, connection: Any) -> None: ...
+
+
+def load(connection: Any) -> None: ...
+
+
+__all__ = ["SupportsLoad", "load"]

--- a/typings/networkx/__init__.pyi
+++ b/typings/networkx/__init__.pyi
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from collections.abc import Hashable, Iterable, Iterator, Mapping, MutableMapping, Sequence
+from typing import Any, Generic, TypeVar
+
+NodeT = TypeVar("NodeT", bound=Hashable)
+_NodeT = TypeVar("_NodeT")
+
+NodeData = MutableMapping[str, Any]
+
+
+class NodeView(Mapping[_NodeT, NodeData], Generic[_NodeT]):
+    def __call__(self, data: bool = ..., default: Any = ...) -> Iterable[_NodeT] | Iterable[tuple[_NodeT, NodeData]]: ...
+
+    def __iter__(self) -> Iterator[_NodeT]: ...
+
+    def __len__(self) -> int: ...
+
+    def __contains__(self, node: object) -> bool: ...
+
+    def __getitem__(self, node: _NodeT) -> NodeData: ...
+
+
+class DiGraph(Generic[_NodeT]):
+    def __init__(self, incoming_graph_data: Any | None = ..., **attr: Any) -> None: ...
+
+    nodes: NodeView[_NodeT]
+
+    def add_node(self, node_for_adding: _NodeT, **attr: Any) -> None: ...
+
+    def add_edge(self, u_of_edge: _NodeT, v_of_edge: _NodeT, **attr: Any) -> None: ...
+
+    def remove_node(self, n: _NodeT) -> None: ...
+
+    def remove_edge(self, u: _NodeT, v: _NodeT) -> None: ...
+
+    def edges(
+        self, data: bool = ..., default: Any = ...
+    ) -> Iterable[tuple[_NodeT, _NodeT]] | Iterable[tuple[_NodeT, _NodeT, dict[str, Any]]]: ...
+
+    def has_node(self, n: _NodeT) -> bool: ...
+
+    def number_of_nodes(self) -> int: ...
+
+    def degree(self) -> Mapping[_NodeT, int]: ...
+
+    def clear(self) -> None: ...
+
+    def __iter__(self) -> Iterator[_NodeT]: ...
+
+
+class MultiDiGraph(Generic[_NodeT]):
+    def __init__(self, incoming_graph_data: Any | None = ..., **attr: Any) -> None: ...
+
+    nodes: NodeView[_NodeT]
+
+    def add_node(self, node_for_adding: _NodeT, **attr: Any) -> None: ...
+
+    def add_edge(self, u_of_edge: _NodeT, v_of_edge: _NodeT, key: Any | None = ..., **attr: Any) -> None: ...
+
+    def remove_node(self, n: _NodeT) -> None: ...
+
+    def edges(
+        self, data: bool = ..., default: Any = ...
+    ) -> Iterable[tuple[_NodeT, _NodeT, Any]] | Iterable[tuple[_NodeT, _NodeT, Any, dict[str, Any]]]: ...
+
+    def has_node(self, n: _NodeT) -> bool: ...
+
+    def number_of_nodes(self) -> int: ...
+
+    def clear(self) -> None: ...
+
+    def __iter__(self) -> Iterator[_NodeT]: ...
+
+
+def spring_layout(
+    graph: DiGraph[NodeT] | MultiDiGraph[NodeT],
+    *,
+    seed: int | None = ...,
+    center: tuple[float, float] | None = ...,
+) -> dict[NodeT, tuple[float, float]]: ...
+
+
+def circular_layout(
+    graph: DiGraph[NodeT] | MultiDiGraph[NodeT],
+) -> dict[NodeT, tuple[float, float]]: ...
+
+
+def draw(graph: DiGraph[NodeT] | MultiDiGraph[NodeT], *args: Any, **kwargs: Any) -> None: ...
+
+
+def draw_networkx_nodes(
+    graph: DiGraph[NodeT] | MultiDiGraph[NodeT],
+    pos: Mapping[NodeT, tuple[float, float]],
+    *args: Any,
+    **kwargs: Any,
+) -> None: ...
+
+
+def draw_networkx_edges(
+    graph: DiGraph[NodeT] | MultiDiGraph[NodeT],
+    pos: Mapping[NodeT, tuple[float, float]],
+    *args: Any,
+    **kwargs: Any,
+) -> None: ...
+
+
+def draw_networkx_labels(
+    graph: DiGraph[NodeT] | MultiDiGraph[NodeT],
+    pos: Mapping[NodeT, tuple[float, float]],
+    *args: Any,
+    **kwargs: Any,
+) -> None: ...
+
+
+def generate_graphml(graph: DiGraph[NodeT] | MultiDiGraph[NodeT]) -> Iterable[str]: ...
+
+
+def all_simple_paths(
+    graph: DiGraph[NodeT] | MultiDiGraph[NodeT],
+    source: NodeT,
+    target: NodeT,
+    cutoff: int | None = ...,
+) -> Iterable[list[NodeT]]: ...
+
+
+__all__ = [
+    "NodeView",
+    "DiGraph",
+    "MultiDiGraph",
+    "spring_layout",
+    "circular_layout",
+    "draw",
+    "draw_networkx_nodes",
+    "draw_networkx_edges",
+    "draw_networkx_labels",
+    "generate_graphml",
+    "all_simple_paths",
+]

--- a/typings/networkx/readwrite/json_graph.pyi
+++ b/typings/networkx/readwrite/json_graph.pyi
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .. import DiGraph, MultiDiGraph
+
+
+def node_link_data(graph: DiGraph[Any] | MultiDiGraph[Any]) -> dict[str, Any]: ...
+
+
+__all__ = ["node_link_data"]

--- a/typings/ray/__init__.pyi
+++ b/typings/ray/__init__.pyi
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any, Generic, Protocol, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+class ObjectRef(Generic[T]):
+    ...
+
+
+class RemoteFunction(Generic[R], Protocol):
+    def remote(self, *args: Any, **kwargs: Any) -> ObjectRef[R]: ...
+
+
+def init(*args: Any, **kwargs: Any) -> None: ...
+
+def shutdown() -> None: ...
+
+def is_initialized() -> bool: ...
+
+def put(value: T) -> ObjectRef[T]: ...
+
+def get(ref: ObjectRef[T] | Sequence[ObjectRef[T]]) -> T | list[T]: ...
+
+def remote(func: Callable[..., R]) -> RemoteFunction[R]: ...
+
+def cluster_resources() -> dict[str, float]: ...
+
+
+__all__ = [
+    "ObjectRef",
+    "RemoteFunction",
+    "init",
+    "shutdown",
+    "is_initialized",
+    "put",
+    "get",
+    "remote",
+    "cluster_resources",
+]

--- a/typings/ray/util/queue.pyi
+++ b/typings/ray/util/queue.pyi
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class Queue(Generic[T]):
+    def __init__(self, maxsize: int | None = ...) -> None: ...
+
+    def put(self, item: T, *, block: bool = ..., timeout: float | None = ...) -> None: ...
+
+    def get(self, *, block: bool = ..., timeout: float | None = ...) -> T: ...
+
+    def shutdown(self) -> None: ...
+
+
+__all__ = ["Queue"]

--- a/typings/streamlit/__init__.pyi
+++ b/typings/streamlit/__init__.pyi
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from collections.abc import Callable, MutableMapping, Sequence
+from contextlib import AbstractContextManager
+from typing import Any, Protocol, TypeVar
+
+T = TypeVar("T")
+
+
+class DeltaGenerator(Protocol):
+    def markdown(self, body: str, *, unsafe_allow_html: bool = ...) -> None: ...
+
+    def text_input(
+        self,
+        label: str,
+        value: str | None = ...,
+        *,
+        key: str | None = ...,
+        help: str | None = ...,
+        placeholder: str | None = ...,
+    ) -> str: ...
+
+    def text_area(
+        self,
+        label: str,
+        value: str | None = ...,
+        *,
+        key: str | None = ...,
+        help: str | None = ...,
+        placeholder: str | None = ...,
+        height: int | None = ...,
+    ) -> str: ...
+
+    def selectbox(
+        self,
+        label: str,
+        options: Sequence[Any],
+        *,
+        index: int | None = ...,
+        key: str | None = ...,
+        help: str | None = ...,
+    ) -> Any: ...
+
+    def multiselect(
+        self,
+        label: str,
+        options: Sequence[Any],
+        *,
+        default: Sequence[Any] | None = ...,
+        key: str | None = ...,
+        help: str | None = ...,
+    ) -> list[Any]: ...
+
+    def slider(
+        self,
+        label: str,
+        min_value: Any = ...,
+        max_value: Any = ...,
+        value: Any | None = ...,
+        *,
+        step: Any | None = ...,
+        key: str | None = ...,
+        help: str | None = ...,
+    ) -> Any: ...
+
+    def checkbox(
+        self,
+        label: str,
+        value: bool | None = ...,
+        *,
+        key: str | None = ...,
+        help: str | None = ...,
+    ) -> bool: ...
+
+    def radio(
+        self,
+        label: str,
+        options: Sequence[Any],
+        *,
+        index: int | None = ...,
+        key: str | None = ...,
+        help: str | None = ...,
+    ) -> Any: ...
+
+    def button(
+        self,
+        label: str,
+        *,
+        key: str | None = ...,
+        help: str | None = ...,
+        use_container_width: bool | None = ...,
+    ) -> bool: ...
+
+    def download_button(
+        self,
+        label: str,
+        data: Any,
+        file_name: str | None = ...,
+        *,
+        mime: str | None = ...,
+        key: str | None = ...,
+    ) -> bool: ...
+
+    def write(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def json(self, obj: Any, *, expanded: bool = ...) -> None: ...
+
+    def table(self, data: Any) -> None: ...
+
+    def dataframe(self, data: Any) -> None: ...
+
+    def metric(self, label: str, value: Any, delta: Any | None = ..., *, delta_color: str | None = ...) -> None: ...
+
+    def image(self, image: Any, *, caption: str | None = ..., use_column_width: bool | str | None = ...) -> None: ...
+
+    def header(self, text: str) -> None: ...
+
+    def subheader(self, text: str) -> None: ...
+
+    def caption(self, text: str) -> None: ...
+
+    def success(self, text: str) -> None: ...
+
+    def warning(self, text: str) -> None: ...
+
+    def error(self, text: str) -> None: ...
+
+    def info(self, text: str) -> None: ...
+
+    def form(self, key: str, *, clear_on_submit: bool = ...) -> Form: ...
+
+    def form_submit_button(
+        self,
+        label: str = ...,
+        *,
+        use_container_width: bool | None = ...,
+        type: str | None = ...,
+    ) -> bool: ...
+
+    def container(self) -> DeltaGenerator: ...
+
+    def columns(
+        self, spec: Sequence[int] | int, *, gap: str | None = ...
+    ) -> Sequence[DeltaGenerator]: ...
+
+    def expander(self, label: str, *, expanded: bool = ...) -> DeltaGenerator: ...
+
+    def tabs(self, names: Sequence[str]) -> Sequence[DeltaGenerator]: ...
+
+    def __getattr__(self, name: str) -> Callable[..., Any]: ...
+
+
+class Form(Protocol):
+    def __enter__(self) -> DeltaGenerator: ...
+
+    def __exit__(self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: Any | None) -> bool | None: ...
+
+    def form_submit_button(
+        self,
+        label: str = ...,
+        *,
+        use_container_width: bool | None = ...,
+        type: str | None = ...,
+    ) -> bool: ...
+
+
+class StreamlitModule(Protocol):
+    session_state: MutableMapping[str, Any]
+    sidebar: DeltaGenerator
+
+    def set_page_config(
+        self,
+        *,
+        page_title: str | None = ...,
+        page_icon: Any | None = ...,
+        layout: str | None = ...,
+        initial_sidebar_state: str | None = ...,
+    ) -> None: ...
+
+    def markdown(self, body: str, *, unsafe_allow_html: bool = ...) -> None: ...
+
+    def rerun(self) -> None: ...
+
+    def experimental_rerun(self) -> None: ...
+
+    def spinner(self, text: str | None = None) -> AbstractContextManager[None]: ...
+
+    def cache_data(
+        self,
+        func: Callable[..., T] | None = ...,
+        *,
+        ttl: float | None = ...,
+        show_spinner: bool | None = ...,
+    ) -> Callable[[Callable[..., T]], Callable[..., T]]: ...
+
+    def stop(self) -> None: ...
+
+    def __getattr__(self, name: str) -> Callable[..., Any]: ...
+
+
+st: StreamlitModule
+
+__all__ = ["DeltaGenerator", "Form", "StreamlitModule", "st"]


### PR DESCRIPTION
## Summary
- add shared typing helpers and update orchestration and monitor tests to use typed fixtures
- tighten orchestration utilities and storage JSON aliases to reduce Any-heavy flows
- vendor basic stubs for Streamlit, Ray, NetworkX, and DuckDB VSS and document the new strict mypy baseline

## Testing
- uv run --extra dev-minimal --extra test mypy --strict tests/unit/orchestration/test_token_utils.py tests/unit/test_orchestrator_helpers.py tests/integration/test_monitor_metrics.py tests/unit/orchestration/test_utils_confidence.py src/autoresearch/orchestration/utils.py src/autoresearch/orchestration/token_utils.py
- uv run --extra dev-minimal --extra test mypy --strict src/autoresearch/orchestration src/autoresearch/storage.py tests/unit tests/integration *(fails: 2,434 existing strict errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e481a52c83339ac48b49677f561a