### PR TITLE
Refine evaluation harness config cloning and A2A runtime typing

### DIFF
--- a/src/autoresearch/agents/messages.py
+++ b/src/autoresearch/agents/messages.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field, ConfigDict
 import time
-from typing import Optional
+from typing import Any, Optional
 from enum import Enum
 
 
@@ -30,6 +30,6 @@ class AgentMessage(BaseModel):
         arbitrary_types_allowed=True,
     )
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Return message as plain dictionary."""
         return self.model_dump(by_alias=True)

--- a/src/autoresearch/api/routing.py
+++ b/src/autoresearch/api/routing.py
@@ -289,7 +289,7 @@ async def async_query_endpoint(
         config.llm_backend = request.llm_backend
 
     task_id = str(uuid4())
-    config_copy: ConfigModel = cast(ConfigModel, cast(Any, config).model_copy(deep=True))
+    config_copy = config.model_copy(deep=True)
 
     async def runner() -> QueryResponseV1 | Any:
         try:

--- a/src/autoresearch/cache.py
+++ b/src/autoresearch/cache.py
@@ -13,7 +13,7 @@ import os
 from copy import deepcopy
 from pathlib import Path
 from threading import Lock
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from tinydb import TinyDB, Query
 
@@ -102,9 +102,11 @@ class SearchCache:
             & (Query().query == query)
             & (Query().backend == backend)
         )
-        row = db.get(condition)
+        row = cast(Optional[Dict[str, Any]], db.get(condition))
         if row:
-            return deepcopy(row.get("results", []))
+            results_raw = row.get("results", [])
+            results = cast(List[Dict[str, Any]], deepcopy(results_raw))
+            return results
         return None
 
     def clear(self, namespace: str | None = None) -> None:

--- a/src/autoresearch/cli_utils.py
+++ b/src/autoresearch/cli_utils.py
@@ -207,6 +207,7 @@ def print_success(
 
 def print_error(
     message: str,
+    *,
     symbol: bool = True,
     min_verbosity: Verbosity = Verbosity.QUIET,
     suggestion: Optional[str] = None,
@@ -453,7 +454,9 @@ def sparql_query_cli(query: str, engine: str | None = None, apply_reasoning: boo
         return
 
     rows = [list(cast(Iterable[rdflib.term.Node], r)) for r in res]
-    headers = [str(v) for v in (res.vars or [])]
+    raw_headers = getattr(res, "vars", None)
+    header_values = list(raw_headers) if raw_headers else []
+    headers = [str(v) for v in header_values]
     console.print(tabulate(rows, headers=headers, tablefmt="github"))
 
 

--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, ClassVar, Dict, List, Mapping, Optional
+from typing import Any, ClassVar, Dict, List, Mapping, Optional, Self, cast
 
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from pydantic.functional_validators import model_validator
@@ -558,5 +558,16 @@ class ConfigModel(BaseModel):
                     except Exception:  # pragma: no cover - ignore bad fields
                         continue
             return model
+
+    def model_copy(
+        self,
+        *,
+        update: Mapping[str, Any] | None = None,
+        deep: bool = False,
+    ) -> Self:
+        """Return a cloned configuration while preserving ``ConfigModel`` typing."""
+
+        base_model = cast(Any, super(ConfigModel, self))
+        return cast(Self, base_model.model_copy(update=update, deep=deep))
 
     model_config: ClassVar[SettingsConfigDict] = {"extra": "ignore"}

--- a/src/autoresearch/main/Prompt.py
+++ b/src/autoresearch/main/Prompt.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-from typing import Any
+from typing import Any, cast
 
 import typer
 
 
 def ask(text: str, *args: Any, **kwargs: Any) -> str:
     """Prompt the user for input using Typer."""
-    return typer.prompt(text, *args, **kwargs)
+    return cast(str, typer.prompt(text, *args, **kwargs))

--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -442,7 +442,7 @@ def search(
         except json.JSONDecodeError as exc:
             print_error(
                 "Invalid JSON for --gate-overrides. Provide a valid JSON object.",
-                detail=str(exc),
+                suggestion=str(exc),
             )
             raise typer.Exit(code=1) from exc
         updates["gate_user_overrides"] = overrides
@@ -475,7 +475,7 @@ def search(
 
         from . import Progress, Prompt
 
-        def on_cycle_end(loop: int, state) -> None:
+        def on_cycle_end(loop: int, state: Any) -> None:
             progress.update(task, advance=1)
             if interactive and loop < loops - 1:
                 refinement = Prompt.ask(
@@ -556,12 +556,12 @@ def search(
                     f"Graph exports available. Re-run with {tips} to download the knowledge graph."
                 )
 
-        export_targets = {
+        raw_targets: dict[str, str | Path | None] = {
             "graphml": graphml,
             "graph_json": graph_json,
         }
-        export_targets = {
-            fmt: target for fmt, target in export_targets.items() if target is not None
+        export_targets: dict[str, str | Path] = {
+            fmt: target for fmt, target in raw_targets.items() if target is not None
         }
         if export_targets:
             if not summary_available:
@@ -873,8 +873,8 @@ def capabilities(
         # Display capabilities in Markdown format
         autoresearch capabilities --output markdown
     """
-    from .llm import get_available_adapters
-    from .orchestration import ReasoningMode
+    from ..llm.registry import get_available_adapters
+    from ..orchestration.reasoning import ReasoningMode
 
     config = _config_loader.load_config()
 
@@ -1009,7 +1009,7 @@ def test_mcp(
         # Output results in JSON format
         autoresearch test_mcp --output json
     """
-    from .test_tools import MCPTestClient, format_test_results
+    from ..test_tools import MCPTestClient, format_test_results
 
     # Create the MCP test client
     client = MCPTestClient(host=host, port=port)
@@ -1067,7 +1067,7 @@ def test_a2a(
         # Output results in JSON format
         autoresearch test_a2a --output json
     """
-    from .test_tools import A2ATestClient, format_test_results
+    from ..test_tools import A2ATestClient, format_test_results
 
     # Create the A2A test client
     client = A2ATestClient(host=host, port=port)

--- a/src/autoresearch/main/config_cli.py
+++ b/src/autoresearch/main/config_cli.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Optional, Any
+from typing import Any, Optional
 
 import importlib.resources as importlib_resources
 import json
+
 import tomli_w
 import tomllib
 import typer
@@ -23,7 +24,8 @@ def config_callback(ctx: typer.Context) -> None:
     """Manage configuration commands."""
     if ctx.invoked_subcommand is None:
         config = _config_loader.load_config()
-        typer.echo(config.json(indent=2))
+        payload = config.model_dump(mode="json")
+        typer.echo(json.dumps(payload, indent=2))
 
 
 @config_app.command("init")

--- a/src/autoresearch/mcp_interface.py
+++ b/src/autoresearch/mcp_interface.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, cast
+from typing import Any, Mapping, cast
 
 import anyio
 from fastmcp import FastMCP, Client
 
-from .logging_utils import get_logger
-from .orchestration.orchestrator import Orchestrator
 from .config import ConfigLoader
+from .logging_utils import get_logger
+from .models import QueryResponse
+from .orchestration.orchestrator import Orchestrator
 
 logger = get_logger(__name__)
 
@@ -26,16 +27,14 @@ def create_server(host: str = "127.0.0.1", port: int = 8080) -> FastMCP:
     @server.tool
     async def research(query: str) -> dict[str, Any]:
         try:
-            result = cast(Any, server).orchestrator.run_query(query, config)
-            return {
+            result: QueryResponse = orchestrator.run_query(query, config)
+            response: dict[str, Any] = {
                 "answer": result.answer,
-                "citations": [
-                    c.model_dump(mode="json") if hasattr(c, "model_dump") else c.dict()
-                    for c in result.citations
-                ],
+                "citations": [_serialise_mapping(c) for c in result.citations],
                 "reasoning": result.reasoning,
                 "metrics": result.metrics,
             }
+            return response
         except Exception as exc:  # pragma: no cover - network errors
             logger.error("Error processing query", exc_info=exc)
             return {"error": str(exc)}
@@ -49,12 +48,27 @@ def query(
     port: int = 8080,
     *,
     transport: FastMCP | None = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Send a query to an MCP server and return the result."""
     target = transport or f"http://{host}:{port}"
 
-    async def _call() -> Dict[str, Any]:
+    async def _call() -> dict[str, Any]:
         async with Client(target) as client:
-            return await client.call_tool("research", {"query": query})
+            result = await client.call_tool("research", {"query": query})
+            return cast(dict[str, Any], result)
 
     return anyio.run(_call)
+
+
+def _serialise_mapping(value: Any) -> dict[str, Any] | Any:
+    """Return a JSON-serialisable representation of ``value``."""
+
+    if hasattr(value, "model_dump") and callable(value.model_dump):
+        dumped = value.model_dump(mode="json")
+        return cast(dict[str, Any], dumped)
+    if isinstance(value, Mapping):
+        return {str(key): val for key, val in value.items()}
+    attrs = getattr(value, "__dict__", None)
+    if isinstance(attrs, Mapping):
+        return {str(key): val for key, val in attrs.items()}
+    return value

--- a/src/autoresearch/storage_typing.py
+++ b/src/autoresearch/storage_typing.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:  # pragma: no cover - imported for typing only
     import kuzu
     import rdflib
     from rdflib.query import Result as RDFQueryResult
-    from rdflib.term import Identifier as RDFNode
+    from rdflib.term import Node as RDFNode
 
 else:  # pragma: no cover - executed only at runtime
     RDFNode = Any  # type: ignore[assignment]

--- a/tests/integration/evaluation/test_harness.py
+++ b/tests/integration/evaluation/test_harness.py
@@ -1,0 +1,107 @@
+"""Integration tests for the evaluation harness persistence layer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import pytest
+
+from autoresearch.config.models import ConfigModel
+from autoresearch.evaluation.datasets import EvaluationExample
+from autoresearch.evaluation.harness import EvaluationHarness
+from autoresearch.models import QueryResponse
+
+
+@pytest.mark.integration
+def test_harness_clones_config_and_closes_connections(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure the harness clones configs via ``update`` and closes DuckDB connections."""
+
+    dataset = "truthfulqa"
+    examples = [
+        EvaluationExample(
+            dataset=dataset,
+            example_id="example-1",
+            prompt="Is water breathable?",
+            expected_answers=("no",),
+        )
+    ]
+
+    monkeypatch.setattr(
+        "autoresearch.evaluation.harness.available_datasets",
+        lambda: [dataset],
+    )
+    monkeypatch.setattr(
+        "autoresearch.evaluation.harness.load_examples",
+        lambda _: examples,
+    )
+
+    copy_calls: list[dict[str, Any]] = []
+    original_model_copy = ConfigModel.model_copy
+
+    def _spy_model_copy(
+        self: ConfigModel, *, update: dict[str, Any] | None = None, deep: bool = False
+    ) -> ConfigModel:
+        copy_calls.append({"update": update, "deep": deep})
+        return original_model_copy(self, update=update, deep=deep)
+
+    monkeypatch.setattr(ConfigModel, "model_copy", _spy_model_copy)
+
+    class TrackingConnection:
+        def __init__(self, inner: duckdb.DuckDBPyConnection) -> None:
+            self._inner = inner
+            self.closed = False
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._inner, name)
+
+        def close(self) -> None:  # pragma: no cover - exercised via context manager
+            self.closed = True
+            self._inner.close()
+
+    connections: list[TrackingConnection] = []
+    original_connect = duckdb.connect
+
+    def _tracking_connect(*args: Any, **kwargs: Any) -> TrackingConnection:
+        connection = original_connect(*args, **kwargs)
+        wrapper = TrackingConnection(connection)
+        connections.append(wrapper)
+        return wrapper
+
+    monkeypatch.setattr(duckdb, "connect", _tracking_connect)
+
+    config = ConfigModel()
+
+    def _runner(prompt: str, cfg: ConfigModel) -> QueryResponse:
+        assert cfg is not config
+        assert prompt
+        return QueryResponse(
+            answer="no",
+            citations=[],
+            reasoning=[],
+            metrics={"execution_metrics": {"total_duration_seconds": 0.1}},
+        )
+
+    harness = EvaluationHarness(
+        output_dir=tmp_path,
+        duckdb_path=tmp_path / "metrics.duckdb",
+        runner=_runner,
+    )
+
+    summaries = harness.run(
+        [dataset],
+        config=config,
+        dry_run=False,
+        store_duckdb=True,
+        store_parquet=False,
+    )
+
+    assert summaries and summaries[0].duckdb_path is not None
+    assert copy_calls, "Expected ConfigModel.model_copy to be invoked"
+    assert copy_calls[0]["update"] == {}
+    assert copy_calls[0]["deep"] is True
+    assert connections, "Expected DuckDB connections to be opened"
+    assert all(conn.closed for conn in connections)

--- a/tests/integration/test_a2a_interface.py
+++ b/tests/integration/test_a2a_interface.py
@@ -19,15 +19,29 @@ for name in list(sys.modules):
     if name.startswith("a2a"):
         del sys.modules[name]
 
-from a2a.types import Message  # noqa: E402
+from a2a.types import Message, MessageSendParams  # noqa: E402
 from a2a.utils.message import get_message_text, new_agent_text_message  # noqa: E402
 
-from autoresearch.a2a_interface import A2A_AVAILABLE, A2AInterface  # noqa: E402
+from autoresearch.a2a_interface import (  # noqa: E402
+    A2A_AVAILABLE,
+    A2AInterface,
+    create_message_send_params,
+    get_message_model_cls,
+)
 from autoresearch.config.loader import ConfigLoader  # noqa: E402
 from autoresearch.config.models import ConfigModel  # noqa: E402
 from scripts.a2a_concurrency_sim import run_simulation  # noqa: E402
 
 pytestmark = pytest.mark.skipif(not A2A_AVAILABLE, reason="A2A SDK not available")
+
+
+def test_runtime_bindings_match_sdk() -> None:
+    """The helper accessors should expose the SDK runtime classes."""
+
+    assert get_message_model_cls() is Message
+    message = new_agent_text_message("hello")
+    params = create_message_send_params(message=message)
+    assert isinstance(params, MessageSendParams)
 
 
 @pytest.fixture

--- a/tests/integration/test_cli_sparql.py
+++ b/tests/integration/test_cli_sparql.py
@@ -1,0 +1,31 @@
+"""Integration tests covering CLI SPARQL utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoresearch.cli_utils import sparql_query_cli
+
+
+@pytest.mark.integration
+def test_sparql_query_cli_handles_missing_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI should tolerate result sets without a ``vars`` attribute."""
+
+    outputs: list[str] = []
+
+    rows = [("subject", "object")]
+
+    monkeypatch.setattr(
+        "autoresearch.storage.StorageManager.query_rdf",
+        staticmethod(lambda _query: rows),
+    )
+
+    def fake_tabulate(rows_arg, headers_arg, tablefmt_arg):
+        return f"{headers_arg}:{list(rows_arg)}"
+
+    monkeypatch.setattr("autoresearch.cli_utils.tabulate", fake_tabulate)
+    monkeypatch.setattr("autoresearch.cli_utils.console.print", outputs.append)
+
+    sparql_query_cli("SELECT ?s ?o WHERE { ?s ?p ?o }", apply_reasoning=False)
+
+    assert outputs == ["[]:[('subject', 'object')]"]


### PR DESCRIPTION
## Summary
- add a typed ConfigModel.model_copy helper and adopt it across the evaluation harness, CLI utilities, and routing API to remove cast-heavy call sites
- wrap DuckDB usage in the evaluation harness with a contextmanager and improve MCP serialization helpers while tightening CLI error handling signatures
- restructure the A2A interface runtime bindings, update cache typing, and extend integration tests covering the harness, CLI SPARQL output, and A2A helpers

## Testing
- uv run mypy src/autoresearch/evaluation/harness.py src/autoresearch/a2a_interface.py src/autoresearch/cli_utils.py src/autoresearch/main/app.py src/autoresearch/main/config_cli.py src/autoresearch/api/routing.py
- uv run mypy src/autoresearch/mcp_interface.py
- uv run task verify *(fails: repository-wide mypy still reports pre-existing strict errors outside the touched modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dafc46a4ec83339ac8171b434cd76b