### PR TITLE
Type incremental and metrics tests

### DIFF
--- a/tests/evaluation/test_harness.py
+++ b/tests/evaluation/test_harness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import closing
 from dataclasses import replace
 from pathlib import Path
+from typing import Any
 
 from duckdb import DuckDBPyConnection
 
@@ -91,7 +92,7 @@ def test_harness_persists_results_and_artifacts(tmp_harness: EvaluationHarness) 
         cycles_completed = 3 if gate_should_debate else 1
         routing_total = 5.0 + idx
         routing_decisions = idx + 1
-        execution_metrics = {
+        execution_metrics: dict[str, Any] = {
             "total_duration_seconds": 1.2 + (0.3 * idx),
             "total_tokens": {"input": 10 + idx, "output": 5 + idx, "total": 15 + 2 * idx},
             "cycles_completed": cycles_completed,
@@ -102,7 +103,7 @@ def test_harness_persists_results_and_artifacts(tmp_harness: EvaluationHarness) 
             * routing_decisions,
             "model_routing_strategy": "balanced",
         }
-        gate_events = [
+        gate_events: list[dict[str, Any]] = [
             {
                 "should_debate": gate_should_debate,
                 "target_loops": cycles_completed,
@@ -112,7 +113,7 @@ def test_harness_persists_results_and_artifacts(tmp_harness: EvaluationHarness) 
                 "thresholds": {"min_score": 0.5},
             }
         ]
-        task_graph = {
+        task_graph: dict[str, Any] = {
             "tasks": [
                 {"id": "t1", "depends_on": []},
                 {"id": "t2", "depends_on": ["t1"]},

--- a/tests/unit/evaluation/test_harness_typing.py
+++ b/tests/unit/evaluation/test_harness_typing.py
@@ -6,16 +6,20 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import duckdb
+from pytest import MonkeyPatch
 
 from autoresearch.evaluation.harness import EvaluationHarness
 
 
-def test_open_duckdb_closes_connection(tmp_path, monkeypatch):
+def test_open_duckdb_closes_connection(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """``EvaluationHarness._open_duckdb`` should close the connection on exit."""
 
-    harness = EvaluationHarness(output_dir=tmp_path, duckdb_path=tmp_path / "truth.duckdb")
-    connection = MagicMock()
-    monkeypatch.setattr(duckdb, "connect", MagicMock(return_value=connection))
+    harness: EvaluationHarness = EvaluationHarness(
+        output_dir=tmp_path, duckdb_path=tmp_path / "truth.duckdb"
+    )
+    connection: MagicMock = MagicMock()
+    connect_mock: MagicMock = MagicMock(return_value=connection)
+    monkeypatch.setattr(duckdb, "connect", connect_mock)
 
     with harness._open_duckdb() as conn:
         assert conn is connection

--- a/tests/unit/test_incremental_updates.py
+++ b/tests/unit/test_incremental_updates.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from pytest import MonkeyPatch
 from unittest.mock import MagicMock, patch
 
 from autoresearch.storage import StorageManager
@@ -5,12 +8,12 @@ from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.config.loader import ConfigLoader
 
 
-def _basic_config():
+def _basic_config() -> ConfigModel:
     return ConfigModel(storage=StorageConfig(), ram_budget_mb=0)
 
 
-def test_refresh_vector_index_calls_backend(monkeypatch):
-    backend = MagicMock()
+def test_refresh_vector_index_calls_backend(monkeypatch: MonkeyPatch) -> None:
+    backend: MagicMock = MagicMock()
     monkeypatch.setattr(StorageManager.context, "db_backend", backend, raising=False)
     monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
 
@@ -19,10 +22,10 @@ def test_refresh_vector_index_calls_backend(monkeypatch):
     backend.refresh_hnsw_index.assert_called_once()
 
 
-def test_persist_claim_triggers_index_refresh(monkeypatch):
-    backend = MagicMock()
-    graph = MagicMock()
-    store = MagicMock()
+def test_persist_claim_triggers_index_refresh(monkeypatch: MonkeyPatch) -> None:
+    backend: MagicMock = MagicMock()
+    graph: MagicMock = MagicMock()
+    store: MagicMock = MagicMock()
     monkeypatch.setattr(StorageManager.context, "db_backend", backend, raising=False)
     monkeypatch.setattr(StorageManager.context, "graph", graph, raising=False)
     monkeypatch.setattr(StorageManager.context, "rdf_store", store, raising=False)
@@ -32,20 +35,22 @@ def test_persist_claim_triggers_index_refresh(monkeypatch):
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: _basic_config())
     ConfigLoader()._config = None
 
-    called = {}
+    called: dict[str, bool] = {}
 
-    def refresh():
+    def refresh() -> None:
         called["r"] = True
 
     monkeypatch.setattr(StorageManager, "refresh_vector_index", refresh)
 
-    StorageManager.persist_claim({"id": "n1", "type": "fact", "content": "c", "embedding": [0.1]})
+    StorageManager.persist_claim(
+        {"id": "n1", "type": "fact", "content": "c", "embedding": [0.1]}
+    )
 
     assert called.get("r") is True
 
 
-def test_update_rdf_claim_wrapper(monkeypatch):
-    store = MagicMock()
+def test_update_rdf_claim_wrapper(monkeypatch: MonkeyPatch) -> None:
+    store: MagicMock = MagicMock()
     monkeypatch.setattr(StorageManager.context, "rdf_store", store, raising=False)
     monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
 


### PR DESCRIPTION
## Summary
- add explicit typing to incremental storage tests, including helper factories and fixtures
- tighten orchestration metrics tests with typed mocks and pytest monkeypatch annotations
- declare dictionary and mock types throughout evaluation harness tests to satisfy mypy

## Testing
- uv run --extra test mypy tests/unit tests/evaluation
- uv run task check

------
https://chatgpt.com/codex/tasks/task_e_68dc92f7e17483339d06e66cc9417b30