### PR TITLE
Annotate storage and Streamlit tests

### DIFF
--- a/tests/unit/storage/test_backup_scheduler.py
+++ b/tests/unit/storage/test_backup_scheduler.py
@@ -18,8 +18,8 @@ from autoresearch.storage_backup import (
 @pytest.fixture()
 def scheduler_environment(
     monkeypatch: pytest.MonkeyPatch,
-) -> tuple[BackupScheduler, list[Any], list[tuple[str, str, str, bool, BackupConfig]]]:
-    timers: list[Any] = []
+) -> tuple[BackupScheduler, list["DummyTimer"], list[tuple[str, str, str, bool, BackupConfig]]]:
+    timers: list[DummyTimer] = []
     backups: list[tuple[str, str, str, bool, BackupConfig]] = []
 
     def fake_create_backup(
@@ -75,7 +75,7 @@ def scheduler_environment(
 
 def test_scheduler_runs_backup_and_reschedules(
     scheduler_environment: tuple[
-        BackupScheduler, list[Any], list[tuple[str, str, str, bool, BackupConfig]]
+        BackupScheduler, list["DummyTimer"], list[tuple[str, str, str, bool, BackupConfig]]
     ],
 ) -> None:
     scheduler, timers, backups = scheduler_environment
@@ -99,7 +99,7 @@ def test_scheduler_runs_backup_and_reschedules(
 
 def test_scheduler_restarts_existing_timer(
     scheduler_environment: tuple[
-        BackupScheduler, list[Any], list[tuple[str, str, str, bool, BackupConfig]]
+        BackupScheduler, list["DummyTimer"], list[tuple[str, str, str, bool, BackupConfig]]
     ],
 ) -> None:
     scheduler, timers, backups = scheduler_environment
@@ -116,7 +116,7 @@ def test_scheduler_restarts_existing_timer(
 
 def test_backup_manager_schedule_uses_resolved_scheduler(
     scheduler_environment: tuple[
-        BackupScheduler, list[Any], list[tuple[str, str, str, bool, BackupConfig]]
+        BackupScheduler, list["DummyTimer"], list[tuple[str, str, str, bool, BackupConfig]]
     ],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/storage/test_claim_audit_persistence.py
+++ b/tests/unit/storage/test_claim_audit_persistence.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
+
 import networkx as nx
 from autoresearch.storage import (
     ClaimAuditStatus,
@@ -12,13 +15,13 @@ from autoresearch.storage_backends import init_rdf_store
 
 class _StubBackend:
     def __init__(self) -> None:
-        self.persisted: list[dict[str, object]] = []
+        self.persisted: list[dict[str, Any]] = []
 
-    def persist_claim_audit(self, payload: dict[str, object]) -> None:
+    def persist_claim_audit(self, payload: dict[str, Any]) -> None:
         self.persisted.append(payload)
 
 
-def test_persist_claim_audit_payload_updates_backends(tmp_path) -> None:
+def test_persist_claim_audit_payload_updates_backends(tmp_path: Path) -> None:
     graph = nx.DiGraph()
     graph.add_node("claim-1")
 

--- a/tests/unit/storage/test_protocols.py
+++ b/tests/unit/storage/test_protocols.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import rdflib
 
 from autoresearch.storage_backends import init_rdf_store
@@ -15,7 +17,7 @@ def test_to_json_dict_returns_copy() -> None:
     assert source["score"] == 0.9
 
 
-def test_init_rdf_store_supports_protocol(tmp_path) -> None:
+def test_init_rdf_store_supports_protocol(tmp_path: Path) -> None:
     store = init_rdf_store("memory", str(tmp_path / "rdf"))
     assert isinstance(store, GraphProtocol)
 

--- a/tests/unit/test_streamlit_accessibility.py
+++ b/tests/unit/test_streamlit_accessibility.py
@@ -1,5 +1,5 @@
-from typing import Any
 import types
+from typing import Any
 
 import pytest
 
@@ -10,8 +10,13 @@ pytestmark = pytest.mark.requires_ui
 
 def test_apply_accessibility(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[Any, ...]] = []
+
+    def record_markdown(*args: Any, **_kwargs: Any) -> None:
+        calls.append(args)
+
     fake_st = types.SimpleNamespace(
-        markdown=lambda *a, **k: calls.append(a), session_state={"high_contrast": True}
+        markdown=record_markdown,
+        session_state={"high_contrast": True},
     )
     monkeypatch.setattr(streamlit_ui, "st", fake_st)
     streamlit_app.apply_accessibility_settings()
@@ -22,25 +27,54 @@ def test_display_query_input_has_accessibility(monkeypatch: pytest.MonkeyPatch) 
     calls: dict[str, list[Any]] = {"markdown": [], "form_submit_button": []}
 
     class Dummy:
-        def __enter__(self):
-            return None
+        def __enter__(self) -> "Dummy":
+            return self
 
-        def __exit__(self, exc_type, exc, tb):
-            pass
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: Any,
+        ) -> bool:
+            return False
 
-    def track_submit(*_args, **kwargs):
+    def track_submit(*_args: Any, **kwargs: Any) -> bool:
         calls["form_submit_button"].append(kwargs)
         return False
 
+    def record_markdown(*args: Any, **kwargs: Any) -> None:
+        calls["markdown"].append((args, kwargs))
+
+    def empty_text_area(*_args: Any, **_kwargs: Any) -> str:
+        return ""
+
+    def empty_selectbox(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def zero_slider(*_args: Any, **_kwargs: Any) -> int:
+        return 0
+
+    def false_button(*_args: Any, **_kwargs: Any) -> bool:
+        return False
+
+    def paired_columns(*_args: Any, **_kwargs: Any) -> tuple[Dummy, Dummy]:
+        return (Dummy(), Dummy())
+
+    def make_container(*_args: Any, **_kwargs: Any) -> Dummy:
+        return Dummy()
+
+    def make_form(*_args: Any, **_kwargs: Any) -> Dummy:
+        return Dummy()
+
     fake_st = types.SimpleNamespace(
-        markdown=lambda *a, **k: calls["markdown"].append((a, k)),
-        text_area=lambda *a, **k: "",
-        selectbox=lambda *a, **k: None,
-        slider=lambda *a, **k: 0,
-        button=lambda *a, **k: False,
-        columns=lambda *a, **k: (Dummy(), Dummy()),
-        container=lambda: Dummy(),
-        form=lambda *a, **k: Dummy(),
+        markdown=record_markdown,
+        text_area=empty_text_area,
+        selectbox=empty_selectbox,
+        slider=zero_slider,
+        button=false_button,
+        columns=paired_columns,
+        container=make_container,
+        form=make_form,
         form_submit_button=track_submit,
         session_state=types.SimpleNamespace(
             config=types.SimpleNamespace(

--- a/tests/unit/test_streamlit_ui_helpers.py
+++ b/tests/unit/test_streamlit_ui_helpers.py
@@ -1,13 +1,18 @@
+from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
 import streamlit as st
 
 from autoresearch.streamlit_ui import apply_theme_settings
 
 
-def test_apply_theme_settings_dark(monkeypatch):
+def test_apply_theme_settings_dark(monkeypatch: pytest.MonkeyPatch) -> None:
     m = MagicMock()
-    monkeypatch.setattr(st, "markdown", m)
+    def apply_markdown(*_args: Any, **_kwargs: Any) -> None:
+        m(*_args, **_kwargs)
+
+    monkeypatch.setattr(st, "markdown", apply_markdown)
     st.session_state["dark_mode"] = True
     apply_theme_settings()
     assert m.called


### PR DESCRIPTION
## Summary
- add precise typing to the Streamlit UI tests, including stub classes and monkeypatched helpers
- type the Streamlit accessibility and helper fixtures to describe call signatures explicitly
- tighten storage test fixtures and stubs with explicit collection and path annotations for mypy

## Testing
- uv run --extra test mypy tests/unit tests/evaluation
- uv run task check

------
https://chatgpt.com/codex/tasks/task_e_68dc9bbe83808333b8c44d6613c7bff8