### PR TITLE
Annotate query and ranking tests

### DIFF
--- a/tests/unit/search/test_ranking_convergence_simulation.py
+++ b/tests/unit/search/test_ranking_convergence_simulation.py
@@ -1,6 +1,8 @@
 import sys
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+from types import ModuleType
+from typing import Any, Type
 
 import pytest
 
@@ -9,8 +11,8 @@ pytestmark = pytest.mark.skip(
 )
 
 
-def _load_module():
-    root = Path(__file__).resolve().parents[3]
+def _load_module() -> ModuleType:
+    root: Path = Path(__file__).resolve().parents[3]
     path = root / "src/autoresearch/search/ranking_convergence.py"
     name = "autoresearch.search.ranking_convergence"
     spec = spec_from_file_location(name, path)
@@ -23,23 +25,25 @@ def _load_module():
 
 
 @pytest.mark.unit
-def test_ranking_converges():
-    module = _load_module()
-    Doc = module.DocScores
-    docs = [
+def test_ranking_converges() -> None:
+    module: ModuleType = _load_module()
+    Doc: Type[Any] = module.DocScores
+    docs: list[Any] = [
         Doc(0.2, 0.5, 0.3),
         Doc(0.1, 0.7, 0.2),
         Doc(0.9, 0.1, 0.0),
     ]
-    weights = (0.4, 0.4, 0.2)
-    orderings = module.simulate_ranking_convergence(docs, weights, iterations=3)
+    weights: tuple[float, float, float] = (0.4, 0.4, 0.2)
+    orderings: list[list[int]] = module.simulate_ranking_convergence(
+        docs, weights, iterations=3
+    )
     assert orderings[0] == orderings[1] == orderings[2]
 
 
 @pytest.mark.unit
-def test_invalid_weights_raise():
-    module = _load_module()
-    Doc = module.DocScores
-    docs = [Doc(0.1, 0.2, 0.7)]
+def test_invalid_weights_raise() -> None:
+    module: ModuleType = _load_module()
+    Doc: Type[Any] = module.DocScores
+    docs: list[Any] = [Doc(0.1, 0.2, 0.7)]
     with pytest.raises(ValueError):
         module.simulate_ranking_convergence(docs, (0.5, 0.5, 0.5))

--- a/tests/unit/test_api_error_handling.py
+++ b/tests/unit/test_api_error_handling.py
@@ -1,15 +1,21 @@
+from __future__ import annotations
+
+import contextlib
+import types
+from typing import Any, NoReturn
+
+import pytest
 from fastapi.testclient import TestClient
 
 from autoresearch.api import app
-from autoresearch.config.models import ConfigModel, APIConfig
 from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import APIConfig, ConfigModel
+from autoresearch.orchestration.orchestrator import Orchestrator
 from scripts.simulate_api_auth_errors import simulate
-import types
-import contextlib
 
 
-def _setup(monkeypatch):
-    cfg = ConfigModel.model_construct(api=APIConfig())
+def _setup(monkeypatch: pytest.MonkeyPatch) -> ConfigModel:
+    cfg: ConfigModel = ConfigModel.model_construct(api=APIConfig())
     cfg.api.role_permissions["anonymous"] = ["query"]
     monkeypatch.setattr("autoresearch.api.routing.get_config", lambda: cfg)
     dummy_loader = types.SimpleNamespace(
@@ -18,37 +24,50 @@ def _setup(monkeypatch):
     monkeypatch.setattr("autoresearch.api.config_loader", dummy_loader)
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
     ConfigLoader.reset_instance()
-    monkeypatch.setattr("autoresearch.api.webhooks.notify_webhook", lambda u, r, timeout=5: None)
+    monkeypatch.setattr(
+        "autoresearch.api.webhooks.notify_webhook",
+        lambda u, r, timeout=5: None,
+    )
     return cfg
 
 
-def test_query_endpoint_runtime_error(monkeypatch, orchestrator):
+def test_query_endpoint_runtime_error(
+    monkeypatch: pytest.MonkeyPatch, orchestrator: Orchestrator
+) -> None:
     _setup(monkeypatch)
 
-    orch = orchestrator
+    orch: Orchestrator = orchestrator
 
-    def raise_error(q, c, callbacks=None):
+    def raise_error(
+        q: str, c: ConfigModel, callbacks: Any | None = None
+    ) -> NoReturn:
         raise RuntimeError("fail")
 
     monkeypatch.setattr(orch, "run_query", raise_error)
     monkeypatch.setattr("autoresearch.api.routing.create_orchestrator", lambda: orch)
-    client = TestClient(app)
+    client: TestClient = TestClient(app)
     resp = client.post("/query", json={"query": "q"})
     assert resp.status_code == 200
-    data = resp.json()
+    data: dict[str, Any] = resp.json()
     assert data["answer"].startswith("Error: fail")
     assert data["metrics"]["error"] == "fail"
 
 
-def test_query_endpoint_invalid_response(monkeypatch, orchestrator):
+def test_query_endpoint_invalid_response(
+    monkeypatch: pytest.MonkeyPatch, orchestrator: Orchestrator
+) -> None:
     _setup(monkeypatch)
-    orch = orchestrator
-    monkeypatch.setattr(orch, "run_query", lambda q, c, callbacks=None: {"foo": "bar"})
+    orch: Orchestrator = orchestrator
+    monkeypatch.setattr(
+        orch,
+        "run_query",
+        lambda q, c, callbacks=None: {"foo": "bar"},
+    )
     monkeypatch.setattr("autoresearch.api.routing.create_orchestrator", lambda: orch)
-    client = TestClient(app)
+    client: TestClient = TestClient(app)
     resp = client.post("/query", json={"query": "q"})
     assert resp.status_code == 200
-    data = resp.json()
+    data: dict[str, Any] = resp.json()
     assert data["answer"] == "Error: Invalid response format"
     assert data["metrics"]["error"] == "Invalid response format"
 

--- a/tests/unit/test_kg_reasoning.py
+++ b/tests/unit/test_kg_reasoning.py
@@ -33,7 +33,7 @@ def _mock_config(
 
 
 def _patch_config(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
     reasoner: str,
     timeout: float | None = None,
     max_triples: int | None = None,
@@ -46,8 +46,8 @@ def _patch_config(
     ConfigLoader()._config = None
 
 
-def test_run_ontology_reasoner_owlrl(monkeypatch):
-    g = rdflib.Graph()
+def test_run_ontology_reasoner_owlrl(monkeypatch: pytest.MonkeyPatch) -> None:
+    g: rdflib.Graph = rdflib.Graph()
     g.add(
         (
             rdflib.URIRef("http://ex/s"),
@@ -59,53 +59,57 @@ def test_run_ontology_reasoner_owlrl(monkeypatch):
     run_ontology_reasoner(g)
 
 
-def test_register_reasoner_adds_plugin():
+def test_register_reasoner_adds_plugin() -> None:
     import autoresearch.kg_reasoning as kr
 
     @register_reasoner("unit_test")
-    def _plugin(store):  # pragma: no cover - no logic needed
+    def _plugin(store: rdflib.Graph) -> None:  # pragma: no cover - no logic needed
         pass
 
     assert kr._REASONER_PLUGINS["unit_test"] is _plugin
     kr._REASONER_PLUGINS.pop("unit_test", None)
 
 
-def test_run_ontology_reasoner_external(monkeypatch):
-    called = {}
+def test_run_ontology_reasoner_external(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, bool] = {}
 
-    def dummy(store):
+    def dummy(store: rdflib.Graph) -> None:
         called["ok"] = True
 
     mod = ModuleType("dummy_mod")
     setattr(mod, "func", dummy)
     monkeypatch.setitem(sys.modules, "dummy_mod", mod)
-    g = rdflib.Graph()
+    g: rdflib.Graph = rdflib.Graph()
     _patch_config(monkeypatch, "dummy_mod:func")
     run_ontology_reasoner(g)
     assert called.get("ok") is True
 
 
-def test_run_ontology_reasoner_invokes_plugin_once(monkeypatch):
+def test_run_ontology_reasoner_invokes_plugin_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import autoresearch.kg_reasoning as kr
 
-    calls = []
+    calls: list[bool] = []
 
     @register_reasoner("once")
-    def _once(store):
+    def _once(store: rdflib.Graph) -> None:
         calls.append(True)
 
-    g = rdflib.Graph()
+    g: rdflib.Graph = rdflib.Graph()
     _patch_config(monkeypatch, "once")
     run_ontology_reasoner(g)
     assert calls == [True]
     kr._REASONER_PLUGINS.pop("once", None)
 
 
-def test_run_ontology_reasoner_preserves_triple_count(monkeypatch):
+def test_run_ontology_reasoner_preserves_triple_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import autoresearch.kg_reasoning as kr
 
     @register_reasoner("adder")
-    def _adder(store):
+    def _adder(store: rdflib.Graph) -> None:
         store.add(
             (
                 rdflib.URIRef("urn:s2"),
@@ -114,7 +118,7 @@ def test_run_ontology_reasoner_preserves_triple_count(monkeypatch):
             )
         )
 
-    g = rdflib.Graph()
+    g: rdflib.Graph = rdflib.Graph()
     g.add((rdflib.URIRef("urn:s1"), rdflib.URIRef("urn:p"), rdflib.URIRef("urn:o")))
     before = len(g)
     _patch_config(monkeypatch, "adder")
@@ -123,21 +127,23 @@ def test_run_ontology_reasoner_preserves_triple_count(monkeypatch):
     kr._REASONER_PLUGINS.pop("adder", None)
 
 
-def test_run_ontology_reasoner_external_error(monkeypatch):
-    def fail(store):
+def test_run_ontology_reasoner_external_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail(store: rdflib.Graph) -> None:
         raise ValueError("boom")
 
     mod = ModuleType("bad_mod")
     setattr(mod, "run", fail)
     monkeypatch.setitem(sys.modules, "bad_mod", mod)
-    g = rdflib.Graph()
+    g: rdflib.Graph = rdflib.Graph()
     _patch_config(monkeypatch, "bad_mod:run")
     with pytest.raises(StorageError):
         run_ontology_reasoner(g)
 
 
-def test_query_with_reasoning(monkeypatch):
-    g = rdflib.Graph()
+def test_query_with_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
+    g: rdflib.Graph = rdflib.Graph()
     s = rdflib.URIRef("http://ex/s")
     p = rdflib.URIRef("http://ex/p")
     o = rdflib.URIRef("http://ex/o")
@@ -149,12 +155,14 @@ def test_query_with_reasoning(monkeypatch):
     assert res[0][0] == o
 
 
-def test_run_ontology_reasoner_without_owlrl(monkeypatch):
+def test_run_ontology_reasoner_without_owlrl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delitem(sys.modules, "owlrl", raising=False)
     import autoresearch.kg_reasoning as kr
 
     kr = importlib.reload(kr)
-    g = rdflib.Graph()
+    g: rdflib.Graph = rdflib.Graph()
     _patch_config(monkeypatch, "owlrl")
     kr.run_ontology_reasoner(g)
 
@@ -186,14 +194,14 @@ def test_run_ontology_reasoner_reload_without_owlrl(
     globals()["register_reasoner"] = module.register_reasoner
 
 
-def test_run_ontology_reasoner_timeout(monkeypatch):
+def test_run_ontology_reasoner_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     import autoresearch.kg_reasoning as kr
 
-    def slow(store):
+    def slow(store: rdflib.Graph) -> None:
         threading.Event().wait()
 
     monkeypatch.setitem(kr._REASONER_PLUGINS, "slow", slow)
-    g = rdflib.Graph()
+    g: rdflib.Graph = rdflib.Graph()
     _patch_config(monkeypatch, "slow", timeout=0)
     with pytest.raises(StorageError) as excinfo:
         run_ontology_reasoner(g)

--- a/tests/unit/test_ranking_convergence.py
+++ b/tests/unit/test_ranking_convergence.py
@@ -1,22 +1,34 @@
+from typing import NotRequired, Sequence, TypedDict
+
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 
-def rank_once(results):
+class RankingResult(TypedDict):
+    """Mutable ranking record containing component scores."""
+
+    id: int
+    bm25: float
+    semantic: float
+    cred: float
+    score: NotRequired[float]
+
+
+def rank_once(results: list[RankingResult]) -> list[RankingResult]:
     """Rank results by a fixed weighted score."""
-    weights = {"bm25": 0.5, "semantic": 0.3, "cred": 0.2}
-    for r in results:
-        r["score"] = sum(r[k] * w for k, w in weights.items())
-    return sorted(results, key=lambda r: r["score"], reverse=True)
+    weights: dict[str, float] = {"bm25": 0.5, "semantic": 0.3, "cred": 0.2}
+    for record in results:
+        record["score"] = sum(record[key] * weight for key, weight in weights.items())
+    return sorted(results, key=lambda record: record["score"], reverse=True)
 
 
-def inversion_distance(order, target):
-    pos = {oid: i for i, oid in enumerate(target)}
+def inversion_distance(order: Sequence[int], target: Sequence[int]) -> int:
+    pos: dict[int, int] = {oid: idx for idx, oid in enumerate(target)}
     count = 0
-    for i, a in enumerate(order):
-        for b in order[i + 1 :]:
-            if pos[a] > pos[b]:
+    for i, anchor in enumerate(order):
+        for follower in order[i + 1 :]:
+            if pos[anchor] > pos[follower]:
                 count += 1
     return count
 
@@ -34,20 +46,20 @@ def inversion_distance(order, target):
         max_size=8,
     )
 )
-def test_ranking_monotonic(scores):
+def test_ranking_monotonic(scores: list[tuple[float, float, float]]) -> None:
     """Inversion count decreases with each ranking iteration."""
-    results = [
+    results: list[RankingResult] = [
         {"id": i, "bm25": b, "semantic": s, "cred": c}
         for i, (b, s, c) in enumerate(scores)
     ]
-    initial = [r["id"] for r in results]
-    ranked1 = rank_once(results)
-    order1 = [r["id"] for r in ranked1]
-    ranked2 = rank_once(ranked1)
-    order2 = [r["id"] for r in ranked2]
-    target = order2
-    i0 = inversion_distance(initial, target)
-    i1 = inversion_distance(order1, target)
-    i2 = inversion_distance(order2, target)
+    initial: list[int] = [record["id"] for record in results]
+    ranked1: list[RankingResult] = rank_once(results)
+    order1: list[int] = [record["id"] for record in ranked1]
+    ranked2: list[RankingResult] = rank_once(ranked1)
+    order2: list[int] = [record["id"] for record in ranked2]
+    target: list[int] = order2
+    i0: int = inversion_distance(initial, target)
+    i1: int = inversion_distance(order1, target)
+    i2: int = inversion_distance(order2, target)
     assert i1 <= i0
     assert i2 <= i1


### PR DESCRIPTION
## Summary
- add explicit parameter and return annotations across query API and KG reasoning tests
- refine ranking convergence helpers with typed dictionaries and intermediate variables for mypy
- update ranking convergence simulation test to use typed module loading helpers

## Testing
- uv run --extra test mypy tests/unit tests/evaluation
- uv run task check

------
https://chatgpt.com/codex/tasks/task_e_68dc945148408333a3198ed12a83be2c