### PR TITLE
Fix QueryState cloning locks and document coverage rerun

### DIFF
--- a/CODE_COMPLETE_PLAN.md
+++ b/CODE_COMPLETE_PLAN.md
@@ -9,15 +9,19 @@ As of **October 1, 2025** the repo-wide strict gate still fails: a **14:39 UTC
 `uv run mypy --strict src tests` sweep reports 2,114 errors across 211 files,
 with the remaining debt clustered in analysis, integration, and behavior
 fixtures that have yet to adopt the expanded `EvaluationSummary` fields. The
-paired **14:40 UTC** `uv run task coverage` run (all non-GPU extras) reaches the
-unit suite before `QueryStateRegistry.register` hits the `_thread.RLock`
-cloning failure in `test_auto_mode_escalates_to_debate_when_gate_requires_`
-`loops`,
-so coverage evidence still leans on the prior 92.4 % log while we wire the typed
-registry hand-off. TestPyPI remains deferred under the alpha directive until the
-coverage gate turns green again.
+paired **14:40 UTC** `uv run task coverage` run (all non-GPU extras) reached the
+unit suite before `QueryStateRegistry.register` hit the `_thread.RLock`
+cloning failure in `test_auto_mode_escalates_to_debate_when_gate_requires`
+`_loops`,
+and a **15:27 UTC** rerun now clears that regression but fails when FastEmbed
+remains importable, leaving
+`test_search_embedding_protocol_falls_back_to_encode` to assert against the
+sentence-transformers fallback. Coverage still leans on the prior 92.4 % log
+while we relax the fallback and strict harness updates, and TestPyPI stays
+deferred under the alpha directive until the coverage gate turns green again.
 【F:baseline/logs/mypy-strict-20251001T143959Z.log†L2358-L2377】
 【F:baseline/logs/task-coverage-20251001T144044Z.log†L122-L241】
+【F:baseline/logs/task-coverage-20251001T152708Z.log†L60-L166】
 
 As of **September 30, 2025**, Autoresearch still targets an **0.1.0a1** preview
 on **September 15, 2026** and a final **0.1.0** release on **October 1, 2026**.

--- a/STATUS.md
+++ b/STATUS.md
@@ -33,6 +33,13 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   at the prior 92.4 % evidence until the registry clone adopts a typed hand-off,
   and the TestPyPI dry run stays deferred under the alpha directive.
   【F:baseline/logs/task-coverage-20251001T144044Z.log†L122-L241】
+- Captured a **15:27 UTC** rerun of the same coverage sweep. With the registry
+  lock fix applied, the unit suite now clears the auto-mode cases and fails when
+  FastEmbed remains available, leaving
+  `test_search_embedding_protocol_falls_back_to_encode` asserting against the
+  sentence-transformers fallback. The log records the new failure mode while the
+  TestPyPI dry run stays deferred under the alpha directive.
+  【F:baseline/logs/task-coverage-20251001T152708Z.log†L60-L166】
 
 ## September 29, 2025
 - Reran `uv run task release:alpha` at 00:08 UTC; extras synced before

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -17,6 +17,14 @@ dry run stays deferred until the registry clone adopts the typed handoff
 captured in the strict backlog above.
 【F:baseline/logs/task-coverage-20251001T144044Z.log†L122-L241】
 
+As of **2025-10-01** at 15:27 UTC the coverage rerun with the same extras clears
+the registry cloning path and now fails when FastEmbed stays importable,
+causing `test_search_embedding_protocol_falls_back_to_encode` to assert that the
+sentence-transformers fallback never activated. The log documents the new
+failure mode while coverage remains below the gate and the TestPyPI dry run
+continues to wait on a green sweep.
+【F:baseline/logs/task-coverage-20251001T152708Z.log†L60-L166】
+
 As of **2025-09-30** at 14:55 UTC the strict `task verify` sweep reaches
 `mypy --strict` before stopping on 118 untyped fixtures and the
 `EvaluationSummary` constructor, which now expects planner depth and routing

--- a/baseline/logs/task-coverage-20251001T152708Z.log
+++ b/baseline/logs/task-coverage-20251001T152708Z.log
@@ -1,0 +1,166 @@
+task: [coverage] echo "[coverage] syncing dependencies"
+[coverage] syncing dependencies
+task: [coverage] uv sync \
+   --extra dev-minimal --extra test --extra nlp --extra ui --extra vss --extra git --extra distributed --extra analysis --extra llm --extra parsers \
+  
+
+Resolved 328 packages in 5ms
+Audited 246 packages in 0.39ms
+task: [coverage] echo "[coverage] erasing previous data"
+[coverage] erasing previous data
+task: [coverage] uv run coverage erase
+task: [coverage] echo "[coverage] running unit tests"
+[coverage] running unit tests
+task: [coverage] uv run pytest -vv --maxfail=1 --durations=10 -x tests/unit -m 'not slow' \
+  --cov=src --cov-report=term-missing --cov-append
+
+===================================================== test session starts ======================================================
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /workspace/autoresearch/.venv/bin/python3
+cachedir: .pytest_cache
+benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+hypothesis profile 'default'
+rootdir: /workspace/autoresearch
+configfile: pytest.ini
+plugins: benchmark-5.1.0, bdd-8.1.0, httpx-0.35.0, langsmith-0.4.31, hypothesis-6.140.2, anyio-4.11.0, cov-7.0.0
+collecting ... collected 1078 items / 25 deselected / 1053 selected
+
+tests/unit/config/test_loader_types.py::test_load_config_file_returns_defaults_when_missing PASSED                       [  0%]
+tests/unit/config/test_loader_types.py::test_load_config_file_rejects_non_mapping PASSED                                 [  0%]
+tests/unit/config/test_loader_types.py::test_env_storage_override_round_trips PASSED                                     [  0%]
+tests/unit/config/test_loader_types.py::test_normalize_ranking_weights_balances_missing_values PASSED                    [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_election_converges_to_minimum PASSED                        [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_election_requires_identifier PASSED                         [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_election_accepts_strings PASSED                             [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent PASSED                     [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_message_processing_returns_copy PASSED                      [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_module_exports_helpers PASSED                               [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_storage_queue_adapter_accepts_mapping_payloads PASSED       [  1%]
+tests/unit/distributed/test_coordination_properties.py::test_storage_queue_adapter_rejects_incompatible_payloads PASSED  [  1%]
+tests/unit/distributed/test_coordination_properties.py::test_storage_queue_adapter_accepts_broker_queue PASSED           [  1%]
+tests/unit/evaluation/test_harness_typing.py::test_open_duckdb_closes_connection PASSED                                  [  1%]
+tests/unit/evidence/test_stability_utils.py::test_aggregate_entailment_scores_stable PASSED                              [  1%]
+tests/unit/evidence/test_stability_utils.py::test_aggregate_entailment_scores_unstable PASSED                            [  1%]
+tests/unit/evidence/test_stability_utils.py::test_sample_paraphrases_returns_unique_variants PASSED                      [  1%]
+tests/unit/knowledge/test_graph_pipeline.py::test_session_graph_pipeline_ingest_records_provenance PASSED                [  1%]
+tests/unit/knowledge/test_graph_pipeline.py::test_session_graph_pipeline_neighbors_uses_storage PASSED                   [  1%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_decodes_prometheus_payload PASSED                     [  1%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_coerces_bytearray PASSED                              [  1%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_handles_memoryview PASSED                             [  2%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_replaces_invalid_bytes PASSED                         [  2%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_handles_failure PASSED                                [  2%]
+tests/unit/orchestration/test_answer_audit.py::test_answer_auditor_hedges_unsupported_claims PASSED                      [  2%]
+tests/unit/orchestration/test_budgeting_algorithm.py::test_budget_scaled_by_loops_and_limits PASSED                      [  2%]
+tests/unit/orchestration/test_budgeting_algorithm.py::test_budget_minimum_buffer_applied PASSED                          [  2%]
+tests/unit/orchestration/test_budgeting_algorithm.py::test_budget_unchanged_within_bounds PASSED                         [  2%]
+tests/unit/orchestration/test_circuit_breaker_determinism.py::test_circuit_breaker_determinism_and_recovery PASSED       [  2%]
+tests/unit/orchestration/test_circuit_breaker_thresholds.py::test_circuit_breaker_threshold_and_recovery PASSED          [  2%]
+tests/unit/orchestration/test_gate_policy.py::test_scout_gate_reduces_loops_when_signals_low PASSED                      [  2%]
+tests/unit/orchestration/test_gate_policy.py::test_scout_gate_respects_force_debate_override PASSED                      [  3%]
+tests/unit/orchestration/test_gate_policy.py::test_scout_gate_flags_coverage_gap_and_confidence PASSED                   [  3%]
+tests/unit/orchestration/test_gate_policy.py::test_scout_gate_applies_graph_thresholds PASSED                            [  3%]
+tests/unit/orchestration/test_metrics_graph_summary.py::test_graph_summary_uses_typed_floats PASSED                      [  3%]
+tests/unit/orchestration/test_metrics_graph_summary.py::test_graph_build_skips_empty_payload PASSED                      [  3%]
+tests/unit/orchestration/test_metrics_graph_summary.py::test_graph_ingestion_saved_payload_is_sanitized PASSED           [  3%]
+tests/unit/orchestration/test_orchestration_simulations.py::test_circuit_breaker_sim_is_deterministic PASSED             [  3%]
+tests/unit/orchestration/test_orchestration_simulations.py::test_parallel_execution_sim_is_deterministic PASSED          [  3%]
+tests/unit/orchestration/test_orchestration_simulations.py::test_cli_runs_modes PASSED                                   [  3%]
+tests/unit/orchestration/test_orchestrator_auto_mode.py::test_auto_mode_returns_direct_answer_when_gate_exits PASSED     [  3%]
+tests/unit/orchestration/test_orchestrator_auto_mode.py::test_auto_mode_escalates_to_debate_when_gate_requires_loops PASSED [  3%]
+tests/unit/orchestration/test_package_exports.py::test_agent_factory_export PASSED                                       [  4%]
+tests/unit/orchestration/test_package_exports.py::test_agent_registry_export PASSED                                      [  4%]
+tests/unit/orchestration/test_package_exports.py::test_orchestrator_export PASSED                                        [  4%]
+tests/unit/orchestration/test_package_exports.py::test_storage_manager_export PASSED                                     [  4%]
+tests/unit/orchestration/test_parallel_execute.py::test_execute_parallel_query_error_and_timeout PASSED                  [  4%]
+tests/unit/orchestration/test_parallel_execute.py::test_execute_parallel_query_all_fail PASSED                           [  4%]
+tests/unit/orchestration/test_parallel_merge_invariant.py::test_parallel_merge_invariant PASSED                          [  4%]
+tests/unit/orchestration/test_query_state_features.py::test_query_state_cloudpickle_serialization_preserves_fields PASSED [  4%]
+tests/unit/orchestration/test_query_state_features.py::test_query_state_registry_clone_produces_independent_copies PASSED [  4%]
+tests/unit/orchestration/test_query_state_features.py::test_query_state_registry_update_refreshes_snapshots PASSED       [  4%]
+tests/unit/orchestration/test_state_registry.py::test_register_and_clone_preserve_lock_and_metadata_types PASSED         [  5%]
+tests/unit/orchestration/test_state_registry.py::test_update_replaces_snapshot_and_preserves_lock_integrity PASSED       [  5%]
+tests/unit/orchestration/test_state_registry.py::test_update_creates_snapshot_when_missing_identifier PASSED             [  5%]
+tests/unit/orchestration/test_state_registry.py::test_registry_round_trip_rehydrates_state_with_fresh_lock PASSED        [  5%]
+tests/unit/orchestration/test_task_coordinator.py::test_task_coordinator_schedules_dependencies PASSED                   [  5%]
+tests/unit/orchestration/test_token_utils.py::test_execute_with_adapter_kwarg PASSED                                     [  5%]
+tests/unit/orchestration/test_token_utils.py::test_execute_with_mutation_hooks_restores_original PASSED                  [  5%]
+tests/unit/orchestration/test_token_utils.py::test_execute_without_adapter_hooks PASSED                                  [  5%]
+tests/unit/orchestration/test_token_utils.py::test_execute_raises_for_non_mapping_result PASSED                          [  5%]
+tests/unit/orchestration/test_token_utils.py::test_type_guards_detect_adapter_features PASSED                            [  5%]
+tests/unit/orchestration/test_token_utils.py::test_is_agent_execution_result_guard PASSED                                [  5%]
+tests/unit/orchestration/test_utils_confidence.py::test_metrics_snapshot_parses_token_usage PASSED                       [  6%]
+tests/unit/orchestration/test_utils_confidence.py::test_confidence_adjusts_with_metrics_payload PASSED                   [  6%]
+tests/unit/orchestration/test_utils_confidence.py::test_graph_metrics_payload_is_sanitized PASSED                        [  6%]
+tests/unit/search/test_property_ranking_monotonicity.py::test_monotonic_ranking PASSED                                   [  6%]
+tests/unit/search/test_query_expansion_convergence.py::test_query_expansion_converges PASSED                             [  6%]
+tests/unit/search/test_query_expansion_convergence.py::test_reset_instance_creates_new_singleton PASSED                  [  6%]
+tests/unit/search/test_query_expansion_convergence.py::test_extract_entities_with_spacy PASSED                           [  6%]
+tests/unit/search/test_query_expansion_convergence.py::test_build_topic_model_with_insufficient_docs PASSED              [  6%]
+tests/unit/search/test_query_expansion_convergence.py::test_try_imports_disabled PASSED                                  [  6%]
+tests/unit/search/test_query_expansion_convergence.py::test_try_import_sentence_transformers_success PASSED              [  6%]
+tests/unit/search/test_query_expansion_convergence.py::test_search_embedding_protocol_prefers_embed PASSED               [  7%]
+tests/unit/search/test_query_expansion_convergence.py::test_search_embedding_protocol_falls_back_to_encode FAILED        [  7%]
+
+=========================================================== FAILURES ===========================================================
+_____________________________________ test_search_embedding_protocol_falls_back_to_encode ______________________________________
+
+monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f1a88ed2ab0>
+
+    def test_search_embedding_protocol_falls_back_to_encode(monkeypatch):
+        """Assume sentence-transformers fallback loads when fastembed is unavailable."""
+    
+        cfg = make_config_model()
+        monkeypatch.setattr(search_core, "_get_runtime_config", lambda: cfg)
+        monkeypatch.setattr(search_core, "SentenceTransformer", None)
+        monkeypatch.setattr(search_core, "SENTENCE_TRANSFORMERS_AVAILABLE", False)
+        monkeypatch.setattr(search_core, "_resolve_sentence_transformer_cls", lambda: None)
+    
+        class FakeSentenceTransformer:
+            last_input: object | None = None
+    
+            def encode(self, sentences):
+                type(self).last_input = sentences
+                return [[3.0, 4.0, 5.0]]
+    
+        module = ModuleType("sentence_transformers")
+        module.SentenceTransformer = FakeSentenceTransformer
+        monkeypatch.setitem(sys.modules, "sentence_transformers", module)
+    
+        search = Search()
+        model = search.get_sentence_transformer()
+>       assert isinstance(model, FakeSentenceTransformer)
+E       AssertionError: assert False
+E        +  where False = isinstance(<tests.unit.search.test_query_expansion_convergence.test_search_embedding_protocol_prefers_embed.<locals>.FakeFastEmbed object at 0x7f1a88ed3830>, <class 'tests.unit.search.test_query_expansion_convergence.test_search_embedding_protocol_falls_back_to_encode.<locals>.FakeSentenceTransformer'>)
+
+/workspace/autoresearch/tests/unit/search/test_query_expansion_convergence.py:176: AssertionError
+--------------------------------------------------- Captured stderr teardown ---------------------------------------------------
+{"text": "2025-10-01 15:27:27.973 | INFO     | autoresearch.logging_utils:emit:113 - No configuration file found; using defaults\n", "record": {"elapsed": {"repr": "0:00:16.449127", "seconds": 16.449127}, "exception": null, "extra": {}, "file": {"name": "logging_utils.py", "path": "/workspace/autoresearch/src/autoresearch/logging_utils.py"}, "function": "emit", "level": {"icon": "ℹ️", "name": "INFO", "no": 20}, "line": 113, "message": "No configuration file found; using defaults", "module": "logging_utils", "name": "autoresearch.logging_utils", "process": {"id": 5045, "name": "MainProcess"}, "thread": {"id": 139752664972160, "name": "MainThread"}, "time": {"repr": "2025-10-01 15:27:27.973332+00:00", "timestamp": 1759332447.973332}}}
+{"text": "2025-10-01 15:27:27.973 | WARNING  | autoresearch.logging_utils:emit:113 - Invalid storage configuration: 1 validation error for StorageConfig\nminimum_deterministic_resident_nodes\n  Input should be a valid integer [type=int_type, input_value=None, input_type=NoneType]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_type\n", "record": {"elapsed": {"repr": "0:00:16.449476", "seconds": 16.449476}, "exception": null, "extra": {}, "file": {"name": "logging_utils.py", "path": "/workspace/autoresearch/src/autoresearch/logging_utils.py"}, "function": "emit", "level": {"icon": "⚠️", "name": "WARNING", "no": 30}, "line": 113, "message": "Invalid storage configuration: 1 validation error for StorageConfig\nminimum_deterministic_resident_nodes\n  Input should be a valid integer [type=int_type, input_value=None, input_type=NoneType]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_type", "module": "logging_utils", "name": "autoresearch.logging_utils", "process": {"id": 5045, "name": "MainProcess"}, "thread": {"id": 139752664972160, "name": "MainThread"}, "time": {"repr": "2025-10-01 15:27:27.973681+00:00", "timestamp": 1759332447.973681}}}
+---------------------------------------------------- Captured log teardown -----------------------------------------------------
+INFO     autoresearch.config.loader:loader.py:104 No configuration file found; using defaults
+WARNING  autoresearch.config.loader:loader.py:363 Invalid storage configuration: 1 validation error for StorageConfig
+minimum_deterministic_resident_nodes
+  Input should be a valid integer [type=int_type, input_value=None, input_type=NoneType]
+    For further information visit https://errors.pydantic.dev/2.11/v/int_type
+======================================================= warnings summary =======================================================
+tests/unit/test_main_config_commands.py:4
+  /workspace/autoresearch/tests/unit/test_main_config_commands.py:4: DeprecationWarning: 'importlib.abc.Traversable' is deprecated and slated for removal in Python 3.14
+    from importlib.abc import Traversable
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+===================================================== slowest 10 durations =====================================================
+0.51s call     tests/unit/orchestration/test_parallel_execute.py::test_execute_parallel_query_error_and_timeout
+0.41s call     tests/unit/distributed/test_coordination_properties.py::test_election_converges_to_minimum
+0.17s call     tests/unit/search/test_property_ranking_monotonicity.py::test_monotonic_ranking
+0.10s call     tests/unit/orchestration/test_parallel_merge_invariant.py::test_parallel_merge_invariant
+0.05s call     tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent
+0.05s call     tests/unit/orchestration/test_orchestration_simulations.py::test_parallel_execution_sim_is_deterministic
+0.03s call     tests/unit/knowledge/test_graph_pipeline.py::test_session_graph_pipeline_ingest_records_provenance
+0.02s call     tests/unit/orchestration/test_orchestration_simulations.py::test_cli_runs_modes
+0.01s setup    tests/unit/config/test_loader_types.py::test_load_config_file_returns_defaults_when_missing
+0.01s setup    tests/unit/orchestration/test_metrics_graph_summary.py::test_graph_summary_uses_typed_floats
+=================================================== short test summary info ====================================================
+FAILED tests/unit/search/test_query_expansion_convergence.py::test_search_embedding_protocol_falls_back_to_encode - AssertionError: assert False
+ +  where False = isinstance(<tests.unit.search.test_query_expansion_convergence.test_search_embedding_protocol_prefers_embed.<locals>.FakeFastEmbed object at 0x7f1a88ed3830>, <class 'tests.unit.search.test_query_expansion_convergence.test_search_embedding_protocol_falls_back_to_encode.<locals>.FakeSentenceTransformer'>)
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+==================================== 1 failed, 74 passed, 25 deselected, 1 warning in 6.25s ====================================
+task: Failed to run task "coverage": exit status 1

--- a/docs/deep_research_upgrade_plan.md
+++ b/docs/deep_research_upgrade_plan.md
@@ -23,9 +23,11 @@ Phase 1 is complete, and the **October 1, 2025** strict and coverage sweeps
 confirm the remaining blockers sit inside typed evaluation fixtures and the
 `QueryStateRegistry.register` clone. Planner upgrades and GraphRAG expansion now
 proceed once the `_thread.RLock` handling and `EvaluationSummary` signature land,
-with the new logs capturing the narrowed scope of work.
+with the new logs capturing the narrowed scope of work and the **15:27 UTC**
+coverage rerun showing the FastEmbed fallback failure after the registry fix.
 【F:baseline/logs/mypy-strict-20251001T143959Z.log†L2358-L2377】
 【F:baseline/logs/task-coverage-20251001T144044Z.log†L122-L241】
+【F:baseline/logs/task-coverage-20251001T152708Z.log†L60-L166】
 
 1. **Phase 1 – Adaptive Gate and Claim Audits**
    - Implement the scout pass and gating heuristics with clear metrics.

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -33,6 +33,14 @@ the alpha directive.
 【F:baseline/logs/mypy-strict-20251001T143959Z.log†L2358-L2377】
 【F:baseline/logs/task-coverage-20251001T144044Z.log†L122-L241】
 
+A **15:27 UTC** rerun of the same coverage sweep now clears the registry clone
+and fails when FastEmbed remains importable, leaving
+`test_search_embedding_protocol_falls_back_to_encode` to assert that the
+sentence-transformers fallback never activated. The log captures the new
+failure mode while the coverage gate stays red and the TestPyPI dry run
+remains deferred.
+【F:baseline/logs/task-coverage-20251001T152708Z.log†L60-L166】
+
 The **September 30, 2025 at 14:55 UTC** `task verify` sweep now reaches
 `mypy --strict` before failing on 118 untyped test fixtures and the
 `EvaluationSummary` constructor, which expects planner depth and routing

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -33,6 +33,14 @@ run reached the unit suite before `QueryStateRegistry.register` hit the
 gate continues to rely on the 92.4 % evidence while TestPyPI stays deferred.
 【F:baseline/logs/mypy-strict-20251001T143959Z.log†L2358-L2377】
 【F:baseline/logs/task-coverage-20251001T144044Z.log†L122-L241】
+
+A **15:27 UTC** rerun of the coverage sweep now clears the registry cloning path
+and fails when FastEmbed remains importable, leaving
+`test_search_embedding_protocol_falls_back_to_encode` to assert that the
+sentence-transformers fallback never loaded. The log captures the revised
+failure mode while the TestPyPI hold and alpha gate remain in place until the
+coverage fix lands.
+【F:baseline/logs/task-coverage-20251001T152708Z.log†L60-L166】
 On **September 30, 2025 at 15:15 UTC** we updated the `A2AMessage` schema to
 accept the SDK's concrete payloads and introduced
 `test_a2a_message_accepts_sdk_message` to guard the regression.


### PR DESCRIPTION
## Summary
- override `QueryState.model_copy` to rebuild synchronization locks without copying private RLock instances
- extend the state registry unit suite with a round-trip rehydration test that ensures cloned locks remain independent
- archive the latest coverage sweep log and update release evidence documents with the new FastEmbed fallback failure

## Testing
- uv run mypy --strict src/autoresearch/orchestration/state_registry.py src/autoresearch/orchestration/state.py tests/unit/orchestration/test_state_registry.py tests/unit/orchestration/test_orchestrator_auto_mode.py
- uv run --extra test pytest tests/unit/orchestration/test_state_registry.py tests/unit/orchestration/test_orchestrator_auto_mode.py
- uv run task coverage EXTRAS="nlp ui vss git distributed analysis llm parsers" *(fails in tests/unit/search/test_query_expansion_convergence.py::test_search_embedding_protocol_falls_back_to_encode while FastEmbed remains importable)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4288f3808333856bb03e0ab9a93f