### PR TITLE
Normalize monitor telemetry floats

### DIFF
--- a/src/autoresearch/monitor/metrics.py
+++ b/src/autoresearch/monitor/metrics.py
@@ -13,8 +13,13 @@ async def metrics_endpoint(_: None = None) -> PlainTextResponse:
         PlainTextResponse: Prometheus metrics with ``200`` status code.
     """
 
+    payload = generate_latest()
+    if isinstance(payload, bytes):
+        body = payload.decode("utf-8", "replace")
+    else:  # pragma: no cover - defensive fallback
+        body = str(payload)
     return PlainTextResponse(
-        generate_latest(),
+        body,
         media_type=CONTENT_TYPE_LATEST,
         status_code=200,
     )

--- a/tests/unit/monitor/test_metrics_endpoint.py
+++ b/tests/unit/monitor/test_metrics_endpoint.py
@@ -1,0 +1,15 @@
+import pytest
+
+from autoresearch.monitor import metrics as monitor_metrics
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_decodes_prometheus_payload(monkeypatch):
+    payload = b"sample_metric 1\n"
+
+    monkeypatch.setattr(monitor_metrics, "generate_latest", lambda: payload)
+
+    response = await monitor_metrics.metrics_endpoint()
+
+    assert response.body == payload
+    assert response.media_type == monitor_metrics.CONTENT_TYPE_LATEST

--- a/tests/unit/orchestration/test_metrics_graph_summary.py
+++ b/tests/unit/orchestration/test_metrics_graph_summary.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from autoresearch.orchestration.metrics import OrchestrationMetrics
+
+
+def test_graph_summary_uses_typed_floats():
+    metrics = OrchestrationMetrics()
+    metadata = {
+        "ingestion": {
+            "entity_count": "2",
+            "relation_count": 3,
+            "seconds": "0.25",
+            "storage_latency": {
+                "persist": "4.5",
+                "load": float("nan"),
+            },
+        },
+        "contradictions": {
+            "items": [
+                {"subject": "a", "predicate": "p", "objects": ["b", 5]},
+                {"subject": "c", "predicate": "q", "objects": ()},
+            ],
+            "raw_score": "1.5",
+            "weighted_score": "2.5",
+            "weight": 3,
+        },
+        "neighbors": {
+            "node-1": [
+                {"target": "x", "predicate": "p", "direction": "out"},
+                {"target": "y", "predicate": "q", "direction": "in"},
+            ]
+        },
+        "paths": [["s", "t"]],
+        "similarity": {
+            "raw_score": "0.5",
+            "weighted_score": "0.25",
+            "weight": "0.75",
+        },
+    }
+    metrics.record_graph_build(metadata, summary={"provenance": [1, 2]})
+
+    summary = metrics.get_summary()["graph_ingestion"]
+    assert summary["runs"] == 1
+
+    totals = summary["totals"]
+    assert totals["entity_count"] == 2.0
+    assert totals["relation_count"] == 3.0
+    assert totals["contradiction_count"] == 2.0
+    assert totals["provenance_count"] == 2.0
+
+    latency_totals = summary["totals_storage_latency"]
+    assert latency_totals == {"persist": 4.5, "load": 0.0}
+
+    averages = summary["averages"]
+    assert averages["entity_count"] == 2.0
+    assert averages["storage_latency"] == {"persist": 4.5, "load": 0.0}
+
+    latest = summary["latest"]
+    assert latest["entity_count"] == 2.0
+    assert latest["storage_latency"] == {"persist": 4.5, "load": 0.0}
+    assert latest["provenance_count"] == 2.0
+    assert latest["contradiction_sample"][0]["objects"] == ["b", "5"]
+    assert list(latest["neighbor_sample"].keys()) == ["node-1"]
+
+
+def test_graph_build_skips_empty_payload():
+    metrics = OrchestrationMetrics()
+    metrics.record_graph_build({"ingestion": {"entity_count": 0, "relation_count": 0}})
+    assert metrics.graph_ingestions == []


### PR DESCRIPTION
## Summary
- coerce orchestration graph ingestion telemetry into typed float aggregates and surface storage latency totals
- normalize system and resource monitor metrics by sanitizing psutil readings and decoding Prometheus output
- expand unit coverage for orchestration graph summaries and monitor endpoints to lock in the new safeguards

## Testing
- uv run task verify *(fails: existing mypy strict errors outside the touched modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dadf7f8c208333836afa820fce8dfb