### PR TITLE
Add direct exit AUTO CLI behavior scenario

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -51,6 +51,7 @@ ALLOWED_STEP_MODULES = {
     "visualization_cli_steps.py",
     "reasoning_modes_all_steps.py",
     "reasoning_modes_auto_steps.py",
+    "reasoning_modes_auto_cli_cycle_steps.py",
     "reasoning_modes_steps.py",
 }
 

--- a/tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature
+++ b/tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature
@@ -10,3 +10,8 @@ Feature: AUTO CLI reasoning captures planner, scout gate, and verification loop
     Then the CLI scout gate decision should escalate to debate
     And the CLI audit badges should include "supported" and "needs_review"
     And the CLI output should record verification loop metrics
+
+  Scenario: AUTO mode CLI run exits directly when the scout gate declines debate
+    Given the scout gate will force a direct exit
+    When I run the AUTO reasoning CLI for query "scout gate direct exit rehearsal"
+    Then the CLI should exit directly without escalation


### PR DESCRIPTION
## Summary
- add a direct-exit AUTO CLI scenario that drives the scout gate to skip debate
- extend the AUTO-mode CLI step definitions to stub the gate decision and assert direct-exit metadata and audit-badge consistency
- whitelist the AUTO CLI cycle steps for behavior collection

## Testing
- task verify -- tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature *(fails: existing mypy errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68dabc324cf88333a067b98dbd639906