### PR TITLE
Include py.typed marker for autoresearch package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include typings *.pyi
+include src/autoresearch/py.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ release_date = "Unreleased" # keep in sync with autoresearch.__release_date__
 include-package-data = true
 
 [tool.setuptools.package-data]
+"autoresearch" = ["py.typed"]
 "autoresearch.examples" = ["autoresearch.toml", ".env.example"]
 
 [tool.setuptools.data-files]

--- a/tests/behavior/steps/api_auth_steps.py
+++ b/tests/behavior/steps/api_auth_steps.py
@@ -10,17 +10,17 @@ from typing import TYPE_CHECKING, Protocol, cast
 import pytest
 from pytest_bdd import parsers
 
-from autoresearch.api import (  # type: ignore[import-untyped]
+from autoresearch.api import (
     config_loader,
     get_request_logger,
 )
-from autoresearch.config.loader import ConfigLoader  # type: ignore[import-untyped]
-from autoresearch.config.models import (  # type: ignore[import-untyped]
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import (
     APIConfig,
     ConfigModel,
 )
-from autoresearch.models import QueryResponse  # type: ignore[import-untyped]
-from autoresearch.orchestration.orchestrator import (  # type: ignore[import-untyped]
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import (
     Orchestrator,
 )
 


### PR DESCRIPTION
## Summary
- add the `py.typed` marker so the package is treated as typed by type checkers
- ensure the marker ships with both the wheel and sdist metadata
- drop now-unnecessary `type: ignore[import-untyped]` directives in the API auth behavior steps

## Testing
- `task mypy:strict-suite` *(fails: repository already has 3971 mypy errors across src/tests prior to this change)*
- `task verify` *(fails: mypy reports 94 errors under the standard verify pipeline on current main)*

------
https://chatgpt.com/codex/tasks/task_e_68dab551aef0833393e2ae2b213bb8b8