### PR TITLE
Align distributed integration tests with typed broker helpers

### DIFF
--- a/tests/integration/_orchestrator_stubs.py
+++ b/tests/integration/_orchestrator_stubs.py
@@ -17,7 +17,11 @@ from pytest import MonkeyPatch
 import autoresearch.storage as storage_module
 from autoresearch.agents.registry import AgentFactory
 from autoresearch.config.models import ConfigModel
-from autoresearch.distributed.broker import BrokerMessage
+from autoresearch.distributed.broker import (
+    BrokerMessage,
+    MessageQueueProtocol,
+    StorageBrokerQueueProtocol,
+)
 from autoresearch.orchestration.state import QueryState
 from autoresearch.storage import StorageManager
 
@@ -169,12 +173,17 @@ def patch_storage_persist(
 
 def patch_storage_queue(
     monkeypatch: MonkeyPatch,
-    queue: BrokerQueueStub | None = None,
-) -> BrokerQueueStub:
+    queue: StorageBrokerQueueProtocol | None = None,
+) -> StorageBrokerQueueProtocol:
     """Attach a stubbed broker queue to :mod:`autoresearch.storage`."""
 
-    stub = queue if queue is not None else BrokerQueueStub()
-    monkeypatch.setattr(storage_module, "_message_queue", stub, raising=False)
+    stub: StorageBrokerQueueProtocol
+    if queue is not None:
+        stub = queue
+    else:
+        stub = BrokerQueueStub()
+    stub_message: MessageQueueProtocol = stub
+    monkeypatch.setattr(storage_module, "_message_queue", stub_message, raising=False)
     return stub
 
 

--- a/tests/integration/test_distributed_analysis_metrics.py
+++ b/tests/integration/test_distributed_analysis_metrics.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
+from autoresearch.distributed.broker import AgentResultMessage
 from tests.optional_imports import import_or_skip
 
 
 @pytest.mark.requires_distributed
 @pytest.mark.requires_analysis
-def test_redis_metrics_dataframe(monkeypatch):
+def test_redis_metrics_dataframe(monkeypatch: pytest.MonkeyPatch) -> None:
     """RedisBroker publishes messages and Polars summarizes metrics."""
     import_or_skip("redis")
     import_or_skip("fakeredis")
@@ -19,16 +21,22 @@ def test_redis_metrics_dataframe(monkeypatch):
     from autoresearch.distributed.broker import RedisBroker
     from autoresearch.data_analysis import metrics_dataframe
 
-    fake = fakeredis.FakeRedis()
+    fake: fakeredis.FakeRedis = fakeredis.FakeRedis()
 
     class DummyRedis:
         @classmethod
-        def from_url(cls, *args, **kwargs):
+        def from_url(cls, *args: Any, **kwargs: Any) -> fakeredis.FakeRedis:
             return fake
 
     monkeypatch.setattr(redis, "Redis", DummyRedis)
     broker = RedisBroker()
-    broker.publish({"val": 1})
+    message: AgentResultMessage = {
+        "action": "agent_result",
+        "agent": "worker",
+        "result": {"metrics": {"latency": 0.1}},
+        "pid": 1234,
+    }
+    broker.publish(message)
     broker.shutdown()
 
     monkeypatch.setattr(
@@ -38,8 +46,8 @@ def test_redis_metrics_dataframe(monkeypatch):
         ),
     )
 
-    df = metrics_dataframe({"agent_timings": {"worker": [0.1, 0.2, 0.3]}})
-    row = df.rows()[0]
-    assert row[0] == "worker"
-    assert pytest.approx(row[1], rel=1e-3) == 0.2
-    assert row[2] == 3
+    df: Any = metrics_dataframe({"agent_timings": {"worker": [0.1, 0.2, 0.3]}})
+    first_row = cast(tuple[Any, ...], df.row(0))
+    assert first_row[0] == "worker"
+    assert pytest.approx(first_row[1], rel=1e-3) == 0.2
+    assert first_row[2] == 3

--- a/tests/integration/test_distributed_orchestration.py
+++ b/tests/integration/test_distributed_orchestration.py
@@ -1,33 +1,44 @@
+from __future__ import annotations
+
 import os
+from pathlib import Path
+from typing import Mapping
+
 import pytest
-from autoresearch.distributed import ProcessExecutor
+
 from autoresearch.config.models import ConfigModel, DistributedConfig, StorageConfig
+from autoresearch.distributed import ProcessExecutor
 from autoresearch.models import QueryResponse
-from autoresearch.orchestration.orchestrator import AgentFactory
 from autoresearch.orchestration.state import QueryState
 from autoresearch.storage import StorageManager
+from tests.integration._orchestrator_stubs import AgentDouble, AgentResultFactory, patch_agent_factory_get
 
 pytestmark = pytest.mark.slow
 
 
-class ClaimAgent:
-    def __init__(self, name: str, pids: list[int]):
-        self.name = name
-        self._pids = pids
+def _claim_result_factory(
+    agent_name: str,
+    pid_log: list[int],
+) -> AgentResultFactory:
+    def build_payload(state: QueryState, config: ConfigModel) -> Mapping[str, object]:
+        del config  # orchestration doubles ignore config content
+        pid_log.append(os.getpid())
+        claim = {"id": f"{agent_name}-1", "type": "fact", "content": agent_name}
+        return {"results": {agent_name: "ok"}, "claims": [claim]}
 
-    def can_execute(self, state: QueryState, config: ConfigModel) -> bool:  # pragma: no cover - dummy
-        return True
-
-    def execute(self, state: QueryState, config: ConfigModel, **_: object) -> dict:
-        self._pids.append(os.getpid())
-        claim = {"id": f"{self.name}-1", "type": "fact", "content": self.name}
-        state.update({"results": {self.name: "ok"}, "claims": [claim]})
-        return {"results": {self.name: "ok"}, "claims": [claim]}
+    return build_payload
 
 
-def test_distributed_orchestration_persistence(tmp_path, monkeypatch):
+def _make_claim_agent(name: str, pid_log: list[int]) -> AgentDouble:
+    return AgentDouble(name=name, result_factory=_claim_result_factory(name, pid_log))
+
+
+def test_distributed_orchestration_persistence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     pids: list[int] = []
-    monkeypatch.setattr(AgentFactory, "get", lambda name: ClaimAgent(name, pids))
+    agents = [_make_claim_agent(agent_name, pids) for agent_name in ("A", "B")]
+    patch_agent_factory_get(monkeypatch, agents)
     cfg = ConfigModel(
         agents=["A", "B"],
         loops=1,

--- a/tests/integration/test_distributed_redis_broker.py
+++ b/tests/integration/test_distributed_redis_broker.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
 import importlib.util
-from typing import Any, cast
+from typing import Any, Mapping, cast
 
 import pytest
 
-from autoresearch.distributed.broker import AgentResultMessage, RedisBroker
+from autoresearch.distributed.broker import (
+    AgentResultMessage,
+    BrokerMessage,
+    MessageQueueProtocol,
+    RedisBroker,
+    StorageBrokerQueueProtocol,
+)
 
 if importlib.util.find_spec("redis") is None:
     pytest.skip("redis not installed", allow_module_level=True)
@@ -18,24 +24,30 @@ pytestmark = [
 ]
 
 
-def _make_agent_result_message(result: dict[str, Any] | None = None) -> AgentResultMessage:
-    return {
+def _make_agent_result_message(
+    result: Mapping[str, Any] | None = None,
+) -> AgentResultMessage:
+    payload: AgentResultMessage = {
         "action": "agent_result",
         "agent": "agent",
-        "result": result or {"value": 1},
+        "result": dict(result or {"value": 1}),
         "pid": 1234,
     }
+    return payload
 
 
 def test_redis_broker_roundtrip(
     monkeypatch: pytest.MonkeyPatch, redis_client: object
 ) -> None:
-    def _from_url(url: str) -> object:
+    def _from_url(url: str, *args: object, **kwargs: object) -> object:
+        del url, args, kwargs
         return redis_client
 
     monkeypatch.setattr(redis.Redis, "from_url", _from_url)
     broker = RedisBroker("redis://localhost:6379/0", queue_name="test")
-    expected = _make_agent_result_message(result={"value": 1})
+    expected: AgentResultMessage = _make_agent_result_message(result={"value": 1})
     broker.publish(expected)
-    message = cast(AgentResultMessage, broker.queue.get())
-    assert message == expected
+    queue: StorageBrokerQueueProtocol = broker.queue
+    queue_protocol: MessageQueueProtocol = queue
+    message: BrokerMessage = queue_protocol.get()
+    assert cast(AgentResultMessage, message) == expected

--- a/tests/integration/test_distributed_results.py
+++ b/tests/integration/test_distributed_results.py
@@ -1,32 +1,40 @@
+from __future__ import annotations
+
 import os
-import ray
+from typing import Mapping
+
 import pytest
-from autoresearch.distributed import RayExecutor
+import ray
+
 from autoresearch.config.models import ConfigModel, DistributedConfig
+from autoresearch.distributed import RayExecutor, ResultAggregator
 from autoresearch.models import QueryResponse
-from autoresearch.orchestration.orchestrator import AgentFactory
 from autoresearch.orchestration.state import QueryState
+from tests.integration._orchestrator_stubs import AgentDouble, AgentResultFactory, patch_agent_factory_get
 
 pytestmark = pytest.mark.slow
 
 
-class DummyAgent:
-    def __init__(self, name: str, pid_list: list[int]):
-        self.name = name
-        self._pids = pid_list
+def _result_factory(
+    agent_name: str,
+    pid_log: list[int],
+) -> AgentResultFactory:
+    def build_payload(state: QueryState, config: ConfigModel) -> Mapping[str, object]:
+        del config  # orchestration doubles ignore config content
+        pid_log.append(os.getpid())
+        return {"results": {agent_name: "ok"}}
 
-    def can_execute(self, state: QueryState, config: ConfigModel) -> bool:  # pragma: no cover - dummy
-        return True
-
-    def execute(self, state: QueryState, config: ConfigModel, **_: object) -> dict:
-        self._pids.append(os.getpid())
-        state.update({"results": {self.name: "ok"}})
-        return {"results": {self.name: "ok"}}
+    return build_payload
 
 
-def test_result_aggregation_multi_process(monkeypatch):
+def _make_agent(name: str, pid_log: list[int]) -> AgentDouble:
+    return AgentDouble(name=name, result_factory=_result_factory(name, pid_log))
+
+
+def test_result_aggregation_multi_process(monkeypatch: pytest.MonkeyPatch) -> None:
     pids: list[int] = []
-    monkeypatch.setattr(AgentFactory, "get", lambda name: DummyAgent(name, pids))
+    agents = [_make_agent(agent_name, pids) for agent_name in ("A", "B")]
+    patch_agent_factory_get(monkeypatch, agents)
     cfg = ConfigModel(
         agents=["A", "B"],
         loops=1,
@@ -37,7 +45,9 @@ def test_result_aggregation_multi_process(monkeypatch):
     resp = executor.run_query("q")
     assert isinstance(resp, QueryResponse)
     assert len(set(pids)) > 1
-    assert len(executor.result_aggregator.results) == len(cfg.agents)
+    aggregator: ResultAggregator | None = executor.result_aggregator
+    assert aggregator is not None
+    assert len(aggregator.results) == len(cfg.agents)
     os.environ["RAY_IGNORE_UNHANDLED_ERRORS"] = "1"
     executor.shutdown()
     ray.shutdown()


### PR DESCRIPTION
## Summary
- import the broker queue protocols into the orchestrator stubs and return typed queue doubles for storage monkeypatching
- refactor distributed integration tests to use AgentDouble helpers, explicit Redis/Ray stubs, and AgentResultMessage payloads
- update extra usage and metrics tests to publish typed broker messages and access dataframe rows safely

## Testing
- uv run mypy --strict tests/integration/test_distributed_orchestration.py tests/integration/test_distributed_results.py tests/integration/test_distributed_node_health.py tests/integration/test_distributed_redis_broker.py tests/integration/test_distributed_analysis_metrics.py
- uv run pytest tests/integration -k "distributed and not storage" -m "not slow"


------
https://chatgpt.com/codex/tasks/task_e_68dd7767bc788333bb2f9c503ae01a03