### PR TITLE
Add HTTP session protocols and adapter tests

### DIFF
--- a/src/autoresearch/llm/adapters.py
+++ b/src/autoresearch/llm/adapters.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 import os
+
 import requests
+
+from ..typing.http import RequestsResponseProtocol, RequestsSessionProtocol
 from .pool import get_session
 
 
@@ -136,8 +139,10 @@ class LMStudioAdapter(LLMAdapter):
                 "model": model,
                 "messages": [{"role": "user", "content": prompt}],
             }
-            session = get_session()
-            resp = session.post(self.endpoint, json=payload, timeout=30)
+            session: RequestsSessionProtocol = get_session()
+            resp: RequestsResponseProtocol = session.post(
+                self.endpoint, json=payload, timeout=30
+            )
             resp.raise_for_status()
             data: Dict[str, Any] = resp.json()
             return str(

--- a/src/autoresearch/llm/pool.py
+++ b/src/autoresearch/llm/pool.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
-from typing import Optional, Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, Optional, cast
 from threading import Lock
+
 import requests
 
 from ..config.loader import get_config
+from ..typing.http import RequestsSessionProtocol
 
-_session: Optional[requests.Session] = None
+_session: Optional[RequestsSessionProtocol] = None
 _lock = Lock()
 
 
-def set_session(session: requests.Session) -> None:
+def set_session(session: RequestsSessionProtocol) -> None:
     """Inject a pre-created HTTP session."""
     global _session
     with _lock:
@@ -25,7 +27,7 @@ _adapters: Dict[str, "LLMAdapter"] = {}
 _adapter_lock = Lock()
 
 
-def get_session() -> requests.Session:
+def get_session() -> RequestsSessionProtocol:
     """Return a pooled HTTP session for LLM adapters."""
     global _session
     with _lock:
@@ -39,7 +41,8 @@ def get_session() -> requests.Session:
             )
             session.mount("http://", adapter)
             session.mount("https://", adapter)
-            _session = session
+            _session = cast(RequestsSessionProtocol, session)
+        assert _session is not None
         return _session
 
 

--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -65,18 +65,15 @@ from weakref import WeakSet
 import numpy as np
 import requests
 
-from ..cache import (
-    SearchCache,
-)
+from ..cache import SearchCache, _SearchCacheView
 from ..cache import cache_results as _cache_results
-from ..cache import (
-    get_cache,
-)
+from ..cache import get_cache
 from ..cache import get_cached_results as _get_cached_results
 from ..config.loader import get_config
 from ..errors import ConfigError, NotFoundError, SearchError, StorageError
 from ..logging_utils import get_logger
 from ..storage import StorageManager
+from ..typing.http import RequestsSessionProtocol
 from . import storage as search_storage
 from .context import SearchContext
 from .http import close_http_session, get_http_session
@@ -427,7 +424,7 @@ class ExternalLookupResult:
     query: str
     results: List[Dict[str, Any]]
     by_backend: Dict[str, List[Dict[str, Any]]]
-    cache: SearchCache
+    cache: SearchCache | _SearchCacheView
     storage: type[StorageManager]
 
     def __iter__(self) -> Iterator[Dict[str, Any]]:
@@ -532,7 +529,9 @@ class Search:
     _shared_instance: ClassVar[Optional["Search"]] = None
     _instances: ClassVar[WeakSet["Search"]] = WeakSet()
 
-    def __init__(self, cache: Optional[SearchCache] = None) -> None:
+    def __init__(
+        self, cache: SearchCache | _SearchCacheView | None = None
+    ) -> None:
         self.backends: Dict[str, Callable[[str, int], List[Dict[str, Any]]]] = dict(
             self._default_backends
         )
@@ -580,7 +579,7 @@ class Search:
         return cls._shared_instance
 
     @staticmethod
-    def get_http_session() -> requests.Session:
+    def get_http_session() -> RequestsSessionProtocol:
         """Expose pooled HTTP session."""
         return get_http_session()
 

--- a/src/autoresearch/typing/__init__.py
+++ b/src/autoresearch/typing/__init__.py
@@ -1,0 +1,14 @@
+"""Typing helpers shared across the project.
+
+This package exposes reusable Protocol definitions and type aliases that keep
+runtime dependencies lightweight while ensuring static analysis remains
+precise. Modules should import the most specific type available instead of
+depending on vendor-specific classes directly.
+"""
+
+from .http import RequestsResponseProtocol, RequestsSessionProtocol
+
+__all__ = [
+    "RequestsResponseProtocol",
+    "RequestsSessionProtocol",
+]

--- a/src/autoresearch/typing/http.py
+++ b/src/autoresearch/typing/http.py
@@ -1,0 +1,48 @@
+"""Protocols describing the subset of the ``requests`` API that we rely on."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class RequestsResponseProtocol(Protocol):
+    """Structural type for ``requests.Response`` objects."""
+
+    status_code: int
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        """Return HTTP headers associated with the response."""
+
+    def json(self, **kwargs: Any) -> Any:
+        """Return a decoded JSON payload."""
+
+    def raise_for_status(self) -> None:
+        """Raise an HTTPError if the response status indicates failure."""
+
+
+@runtime_checkable
+class RequestsSessionProtocol(Protocol):
+    """Structural type for ``requests.Session`` objects."""
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        """Return default headers sent with each request."""
+
+    def mount(self, prefix: str, adapter: Any) -> None:
+        """Register an adapter that handles the given URL prefix."""
+
+    def close(self) -> None:
+        """Release any pooled network resources."""
+
+    def request(
+        self, method: str, url: str, *args: Any, **kwargs: Any
+    ) -> RequestsResponseProtocol:
+        """Issue an HTTP request with the provided method and URL."""
+
+    def get(self, url: str, *args: Any, **kwargs: Any) -> RequestsResponseProtocol:
+        """Issue a GET request."""
+
+    def post(self, url: str, *args: Any, **kwargs: Any) -> RequestsResponseProtocol:
+        """Issue a POST request."""

--- a/tests/targeted/test_llm_adapters.py
+++ b/tests/targeted/test_llm_adapters.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import requests
+
+from autoresearch.errors import LLMError
+from autoresearch.llm import adapters
+from autoresearch.typing.http import RequestsSessionProtocol
+
+
+class RecordingResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+        self.raise_called = False
+        self._headers: dict[str, str] = {}
+        self.status_code = 200
+
+    def json(self, **kwargs: Any) -> dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        self.raise_called = True
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return self._headers
+
+
+class RecordingSession:
+    def __init__(self, response: RecordingResponse) -> None:
+        self._response = response
+        self.mounted: list[tuple[str, object]] = []
+        self.requests: list[tuple[str, str, dict[str, Any]]] = []
+        self._headers: dict[str, str] = {}
+
+    def mount(self, prefix: str, adapter: object) -> None:
+        self.mounted.append((prefix, adapter))
+
+    def close(self) -> None:
+        pass
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return self._headers
+
+    def request(self, method: str, url: str, *args: Any, **kwargs: Any) -> RecordingResponse:
+        self.requests.append((method, url, kwargs))
+        return self._response
+
+    def get(self, url: str, *args: Any, **kwargs: Any) -> RecordingResponse:
+        return self.request("GET", url, *args, **kwargs)
+
+    def post(self, url: str, *args: Any, **kwargs: Any) -> RecordingResponse:
+        return self.request("POST", url, *args, **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("adapter_cls", "env"),
+    [
+        (adapters.LMStudioAdapter, {}),
+        (adapters.OpenAIAdapter, {"OPENAI_API_KEY": "sk-test"}),
+        (adapters.OpenRouterAdapter, {"OPENROUTER_API_KEY": "or-test"}),
+    ],
+)
+def test_adapter_generate_invokes_raise_for_status(monkeypatch, adapter_cls, env):
+    """Adapters use the shared session and trigger response validation."""
+
+    payload = {"choices": [{"message": {"content": "ok"}}]}
+    response = RecordingResponse(payload)
+    session = RecordingSession(response)
+    assert isinstance(session, RequestsSessionProtocol)
+    monkeypatch.setattr(adapters, "get_session", lambda: session)
+
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    adapter = adapter_cls()
+    result = adapter.generate("prompt")
+
+    assert response.raise_called is True
+    assert "ok" in result
+    assert session.requests
+
+
+@pytest.mark.parametrize(
+    "adapter_factory",
+    [
+        lambda: adapters.LMStudioAdapter(),
+        lambda: adapters.OpenAIAdapter(),
+        lambda: adapters.OpenRouterAdapter(),
+    ],
+)
+def test_adapter_generate_wraps_request_exceptions(monkeypatch, adapter_factory):
+    """Network failures surface as LLMError with preserved context."""
+
+    def boom(*args: Any, **kwargs: Any) -> RecordingResponse:  # pragma: no cover - type stub
+        raise requests.RequestException("boom")
+
+    class FailingSession:
+        def __init__(self) -> None:
+            self._headers: dict[str, str] = {}
+
+        def post(self, *args: Any, **kwargs: Any) -> RecordingResponse:
+            return boom(*args, **kwargs)
+
+        def mount(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - not invoked
+            return None
+
+        def close(self) -> None:  # pragma: no cover - not invoked
+            return None
+
+        def get(self, *args: Any, **kwargs: Any) -> RecordingResponse:  # pragma: no cover - type stub
+            return boom(*args, **kwargs)
+
+        def request(self, *args: Any, **kwargs: Any) -> RecordingResponse:  # pragma: no cover - type stub
+            return boom(*args, **kwargs)
+
+        @property
+        def headers(self) -> dict[str, str]:
+            return self._headers
+
+    session: RequestsSessionProtocol = FailingSession()
+    monkeypatch.setattr(adapters, "get_session", lambda: session)
+    monkeypatch.setenv("OPENAI_API_KEY", "token")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "token")
+
+    adapter = adapter_factory()
+
+    with pytest.raises(LLMError):
+        adapter.generate("prompt")

--- a/typings/requests/__init__.pyi
+++ b/typings/requests/__init__.pyi
@@ -1,61 +1,62 @@
 from __future__ import annotations
 
-from typing import Any, Mapping, MutableMapping, overload
+from typing import Any, Mapping
 
-
-class RequestException(Exception): ...
+from . import exceptions
+from .adapters import HTTPAdapter
 
 
 class Response:
     status_code: int
-    headers: Mapping[str, str]
     text: str
 
-    def json(self) -> Any: ...
+    def __init__(self, *, status_code: int = 200, text: str = "", content: Any = ...) -> None: ...
+
+    def json(self, **kwargs: Any) -> Any: ...
+
+    def raise_for_status(self) -> None: ...
+
+    @property
+    def headers(self) -> Mapping[str, str]: ...
 
 
 class Session:
-    headers: MutableMapping[str, str]
+    def __init__(self) -> None: ...
 
-    def get(
-        self,
-        url: str,
-        *,
-        params: Mapping[str, Any] | None = ...,
-        headers: Mapping[str, str] | None = ...,
-        timeout: float | tuple[float, float] | None = ...,
-    ) -> Response: ...
+    def get(self, url: str, *args: Any, **kwargs: Any) -> Response: ...
 
-    def post(
-        self,
-        url: str,
-        *,
-        json: Any = ...,
-        data: Any = ...,
-        headers: Mapping[str, str] | None = ...,
-        timeout: float | tuple[float, float] | None = ...,
-    ) -> Response: ...
+    def post(self, url: str, *args: Any, **kwargs: Any) -> Response: ...
+
+    def request(self, method: str, url: str, *args: Any, **kwargs: Any) -> Response: ...
 
     def close(self) -> None: ...
 
+    def mount(self, prefix: str, adapter: HTTPAdapter) -> None: ...
 
-def get(
-    url: str,
-    *,
-    params: Mapping[str, Any] | None = ...,
-    headers: Mapping[str, str] | None = ...,
-    timeout: float | tuple[float, float] | None = ...,
-) -> Response: ...
+    @property
+    def headers(self) -> Mapping[str, str]: ...
 
 
-def post(
-    url: str,
-    *,
-    json: Any = ...,
-    data: Any = ...,
-    headers: Mapping[str, str] | None = ...,
-    timeout: float | tuple[float, float] | None = ...,
-) -> Response: ...
+def get(url: str, *args: Any, **kwargs: Any) -> Response: ...
 
 
-__all__ = ["RequestException", "Response", "Session", "get", "post"]
+def post(url: str, *args: Any, **kwargs: Any) -> Response: ...
+
+
+def request(method: str, url: str, *args: Any, **kwargs: Any) -> Response: ...
+
+
+RequestException = exceptions.RequestException
+Timeout = exceptions.Timeout
+
+__all__ = [
+    "HTTPAdapter",
+    "RequestException",
+    "Response",
+    "Session",
+    "Timeout",
+    "exceptions",
+    "get",
+    "post",
+    "request",
+]

--- a/typings/requests/adapters.pyi
+++ b/typings/requests/adapters.pyi
@@ -1,0 +1,8 @@
+from typing import Any
+
+
+class HTTPAdapter:
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+
+__all__ = ["HTTPAdapter"]

--- a/typings/spacy/cli/__init__.pyi
+++ b/typings/spacy/cli/__init__.pyi
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def download(model: str, *args: Any, **kwargs: Any) -> None: ...
+
+__all__ = ["download"]


### PR DESCRIPTION
## Summary
- introduce reusable HTTP session/response protocols and apply them across the LLM pool, adapters, and search HTTP helpers
- vendor requests and spaCy CLI type stubs so strict mode resolves third-party imports
- extend targeted coverage for pooled HTTP sessions and add fast adapter tests exercising the new protocols

## Testing
- uv run task verify *(fails: repository-wide mypy backlog unrelated to the updated HTTP modules)*
- uv run pytest tests/targeted/test_http_session.py tests/targeted/test_llm_adapters.py

------
https://chatgpt.com/codex/tasks/task_e_68dadb6ac08c8333b804962016ea55c2