### PR TITLE
Add planner graph conditioning scenario and docs

### DIFF
--- a/docs/deep_research_upgrade_plan.md
+++ b/docs/deep_research_upgrade_plan.md
@@ -56,6 +56,10 @@ keep truthfulness, verifiability, and cost discipline in balance.
      operators can monitor GraphRAG uptake.
    - Export lightweight GraphML or JSON artifacts via the output formatter
      so downstream tools can visualise graph state per session.
+   - Document how to toggle `search.context_aware.planner_graph_conditioning`
+     for planner prompts, and cover the cues with
+     `tests/behavior/features/reasoning_modes/planner_graph_conditioning.feature`
+     so regression sweeps keep contradiction and neighbour hints intact.
 4. **Phase 4 – Evaluation Harness and Layered UX**
    - Automate TruthfulQA, FEVER, and HotpotQA smoke runs with KPIs.
    - Add layered summaries, Socratic prompts, per-claim audit toggles, and

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -19,6 +19,18 @@ trace**, **Show knowledge graph**, and **Enable graph exports**. Toggle defaults
 are bound to the current depth so that moving to deeper views surfaces more
 context without retaining stale preferences.
 
+## Planner graph conditioning
+
+Knowledge graph signals can be threaded into planner prompts when retrieval
+surfaces contradictions or informative neighbours. Enable the feature in
+`search.context_aware` by setting `planner_graph_conditioning = true` after the
+graph pipeline has been validated for your deployment. The toggle works best
+for sessions that ingest at least one retrieval batch; the planner reuses
+stored contradictions, neighbour previews, and provenance to seed the prompt.
+The AUTO workflow now ships with
+`tests/behavior/features/reasoning_modes/planner_graph_conditioning.feature` so
+operators can confirm the cues before enabling the option in production.
+
 ## Provenance verification
 
 Claim verification is surfaced through the dedicated Provenance panel. Claim

--- a/issues/launch-session-graphrag-support.md
+++ b/issues/launch-session-graphrag-support.md
@@ -21,5 +21,12 @@ coordinate schema updates, graph exports, and orchestration integration.
   referenced in output bundles.
 - Documentation and diagrams explain the graph flow and operator controls.
 
+## QA Coverage
+
+- Behavior coverage now lives in
+  `tests/behavior/features/reasoning_modes/planner_graph_conditioning.feature`
+  to prove planner prompts surface contradiction and neighbour cues when graph
+  conditioning is enabled.
+
 ## Status
 Open

--- a/issues/session-graph-rag-integration.md
+++ b/issues/session-graph-rag-integration.md
@@ -23,5 +23,12 @@ artifacts plus contradiction signals to the orchestrator.
   and `docs/deep_research_upgrade_plan.md` describe graph usage patterns and
   guardrails.
 
+## QA Coverage
+
+- Scenario coverage in
+  `tests/behavior/features/reasoning_modes/planner_graph_conditioning.feature`
+  now exercises planner graph conditioning prompts and telemetry so graph
+  signals stay regression-proof.
+
 ## Status
 Open

--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -50,6 +50,7 @@ ALLOWED_STEP_MODULES = {
     "query_interface_steps.py",
     "visualization_cli_steps.py",
     "reasoning_modes_all_steps.py",
+    "reasoning_modes_auto_steps.py",
     "reasoning_modes_steps.py",
 }
 

--- a/tests/behavior/features/reasoning_modes/planner_graph_conditioning.feature
+++ b/tests/behavior/features/reasoning_modes/planner_graph_conditioning.feature
@@ -1,0 +1,8 @@
+@behavior @reasoning_modes
+Feature: Planner graph conditioning surfaces knowledge graph cues
+  Scenario: Planner prompt incorporates contradiction and neighbour metadata
+    Given planner graph conditioning is enabled in configuration
+    And the knowledge graph metadata includes contradictions and neighbours
+    When I execute the planner for query "graph conditioning rehearsal"
+    Then the planner prompt should include contradiction and neighbour cues
+    And the planner telemetry should record objectives and tasks


### PR DESCRIPTION
## Summary
- add a behaviour-driven scenario and steps that exercise planner graph conditioning with synthetic graph metadata
- enable the reasoning modes auto step module, update the deep research plan, and extend the user guide with the graph conditioning toggle
- record the new QA coverage in the graph-focused issue trackers

## Testing
- uv run --extra test pytest tests/behavior/steps/reasoning_modes_auto_steps.py::test_planner_prompt_incorporates_contradiction_and_neighbour_metadata

------
https://chatgpt.com/codex/tasks/task_e_68da09cc1550833393010f15331ce593