### PR TITLE
Annotate storage integration tests

### DIFF
--- a/tests/integration/test_distributed_process_storage.py
+++ b/tests/integration/test_distributed_process_storage.py
@@ -1,10 +1,18 @@
+from __future__ import annotations
+
 import os
+from pathlib import Path
+from typing import Any
+
 import pytest
-from autoresearch.distributed import ProcessExecutor
+from _pytest.monkeypatch import MonkeyPatch
+
+import autoresearch.orchestration.orchestrator as orchestrator_module
 from autoresearch.config.models import ConfigModel, DistributedConfig, StorageConfig
-from autoresearch.storage import StorageManager
-from autoresearch.orchestration.orchestrator import AgentFactory
+from autoresearch.distributed import ProcessExecutor
 from autoresearch.orchestration.state import QueryState
+from autoresearch.storage import StorageContext, StorageManager, StorageState
+from autoresearch.storage_typing import JSONDict
 
 pytestmark = pytest.mark.slow
 
@@ -14,20 +22,29 @@ class ClaimAgent:
         self.name = name
         self._pids = pids
 
-    def can_execute(self, state: QueryState, config: ConfigModel) -> bool:  # pragma: no cover - dummy
+    def can_execute(
+        self, state: QueryState, config: ConfigModel
+    ) -> bool:  # pragma: no cover - dummy
         return True
 
-    def execute(self, state: QueryState, config: ConfigModel, **_: object) -> dict:
+    def execute(
+        self, state: QueryState, config: ConfigModel, **_: Any
+    ) -> JSONDict:
         self._pids.append(os.getpid())
-        StorageManager.persist_claim({"id": self.name, "type": "fact", "content": "x"})
+        claim: JSONDict = {"id": self.name, "type": "fact", "content": "x"}
+        StorageManager.persist_claim(claim)
         state.update({"results": {self.name: "ok"}})
         return {"results": {self.name: "ok"}}
 
 
-def test_process_storage_with_executor(tmp_path, monkeypatch):
+def test_process_storage_with_executor(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     pids: list[int] = []
-    monkeypatch.setattr(AgentFactory, "get", lambda name: ClaimAgent(name, pids))
-    cfg = ConfigModel(
+
+    def agent_factory(name: str) -> ClaimAgent:
+        return ClaimAgent(name, pids)
+
+    monkeypatch.setattr(AgentFactoryClass, "get", agent_factory)
+    cfg: ConfigModel = ConfigModel(
         agents=["A", "B"],
         loops=1,
         distributed=True,
@@ -38,7 +55,19 @@ def test_process_storage_with_executor(tmp_path, monkeypatch):
     executor.run_query("q")
     assert len(set(pids)) > 1
     executor.shutdown()
-    StorageManager.setup(str(tmp_path / "kg.duckdb"))
-    conn = StorageManager.get_duckdb_conn()
-    rows = conn.execute("SELECT id FROM nodes ORDER BY id").fetchall()
-    assert [r[0] for r in rows] == ["A", "B"]
+
+    context: StorageContext = StorageContext()
+    state: StorageState = StorageState(context=context)
+    StorageManager.setup(str(tmp_path / "kg.duckdb"), context=context, state=state)
+    try:
+        conn = StorageManager.get_duckdb_conn()
+        rows: list[tuple[str]] = conn.execute(
+            "SELECT id FROM nodes ORDER BY id"
+        ).fetchall()
+    finally:
+        StorageManager.teardown(remove_db=True, context=context, state=state)
+        StorageManager.state = StorageState()
+        StorageManager.context = StorageContext()
+
+    assert [row[0] for row in rows] == ["A", "B"]
+AgentFactoryClass = getattr(orchestrator_module, "AgentFactory")

--- a/tests/integration/test_distributed_storage.py
+++ b/tests/integration/test_distributed_storage.py
@@ -1,42 +1,82 @@
+from __future__ import annotations
+
 import os
-import ray
+from pathlib import Path
+from typing import cast
+
 import pytest
+import ray
+
 from autoresearch.config.models import ConfigModel, DistributedConfig, StorageConfig
-from autoresearch.distributed import start_storage_coordinator
-from autoresearch.storage import StorageManager
+from autoresearch.distributed import (
+    BrokerType,
+    StorageCoordinator,
+    start_storage_coordinator,
+)
+from autoresearch.distributed.broker import (
+    PersistClaimMessage,
+    STOP_MESSAGE,
+    StorageBrokerQueueProtocol,
+)
+from autoresearch.storage import (
+    StorageContext,
+    StorageManager,
+    StorageState,
+)
+from autoresearch.storage_typing import JSONDict
 
 pytestmark = pytest.mark.slow
 
 
-def test_distributed_storage(tmp_path):
-    cfg = ConfigModel(
+def test_distributed_storage(tmp_path: Path) -> None:
+    db_path: Path = tmp_path / "kg.duckdb"
+    cfg: ConfigModel = ConfigModel(
         distributed=True,
-        distributed_config=DistributedConfig(enabled=True, num_cpus=2, message_broker="memory"),
-        storage=StorageConfig(duckdb_path=str(tmp_path / "kg.duckdb")),
+        distributed_config=DistributedConfig(
+            enabled=True, num_cpus=2, message_broker="memory"
+        ),
+        storage=StorageConfig(duckdb_path=str(db_path)),
     )
 
-    coordinator, broker = start_storage_coordinator(cfg)
+    coordinator: StorageCoordinator
+    broker_instance: BrokerType
+    coordinator, broker_instance = start_storage_coordinator(cfg)
     ray.init(num_cpus=2, ignore_reinit_error=True, configure_logging=False)
 
     @ray.remote
-    def persist(claim, q):
-        q.put({"action": "persist_claim", "claim": claim})
+    def persist(claim: JSONDict, q: StorageBrokerQueueProtocol) -> int:
+        message: PersistClaimMessage = {
+            "action": "persist_claim",
+            "claim": claim,
+            "partial_update": False,
+        }
+        q.put(message)
         return os.getpid()
 
-    claims = [
+    claims: list[JSONDict] = [
         {"id": "c1", "type": "fact", "content": "a"},
         {"id": "c2", "type": "fact", "content": "b"},
     ]
-    pids = ray.get([persist.remote(c, broker.queue) for c in claims])
-    assert len(set(pids)) == len(claims)
+    pids = cast(list[int], ray.get([persist.remote(c, broker_instance.queue) for c in claims]))
+    assert len({pid for pid in pids}) == len(claims)
 
-    broker.publish({"action": "stop"})
+    broker_instance.publish(STOP_MESSAGE)
     coordinator.join()
-    broker.shutdown()
+    broker_instance.shutdown()
     os.environ["RAY_IGNORE_UNHANDLED_ERRORS"] = "1"
     ray.shutdown()
 
-    StorageManager.setup(str(tmp_path / "kg.duckdb"))
-    conn = StorageManager.get_duckdb_conn()
-    rows = conn.execute("SELECT id FROM nodes ORDER BY id").fetchall()
-    assert [r[0] for r in rows] == ["c1", "c2"]
+    context: StorageContext = StorageContext()
+    state: StorageState = StorageState(context=context)
+    StorageManager.setup(str(db_path), context=context, state=state)
+    try:
+        conn = StorageManager.get_duckdb_conn()
+        rows: list[tuple[str]] = conn.execute(
+            "SELECT id FROM nodes ORDER BY id"
+        ).fetchall()
+    finally:
+        StorageManager.teardown(remove_db=True, context=context, state=state)
+        StorageManager.state = StorageState()
+        StorageManager.context = StorageContext()
+
+    assert [row[0] for row in rows] == ["c1", "c2"]

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
-from autoresearch.config import ConfigModel, StorageConfig, temporary_config
-from autoresearch.storage import ClaimAuditStatus, StorageContext, StorageManager, StorageState
+from pathlib import Path
+from typing import Any
+
 from unittest.mock import patch
 
+from autoresearch.config import ConfigModel, StorageConfig, temporary_config
+from autoresearch.storage import (
+    ClaimAuditRecord,
+    ClaimAuditStatus,
+    StorageContext,
+    StorageManager,
+    StorageState,
+)
+from autoresearch.storage_typing import JSONDict
 
-def test_storage_persistence_and_audit_flow(tmp_path) -> None:
-    db_path = tmp_path / "kg.duckdb"
-    rdf_path = tmp_path / "rdf"
-    config = ConfigModel(
+
+def test_storage_persistence_and_audit_flow(tmp_path: Path) -> None:
+    db_path: Path = tmp_path / "kg.duckdb"
+    rdf_path: Path = tmp_path / "rdf"
+    config: ConfigModel = ConfigModel(
         storage=StorageConfig(
             duckdb_path=str(db_path),
             rdf_backend="memory",
@@ -17,15 +28,15 @@ def test_storage_persistence_and_audit_flow(tmp_path) -> None:
         )
     )
 
-    context = StorageContext()
-    state = StorageState(context=context)
-    original_context = StorageManager.context
-    original_state = StorageManager.state
+    context: StorageContext = StorageContext()
+    state: StorageState = StorageState(context=context)
+    original_context: StorageContext = StorageManager.context
+    original_state: StorageState = StorageManager.state
 
     try:
         with temporary_config(config):
             StorageManager.setup(str(db_path), context=context, state=state)
-            claim = {
+            claim: JSONDict = {
                 "id": "typed-claim",
                 "type": "claim",
                 "content": "Typed persistence check",
@@ -42,11 +53,12 @@ def test_storage_persistence_and_audit_flow(tmp_path) -> None:
 
             graph = StorageManager.context.graph
             assert graph is not None and graph.has_node("typed-claim")
-            audit_payload = graph.nodes["typed-claim"]["audit"]
-            assert isinstance(audit_payload, dict)
+            audit_payload_raw: Any = graph.nodes["typed-claim"].get("audit")
+            assert isinstance(audit_payload_raw, dict)
+            audit_payload: JSONDict = audit_payload_raw
             assert audit_payload["status"] == "supported"
 
-            audits = StorageManager.list_claim_audits("typed-claim")
+            audits: list[ClaimAuditRecord] = StorageManager.list_claim_audits("typed-claim")
             assert audits and audits[0].claim_id == "typed-claim"
             assert audits[0].status is ClaimAuditStatus.SUPPORTED
 

--- a/tests/integration/test_storage_backup_roundtrip.py
+++ b/tests/integration/test_storage_backup_roundtrip.py
@@ -1,19 +1,21 @@
 """Integration test for backup and restore using real files."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
-from autoresearch.storage_backup import BackupManager
+from autoresearch.storage_backup import BackupInfo, BackupManager
 
 
-def test_backup_roundtrip(tmp_path):
+def test_backup_roundtrip(tmp_path: Path) -> None:
     """BackupManager can create and restore backups on disk."""
-    db = tmp_path / "data.db"
-    rdf = tmp_path / "store.rdf"
+    db: Path = tmp_path / "data.db"
+    rdf: Path = tmp_path / "store.rdf"
     db.write_text("db")
     rdf.write_text("rdf")
-    backup_dir = tmp_path / "backups"
+    backup_dir: Path = tmp_path / "backups"
 
-    info = BackupManager.create_backup(
+    info: BackupInfo = BackupManager.create_backup(
         backup_dir=str(backup_dir),
         db_path=str(db),
         rdf_path=str(rdf),
@@ -22,7 +24,7 @@ def test_backup_roundtrip(tmp_path):
 
     db.unlink()
     rdf.unlink()
-    restore_dir = tmp_path / "restore"
+    restore_dir: Path = tmp_path / "restore"
     BackupManager.restore_backup(
         info.path,
         target_dir=str(restore_dir),

--- a/tests/integration/test_storage_baseline.py
+++ b/tests/integration/test_storage_baseline.py
@@ -1,32 +1,52 @@
+from __future__ import annotations
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from _pytest.monkeypatch import MonkeyPatch
+
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.storage import StorageContext, StorageManager, StorageState
+from autoresearch.storage_typing import JSONDict
 
 
-def test_ram_budget_respects_baseline(tmp_path, monkeypatch):
+def test_ram_budget_respects_baseline(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """Eviction uses memory delta from setup baseline."""
-    cfg = ConfigModel(
+    cfg: ConfigModel = ConfigModel(
         storage=StorageConfig(duckdb_path=str(tmp_path / "kg.duckdb")),
         ram_budget_mb=1,
         graph_eviction_policy="lru",
     )
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    def load_config_stub(_: ConfigLoader) -> ConfigModel:
+        return cfg
+
+    monkeypatch.setattr(ConfigLoader, "load_config", load_config_stub)
     ConfigLoader()._config = None
 
     # Simulate high baseline memory before setup
-    monkeypatch.setattr("autoresearch.storage._process_ram_mb", lambda: 1000)
-    st = StorageState()
-    ctx = StorageContext()
+    def high_baseline() -> float:
+        return 1000.0
+
+    monkeypatch.setattr("autoresearch.storage._process_ram_mb", high_baseline)
+    st: StorageState = StorageState()
+    ctx: StorageContext = StorageContext()
     StorageManager.setup(db_path=cfg.storage.duckdb_path, context=ctx, state=st)
 
     # Avoid ontology reasoning delays during persistence
-    monkeypatch.setattr(
-        "autoresearch.storage.run_ontology_reasoner", lambda *_, **__: None
-    )
+    def noop_reasoner(*_: object, **__: object) -> None:
+        return None
+
+    monkeypatch.setattr("autoresearch.storage.run_ontology_reasoner", noop_reasoner)
 
     # After setup memory increases slightly
-    monkeypatch.setattr("autoresearch.storage._process_ram_mb", lambda: 1001)
-    StorageManager.persist_claim({"id": "a", "type": "fact", "content": "c"})
+    def slightly_higher() -> float:
+        return 1001.0
+
+    monkeypatch.setattr("autoresearch.storage._process_ram_mb", slightly_higher)
+    claim: JSONDict = {"id": "a", "type": "fact", "content": "c"}
+    StorageManager.persist_claim(claim)
     assert StorageManager.get_graph().number_of_nodes() == 1
 
     StorageManager.teardown(remove_db=True, context=ctx, state=st)
@@ -35,38 +55,49 @@ def test_ram_budget_respects_baseline(tmp_path, monkeypatch):
     ConfigLoader()._config = None
 
 
-def test_eviction_respects_baseline_without_reasoner(tmp_path, monkeypatch):
+def test_eviction_respects_baseline_without_reasoner(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
     """Eviction honors baseline when ontology reasoning is bypassed."""
 
-    cfg = ConfigModel(
+    cfg: ConfigModel = ConfigModel(
         storage=StorageConfig(duckdb_path=str(tmp_path / "kg.duckdb")),
         ram_budget_mb=1,
         graph_eviction_policy="lru",
     )
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    def load_config_stub(_: ConfigLoader) -> ConfigModel:
+        return cfg
+
+    monkeypatch.setattr(ConfigLoader, "load_config", load_config_stub)
     ConfigLoader()._config = None
 
     # Establish baseline memory before setup
-    monkeypatch.setattr("autoresearch.storage._process_ram_mb", lambda: 1000)
-    st = StorageState()
-    ctx = StorageContext()
+    def high_baseline() -> float:
+        return 1000.0
+
+    monkeypatch.setattr("autoresearch.storage._process_ram_mb", high_baseline)
+    st: StorageState = StorageState()
+    ctx: StorageContext = StorageContext()
     StorageManager.setup(db_path=cfg.storage.duckdb_path, context=ctx, state=st)
 
     # Skip ontology reasoning to avoid unrelated failures
-    monkeypatch.setattr(
-        "autoresearch.storage.run_ontology_reasoner", lambda *_, **__: None
-    )
+    def noop_reasoner(*_: object, **__: object) -> None:
+        return None
+
+    monkeypatch.setattr("autoresearch.storage.run_ontology_reasoner", noop_reasoner)
 
     # Sequence of RAM readings: under budget, then over budget, then back under
-    ram_values = [0.5, 2.0, 0.5]
+    ram_values: list[float] = [0.5, 2.0, 0.5]
 
     def fake_ram_mb() -> float:
         return ram_values.pop(0) if ram_values else 0.5
 
     monkeypatch.setattr(StorageManager, "_current_ram_mb", fake_ram_mb)
 
-    StorageManager.persist_claim({"id": "a", "type": "fact", "content": "a"})
-    StorageManager.persist_claim({"id": "b", "type": "fact", "content": "b"})
+    first_claim: JSONDict = {"id": "a", "type": "fact", "content": "a"}
+    second_claim: JSONDict = {"id": "b", "type": "fact", "content": "b"}
+    StorageManager.persist_claim(first_claim)
+    StorageManager.persist_claim(second_claim)
 
     graph = StorageManager.get_graph()
     assert graph.number_of_nodes() == 1

--- a/tests/integration/test_storage_concurrency.py
+++ b/tests/integration/test_storage_concurrency.py
@@ -1,39 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
 from threading import Thread
+
+from _pytest.monkeypatch import MonkeyPatch
 
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.storage import StorageContext, StorageManager, StorageState
+from autoresearch.storage_typing import JSONDict
 
 
-def _setup(tmp_path, monkeypatch, ram_budget):
-    cfg = ConfigModel(
+def _setup(
+    tmp_path: Path, monkeypatch: MonkeyPatch, ram_budget: int
+) -> tuple[ConfigModel, StorageState, StorageContext]:
+    cfg: ConfigModel = ConfigModel(
         storage=StorageConfig(duckdb_path=str(tmp_path / "kg.duckdb")),
         ram_budget_mb=ram_budget,
         graph_eviction_policy="lru",
     )
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    
+    def load_config_stub(_: ConfigLoader) -> ConfigModel:
+        return cfg
+
+    monkeypatch.setattr(ConfigLoader, "load_config", load_config_stub)
     ConfigLoader()._config = None
 
-    st = StorageState()
-    ctx = StorageContext()
+    st: StorageState = StorageState()
+    ctx: StorageContext = StorageContext()
     StorageManager.setup(db_path=cfg.storage.duckdb_path, context=ctx, state=st)
     return cfg, st, ctx
 
 
-def _teardown(st, ctx):
+def _teardown(st: StorageState, ctx: StorageContext) -> None:
     StorageManager.teardown(remove_db=True, context=ctx, state=st)
     StorageManager.state = StorageState()
     StorageManager.context = StorageContext()
     ConfigLoader()._config = None
 
 
-def test_concurrent_writes(tmp_path, monkeypatch):
+def test_concurrent_writes(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     cfg, st, ctx = _setup(tmp_path, monkeypatch, ram_budget=50)
 
     def persist(idx: int) -> None:
-        StorageManager.persist_claim({"id": f"c{idx}", "type": "fact", "content": "c"})
+        claim: JSONDict = {"id": f"c{idx}", "type": "fact", "content": "c"}
+        StorageManager.persist_claim(claim)
 
-    threads = [Thread(target=persist, args=(i,)) for i in range(5)]
+    threads: list[Thread] = [Thread(target=persist, args=(i,)) for i in range(5)]
     for t in threads:
         t.start()
     for t in threads:
@@ -43,15 +56,20 @@ def test_concurrent_writes(tmp_path, monkeypatch):
     _teardown(st, ctx)
 
 
-def test_concurrent_eviction(tmp_path, monkeypatch):
+def test_concurrent_eviction(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     cfg, st, ctx = _setup(tmp_path, monkeypatch, ram_budget=1)
-    monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 1000)
+
+    def high_ram() -> float:
+        return 1000.0
+
+    monkeypatch.setattr(StorageManager, "_current_ram_mb", high_ram)
 
     def persist(idx: int) -> None:
-        StorageManager.persist_claim({"id": f"c{idx}", "type": "fact", "content": "c"})
+        claim: JSONDict = {"id": f"c{idx}", "type": "fact", "content": "c"}
+        StorageManager.persist_claim(claim)
         StorageManager._enforce_ram_budget(cfg.ram_budget_mb)
 
-    threads = [Thread(target=persist, args=(i,)) for i in range(5)]
+    threads: list[Thread] = [Thread(target=persist, args=(i,)) for i in range(5)]
     for t in threads:
         t.start()
     for t in threads:

--- a/tests/integration/test_storage_duckdb_fallback.py
+++ b/tests/integration/test_storage_duckdb_fallback.py
@@ -1,23 +1,39 @@
-from autoresearch.storage import StorageContext, StorageManager, StorageState
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+from _pytest.monkeypatch import MonkeyPatch
+
+if TYPE_CHECKING:
+    from pytest_benchmark.fixture import BenchmarkFixture  # type: ignore[import-untyped]
+else:  # pragma: no cover - typing fallback
+    BenchmarkFixture = Any
+
 from autoresearch.config import ConfigLoader
+from autoresearch.storage import StorageContext, StorageManager, StorageState
+from autoresearch.storage_typing import JSONDict
 
 from tests.optional_imports import import_or_skip
 
 import_or_skip("pytest_benchmark")
 
 
-def test_duckdb_vss_fallback(tmp_path, monkeypatch):
+def test_duckdb_vss_fallback(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """Storage operates without VSS when the extension is missing."""
     ConfigLoader()._config = None
     cfg = ConfigLoader().config
     cfg.storage.duckdb_path = str(tmp_path / "kg.duckdb")
     cfg.storage.vector_extension = True
 
-    st = StorageState()
-    ctx = StorageContext()
+    st: StorageState = StorageState()
+    ctx: StorageContext = StorageContext()
+
+    def disable_extension(_: object) -> bool:
+        return False
 
     monkeypatch.setattr(
-        "autoresearch.extensions.VSSExtensionLoader.load_extension", lambda _c: False
+        "autoresearch.extensions.VSSExtensionLoader.load_extension", disable_extension
     )
 
     StorageManager.setup(db_path=cfg.storage.duckdb_path, context=ctx, state=st)
@@ -31,19 +47,26 @@ def test_duckdb_vss_fallback(tmp_path, monkeypatch):
         ConfigLoader()._config = None
 
 
-def test_ram_budget_benchmark(tmp_path, monkeypatch, benchmark):
+def test_ram_budget_benchmark(
+    tmp_path: Path, monkeypatch: MonkeyPatch, benchmark: BenchmarkFixture
+) -> None:
     ConfigLoader()._config = None
     cfg = ConfigLoader().config
     cfg.storage.duckdb_path = str(tmp_path / "kg.duckdb")
     cfg.ram_budget_mb = 1
 
-    st = StorageState()
-    ctx = StorageContext()
-    monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 1000)
+    st: StorageState = StorageState()
+    ctx: StorageContext = StorageContext()
+
+    def high_ram() -> float:
+        return 1000.0
+
+    monkeypatch.setattr(StorageManager, "_current_ram_mb", high_ram)
     StorageManager.setup(db_path=cfg.storage.duckdb_path, context=ctx, state=st)
 
     def run() -> None:
-        StorageManager.persist_claim({"id": "b", "type": "fact", "content": "c"})
+        claim: JSONDict = {"id": "b", "type": "fact", "content": "c"}
+        StorageManager.persist_claim(claim)
 
     benchmark(run)
     assert StorageManager.get_graph().number_of_nodes() == 0

--- a/tests/integration/test_storage_eviction.py
+++ b/tests/integration/test_storage_eviction.py
@@ -1,31 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
 from threading import Thread
+
+from _pytest.monkeypatch import MonkeyPatch
 
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.orchestration import metrics
 from autoresearch.storage import StorageContext, StorageManager, StorageState
+from autoresearch.storage_typing import JSONDict
 
 
-def test_concurrent_eviction(tmp_path, monkeypatch):
-    cfg = ConfigModel(
+def test_concurrent_eviction(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    cfg: ConfigModel = ConfigModel(
         storage=StorageConfig(duckdb_path=str(tmp_path / "kg.duckdb")),
         ram_budget_mb=1,
         graph_eviction_policy="lru",
     )
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    
+    def load_config_stub(_: ConfigLoader) -> ConfigModel:
+        return cfg
+
+    monkeypatch.setattr(ConfigLoader, "load_config", load_config_stub)
     ConfigLoader()._config = None
 
-    st = StorageState()
-    ctx = StorageContext()
-    monkeypatch.setattr(StorageManager, "_current_ram_mb", lambda: 1000)
+    st: StorageState = StorageState()
+    ctx: StorageContext = StorageContext()
+
+    def high_ram() -> float:
+        return 1000.0
+
+    monkeypatch.setattr(StorageManager, "_current_ram_mb", high_ram)
     StorageManager.setup(db_path=cfg.storage.duckdb_path, context=ctx, state=st)
 
-    start = metrics.EVICTION_COUNTER._value.get()
+    start: float = metrics.EVICTION_COUNTER._value.get()
 
     def persist(idx: int) -> None:
-        StorageManager.persist_claim({"id": f"c{idx}", "type": "fact", "content": "c"})
+        claim: JSONDict = {"id": f"c{idx}", "type": "fact", "content": "c"}
+        StorageManager.persist_claim(claim)
 
-    threads = [Thread(target=persist, args=(i,)) for i in range(5)]
+    threads: list[Thread] = [Thread(target=persist, args=(i,)) for i in range(5)]
     for t in threads:
         t.start()
     for t in threads:

--- a/tests/integration/test_storage_eviction_sim.py
+++ b/tests/integration/test_storage_eviction_sim.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from types import ModuleType
 
 from autoresearch.orchestration.metrics import EVICTION_COUNTER
 
 
-def _load_sim_module():
-    path = Path(__file__).resolve().parents[2] / "scripts" / "storage_eviction_sim.py"
+def _load_sim_module() -> ModuleType:
+    path: Path = Path(__file__).resolve().parents[2] / "scripts" / "storage_eviction_sim.py"
     spec = importlib.util.spec_from_file_location("storage_eviction_sim", path)
     if spec is None or spec.loader is None:
         raise RuntimeError("Unable to load storage_eviction_sim module")
@@ -24,15 +25,15 @@ sim = _load_sim_module()
 def test_normal_scenario_eviction() -> None:
     """High usage triggers eviction leaving no nodes."""
 
-    remaining = sim._run(threads=2, items=2, policy="lru", scenario="normal")
+    remaining: int = sim._run(threads=2, items=2, policy="lru", scenario="normal")
     assert remaining == 0
 
 
 def test_zero_budget_keeps_nodes() -> None:
     """Zero budget disables eviction."""
 
-    start = EVICTION_COUNTER._value.get()
-    remaining = sim._run(threads=1, items=3, policy="lru", scenario="zero_budget")
+    start: float = EVICTION_COUNTER._value.get()
+    remaining: int = sim._run(threads=1, items=3, policy="lru", scenario="zero_budget")
     assert remaining == 3
     assert EVICTION_COUNTER._value.get() == start
 
@@ -40,21 +41,21 @@ def test_zero_budget_keeps_nodes() -> None:
 def test_under_budget_keeps_nodes() -> None:
     """Usage below budget preserves all persisted nodes."""
 
-    remaining = sim._run(threads=2, items=1, policy="lru", scenario="under_budget")
+    remaining: int = sim._run(threads=2, items=1, policy="lru", scenario="under_budget")
     assert remaining == 2
 
 
 def test_no_nodes_scenario() -> None:
     """Enforcing the budget on an empty graph is a no-op."""
 
-    remaining = sim._run(threads=2, items=2, policy="lru", scenario="no_nodes")
+    remaining: int = sim._run(threads=2, items=2, policy="lru", scenario="no_nodes")
     assert remaining == 0
 
 
 def test_deterministic_override_caps_graph() -> None:
     """Deterministic override bounds the graph even when usage metrics are absent."""
 
-    remaining = sim._run(
+    remaining: int = sim._run(
         threads=2,
         items=2,
         policy="lru",

--- a/tests/integration/test_storage_search_link.py
+++ b/tests/integration/test_storage_search_link.py
@@ -1,15 +1,24 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
 import numpy as np
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from numpy.typing import NDArray
 
+from autoresearch import storage
+from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel
 from autoresearch.search import Search
 from autoresearch.storage import StorageManager
-from autoresearch.config.models import ConfigModel
-from autoresearch.config.loader import ConfigLoader
-from autoresearch import storage
+from autoresearch.storage_typing import DuckDBConnectionProtocol, JSONDict
 
 
 @pytest.fixture(autouse=True)
-def setup_storage(tmp_path, monkeypatch):
+def setup_storage(tmp_path: Path, monkeypatch: MonkeyPatch) -> Iterator[None]:
     """Configure isolated in-memory storage and search for each test."""
     monkeypatch.chdir(tmp_path)
     ConfigLoader.reset_instance()
@@ -22,11 +31,17 @@ def setup_storage(tmp_path, monkeypatch):
     cfg.storage.rdf_backend = "memory"
     cfg.storage.duckdb_path = str(tmp_path / "kg.duckdb")
 
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+    def load_config_stub(_: ConfigLoader) -> ConfigModel:
+        return cfg
+
+    monkeypatch.setattr(ConfigLoader, "load_config", load_config_stub)
 
     # Avoid ontology reasoning overhead during tests
+    def noop_reasoner(*_: object, **__: object) -> None:
+        return None
+
     monkeypatch.setattr(
-        "autoresearch.storage.run_ontology_reasoner", lambda store, engine=None: None
+        "autoresearch.storage.run_ontology_reasoner", noop_reasoner
     )
 
     storage.teardown(remove_db=True)
@@ -38,10 +53,17 @@ def setup_storage(tmp_path, monkeypatch):
         ConfigLoader.reset_instance()
 
 
-def _duckdb_backend_with_citations(query_embedding, max_results=5):
-    conn = StorageManager.context.db_backend._conn
-    rows = conn.execute("SELECT id, content FROM nodes WHERE content ILIKE '%python%'").fetchall()
-    results = []
+def _duckdb_backend_with_citations(
+    _query_embedding: NDArray[np.float64] | list[float], max_results: int = 5
+) -> list[JSONDict]:
+    db_backend = StorageManager.context.db_backend
+    if db_backend is None:
+        raise RuntimeError("DuckDB backend is not initialised")
+    conn: DuckDBConnectionProtocol = db_backend.get_connection()
+    rows = conn.execute(
+        "SELECT id, content FROM nodes WHERE content ILIKE '%python%'"
+    ).fetchall()
+    results: list[JSONDict] = []
     for node_id, content in rows:
         citation_rows = conn.execute("SELECT dst FROM edges WHERE src = ?", [node_id]).fetchall()
         citations = [c[0] for c in citation_rows]
@@ -57,24 +79,28 @@ def _duckdb_backend_with_citations(query_embedding, max_results=5):
 
 
 @pytest.mark.slow
-def test_external_lookup_returns_citations(monkeypatch):
+def test_external_lookup_returns_citations(monkeypatch: MonkeyPatch) -> None:
     # Disable network backends and ranking complexity
     monkeypatch.setattr(Search, "backends", {})
-    monkeypatch.setattr(
-        Search,
-        "cross_backend_rank",
-        lambda q, b, query_embedding=None: sum(b.values(), []),
-    )
+
+    def rank_all(
+        _query: JSONDict,
+        backends: dict[str, list[JSONDict]],
+        query_embedding: NDArray[np.float64] | None = None,
+    ) -> list[JSONDict]:
+        return [item for results in backends.values() for item in results]
+
+    monkeypatch.setattr(Search, "cross_backend_rank", rank_all)
     Search.embedding_backends["duckdb"] = _duckdb_backend_with_citations
 
-    source = {
+    source: JSONDict = {
         "id": "https://python.org",
         "type": "source",
         "content": "Python official website",
     }
     StorageManager.persist_claim(source)
 
-    claim = {
+    claim: JSONDict = {
         "id": "c1",
         "type": "fact",
         "content": "Python is a programming language.",
@@ -82,11 +108,14 @@ def test_external_lookup_returns_citations(monkeypatch):
         "relations": [{"src": "c1", "dst": source["id"], "rel": "cites"}],
     }
     StorageManager.persist_claim(claim)
-    monkeypatch.setattr(StorageManager, "persist_claim", lambda *a, **k: None)
 
-    results = Search.external_lookup(
-        {"text": "python", "embedding": np.array([0.1, 0.2])}, max_results=5
-    )
+    def ignore_persist(*_: Any, **__: Any) -> None:
+        return None
+
+    monkeypatch.setattr(StorageManager, "persist_claim", ignore_persist)
+
+    query: JSONDict = {"text": "python", "embedding": np.array([0.1, 0.2])}
+    results = Search.external_lookup(query, max_results=5)
 
     assert any(r["url"] == claim["id"] for r in results)
     retrieved = next(r for r in results if r["url"] == claim["id"])


### PR DESCRIPTION
## Summary
- add precise type annotations, typed helper functions, and sanitized fixtures across the storage integration suite to satisfy strict mypy checks【F:tests/integration/test_storage.py†L19-L71】【F:tests/integration/test_storage_concurrency.py†L14-L79】
- tighten distributed storage tests with explicit queue protocols, casting, and teardown cleanup for deterministic resource handling【F:tests/integration/test_distributed_storage.py†L31-L82】【F:tests/integration/test_distributed_process_storage.py†L20-L72】
- refactor storage search/orchestrator tests to use typed callables and richer stubs so synthesized answers and citations remain stable under strict typing【F:tests/integration/test_storage_search_link.py†L20-L122】【F:tests/integration/test_orchestrator_search_storage.py†L200-L262】

## Testing
- `uv run mypy --strict tests/integration/test_storage.py tests/integration/test_storage_backup_roundtrip.py tests/integration/storage/test_simulation_benchmarks.py tests/integration/test_storage_baseline.py tests/integration/test_storage_concurrency.py tests/integration/test_storage_duckdb_fallback.py tests/integration/test_storage_eviction.py tests/integration/test_storage_eviction_sim.py tests/integration/test_storage_schema.py tests/integration/test_storage_search_link.py tests/integration/test_distributed_storage.py tests/integration/test_distributed_process_storage.py`
- `uv run pytest tests/integration -k "storage or distributed_storage"`


------
https://chatgpt.com/codex/tasks/task_e_68dd649e1a2c8333bf59aeebd3702318