### PR TITLE
Type annotate token and visualization tests

### DIFF
--- a/tests/unit/test_token_budgeting_hypothesis.py
+++ b/tests/unit/test_token_budgeting_hypothesis.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-from typing import Any
 import string
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from hypothesis import HealthCheck, given, settings, strategies as st
+from hypothesis.strategies import SearchStrategy
 
 import autoresearch.llm as llm
 from autoresearch.config.models import ConfigModel
@@ -13,20 +14,30 @@ from autoresearch.orchestration import token_utils
 from autoresearch.orchestration.metrics import OrchestrationMetrics
 
 
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
-@given(
-    words=st.lists(
-        st.text(alphabet=string.ascii_letters, min_size=1, max_size=5),
-        min_size=1,
-        max_size=20,
-    ),
-    budget=st.integers(min_value=1, max_value=20),
+# Predefine strategies with explicit typing for MyPy's benefit.
+WORDS_STRATEGY: SearchStrategy[list[str]] = st.lists(
+    st.text(alphabet=string.ascii_letters, min_size=1, max_size=5),
+    min_size=1,
+    max_size=20,
 )
+TOKEN_BUDGET_STRATEGY: SearchStrategy[int] = st.integers(min_value=1, max_value=20)
+START_STRATEGY: SearchStrategy[int] = st.integers(min_value=1, max_value=200)
+USAGE_STRATEGY: SearchStrategy[int] = st.integers(min_value=1, max_value=200)
+NEG_MARGIN_STRATEGY: SearchStrategy[float] = st.floats(
+    max_value=-0.01, allow_infinity=False, allow_nan=False
+)
+MARGIN_RANGE_STRATEGY: SearchStrategy[float] = st.floats(
+    min_value=-1.0, max_value=2.0, allow_nan=False
+)
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(words=WORDS_STRATEGY, budget=TOKEN_BUDGET_STRATEGY)
 def test_capture_token_usage_respects_budget(
     words: list[str],
     budget: int,
     monkeypatch: pytest.MonkeyPatch,
-    flexible_llm_adapter,
+    flexible_llm_adapter: Any,
 ) -> None:
     """Prompts exceeding ``token_budget`` are compressed before counting.
 
@@ -50,7 +61,7 @@ def test_capture_token_usage_respects_budget(
     with token_utils._capture_token_usage("agent", metrics, mock_config) as (_, adapter):
         adapter.generate(prompt)
 
-    counts = metrics.token_counts["agent"]
+    counts: dict[str, int] = metrics.token_counts["agent"]
     tokens_in = counts["in"]
     original_len = len(prompt.split())
     limit = original_len if original_len <= budget else max(budget, 3)
@@ -60,12 +71,10 @@ def test_capture_token_usage_respects_budget(
     assert len(captured["prompt"].split()) == tokens_in
 
 
-@given(
-    start=st.integers(min_value=1, max_value=200),
-    usage=st.integers(min_value=1, max_value=200),
-    margin=st.floats(max_value=-0.01, allow_infinity=False, allow_nan=False),
-)
-def test_negative_margin_treated_as_zero(start: int, usage: int, margin: float) -> None:
+@given(start=START_STRATEGY, usage=USAGE_STRATEGY, margin=NEG_MARGIN_STRATEGY)
+def test_negative_margin_treated_as_zero(
+    start: int, usage: int, margin: float
+) -> None:
     """Negative margins behave identically to zero margin."""
     metrics = OrchestrationMetrics()
     metrics.record_tokens("agent", usage, 0)
@@ -78,7 +87,7 @@ def test_negative_margin_treated_as_zero(start: int, usage: int, margin: float) 
     assert budget_neg == budget_zero
 
 
-@given(margin=st.floats(min_value=-1.0, max_value=2.0, allow_nan=False))
+@given(margin=MARGIN_RANGE_STRATEGY)
 def test_zero_start_remains_zero_without_usage(margin: float) -> None:
     """A zero starting budget stays zero until usage occurs."""
     metrics = OrchestrationMetrics()

--- a/tests/unit/test_token_monitoring.py
+++ b/tests/unit/test_token_monitoring.py
@@ -1,21 +1,23 @@
 import json
+from pathlib import Path
+from typing import cast
 
 from autoresearch.orchestration.metrics import OrchestrationMetrics
 
 
-def test_record_and_regression(tmp_path):
+def test_record_and_regression(tmp_path: Path) -> None:
     metrics = OrchestrationMetrics()
     metrics.record_tokens("A", 2, 3)
     metrics.record_tokens("B", 1, 1)
 
-    metrics_path = tmp_path / "metrics.json"
-    baseline_path = tmp_path / "baseline.json"
+    metrics_path: Path = tmp_path / "metrics.json"
+    baseline_path: Path = tmp_path / "baseline.json"
 
     # baseline lower than current total (7)
     baseline_path.write_text(json.dumps({"q": 5}))
 
     metrics.record_query_tokens("q", metrics_path)
-    saved = json.loads(metrics_path.read_text())
+    saved = cast(dict[str, int], json.loads(metrics_path.read_text()))
     assert saved["q"] == 7
 
     assert metrics.check_query_regression("q", baseline_path) is True

--- a/tests/unit/test_token_usage.py
+++ b/tests/unit/test_token_usage.py
@@ -8,6 +8,8 @@ recorded when using LLM adapters.
 from unittest.mock import MagicMock
 from typing import Any
 
+import pytest
+
 from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.orchestration.metrics import OrchestrationMetrics
 from autoresearch.config.models import ConfigModel
@@ -15,7 +17,9 @@ from autoresearch.llm.token_counting import compress_prompt
 import autoresearch.llm as llm
 
 
-def test_capture_token_usage_counts_correctly(monkeypatch, flexible_llm_adapter):
+def test_capture_token_usage_counts_correctly(
+    monkeypatch: pytest.MonkeyPatch, flexible_llm_adapter: Any
+) -> None:
     """Test that the token counting context manager correctly counts tokens.
 
     This test verifies that:
@@ -40,12 +44,14 @@ def test_capture_token_usage_counts_correctly(monkeypatch, flexible_llm_adapter)
         wrapped_adapter.generate("hello world")
 
     # Verify
-    counts = metrics.token_counts["agent"]
+    counts: dict[str, int] = metrics.token_counts["agent"]
     assert counts["in"] == 2  # "hello world" has 2 tokens
     assert counts["out"] > 0  # The output should have at least 1 token
 
 
-def test_token_budget_truncates_prompt(monkeypatch, flexible_llm_adapter):
+def test_token_budget_truncates_prompt(
+    monkeypatch: pytest.MonkeyPatch, flexible_llm_adapter: Any
+) -> None:
     """Ensure prompts are truncated to the configured token budget."""
 
     metrics = OrchestrationMetrics()
@@ -61,11 +67,13 @@ def test_token_budget_truncates_prompt(monkeypatch, flexible_llm_adapter):
     ):
         wrapped_adapter.generate("one two three four five")
 
-    counts = metrics.token_counts["agent"]
+    counts: dict[str, int] = metrics.token_counts["agent"]
     assert counts["in"] <= mock_config.token_budget
 
 
-def test_prompt_passed_to_adapter_is_compressed(monkeypatch, flexible_llm_adapter):
+def test_prompt_passed_to_adapter_is_compressed(
+    monkeypatch: pytest.MonkeyPatch, flexible_llm_adapter: Any
+) -> None:
     """Prompts exceeding the budget are compressed before LLM generation."""
 
     metrics = OrchestrationMetrics()
@@ -91,7 +99,7 @@ def test_prompt_passed_to_adapter_is_compressed(monkeypatch, flexible_llm_adapte
     assert len(captured["prompt"].split()) <= mock_config.token_budget
 
 
-def test_compress_prompt_with_summarizer():
+def test_compress_prompt_with_summarizer() -> None:
     """Summarizer is used when prompt exceeds the budget."""
 
     called = {}
@@ -105,7 +113,7 @@ def test_compress_prompt_with_summarizer():
     assert "p" in called
 
 
-def test_summarizer_skipped_when_within_budget():
+def test_summarizer_skipped_when_within_budget() -> None:
     """Summarizer is ignored when the prompt already fits the budget."""
 
     called = {}
@@ -119,7 +127,7 @@ def test_summarizer_skipped_when_within_budget():
     assert called == {}
 
 
-def test_summarizer_fallback_to_truncation():
+def test_summarizer_fallback_to_truncation() -> None:
     """If the summary is too long an ellipsis-based truncation is used."""
 
     def long_summary(prompt: str, budget: int) -> str:
@@ -130,7 +138,7 @@ def test_summarizer_fallback_to_truncation():
     assert len(result.split()) == 3
 
 
-def test_budget_considers_agent_history():
+def test_budget_considers_agent_history() -> None:
     """Token budget suggestion accounts for per-agent history."""
 
     m = OrchestrationMetrics()

--- a/tests/unit/test_token_utils_module.py
+++ b/tests/unit/test_token_utils_module.py
@@ -1,5 +1,7 @@
-from unittest.mock import MagicMock
 from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
 
 from autoresearch.config.models import ConfigModel
 from autoresearch.orchestration.metrics import OrchestrationMetrics
@@ -8,7 +10,9 @@ from autoresearch.orchestration import token_utils
 import autoresearch.llm as llm
 
 
-def test_capture_token_usage_counts(monkeypatch, flexible_llm_adapter):
+def test_capture_token_usage_counts(
+    monkeypatch: pytest.MonkeyPatch, flexible_llm_adapter: Any
+) -> None:
     metrics = OrchestrationMetrics()
     mock_config = MagicMock(spec=ConfigModel)
     mock_config.llm_backend = "flexible"
@@ -20,12 +24,12 @@ def test_capture_token_usage_counts(monkeypatch, flexible_llm_adapter):
     ):
         adapter.generate("hello world")
 
-    counts = metrics.token_counts["agent"]
+    counts: dict[str, int] = metrics.token_counts["agent"]
     assert counts["in"] == 2
     assert counts["out"] > 0
 
 
-def test_execute_with_adapter_injection_methods():
+def test_execute_with_adapter_injection_methods() -> None:
     class AgentWithParam:
         def __init__(self) -> None:
             self.used: Any | None = None


### PR DESCRIPTION
## Summary
- add explicit parameter annotations and return types for token monitoring, token usage, and visualization tests
- define typed Hypothesis strategies and helper structures so mypy can reason about token budgeting fixtures

## Testing
- `uv run --extra test mypy tests/unit tests/evaluation`
- `uv run task check`


------
https://chatgpt.com/codex/tasks/task_e_68dca0904664833399c1b85f02443673