### PR TITLE
Refine config cloning and interface serialization

### DIFF
--- a/src/autoresearch/config/models.py
+++ b/src/autoresearch/config/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, ClassVar, Dict, List, Mapping, Optional, Self, cast
+from typing import Any, ClassVar, Dict, List, Mapping, Optional
 
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from pydantic.functional_validators import model_validator
@@ -295,6 +295,19 @@ class StorageConfig(BaseModel):
         ),
     )
 
+    def model_copy(
+        self,
+        *,
+        update: Mapping[str, Any] | None = None,
+        deep: bool = False,
+    ) -> "StorageConfig":
+        """Return a cloned storage configuration preserving type information."""
+
+        payload = self.model_dump(mode="python")
+        if update:
+            payload = {**payload, **dict(update)}
+        return StorageConfig.model_validate(payload)
+
     _validate_rdf_backend = field_validator("rdf_backend")(validate_rdf_backend)
 
 
@@ -564,10 +577,12 @@ class ConfigModel(BaseModel):
         *,
         update: Mapping[str, Any] | None = None,
         deep: bool = False,
-    ) -> Self:
+    ) -> "ConfigModel":
         """Return a cloned configuration while preserving ``ConfigModel`` typing."""
 
-        base_model = cast(Any, super(ConfigModel, self))
-        return cast(Self, base_model.model_copy(update=update, deep=deep))
+        payload = self.model_dump(mode="python")
+        if update:
+            payload = {**payload, **dict(update)}
+        return ConfigModel.model_validate(payload)
 
     model_config: ClassVar[SettingsConfigDict] = {"extra": "ignore"}

--- a/src/autoresearch/evaluation/harness.py
+++ b/src/autoresearch/evaluation/harness.py
@@ -205,7 +205,7 @@ class EvaluationHarness:
                     )
                 )
                 continue
-            config_copy = config.model_copy(deep=True)
+            config_copy = config.model_copy(update={}, deep=True)
             response = runner(example.prompt, config_copy)
             results.append(self._build_result(example, response))
         return results

--- a/src/autoresearch/main/app.py
+++ b/src/autoresearch/main/app.py
@@ -42,7 +42,6 @@ from ..cli_utils import (
 from ..cli_utils import visualize_query_cli as _cli_visualize_query
 from ..cli_utils import visualize_rdf_cli as _cli_visualize
 from ..config.loader import ConfigLoader
-from ..config.models import ConfigModel
 from ..error_utils import format_error_for_cli, get_error_info
 from ..errors import StorageError
 from ..logging_utils import configure_logging
@@ -454,9 +453,9 @@ def search(
     if ontology_reasoner is not None:
         storage_updates["ontology_reasoner"] = ontology_reasoner
     if storage_updates:
-        updates["storage"] = {**config.storage.model_dump(), **storage_updates}
+        updates["storage"] = config.storage.model_copy(update=storage_updates)
     if updates:
-        config = ConfigModel.model_validate({**config.model_dump(), **updates})
+        config = config.model_copy(update=updates)
 
     if ontology:
         StorageManager.load_ontology(ontology)

--- a/src/autoresearch/main/config_cli.py
+++ b/src/autoresearch/main/config_cli.py
@@ -11,7 +11,6 @@ import typer
 
 from ..cli_backup import backup_app
 from ..config.loader import ConfigLoader
-from ..config.models import ConfigModel
 from ..config_utils import validate_config
 from ..errors import ConfigError
 from .app import _config_loader
@@ -24,7 +23,7 @@ def config_callback(ctx: typer.Context) -> None:
     """Manage configuration commands."""
     if ctx.invoked_subcommand is None:
         config = _config_loader.load_config()
-        payload = config.model_dump(mode="json")
+        payload = config.model_dump(mode="python")
         typer.echo(json.dumps(payload, indent=2))
 
 
@@ -217,7 +216,7 @@ def config_reasoning(
                 provided=gate_user_overrides,
                 cause=ValueError("Overrides must be a JSON object"),
             )
-    new_cfg = ConfigModel.model_validate({**data, **updates})
+    new_cfg = cfg.model_copy(update=updates)
     path = next(
         (p for p in _config_loader.search_paths if p.exists()),
         _config_loader.search_paths[0],

--- a/src/autoresearch/mcp_interface.py
+++ b/src/autoresearch/mcp_interface.py
@@ -64,7 +64,7 @@ def _serialise_mapping(value: Any) -> dict[str, Any] | Any:
     """Return a JSON-serialisable representation of ``value``."""
 
     if hasattr(value, "model_dump") and callable(value.model_dump):
-        dumped = value.model_dump(mode="json")
+        dumped = value.model_dump(mode="python")
         return cast(dict[str, Any], dumped)
     if isinstance(value, Mapping):
         return {str(key): val for key, val in value.items()}

--- a/tests/integration/test_a2a_interface.py
+++ b/tests/integration/test_a2a_interface.py
@@ -82,7 +82,7 @@ def running_server(monkeypatch):
 
 def _build_payload(text: str) -> dict:
     msg = new_agent_text_message(text)
-    return {"type": "query", "message": msg.model_dump(mode="json")}
+    return {"type": "query", "message": msg.model_dump(mode="python")}
 
 
 @pytest.mark.slow

--- a/tests/integration/test_cli_progress.py
+++ b/tests/integration/test_cli_progress.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from autoresearch.main import app as cli_app
 from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
@@ -61,3 +63,57 @@ def test_cli_progress_and_interactive(monkeypatch):
     assert progress_instances[0].updates == [1, 1]
     # One prompt for each cycle except the last
     assert len(prompts) == 1
+
+
+def test_cli_search_uses_model_copy(monkeypatch, tmp_path):
+    """The search command should clone configs via ``model_copy`` when updating."""
+
+    import autoresearch.main as main_module
+
+    config_path = tmp_path / "autoresearch.toml"
+    config_path.write_text("[core]\nloops = 1\n", encoding="utf-8")
+
+    monkeypatch.setattr(main_module._config_loader, "search_paths", [config_path])
+    monkeypatch.setattr(main_module._config_loader, "env_path", tmp_path / ".env")
+
+    cfg = ConfigModel()
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    monkeypatch.setattr(main_module._config_loader, "_config", cfg)
+
+    copy_calls: list[dict[str, Any]] = []
+    original_model_copy = ConfigModel.model_copy
+
+    def _spy_model_copy(
+        self: ConfigModel,
+        *,
+        update: dict[str, Any] | None = None,
+        deep: bool = False,
+    ) -> ConfigModel:
+        copy_calls.append({"update": update, "deep": deep})
+        return original_model_copy(self, update=update, deep=deep)
+
+    monkeypatch.setattr(ConfigModel, "model_copy", _spy_model_copy)
+
+    class StubStorageManager:
+        @staticmethod
+        def setup() -> None:  # pragma: no cover - no side effects in tests
+            return None
+
+    monkeypatch.setattr("autoresearch.storage.StorageManager", StubStorageManager)
+
+    def dummy_run_query(self, query, config, callbacks=None, visualize=None, **kwargs):
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+
+    monkeypatch.setattr(
+        "autoresearch.orchestration.orchestrator.Orchestrator.run_query",
+        dummy_run_query,
+    )
+    monkeypatch.setattr("autoresearch.output_format.OutputFormatter.format", lambda *_, **__: None)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["search", "prompt", "--loops", "3"])
+
+    assert result.exit_code == 0
+    assert copy_calls, "Expected ConfigModel.model_copy to be invoked"
+    assert copy_calls[0]["update"] == {"loops": 3}


### PR DESCRIPTION
## Summary
- add typed `model_copy` helpers for `StorageConfig` and `ConfigModel`, and ensure the evaluation harness clones configs via `update={}`
- update CLI pathways and MCP/A2A serializers to avoid json-mode dumps while relying on the typed copy helpers
- extend CLI and A2A integration tests to exercise the updated configuration and serialization flows

## Testing
- uv run task verify *(fails: existing mypy errors outside evaluation/CLI/A2A packages)*
- uv run mypy src/autoresearch/evaluation/harness.py src/autoresearch/main/app.py src/autoresearch/main/config_cli.py src/autoresearch/mcp_interface.py src/autoresearch/a2a_interface.py

------
https://chatgpt.com/codex/tasks/task_e_68db2681c5c083339774c038f732ac8a