### PR TITLE
Refine orchestrator concurrency and performance tests

### DIFF
--- a/tests/integration/test_orchestrator_concurrency.py
+++ b/tests/integration/test_orchestrator_concurrency.py
@@ -1,56 +1,96 @@
 import asyncio
 import time
-from typing import List
+from dataclasses import asdict, dataclass, field
+from typing import cast
 
 import pytest
 from autoresearch.config.models import ConfigModel
 from autoresearch.orchestration import orchestrator as orch_mod
 from autoresearch.orchestration.reasoning import ReasoningMode
+from autoresearch.orchestration.state import QueryState
+
+from tests.integration._orchestrator_stubs import AgentDouble, patch_agent_factory_get
 
 Orchestrator = orch_mod.Orchestrator
-AgentFactory = orch_mod.AgentFactory
 
 
-class _SleepAgent:
-    def __init__(self, name: str, starts: List[float], delay: float = 0.3) -> None:
-        self.name = name
-        self.delay = delay
-        self.starts = starts
+@dataclass(slots=True)
+class ParsedConfigParams:
+    agents: list[str]
+    agent_groups: list[list[str]]
+    primus_index: int
+    loops: int
+    mode: ReasoningMode
+    max_errors: int
+    circuit_breaker_threshold: int
+    circuit_breaker_cooldown: int
+    retry_attempts: int
+    retry_backoff: float
+    enable_agent_messages: bool
+    enable_feedback: bool
+    coalitions: dict[str, list[str]]
 
-    def can_execute(self, state, config):  # pragma: no cover - simple
-        return True
 
-    def execute(self, state, config, **kwargs):
+@dataclass(slots=True)
+class SleepAgentDouble(AgentDouble):
+    starts: list[float] = field(default_factory=list)
+    delay: float = 0.3
+
+    def execute(
+        self,
+        state: QueryState,
+        config: ConfigModel,
+        **_: object,
+    ) -> dict[str, object]:
         self.starts.append(time.perf_counter())
         time.sleep(self.delay)
+        payload = cast(dict[str, object], {"results": {self.name: "ok"}})
+        state.update(payload)
         state.results["final_answer"] = "ok"
-        return {"results": {self.name: "ok"}}
+        return payload
 
 
-async def _run(concurrent: bool, monkeypatch: pytest.MonkeyPatch) -> List[float]:
-    starts: List[float] = []
-    monkeypatch.setattr(AgentFactory, "get", lambda name: _SleepAgent(name, starts))
+def _install_sleep_agents(
+    monkeypatch: pytest.MonkeyPatch,
+    starts: list[float],
+    delay: float = 0.3,
+) -> None:
+    agents = (
+        SleepAgentDouble(name="A", starts=starts, delay=delay),
+        SleepAgentDouble(name="B", starts=starts, delay=delay),
+    )
+    patch_agent_factory_get(monkeypatch, agents)
+
+
+def _patch_config(monkeypatch: pytest.MonkeyPatch, orchestrator: Orchestrator) -> None:
+    params = ParsedConfigParams(
+        agents=["A", "B"],
+        agent_groups=[["A", "B"]],
+        primus_index=0,
+        loops=1,
+        mode=ReasoningMode.DIALECTICAL,
+        max_errors=3,
+        circuit_breaker_threshold=3,
+        circuit_breaker_cooldown=30,
+        retry_attempts=1,
+        retry_backoff=0.0,
+        enable_agent_messages=False,
+        enable_feedback=False,
+        coalitions={},
+    )
+
+    def _stub_parse_config(_: ConfigModel) -> dict[str, object]:
+        return asdict(params)
+
+    monkeypatch.setattr(orchestrator, "_parse_config", _stub_parse_config)
+
+
+async def _run(concurrent: bool, monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    starts: list[float] = []
+    _install_sleep_agents(monkeypatch, starts)
     cfg = ConfigModel(agents=["A", "B"], loops=1)
     orch = Orchestrator()
-    monkeypatch.setattr(
-        orch,
-        "_parse_config",
-        lambda config: {
-            "agents": ["A", "B"],
-            "agent_groups": [["A", "B"]],
-            "primus_index": 0,
-            "loops": 1,
-            "mode": ReasoningMode.DIALECTICAL,
-            "max_errors": 3,
-            "circuit_breaker_threshold": 3,
-            "circuit_breaker_cooldown": 30,
-            "retry_attempts": 1,
-            "retry_backoff": 0.0,
-            "enable_agent_messages": False,
-            "enable_feedback": False,
-            "coalitions": {},
-        },
-    )
+    _patch_config(monkeypatch, orch)
     await orch.run_query_async("q", cfg, concurrent=concurrent)
     return starts
 

--- a/tests/integration/test_orchestrator_performance.py
+++ b/tests/integration/test_orchestrator_performance.py
@@ -3,7 +3,7 @@ import subprocess
 from pathlib import Path
 
 
-def test_orchestrator_perf_metrics():
+def test_orchestrator_perf_metrics() -> None:
     script = Path(__file__).resolve().parents[2] / "scripts" / "orchestrator_perf_sim.py"
     cmd = [
         "uv",

--- a/tests/integration/test_query_latency_memory_tokens.py
+++ b/tests/integration/test_query_latency_memory_tokens.py
@@ -1,5 +1,6 @@
 import time
 from contextlib import contextmanager
+from typing import Any, Callable, Iterator
 
 import pytest
 
@@ -24,12 +25,20 @@ class BenchAgent:
         return {"results": {self.name: "ok"}}
 
 
+def _build_bench_agent(name: str, llm_adapter: Any | None = None) -> BenchAgent:
+    return BenchAgent(name)
+
+
 def test_query_latency_memory_tokens(monkeypatch, token_baseline):
-    monkeypatch.setattr(AgentFactory, "get", lambda name, llm_adapter=None: BenchAgent(name))
+    monkeypatch.setattr(AgentFactory, "get", _build_bench_agent)
 
     @contextmanager
-    def capture(agent_name, metrics, config):
-        def generate(prompt):
+    def capture(
+        agent_name: str,
+        metrics: Any,
+        config: ConfigModel,
+    ) -> Iterator[tuple[dict[str, Any], Callable[[str], str]]]:
+        def generate(prompt: str) -> str:
             metrics.record_tokens(agent_name, len(prompt.split()), 1)
             return "ok"
 

--- a/tests/integration/test_query_performance.py
+++ b/tests/integration/test_query_performance.py
@@ -1,5 +1,6 @@
 import time
 from contextlib import contextmanager
+from typing import Any, Iterator
 
 import pytest
 
@@ -26,13 +27,21 @@ class PerfAgent:
         return {"results": {self.name: "ok"}}
 
 
+def _build_perf_agent(name: str, llm_adapter: Any | None = None) -> PerfAgent:
+    return PerfAgent(name)
+
+
 def test_query_performance(monkeypatch) -> None:
     """Ensure query performance stays within configured limits."""
 
-    monkeypatch.setattr(AgentFactory, "get", lambda name, llm_adapter=None: PerfAgent(name))
+    monkeypatch.setattr(AgentFactory, "get", _build_perf_agent)
 
     @contextmanager
-    def capture(agent_name, metrics, config):
+    def capture(
+        agent_name: str,
+        metrics: Any,
+        config: ConfigModel,
+    ) -> Iterator[tuple[dict[str, int], Any]]:
         token_counts = {"in": 0, "out": 0}
 
         class Adapter:


### PR DESCRIPTION
## Summary
- replace inline monkeypatch lambdas in orchestrator concurrency and performance tests with named helpers built on the shared AgentFactory stubs
- add structured configuration dataclass for concurrency parsing expectations and tighten agent doubles used across integration suites
- annotate helper context managers and subprocess-driven tests to satisfy strict type checking

## Testing
- uv run mypy --strict tests/integration/test_orchestrator_concurrency.py tests/integration/test_orchestrator_performance.py
- uv run pytest tests/integration -k "orchestrator and (concurrency or performance)" -m "not slow"


------
https://chatgpt.com/codex/tasks/task_e_68dd752daf8c8333937212947e6ee8e9