### PR TITLE
Sanitize monitoring floats and normalize graph latency

### DIFF
--- a/src/autoresearch/monitor/metrics.py
+++ b/src/autoresearch/monitor/metrics.py
@@ -14,7 +14,7 @@ async def metrics_endpoint(_: None = None) -> PlainTextResponse:
     """
 
     try:
-        payload = generate_latest()
+        raw_payload = generate_latest()
     except Exception:
         # Ensure monitoring surfaces a valid response even if Prometheus internals fail.
         return PlainTextResponse(
@@ -22,10 +22,11 @@ async def metrics_endpoint(_: None = None) -> PlainTextResponse:
             media_type=CONTENT_TYPE_LATEST,
             status_code=503,
         )
-    if isinstance(payload, (bytes, bytearray, memoryview)):
-        body = bytes(payload).decode("utf-8", "replace")
+    if isinstance(raw_payload, (bytes, bytearray, memoryview)):
+        payload = bytes(raw_payload).decode("utf-8", "replace")
     else:  # pragma: no cover - defensive fallback
-        body = str(payload)
+        payload = str(raw_payload)
+    body: str = payload
     return PlainTextResponse(
         body,
         media_type=CONTENT_TYPE_LATEST,

--- a/src/autoresearch/monitor/system_monitor.py
+++ b/src/autoresearch/monitor/system_monitor.py
@@ -4,7 +4,7 @@ import math
 import threading
 import time
 from collections.abc import Sequence
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, SupportsFloat
 
 import psutil
 from prometheus_client import REGISTRY, CollectorRegistry, Gauge
@@ -17,9 +17,20 @@ def _coerce_float(value: Any) -> float:
         for item in value:
             return _coerce_float(item)
         return 0.0
-    try:
-        result = float(value)
-    except (TypeError, ValueError):
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return 0.0
+        try:
+            result = float(text)
+        except ValueError:
+            return 0.0
+    elif isinstance(value, SupportsFloat):
+        try:
+            result = float(value)
+        except (TypeError, ValueError):
+            return 0.0
+    else:
         return 0.0
     if not math.isfinite(result):
         return 0.0


### PR DESCRIPTION
## Summary
- update system monitoring float coercion and Prometheus endpoint decoding to return finite text payloads
- introduce `_safe_float` and `_normalize_latency_mapping` to flatten graph ingestion latency metrics and reuse sanitized values in summaries
- extend unit coverage for metrics sanitization and decoding paths

## Testing
- `uv run mypy --strict src/autoresearch/orchestration/metrics.py src/autoresearch/monitor`
- `uv run pytest tests/unit/monitor/test_metrics_endpoint.py tests/unit/orchestration/test_utils_confidence.py`
- `uv run task verify` *(fails: repository-wide strict mypy on tests reports pre-existing annotation issues)*

------
https://chatgpt.com/codex/tasks/task_e_68dc05a19e348333bd11f96e118e84b1