### PR TITLE
Add typed fallbacks for optional analysis and reasoning deps

### DIFF
--- a/docs/dev/typing-strictness.md
+++ b/docs/dev/typing-strictness.md
@@ -89,6 +89,12 @@
   This pattern aligns with the preferred approach—runtime availability remains
   optional while type checkers benefit from the annotations. New strict work
   should follow the same structure for optional dependencies.
+- [src/autoresearch/data_analysis.py]
+  (../../src/autoresearch/data_analysis.py) and
+  [src/autoresearch/kg_reasoning.py]
+  (../../src/autoresearch/kg_reasoning.py) now use lightweight protocols to
+  represent optional extras. Follow the same pattern—define sentinel classes or
+  protocols instead of `type: ignore` when guarding imports.
 
 ## Suggested sequencing towards strict gating
 


### PR DESCRIPTION
## Summary
- replace the Polars and OwlRL fallbacks with protocol-based sentinels so `type: ignore` comments are no longer needed
- add regression tests that reload the modules with mocked imports to exercise the missing dependency paths
- document the new optional dependency typing guidance in the strict typing notes

## Testing
- uv run pytest tests/unit/test_data_analysis.py tests/unit/test_kg_reasoning.py
- uv run mypy --strict src tests *(fails: repository-wide strict run reports thousands of pre-existing errors)*
- uv run task verify *(fails: repository-wide strict run reports existing mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_68da071a5ecc8333bddd0791c0a21f30