### PR TITLE
Refactor orchestrator integration tests to use shared stubs

### DIFF
--- a/tests/integration/test_orchestrator_all_pairings.py
+++ b/tests/integration/test_orchestrator_all_pairings.py
@@ -1,63 +1,96 @@
+from __future__ import annotations
+
 import itertools
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from typing import Any
 
 import pytest
 
 from autoresearch.config.models import ConfigModel
-from autoresearch.orchestration.orchestrator import Orchestrator, AgentFactory
-from autoresearch.search import Search
-from autoresearch.storage import StorageManager
 from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import Orchestrator
+from pytest import MonkeyPatch
+from tests.integration._orchestrator_stubs import (
+    AgentDouble,
+    PersistClaimCall,
+    patch_agent_factory_get,
+    patch_storage_persist,
+)
 
 
-def make_agent(name, calls, store_calls):
-    class DummyAgent:
-        def __init__(self, name: str, llm_adapter=None):
-            self.name = name
-
-        def can_execute(self, state, config):  # pragma: no cover - dummy
-            return True
-
-        def execute(self, state, config, **kwargs):
-            # Simulate search and storage interaction
-            Search.rank_results("q", [{"title": "t", "url": "u"}])
-            StorageManager.persist_claim({"id": name, "type": "fact", "content": name})
-            calls.append(name)
-            store_calls.append(name)
-            state.results[name] = "ok"
-            if name == "Synthesizer":
-                state.results["final_answer"] = f"Answer from {name}"
-            return {"results": {name: "ok"}}
-
-    return DummyAgent(name)
-
-
-pairs = list(itertools.permutations(["AgentA", "AgentB", "AgentC", "Synthesizer"], 2))
+pairs: list[tuple[str, str]] = list(
+    itertools.permutations(["AgentA", "AgentB", "AgentC", "Synthesizer"], 2)
+)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize("agents", pairs)
-def test_orchestrator_all_agent_pairings(monkeypatch, agents):
+def test_orchestrator_all_agent_pairings(
+    monkeypatch: MonkeyPatch,
+    agents: tuple[str, str],
+) -> None:
     calls: list[str] = []
-    stored: list[str] = []
+    persist_calls: list[PersistClaimCall] = []
+    patch_storage_persist(monkeypatch, persist_calls)
 
-    monkeypatch.setattr(Search, "rank_results", lambda q, r: r)
-    monkeypatch.setattr(StorageManager, "persist_claim", lambda claim: stored.append(claim["id"]))
-    monkeypatch.setattr(
-        AgentFactory, "get", lambda name, llm_adapter=None: make_agent(name, calls, stored)
-    )
+    agent_doubles: list[AgentDouble] = []
+    for agent_name in ["AgentA", "AgentB", "AgentC", "Synthesizer"]:
+        double = AgentDouble(name=agent_name)
+
+        def result_factory(
+            state: Any,
+            config: ConfigModel,
+            *,
+            name: str = agent_name,
+            stub: AgentDouble = double,
+        ) -> dict[str, Any]:
+            original_factory = stub.result_factory
+            stub.result_factory = None
+            try:
+                payload = stub._build_payload(state, config)
+            finally:
+                stub.result_factory = original_factory
+            results_section = dict(payload.get("results", {}))
+            if name == "Synthesizer":
+                results_section["final_answer"] = f"Answer from {name}"
+                payload["answer"] = f"Answer from {name}"
+            payload["results"] = results_section
+            sources_section = payload.get("sources")
+            if not isinstance(sources_section, list) or not sources_section:
+                payload["sources"] = [
+                    {
+                        "id": f"{name.lower()}-source",
+                        "type": "url",
+                        "value": f"https://example.com/{name.lower()}",
+                    }
+                ]
+            return payload
+
+        double.result_factory = result_factory
+        double.call_log = calls
+        agent_doubles.append(double)
+
+    patch_agent_factory_get(monkeypatch, agent_doubles)
 
     @contextmanager
-    def no_token_capture(agent_name, metrics, config):
-        yield (lambda *a, **k: None, None)
+    def no_token_capture(
+        agent_name: str,
+        metrics: Any,
+        config: ConfigModel,
+    ) -> Iterator[tuple[Callable[..., None], None]]:
+        del agent_name, metrics, config
+        yield (lambda *args, **kwargs: None, None)
 
     monkeypatch.setattr(Orchestrator, "_capture_token_usage", no_token_capture)
 
-    cfg = ConfigModel(agents=list(agents), loops=1)
+    agent_list: list[str] = list(agents)
+    cfg: ConfigModel = ConfigModel(agents=agent_list, loops=1)
     response = Orchestrator().run_query("q", cfg)
 
     assert isinstance(response, QueryResponse)
-    assert calls == list(agents)
-    assert stored == list(agents)
+    assert calls == agent_list
+    expected_claim_ids = [f"{agent.lower()}-claim" for agent in agent_list]
+    assert [call.claim["id"] for call in persist_calls] == expected_claim_ids
     expected = "Answer from Synthesizer" if "Synthesizer" in agents else "No answer synthesized"
     assert response.answer == expected

--- a/tests/integration/test_simple_orchestration.py
+++ b/tests/integration/test_simple_orchestration.py
@@ -1,49 +1,57 @@
+from __future__ import annotations
+
 from typing import Any
 
 import pytest
 
-from autoresearch.orchestration.orchestrator import AgentFactory, Orchestrator
-from autoresearch.config.models import ConfigModel
+from autoresearch.agents.registry import AgentFactory
 from autoresearch.config.loader import ConfigLoader
+from autoresearch.config.models import ConfigModel
 from autoresearch.models import QueryResponse
-from autoresearch.storage import StorageManager
-
-
-def make_agent(name: str, calls: list[str]):
-
-    class DummyAgent:
-        def __init__(self, agent_name: str, llm_adapter: Any | None = None) -> None:
-            self.name = agent_name
-
-        def can_execute(self, state: Any, config: ConfigModel) -> bool:
-            return True
-
-        def execute(self, state: Any, config: ConfigModel, **kwargs: Any) -> dict[str, Any]:
-            calls.append(self.name)
-            state.update(
-                {
-                    "results": {self.name: "ok"},
-                    "claims": [
-                        {"type": "fact", "content": self.name, "id": self.name}
-                    ],
-                }
-            )
-            if self.name == "Synthesizer":
-                state.results["final_answer"] = f"Answer from {self.name}"
-            return {
-                "results": {self.name: "ok"},
-                "claims": [
-                    {"type": "fact", "content": self.name, "id": self.name}
-                ],
-            }
-
-    return DummyAgent(name)
+from autoresearch.orchestration.orchestrator import Orchestrator
+from tests.integration._orchestrator_stubs import (
+    AgentDouble,
+    PersistClaimCall,
+    patch_agent_factory_get,
+    patch_storage_persist,
+)
 
 
 def test_orchestrator_run_query(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
-    monkeypatch.setattr(StorageManager, "persist_claim", lambda claim: None)
-    monkeypatch.setattr(AgentFactory, "get", lambda name: make_agent(name, calls))
+    persist_calls: list[PersistClaimCall] = []
+    patch_storage_persist(monkeypatch, persist_calls)
+
+    synthesizer = AgentDouble(name="Synthesizer")
+
+    def result_factory(
+        state: Any,
+        config: ConfigModel,
+        *,
+        stub: AgentDouble = synthesizer,
+    ) -> dict[str, Any]:
+        original_factory = stub.result_factory
+        stub.result_factory = None
+        try:
+            payload = stub._build_payload(state, config)
+        finally:
+            stub.result_factory = original_factory
+        results_section = dict(payload.get("results", {}))
+        results_section["final_answer"] = "Answer from Synthesizer"
+        payload["results"] = results_section
+        payload["answer"] = "Answer from Synthesizer"
+        payload["sources"] = [
+            {
+                "id": "synthesizer-source",
+                "type": "url",
+                "value": "https://example.com/synthesizer",
+            }
+        ]
+        return payload
+
+    synthesizer.result_factory = result_factory
+    synthesizer.call_log = calls
+    patch_agent_factory_get(monkeypatch, [synthesizer])
 
     cfg = ConfigModel(agents=["Synthesizer"], loops=1)
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)


### PR DESCRIPTION
## Summary
- switch orchestrator integration tests to shared `AgentDouble` helpers and capture typed storage patches
- ensure results include deterministic claims and sources so orchestrator answers remain stable
- update simple orchestrator smoke test to use the shared stub infrastructure

## Testing
- `uv run mypy --strict tests/integration/test_orchestrator_all_agent_combinations.py tests/integration/test_orchestrator_combinations.py tests/integration/test_orchestrator_registered_pairs.py tests/integration/test_simple_orchestration.py`
- `uv run pytest tests/integration -k "orchestrator and not concurrency and not performance" -m "not slow"`


------
https://chatgpt.com/codex/tasks/task_e_68dd72600b9083338cb3ff7e1083b094