### PR TITLE
Type search and scheduler tests

### DIFF
--- a/tests/unit/test_scheduler_benchmark.py
+++ b/tests/unit/test_scheduler_benchmark.py
@@ -1,16 +1,22 @@
 """Micro-benchmark tests for scheduler resource usage."""
 
 from collections import deque
+from typing import Iterable, Sequence
 
 import pytest
 
 from autoresearch.orchestration.utils import enqueue_with_limit
 from autoresearch.scheduler_benchmark import benchmark_scheduler
 
+BenchmarkResult = tuple[float, int]
+BenchmarkResults = Iterable[BenchmarkResult]
+
 
 @pytest.mark.parametrize("duration", [0.01, 0.05, 0.1])
 def test_benchmark_scheduler_resources(duration: float) -> None:
     """Scheduler consumes minimal CPU time and memory."""
+    cpu_time: float
+    mem_kb: int
     cpu_time, mem_kb = benchmark_scheduler(duration)
     assert 0.0 <= cpu_time < 1.0
     assert 0 <= mem_kb < 50000
@@ -18,10 +24,10 @@ def test_benchmark_scheduler_resources(duration: float) -> None:
 
 def test_benchmark_scheduler_time_scales_with_duration() -> None:
     """CPU time is non-decreasing for longer durations."""
-    durations = [0.01, 0.05, 0.1]
-    results = [benchmark_scheduler(d) for d in durations]
-    cpu_times = [r[0] for r in results]
-    mem_usages = [r[1] for r in results]
+    durations: Sequence[float] = (0.01, 0.05, 0.1)
+    results: BenchmarkResults = [benchmark_scheduler(d) for d in durations]
+    cpu_times: list[float] = [cpu for cpu, _ in results]
+    mem_usages: list[int] = [mem for _, mem in results]
     assert cpu_times == sorted(cpu_times)
     assert max(mem_usages) < 50000
 


### PR DESCRIPTION
## Summary
- add explicit type aliases and annotations for search fixtures, responses usage, and helper utilities
- improve scheduler benchmark coverage with typed helper aliases and clarified result handling

## Testing
- `uv run --extra test mypy tests/unit tests/evaluation`
- `uv run task check`


------
https://chatgpt.com/codex/tasks/task_e_68dc961e83e08333a0d283d45c18a2e2