### PR TITLE
Add precise typing to stub modules and source credibility simulation

### DIFF
--- a/scripts/simulate_source_credibility.py
+++ b/scripts/simulate_source_credibility.py
@@ -9,9 +9,18 @@ from __future__ import annotations
 
 import re
 from statistics import mean
-from typing import List, Tuple
+from typing import Iterable, TypedDict
 
-LABELED_DATASET: List[dict] = [
+
+class Document(TypedDict):
+    url: str
+
+
+class LabeledDocument(Document):
+    label: int
+
+
+LABELED_DATASET: list[LabeledDocument] = [
     {"url": "https://en.wikipedia.org/wiki/Artificial_intelligence", "label": 1},
     {"url": "https://nih.gov/research", "label": 1},
     {"url": "https://dept.university.edu/paper", "label": 1},
@@ -20,7 +29,7 @@ LABELED_DATASET: List[dict] = [
     {"url": "https://example.com/post", "label": 0},
 ]
 
-AUTHORITY = {
+AUTHORITY: dict[str, float] = {
     "wikipedia.org": 0.9,
     "nih.gov": 0.95,
     "edu": 0.8,
@@ -28,9 +37,9 @@ AUTHORITY = {
 }
 
 
-def assess_source_credibility(documents: List[dict]) -> List[float]:
+def assess_source_credibility(documents: Iterable[Document]) -> list[float]:
     """Return heuristic credibility scores for each document."""
-    scores: List[float] = []
+    scores: list[float] = []
     for doc in documents:
         url = doc.get("url", "")
         domain = ""
@@ -49,11 +58,11 @@ def assess_source_credibility(documents: List[dict]) -> List[float]:
     return scores
 
 
-def score_dataset() -> List[Tuple[int, float]]:
+def score_dataset() -> list[tuple[int, float]]:
     """Return (label, score) pairs for the labeled dataset."""
-    docs = [{"url": item["url"]} for item in LABELED_DATASET]
+    docs: list[Document] = [{"url": item["url"]} for item in LABELED_DATASET]
     scores = assess_source_credibility(docs)
-    return [(item["label"], score) for item, score in zip(LABELED_DATASET, scores)]
+    return [(item["label"], score) for item, score in zip(LABELED_DATASET, scores, strict=True)]
 
 
 def main() -> None:

--- a/tests/stubs/fastmcp.py
+++ b/tests/stubs/fastmcp.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable
-from types import ModuleType
-from typing import Any, Callable, Dict, Protocol, cast
+from types import ModuleType, TracebackType
+from typing import Any, Callable, Protocol, cast
 
 from ._registry import install_stub_module
 
 
 class FastMCP:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.tools: Dict[str, Callable[..., Awaitable[Any] | Any]] = {}
+        self.tools: dict[str, Callable[..., Awaitable[Any] | Any]] = {}
 
     def tool(self, func: Callable[..., Awaitable[Any] | Any]) -> Callable[..., Awaitable[Any] | Any]:
         self.tools[func.__name__] = func
@@ -32,7 +32,12 @@ class Client:
     async def __aenter__(self) -> Client:
         return self
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:  # pragma: no cover - trivial
         return None
 
     async def call_tool(self, name: str, params: dict[str, Any]) -> Any:

--- a/tests/stubs/pdfminer.py
+++ b/tests/stubs/pdfminer.py
@@ -4,24 +4,24 @@ from __future__ import annotations
 
 import importlib.util
 from types import ModuleType
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 from ._registry import install_stub_module
 
 
-def extract_text(*args, **kwargs) -> str:
+def extract_text(*args: Any, **kwargs: Any) -> str:
     return ""
 
 
 class PdfminerHighLevelModule(Protocol):
-    def extract_text(self, *args, **kwargs) -> str: ...
+    def extract_text(self, *args: Any, **kwargs: Any) -> str: ...
 
 
 class _PdfminerHighLevelModule(ModuleType):
     def __init__(self) -> None:
         super().__init__("pdfminer.high_level")
 
-    def extract_text(self, *args, **kwargs) -> str:
+    def extract_text(self, *args: Any, **kwargs: Any) -> str:
         return extract_text(*args, **kwargs)
 
 

--- a/tests/stubs/streamlit.py
+++ b/tests/stubs/streamlit.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import importlib.util
-from types import ModuleType, SimpleNamespace
-from typing import Any, Protocol, Sequence, cast
+from types import ModuleType, SimpleNamespace, TracebackType
+from typing import Any, ContextManager, Protocol, Sequence, cast
 
 from ._registry import install_stub_module
 
@@ -35,16 +35,21 @@ class StreamlitModule(Protocol):
 
     def columns(self, *args: Any, **kwargs: Any) -> Sequence[SimpleNamespace]: ...
 
-    def container(self) -> SimpleNamespace: ...
+    def container(self) -> ContextManager[SimpleNamespace]: ...
 
-    def modal(self, *args: Any, **kwargs: Any) -> SimpleNamespace: ...
+    def modal(self, *args: Any, **kwargs: Any) -> ContextManager[SimpleNamespace]: ...
 
 
 class _ContextManager(SimpleNamespace):
-    def __enter__(self) -> None:  # pragma: no cover - trivial
-        return None
+    def __enter__(self) -> SimpleNamespace:  # pragma: no cover - trivial
+        return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:  # pragma: no cover - trivial
         return None
 
 
@@ -77,10 +82,10 @@ class _StreamlitModule(ModuleType):
     def columns(self, *args: Any, **kwargs: Any) -> Sequence[SimpleNamespace]:
         return (SimpleNamespace(), SimpleNamespace())
 
-    def container(self) -> SimpleNamespace:
+    def container(self) -> ContextManager[SimpleNamespace]:
         return _ContextManager()
 
-    def modal(self, *args: Any, **kwargs: Any) -> SimpleNamespace:
+    def modal(self, *args: Any, **kwargs: Any) -> ContextManager[SimpleNamespace]:
         return _ContextManager()
 
 

--- a/tests/stubs/watchfiles.py
+++ b/tests/stubs/watchfiles.py
@@ -4,25 +4,25 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from types import ModuleType
-from typing import Iterable, Protocol, cast
+from typing import Any, Iterable, Protocol, cast
 
 from ._registry import install_stub_module
 
 
-def watch(*_args, **_kwargs) -> Generator[tuple[str, str], None, None]:
+def watch(*_args: Any, **_kwargs: Any) -> Generator[tuple[str, str], None, None]:
     if False:
         yield ("", "")
 
 
 class WatchfilesModule(Protocol):
-    def watch(self, *args, **kwargs) -> Iterable[tuple[str, str]]: ...
+    def watch(self, *args: Any, **kwargs: Any) -> Iterable[tuple[str, str]]: ...
 
 
 class _WatchfilesModule(ModuleType):
     def __init__(self) -> None:
         super().__init__("watchfiles")
 
-    def watch(self, *args, **kwargs) -> Iterable[tuple[str, str]]:
+    def watch(self, *args: Any, **kwargs: Any) -> Iterable[tuple[str, str]]:
         return watch(*args, **kwargs)
 
 


### PR DESCRIPTION
## Summary
- annotate watchfiles, streamlit, pdfminer, fastmcp, and slowapi stubs with explicit Any varargs and richer protocol/context manager typing to mirror runtime behavior
- model the simulated credibility dataset with TypedDict definitions and concrete return types
- ensure mypy strict mode stays clean for the shared scaffolding

## Testing
- uv run mypy --strict tests/stubs scripts/simulate_source_credibility.py

------
https://chatgpt.com/codex/tasks/task_e_68dc2607c3588333b94641c655aaada3