### PR TITLE
Refine broker message tests and API auth typing

### DIFF
--- a/tests/integration/extras/test_distributed_extra.py
+++ b/tests/integration/extras/test_distributed_extra.py
@@ -2,15 +2,28 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 
-from autoresearch.distributed.broker import get_message_broker
+from autoresearch.distributed.broker import AgentResultMessage, get_message_broker
+
+
+def _make_agent_result_message(result: dict[str, Any] | None = None) -> AgentResultMessage:
+    return {
+        "action": "agent_result",
+        "agent": "agent",
+        "result": result or {"k": "v"},
+        "pid": 1234,
+    }
 
 
 @pytest.mark.requires_distributed
 def test_inmemory_broker_roundtrip() -> None:
     """The distributed extra adds message brokers."""
     broker = get_message_broker("memory")
-    broker.publish({"k": "v"})
-    assert broker.queue.get()["k"] == "v"
+    expected = _make_agent_result_message()
+    broker.publish(expected)
+    message = cast(AgentResultMessage, broker.queue.get())
+    assert message == expected
     broker.shutdown()

--- a/tests/integration/test_api_auth.py
+++ b/tests/integration/test_api_auth.py
@@ -31,7 +31,13 @@ def _setup(monkeypatch: pytest.MonkeyPatch) -> ConfigModel:
         callbacks: CallbackMap | None = None,
         **kwargs: object,
     ) -> QueryResponse:
-        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+        return QueryResponse(
+            query=query,
+            answer="ok",
+            citations=[],
+            reasoning=[],
+            metrics={},
+        )
 
     run_query_stub: QueryRunner = _run_query_stub
     monkeypatch.setattr(ConfigLoader, "load_config", _load_config_stub)

--- a/tests/integration/test_api_auth_middleware.py
+++ b/tests/integration/test_api_auth_middleware.py
@@ -1,55 +1,92 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
+import pytest
+from fastapi.testclient import TestClient
+from requests import Response as HTTPResponse
+
+from autoresearch.models import QueryResponse
+
 from .test_api_auth import _setup
 
 
-def test_auth_validated_before_body(monkeypatch, api_client):
+def test_auth_validated_before_body(
+    monkeypatch: pytest.MonkeyPatch, api_client: TestClient
+) -> None:
     cfg = _setup(monkeypatch)
     cfg.api.api_key = "secret"
+    client = cast(Any, api_client)
 
-    resp = api_client.post(
-        "/query",
-        content="not json",
-        headers={"Content-Type": "application/json"},
+    resp = cast(
+        HTTPResponse,
+        client.post(
+            "/query",
+            content="not json",
+            headers={"Content-Type": "application/json"},
+        ),
     )
     assert resp.status_code == 401
     assert resp.json()["detail"] == "Missing API key"
 
 
-def test_invalid_key_before_body(monkeypatch, api_client):
+def test_invalid_key_before_body(
+    monkeypatch: pytest.MonkeyPatch, api_client: TestClient
+) -> None:
     cfg = _setup(monkeypatch)
     cfg.api.api_key = "secret"
+    client = cast(Any, api_client)
 
-    resp = api_client.post(
-        "/query",
-        content="not json",
-        headers={"Content-Type": "application/json", "X-API-Key": "bad"},
+    resp = cast(
+        HTTPResponse,
+        client.post(
+            "/query",
+            content="not json",
+            headers={"Content-Type": "application/json", "X-API-Key": "bad"},
+        ),
     )
     assert resp.status_code == 401
     assert resp.json()["detail"] == "Invalid API key"
 
 
-def test_webhook_auth(monkeypatch, api_client):
+def test_webhook_auth(
+    monkeypatch: pytest.MonkeyPatch, api_client: TestClient
+) -> None:
     cfg = _setup(monkeypatch)
     cfg.api.api_key = "secret"
     called: list[str] = []
-    monkeypatch.setattr(
-        "autoresearch.api.webhooks.notify_webhook",
-        lambda url, result, timeout=5, retries=3, backoff=0.5: called.append(url),
-    )
 
-    resp = api_client.post(
-        "/query",
-        json={"query": "q", "webhook_url": "http://example.com"},
-        headers={"X-API-Key": "secret"},
+    def _notify_webhook(
+        url: str,
+        result: QueryResponse,
+        timeout: float = 5,
+        retries: int = 3,
+        backoff: float = 0.5,
+    ) -> None:
+        called.append(url)
+
+    monkeypatch.setattr("autoresearch.api.webhooks.notify_webhook", _notify_webhook)
+
+    client = cast(Any, api_client)
+
+    resp = cast(
+        HTTPResponse,
+        client.post(
+            "/query",
+            json={"query": "q", "webhook_url": "http://example.com"},
+            headers={"X-API-Key": "secret"},
+        ),
     )
     assert resp.status_code == 200
     assert called == ["http://example.com"]
 
     called.clear()
-    resp_bad = api_client.post(
-        "/query",
-        json={"query": "q", "webhook_url": "http://example.com"},
+    resp_bad = cast(
+        HTTPResponse,
+        client.post(
+            "/query",
+            json={"query": "q", "webhook_url": "http://example.com"},
+        ),
     )
     assert resp_bad.status_code == 401
     assert called == []

--- a/tests/integration/test_api_auth_streaming.py
+++ b/tests/integration/test_api_auth_streaming.py
@@ -1,87 +1,131 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
 import pytest
+from fastapi.testclient import TestClient
+from requests import Response as HTTPResponse
 
 from autoresearch.api.utils import generate_bearer_token
+from autoresearch.config.models import ConfigModel
 from autoresearch.models import QueryResponse
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.orchestration.state import QueryState
+from autoresearch.orchestration.types import CallbackMap, CycleCallback
+from tests.typing_helpers import QueryRunner
 
 from .test_api_auth import _setup
 
 
-def _setup_stream(monkeypatch):
+def _setup_stream(monkeypatch: pytest.MonkeyPatch) -> ConfigModel:
     cfg = _setup(monkeypatch)
 
-    def dummy_run_query(query, config, callbacks=None, **kwargs):
+    def dummy_run_query(
+        query: str,
+        config: ConfigModel,
+        callbacks: CallbackMap | None = None,
+        **kwargs: object,
+    ) -> QueryResponse:
         state = QueryState(query=query)
         if callbacks and "on_cycle_end" in callbacks:
-            callbacks["on_cycle_end"](0, state)
-        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+            on_cycle_end = cast(CycleCallback, callbacks["on_cycle_end"])
+            on_cycle_end(0, state)
+        return QueryResponse(
+            query=query,
+            answer="ok",
+            citations=[],
+            reasoning=[],
+            metrics={},
+        )
 
-    monkeypatch.setattr(Orchestrator, "run_query", dummy_run_query)
+    run_query_stub: QueryRunner = dummy_run_query
+    monkeypatch.setattr(Orchestrator, "run_query", run_query_stub)
     return cfg
 
 
 @pytest.mark.slow
-def test_streaming_with_api_key(monkeypatch, api_client):
+def test_streaming_with_api_key(
+    monkeypatch: pytest.MonkeyPatch, api_client: TestClient
+) -> None:
     cfg = _setup_stream(monkeypatch)
     cfg.api.api_key = "secret"
+    client = cast(Any, api_client)
 
-    with api_client.stream(
+    with client.stream(
         "POST", "/query?stream=true", json={"query": "q"}, headers={"X-API-Key": "secret"}
     ) as resp:
-        assert resp.status_code == 200
-        _ = [line for line in resp.iter_lines()]
+        response = cast(HTTPResponse, resp)
+        assert response.status_code == 200
+        response_lines = cast(Any, response)
+        _ = [line for line in response_lines.iter_lines()]
 
-    bad = api_client.post("/query?stream=true", json={"query": "q"}, headers={"X-API-Key": "bad"})
+    bad = cast(
+        HTTPResponse,
+        client.post("/query?stream=true", json={"query": "q"}, headers={"X-API-Key": "bad"}),
+    )
     assert bad.status_code == 401
     assert bad.json()["detail"] == "Invalid API key"
     assert bad.headers["WWW-Authenticate"] == "API-Key"
 
-    missing = api_client.post("/query?stream=true", json={"query": "q"})
+    missing = cast(HTTPResponse, client.post("/query?stream=true", json={"query": "q"}))
     assert missing.status_code == 401
     assert missing.json()["detail"] == "Missing API key"
     assert missing.headers["WWW-Authenticate"] == "API-Key"
 
 
 @pytest.mark.slow
-def test_streaming_forbidden(monkeypatch, api_client):
+def test_streaming_forbidden(
+    monkeypatch: pytest.MonkeyPatch, api_client: TestClient
+) -> None:
     cfg = _setup_stream(monkeypatch)
     cfg.api.api_keys = {"usr": "user"}
     cfg.api.role_permissions = {"user": []}
-    resp = api_client.post(
-        "/query?stream=true",
-        json={"query": "q"},
-        headers={"X-API-Key": "usr"},
+    client = cast(Any, api_client)
+    resp = cast(
+        HTTPResponse,
+        client.post(
+            "/query?stream=true",
+            json={"query": "q"},
+            headers={"X-API-Key": "usr"},
+        ),
     )
     assert resp.status_code == 403
     assert resp.json()["detail"] == "Insufficient permissions"
 
 
 @pytest.mark.slow
-def test_streaming_with_bearer_token(monkeypatch, api_client):
+def test_streaming_with_bearer_token(
+    monkeypatch: pytest.MonkeyPatch, api_client: TestClient
+) -> None:
     cfg = _setup_stream(monkeypatch)
     token = generate_bearer_token()
     cfg.api.bearer_token = token
+    client = cast(Any, api_client)
 
-    with api_client.stream(
+    with client.stream(
         "POST",
         "/query?stream=true",
         json={"query": "q"},
         headers={"Authorization": f"Bearer {token}"},
     ) as resp:
-        assert resp.status_code == 200
-        _ = [line for line in resp.iter_lines()]
+        response = cast(HTTPResponse, resp)
+        assert response.status_code == 200
+        response_lines = cast(Any, response)
+        _ = [line for line in response_lines.iter_lines()]
 
-    bad = api_client.post(
-        "/query?stream=true",
-        json={"query": "q"},
-        headers={"Authorization": "Bearer bad"},
+    bad = cast(
+        HTTPResponse,
+        client.post(
+            "/query?stream=true",
+            json={"query": "q"},
+            headers={"Authorization": "Bearer bad"},
+        ),
     )
     assert bad.status_code == 401
     assert bad.json()["detail"] == "Invalid token"
     assert bad.headers["WWW-Authenticate"] == "Bearer"
 
-    missing = api_client.post("/query?stream=true", json={"query": "q"})
+    missing = cast(HTTPResponse, client.post("/query?stream=true", json={"query": "q"}))
     assert missing.status_code == 401
     assert missing.json()["detail"] == "Missing token"
     assert missing.headers["WWW-Authenticate"] == "Bearer"

--- a/tests/integration/test_distributed_redis_broker.py
+++ b/tests/integration/test_distributed_redis_broker.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import importlib.util
+from typing import Any, cast
 
 import pytest
 
-from autoresearch.distributed.broker import RedisBroker
+from autoresearch.distributed.broker import AgentResultMessage, RedisBroker
 
 if importlib.util.find_spec("redis") is None:
     pytest.skip("redis not installed", allow_module_level=True)
@@ -15,9 +18,24 @@ pytestmark = [
 ]
 
 
-def test_redis_broker_roundtrip(monkeypatch: pytest.MonkeyPatch, redis_client) -> None:
-    monkeypatch.setattr(redis.Redis, "from_url", lambda url: redis_client)
+def _make_agent_result_message(result: dict[str, Any] | None = None) -> AgentResultMessage:
+    return {
+        "action": "agent_result",
+        "agent": "agent",
+        "result": result or {"value": 1},
+        "pid": 1234,
+    }
+
+
+def test_redis_broker_roundtrip(
+    monkeypatch: pytest.MonkeyPatch, redis_client: object
+) -> None:
+    def _from_url(url: str) -> object:
+        return redis_client
+
+    monkeypatch.setattr(redis.Redis, "from_url", _from_url)
     broker = RedisBroker("redis://localhost:6379/0", queue_name="test")
-    broker.publish({"a": 1})
-    msg = broker.queue.get()
-    assert msg == {"a": 1}
+    expected = _make_agent_result_message(result={"value": 1})
+    broker.publish(expected)
+    message = cast(AgentResultMessage, broker.queue.get())
+    assert message == expected


### PR DESCRIPTION
## Summary
- use helper constructors for AgentResultMessage payloads in Redis broker integration tests
- tighten API auth streaming and middleware tests with concrete typing and typed monkeypatches
- ensure shared API auth setup produces QueryResponse objects with query metadata

## Testing
- `uv run mypy --strict tests/integration` *(fails: existing strict typing violations across integration suite)*

------
https://chatgpt.com/codex/tasks/task_e_68dc296e38208333809687f251b1c29e