### PR TITLE
Type annotate token and visualization tests

### DIFF
--- a/tests/unit/test_token_budget.py
+++ b/tests/unit/test_token_budget.py
@@ -1,12 +1,16 @@
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
 
 from autoresearch.config.models import ConfigModel
 from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
 from autoresearch.orchestration.metrics import OrchestrationMetrics
 
 
-@given(st.integers(min_value=1, max_value=4000), st.text(min_size=1, max_size=200))
-def test_budget_within_bounds(initial_budget, query):
+@given(
+    initial_budget=st.integers(min_value=1, max_value=4000),
+    query=st.text(min_size=1, max_size=200),
+)
+def test_budget_within_bounds(initial_budget: int, query: str) -> None:
     cfg = ConfigModel(token_budget=initial_budget)
     OrchestrationUtils.apply_adaptive_token_budget(cfg, query)
     q_tokens = len(query.split())
@@ -15,19 +19,19 @@ def test_budget_within_bounds(initial_budget, query):
     assert cfg.token_budget <= max_budget
 
 
-@given(st.text(min_size=1))
-def test_budget_none_unmodified(query):
+@given(query=st.text(min_size=1))
+def test_budget_none_unmodified(query: str) -> None:
     cfg = ConfigModel(token_budget=None)
     OrchestrationUtils.apply_adaptive_token_budget(cfg, query)
     assert cfg.token_budget is None
 
 
 @given(
-    st.integers(min_value=1, max_value=4000),
-    st.integers(min_value=1, max_value=10),
-    st.integers(min_value=1, max_value=20),
+    initial_budget=st.integers(min_value=1, max_value=4000),
+    loops=st.integers(min_value=1, max_value=10),
+    q_tokens=st.integers(min_value=1, max_value=20),
 )
-def test_budget_scaling_exact(initial_budget, loops, q_tokens):
+def test_budget_scaling_exact(initial_budget: int, loops: int, q_tokens: int) -> None:
     query = " ".join("x" for _ in range(q_tokens))
     cfg = ConfigModel(token_budget=initial_budget, loops=loops)
     OrchestrationUtils.apply_adaptive_token_budget(cfg, query)
@@ -46,7 +50,7 @@ def test_budget_scaling_exact(initial_budget, loops, q_tokens):
     assert cfg.token_budget == expected
 
 
-def test_budget_adaptive_history():
+def test_budget_adaptive_history() -> None:
     """Budget adapts to an agent's evolving token usage."""
 
     m = OrchestrationMetrics()
@@ -65,7 +69,7 @@ def test_budget_adaptive_history():
     assert budget == 11
 
 
-def test_compress_prompt_history():
+def test_compress_prompt_history() -> None:
     m = OrchestrationMetrics()
     budget = 5
     prompt = "one two three four five"

--- a/tests/unit/test_token_monitoring.py
+++ b/tests/unit/test_token_monitoring.py
@@ -6,7 +6,7 @@ from autoresearch.orchestration.metrics import OrchestrationMetrics
 
 
 def test_record_and_regression(tmp_path: Path) -> None:
-    metrics = OrchestrationMetrics()
+    metrics: OrchestrationMetrics = OrchestrationMetrics()
     metrics.record_tokens("A", 2, 3)
     metrics.record_tokens("B", 1, 1)
 
@@ -17,7 +17,7 @@ def test_record_and_regression(tmp_path: Path) -> None:
     baseline_path.write_text(json.dumps({"q": 5}))
 
     metrics.record_query_tokens("q", metrics_path)
-    saved = cast(dict[str, int], json.loads(metrics_path.read_text()))
+    saved: dict[str, int] = cast(dict[str, int], json.loads(metrics_path.read_text()))
     assert saved["q"] == 7
 
     assert metrics.check_query_regression("q", baseline_path) is True

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -11,17 +11,17 @@ from autoresearch.visualization import save_knowledge_graph
 
 
 class DummyGraph:
-    def add_node(self, *args, **kwargs):
+    def add_node(self, *args: object, **kwargs: object) -> None:
         pass
 
-    def add_edge(self, *args, **kwargs):
+    def add_edge(self, *args: object, **kwargs: object) -> None:
         pass
 
 
 @pytest.fixture(autouse=True)
 def fake_deps(monkeypatch: pytest.MonkeyPatch) -> Generator[ModuleType, None, None]:
     """Provide dummy matplotlib and networkx implementations."""
-    fake_plt = ModuleType("pyplot")
+    fake_plt: ModuleType = ModuleType("pyplot")
     setattr(fake_plt, "figure", lambda *a, **k: None)
     setattr(fake_plt, "tight_layout", lambda *a, **k: None)
     setattr(fake_plt, "close", lambda *a, **k: None)
@@ -30,7 +30,7 @@ def fake_deps(monkeypatch: pytest.MonkeyPatch) -> Generator[ModuleType, None, No
     monkeypatch.setitem(sys.modules, "matplotlib.pyplot", fake_plt)
     monkeypatch.setattr("autoresearch.visualization.plt", fake_plt, raising=False)
 
-    fake_mpl = ModuleType("matplotlib")
+    fake_mpl: ModuleType = ModuleType("matplotlib")
     setattr(fake_mpl, "use", lambda *a, **k: None)
     monkeypatch.setitem(sys.modules, "matplotlib", fake_mpl)
 
@@ -49,14 +49,14 @@ def test_save_knowledge_graph(
     tmp_path: Path,
     fake_deps: ModuleType,
 ) -> None:
-    plt = fake_deps
-    response = QueryResponse(
+    plt: ModuleType = fake_deps
+    response: QueryResponse = QueryResponse(
         answer="a",
         citations=["c1", "c2"],
         reasoning=["r1", "r2"],
         metrics={},
     )
-    out_file = tmp_path / "graph.png"
+    out_file: Path = tmp_path / "graph.png"
     save_knowledge_graph(response, str(out_file))
     plt.savefig.assert_called_once_with(str(out_file))
 
@@ -66,9 +66,14 @@ def test_save_knowledge_graph_spring_fallback(
     tmp_path: Path,
     fake_deps: ModuleType,
 ) -> None:
-    plt = fake_deps
-    response = QueryResponse(answer="a", citations=[], reasoning=["r"], metrics={})
-    out_file = tmp_path / "graph.png"
+    plt: ModuleType = fake_deps
+    response: QueryResponse = QueryResponse(
+        answer="a",
+        citations=[],
+        reasoning=["r"],
+        metrics={},
+    )
+    out_file: Path = tmp_path / "graph.png"
     import networkx as real_nx
 
     def boom(*args: object, **kwargs: object) -> None:


### PR DESCRIPTION
## Summary
- add explicit parameter and return annotations to token budget tests to satisfy mypy
- clarify visualization fixtures and token monitoring structures with explicit typing for linting

## Testing
- uv run --extra test mypy tests/unit tests/evaluation
- uv run task check

------
https://chatgpt.com/codex/tasks/task_e_68dca37d44cc8333802d5c61b4016e64