### PR TITLE
Refine CLI visualization hooks typing

### DIFF
--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -22,6 +22,7 @@ from ..cli_helpers import (
 )
 from ..cli_utils import (
     Verbosity,
+    VisualizationHooks,
     attach_cli_hooks,
     console,
     format_success,
@@ -63,7 +64,7 @@ app = typer.Typer(
     # Disable pretty exceptions to handle them ourselves
 )
 # Provide test hooks without mutating private Typer attributes directly.
-attach_cli_hooks(
+visualization_hooks: VisualizationHooks = attach_cli_hooks(
     app,
     visualize=_cli_visualize,
     visualize_query=_cli_visualize_query,
@@ -84,7 +85,7 @@ from ..cli_evaluation import evaluation_app as _evaluation_app  # noqa: E402
 
 from .config_cli import config_app as _config_app, config_init  # noqa: E402  # isort: skip
 
-config_app = _config_app  # type: ignore[has-type]
+config_app: typer.Typer = _config_app
 app.add_typer(config_app, name="config")
 
 backup_app = _backup_app
@@ -1127,7 +1128,7 @@ def visualize(
     """Run a query and render a knowledge graph."""
     try:
         # Call through the Typer app attribute so tests can monkeypatch it
-        app._cli_visualize_query(  # type: ignore[attr-defined]
+        visualization_hooks.visualize_query(
             query,
             output,
             layout=layout,
@@ -1149,7 +1150,7 @@ def visualize_rdf_cli(
     """Generate a PNG visualization of the RDF knowledge graph."""
     try:
         # Call through the Typer app attribute so tests can monkeypatch it
-        app._cli_visualize(output)  # type: ignore[attr-defined]
+        visualization_hooks.visualize(output)
     except Exception:
         raise typer.Exit(1)
 

--- a/tests/behavior/steps/visualization_cli_steps.py
+++ b/tests/behavior/steps/visualization_cli_steps.py
@@ -13,7 +13,7 @@ def run_visualize_query(
     def fake_visualize(q, output, layout='spring'):
         Path(output).touch()
 
-    monkeypatch.setattr('autoresearch.main.app._cli_visualize_query', fake_visualize)
+    monkeypatch.setattr(cli_app.visualization_hooks, "visualize_query", fake_visualize)
     result = cli_runner.invoke(
         cli_app, ['visualize', query, str(output_path)], catch_exceptions=False
     )
@@ -22,7 +22,7 @@ def run_visualize_query(
 
 @when('I run `autoresearch visualize-rdf rdf_graph.png`')
 def run_visualize_rdf(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
-    monkeypatch.setattr('autoresearch.main.app._cli_visualize', lambda *a, **k: None)
+    monkeypatch.setattr(cli_app.visualization_hooks, "visualize", lambda *a, **k: None)
     result = cli_runner.invoke(cli_app, ['visualize-rdf', 'rdf_graph.png'], catch_exceptions=False)
     bdd_context['result'] = result
 
@@ -31,7 +31,7 @@ def run_visualize_rdf(cli_runner, bdd_context, monkeypatch, temp_config, isolate
 def run_visualize_missing(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
     def _raise(*a, **k):
         raise RuntimeError('missing output')
-    monkeypatch.setattr('autoresearch.main.app._cli_visualize_query', _raise)
+    monkeypatch.setattr(cli_app.visualization_hooks, "visualize_query", _raise)
     result = cli_runner.invoke(cli_app, ['visualize', 'What is quantum computing?'], catch_exceptions=False)
     bdd_context['result'] = result
 

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -14,8 +14,11 @@ def test_attach_cli_hooks_exposes_attributes() -> None:
     def visualize_query() -> None:  # pragma: no cover - simple stub
         return None
 
-    attach_cli_hooks(app, visualize=visualize, visualize_query=visualize_query, name="demo")
+    hooks = attach_cli_hooks(
+        app, visualize=visualize, visualize_query=visualize_query, name="demo"
+    )
 
     assert getattr(app, "name") == "demo"
-    assert getattr(app, "_cli_visualize") is visualize
-    assert getattr(app, "_cli_visualize_query") is visualize_query
+    assert hooks.visualize is visualize
+    assert hooks.visualize_query is visualize_query
+    assert getattr(app, "visualization_hooks") is hooks


### PR DESCRIPTION
## Summary
- expose visualization helpers through a typed VisualizationHooks container
- update the Typer app to use the typed hooks and annotate the config CLI Typer
- adjust tests to monkeypatch the new hook accessors

## Testing
- `uv run task mypy:strict-suite` *(fails: strict suite reports existing type errors across tests and auxiliary modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dab9ffd0b883338b8a36a43b760d54