### PR TITLE
Stabilize answer auditing dependencies and linting

### DIFF
--- a/docs/deep_research_upgrade_plan.md
+++ b/docs/deep_research_upgrade_plan.md
@@ -26,6 +26,10 @@ keep truthfulness, verifiability, and cost discipline in balance.
      tailor the decision boundary.
    - Extend the evidence pipeline to record per-claim support status.
    - Update response formats so clients can render audit tables.
+   - Introduce an answer auditor that reviews claim audits before synthesis,
+     triggers targeted re-retrieval for unsupported statements, hedges the
+     final answer, and records structured retry provenance for downstream
+     clients.
    - Add behavior coverage for the AUTO planner → scout gate → verify loop so
      gate decisions and audit badges stay regression-proof, including CLI
      orchestration to confirm telemetry exposes verification badges end to end.

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -48,7 +48,8 @@ Deep research tickets stay referenced for release sign-off:
 
 - **Phase 1 – Adaptive gate and claim audits:** See
   [adaptive-gate-and-claim-audit-rollout][phase1-ticket] for the gating
-  heuristics, scout pass, and audit tables.
+  heuristics, scout pass, audit tables, and the new answer auditor that hedges
+  unsupported claims after a targeted re-retrieval pass.
 - **Phase 2 – Planner and coordinator upgrades:**
   [planner-coordinator-react-upgrade][phase2-ticket] records the ReAct
   telemetry and scheduling refinements.

--- a/src/autoresearch/agents/specialized/planner.py
+++ b/src/autoresearch/agents/specialized/planner.py
@@ -177,24 +177,24 @@ class PlannerPromptBuilder:
                 preview = entries[:3]
                 if preview:
                     sections.append("  Contradictory findings:")
-                    for item in preview:
-                        subject = str(item.get("subject") or "?")
-                        predicate = str(item.get("predicate") or "?")
-                        objects = item.get("objects")
-                        if isinstance(objects, Sequence) and objects:
-                            object_preview = ", ".join(
-                                str(obj) for obj in list(objects)[:3]
-                            )
-                            if len(objects) > 3:
-                                object_preview += ", …"
-                        else:
-                            object_preview = "?"
-                        sections.append(
-                            f"    - {subject} --{predicate}--> {object_preview}"
+                for item_mapping in preview:
+                    subject = str(item_mapping.get("subject") or "?")
+                    predicate = str(item_mapping.get("predicate") or "?")
+                    objects = item_mapping.get("objects")
+                    if isinstance(objects, Sequence) and objects:
+                        object_preview = ", ".join(
+                            str(obj) for obj in list(objects)[:3]
                         )
-                    remaining = len(entries) - len(preview)
-                    if remaining > 0:
-                        sections.append(f"    - … ({remaining} more)")
+                        if len(objects) > 3:
+                            object_preview += ", …"
+                    else:
+                        object_preview = "?"
+                    sections.append(
+                        f"    - {subject} --{predicate}--> {object_preview}"
+                    )
+                remaining = len(entries) - len(preview)
+                if remaining > 0:
+                    sections.append(f"    - … ({remaining} more)")
 
         neighbors = context.get("neighbors")
         if isinstance(neighbors, Mapping):
@@ -240,8 +240,8 @@ class PlannerPromptBuilder:
                     formatted_paths.append(" → ".join(nodes))
             if formatted_paths:
                 sections.append("- Multi-hop paths:")
-                for item in formatted_paths:
-                    sections.append(f"  - {item}")
+                for path_summary in formatted_paths:
+                    sections.append(f"  - {path_summary}")
                 if total_paths > len(formatted_paths):
                     sections.append("  - …")
 

--- a/src/autoresearch/distributed/__init__.py
+++ b/src/autoresearch/distributed/__init__.py
@@ -3,6 +3,8 @@
 See docs/algorithms/distributed_coordination.md for mathematical models.
 """
 
+from typing import TYPE_CHECKING
+
 from .broker import (
     InMemoryBroker,
     RedisBroker,
@@ -17,8 +19,8 @@ from .coordinator import (
     start_result_aggregator,
     publish_claim,
 )
-from .executors import RayExecutor, ProcessExecutor
-
+# Lazy-loaded exports are declared as strings to avoid eager imports that
+# would otherwise create circular dependencies during module initialisation.
 __all__ = [
     "InMemoryBroker",
     "RedisBroker",
@@ -33,3 +35,17 @@ __all__ = [
     "RayExecutor",
     "ProcessExecutor",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Lazily import executor classes on demand."""
+
+    if name in {"RayExecutor", "ProcessExecutor"}:
+        from . import executors as _executors
+
+        return getattr(_executors, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only for static analysis
+    from .executors import ProcessExecutor, RayExecutor

--- a/src/autoresearch/extensions.py
+++ b/src/autoresearch/extensions.py
@@ -242,8 +242,9 @@ class VSSExtensionLoader:
         try:
             import duckdb_extension_vss as vss
 
-            if hasattr(vss, "load"):
-                vss.load(conn)  # type: ignore[attr-defined]
+            load_fn = getattr(vss, "load", None)
+            if callable(load_fn):
+                load_fn(conn)
                 return VSSExtensionLoader.verify_extension(conn, verbose=False)
             path = Path(getattr(vss, "__file__", "")).parent / "vss.duckdb_extension"
             if path.exists():

--- a/src/autoresearch/orchestration/model_routing.py
+++ b/src/autoresearch/orchestration/model_routing.py
@@ -32,7 +32,7 @@ class RoutingOverrideRequest:
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-friendly representation of the override."""
 
-        payload = {
+        payload: dict[str, Any] = {
             "agent": self.agent,
             "requested_model": self.requested_model,
             "source": self.source,

--- a/src/autoresearch/orchestration/orchestration_utils.py
+++ b/src/autoresearch/orchestration/orchestration_utils.py
@@ -129,7 +129,11 @@ class ScoutGatePolicy:
         )
         nli_conflict, conflict_details = self._nli_conflict(state, details=True)
 
-        agreement_score, agreement_details = self._scout_agreement(state, details=True)
+        agreement_result = self._scout_agreement(state, details=True)
+        if isinstance(agreement_result, tuple):
+            agreement_score, agreement_details = agreement_result
+        else:
+            agreement_score, agreement_details = agreement_result, {}
 
         heuristics = {
             "retrieval_overlap": self._retrieval_overlap(state),

--- a/src/autoresearch/search/context.py
+++ b/src/autoresearch/search/context.py
@@ -825,12 +825,12 @@ class SearchContext:
             for record in provenance_records:
                 if not isinstance(record, Mapping):
                     continue
-                subject = record.get("subject")
-                obj = record.get("object")
-                if isinstance(subject, str):
-                    nodes_for_neighbors.append(subject)
-                if isinstance(obj, str):
-                    nodes_for_neighbors.append(obj)
+                subject_value = record.get("subject")
+                object_value = record.get("object")
+                if isinstance(subject_value, str):
+                    nodes_for_neighbors.append(subject_value)
+                if isinstance(object_value, str):
+                    nodes_for_neighbors.append(object_value)
 
         neighbors = self.get_graph_neighbors_for_nodes(nodes_for_neighbors, direction="both")
 

--- a/tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature
+++ b/tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature
@@ -17,3 +17,16 @@ Feature: AUTO CLI reasoning captures planner, scout gate, and verification loop
     When I run the AUTO reasoning CLI for query "scout gate direct exit rehearsal"
     Then the CLI should exit directly without escalation
     And the AUTO metrics should record scout samples and agreement
+
+  Scenario: AUTO direct exit hedges unsupported claims
+    Given the scout gate will force a direct exit
+    When I run the AUTO reasoning CLI for query "unsupported direct exit rehearsal"
+    Then the CLI should exit directly without escalation
+    And the CLI TLDR should warn about unsupported claims
+    And the CLI key findings should omit unsupported claims
+
+  Scenario: AUTO debate flow hedges unsupported claims
+    When I run the AUTO reasoning CLI for query "unsupported debate rehearsal"
+    Then the CLI scout gate decision should escalate to debate
+    And the CLI TLDR should warn about unsupported claims
+    And the CLI key findings should omit unsupported claims

--- a/tests/unit/orchestration/test_answer_audit.py
+++ b/tests/unit/orchestration/test_answer_audit.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from autoresearch.output_format import OutputDepth, OutputFormatter
+from autoresearch.orchestration.state import QueryState
+from autoresearch.storage import ClaimAuditStatus
+
+
+@pytest.fixture()
+def unsupported_state(monkeypatch: pytest.MonkeyPatch) -> QueryState:
+    """Provide a QueryState with an unsupported claim for audit testing."""
+
+    def fake_external_lookup(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        return [
+            {
+                "title": "Placeholder evidence",
+                "snippet": "No corroborating evidence for the unsupported claim.",
+                "url": "https://example.com/unsupported",
+            }
+        ]
+
+    monkeypatch.setattr(
+        "autoresearch.search.Search.external_lookup",
+        fake_external_lookup,
+    )
+
+    return QueryState(
+        query="unsupported audit rehearsal",
+        results={"final_answer": "Original answer without hedging."},
+        claims=[
+            {
+                "id": "c1",
+                "type": "synthesis",
+                "content": "The system guarantees an unverified capability.",
+            }
+        ],
+        claim_audits=[
+            {
+                "claim_id": "c1",
+                "status": ClaimAuditStatus.UNSUPPORTED.value,
+                "entailment_score": 0.05,
+            }
+        ],
+    )
+
+
+def test_answer_auditor_hedges_unsupported_claims(unsupported_state: QueryState) -> None:
+    """Answer auditing should hedge unsupported claims and update provenance."""
+
+    response = unsupported_state.synthesize()
+
+    assert response.answer.startswith("⚠️"), "Answer should be prefixed with a caution symbol"
+    assert response.metrics["answer_audit"]["unsupported_claims"] == ["c1"]
+
+    reasoning = response.reasoning[0]
+    assert reasoning.get("hedged_content", "").startswith("⚠️ Unsupported")
+    audit_entries = [
+        audit for audit in response.claim_audits if audit.get("claim_id") == "c1"
+    ]
+    assert any(
+        audit.get("provenance", {}).get("retrieval", {}).get("mode")
+        == "answer_audit.retry"
+        for audit in audit_entries
+    )
+
+    depth_payload = OutputFormatter.plan_response_depth(response, OutputDepth.CONCISE)
+    assert all(
+        "unverified capability" not in finding.lower()
+        for finding in depth_payload.key_findings
+    )
+    assert "unsupported claims" in depth_payload.notes.get("key_findings", "").lower()


### PR DESCRIPTION
## Summary
- lazily export distributed executors to remove the storage/search circular import and keep static typing happy
- filter unsupported-claim cautions out of key findings and tighten audit bookkeeping to satisfy mypy
- harden capability probing, planner graph formatting, and search helpers so strict typing succeeds across the codebase

## Testing
- uv run pytest tests/unit/orchestration/test_answer_audit.py
- uv run task verify *(fails: existing mypy errors across tests and strict suite)*
- uv run task coverage EXTRAS="dev-minimal test" *(fails: pydantic schema error in tests/unit/test_a2a_interface.py)*

------
https://chatgpt.com/codex/tasks/task_e_68db5b1f640483339be5590ed7b1b907