### PR TITLE
Add evaluation summary helper fixture for tests

### DIFF
--- a/tests/evaluation/test_harness.py
+++ b/tests/evaluation/test_harness.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from contextlib import closing
 from dataclasses import replace
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import List
 
@@ -14,6 +13,7 @@ import pytest
 from autoresearch.config.models import ConfigModel
 from autoresearch.evaluation import EvaluationHarness, EvaluationSummary
 from autoresearch.models import QueryResponse
+from tests.unit.typing_helpers import build_summary_fixture
 
 
 @pytest.fixture
@@ -239,12 +239,9 @@ def test_harness_persists_results_and_artifacts(tmp_harness: EvaluationHarness) 
 def test_compare_routing_strategies() -> None:
     """Comparisons report deltas between baseline and variant strategies."""
 
-    base = EvaluationSummary(
-        dataset="truthfulqa",
+    base = build_summary_fixture(
         run_id="baseline",
-        started_at=datetime.now(tz=timezone.utc),
-        completed_at=datetime.now(tz=timezone.utc),
-        total_examples=1,
+        config_signature="base",
         accuracy=0.5,
         citation_coverage=0.5,
         contradiction_rate=0.1,
@@ -261,7 +258,6 @@ def test_compare_routing_strategies() -> None:
         total_routing_delta=10.0,
         avg_routing_decisions=2.0,
         routing_strategy="balanced",
-        config_signature="base",
         duckdb_path=None,
         example_parquet=None,
         summary_parquet=None,

--- a/tests/unit/test_additional_coverage.py
+++ b/tests/unit/test_additional_coverage.py
@@ -1,7 +1,6 @@
 import json
 import types
 from collections import OrderedDict
-from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -22,6 +21,7 @@ from autoresearch.streamlit_app import track_agent_performance
 from autoresearch.typing.http import HTTPAdapter
 
 from .typing_helpers import (
+    build_summary_fixture,
     make_llm_pool_config,
     make_psutil_stub,
     make_runtime_config,
@@ -218,51 +218,33 @@ def dummy_table(monkeypatch: pytest.MonkeyPatch) -> list[_DummyTable]:
 
 @pytest.fixture
 def populated_summary() -> EvaluationSummary:
-    now = datetime.now(timezone.utc)
-    return EvaluationSummary(
-        dataset="truthfulqa",
-        run_id="run-123",
-        started_at=now,
-        completed_at=now,
+    return build_summary_fixture(
         total_examples=2,
-        config_signature="cfg",
-        accuracy=0.5,
-        citation_coverage=1.0,
-        contradiction_rate=0.0,
-        avg_latency_seconds=2.5,
-        avg_tokens_input=100.0,
-        avg_tokens_output=50.0,
-        avg_tokens_total=150.0,
-        avg_cycles_completed=1.0,
-        gate_debate_rate=0.0,
-        gate_exit_rate=0.25,
-        gated_example_ratio=1.0,
+        example_csv=Path("artifacts/examples.csv"),
+        summary_csv=Path("artifacts/summary.csv"),
         avg_planner_depth=2.5,
         avg_routing_delta=1.75,
         total_routing_delta=3.5,
         avg_routing_decisions=1.5,
         routing_strategy="balanced",
-        example_csv=Path("artifacts/examples.csv"),
-        summary_csv=Path("artifacts/summary.csv"),
     )
 
 
 def test_render_evaluation_summary_joins_artifacts(
     dummy_table: list[_DummyTable],
 ) -> None:
-    now = datetime.now(timezone.utc)
-    summary = EvaluationSummary(
-        dataset="truthfulqa",
-        run_id="run-123",
-        started_at=now,
-        completed_at=now,
+    summary = build_summary_fixture(
         total_examples=1,
-        config_signature="cfg",
         duckdb_path=Path("artifacts/run.duckdb"),
         example_parquet=Path("artifacts/examples.parquet"),
         summary_parquet=Path("artifacts/summary.parquet"),
         example_csv=Path("artifacts/examples.csv"),
         summary_csv=Path("artifacts/summary.csv"),
+        avg_planner_depth=None,
+        avg_routing_delta=None,
+        total_routing_delta=None,
+        avg_routing_decisions=None,
+        routing_strategy=None,
     )
 
     render_evaluation_summary([summary])

--- a/tests/unit/typing_helpers.py
+++ b/tests/unit/typing_helpers.py
@@ -9,7 +9,11 @@ checking.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, Iterable, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+from autoresearch.evaluation.harness import EvaluationSummary
 
 
 @dataclass(slots=True)
@@ -103,6 +107,74 @@ def make_runtime_config(
         distributed_config=DistributedConfig(enabled=distributed_enabled),
         storage=storage or StorageConfig(),
     )
+
+
+def build_summary_fixture(
+    *,
+    dataset: str = "truthfulqa",
+    run_id: str = "run-123",
+    started_at: datetime | None = None,
+    completed_at: datetime | None = None,
+    total_examples: int = 1,
+    config_signature: str = "cfg",
+    accuracy: float | None = 0.5,
+    citation_coverage: float | None = 1.0,
+    contradiction_rate: float | None = 0.0,
+    avg_latency_seconds: float | None = 2.5,
+    avg_tokens_input: float | None = 100.0,
+    avg_tokens_output: float | None = 50.0,
+    avg_tokens_total: float | None = 150.0,
+    avg_cycles_completed: float | None = 1.0,
+    gate_debate_rate: float | None = 0.0,
+    gate_exit_rate: float | None = 0.25,
+    gated_example_ratio: float | None = 1.0,
+    avg_planner_depth: float | None = 2.5,
+    avg_routing_delta: float | None = 1.75,
+    total_routing_delta: float | None = 3.5,
+    avg_routing_decisions: float | None = 1.5,
+    routing_strategy: str | None = "balanced",
+    duckdb_path: Path | None = None,
+    example_parquet: Path | None = None,
+    summary_parquet: Path | None = None,
+    example_csv: Path | None = None,
+    summary_csv: Path | None = None,
+    **overrides: Any,
+) -> EvaluationSummary:
+    """Construct a populated :class:`EvaluationSummary` for tests."""
+
+    started = started_at or datetime.now(tz=timezone.utc)
+    completed = completed_at or started
+    summary_kwargs: dict[str, Any] = {
+        "dataset": dataset,
+        "run_id": run_id,
+        "started_at": started,
+        "completed_at": completed,
+        "total_examples": total_examples,
+        "config_signature": config_signature,
+        "accuracy": accuracy,
+        "citation_coverage": citation_coverage,
+        "contradiction_rate": contradiction_rate,
+        "avg_latency_seconds": avg_latency_seconds,
+        "avg_tokens_input": avg_tokens_input,
+        "avg_tokens_output": avg_tokens_output,
+        "avg_tokens_total": avg_tokens_total,
+        "avg_cycles_completed": avg_cycles_completed,
+        "gate_debate_rate": gate_debate_rate,
+        "gate_exit_rate": gate_exit_rate,
+        "gated_example_ratio": gated_example_ratio,
+        "avg_planner_depth": avg_planner_depth,
+        "avg_routing_delta": avg_routing_delta,
+        "total_routing_delta": total_routing_delta,
+        "avg_routing_decisions": avg_routing_decisions,
+        "routing_strategy": routing_strategy,
+        "duckdb_path": duckdb_path,
+        "example_parquet": example_parquet,
+        "summary_parquet": summary_parquet,
+        "example_csv": example_csv,
+        "summary_csv": summary_csv,
+    }
+    summary_kwargs.update(overrides)
+    return EvaluationSummary(**summary_kwargs)
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- add a typed `build_summary_fixture` helper centralising default evaluation metrics
- refactor unit and evaluation tests to reuse the helper while overriding scenario-specific fields

## Testing
- uv run --extra test mypy tests/unit tests/evaluation
- uv run task check

------
https://chatgpt.com/codex/tasks/task_e_68dc63dc5858833394f37f8a595441f2