### PR TITLE
Refine search embeddings typing and cache handling

### DIFF
--- a/src/autoresearch/cache.py
+++ b/src/autoresearch/cache.py
@@ -104,9 +104,8 @@ class SearchCache:
         )
         row = cast(Optional[Dict[str, Any]], db.get(condition))
         if row:
-            results_raw = row.get("results", [])
-            results = cast(List[Dict[str, Any]], deepcopy(results_raw))
-            return results
+            results_raw = cast(List[Dict[str, Any]], row.get("results", []))
+            return deepcopy(results_raw)
         return None
 
     def clear(self, namespace: str | None = None) -> None:
@@ -170,6 +169,18 @@ class _SearchCacheView:
 
     def namespaced(self, namespace: str | None) -> "SearchCache | _SearchCacheView":
         return self._base.namespaced(namespace)
+
+    @property
+    def base(self) -> SearchCache:
+        """Return the underlying :class:`SearchCache` instance."""
+
+        return self._base
+
+    @property
+    def namespace(self) -> str:
+        """Return the namespace applied to this view."""
+
+        return self._namespace
 
 
 _shared_cache = SearchCache()

--- a/typings/spacy/cli.pyi
+++ b/typings/spacy/cli.pyi
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def download(model: str, *args: Any, **kwargs: Any) -> None: ...
+
+__all__ = ["download"]


### PR DESCRIPTION
## Summary
- introduce an embedding model protocol so both fastembed and sentence-transformers share a typed initialization path and adjust Search to normalize cache views when bundling lookup results
- guard spaCy CLI imports, add a stub for strict type checking, and expose cache view metadata for safer reuse
- extend the query expansion convergence suite to exercise the fastembed and sentence-transformers code paths with lightweight fakes

## Testing
- uv run mypy --strict src/autoresearch/search src/autoresearch/cache.py
- uv run task verify *(fails: existing mypy strict errors throughout tests and scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68dc00477f608333bf02d943f93b22b6