### PR TITLE
Add shared behavior context typing helpers

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -30,6 +30,7 @@ from autoresearch.config.loader import ConfigLoader  # noqa: E402
 from autoresearch.config.models import ConfigModel  # noqa: E402
 from autoresearch.orchestration.state import QueryState  # noqa: E402
 from autoresearch.storage import StorageContext, StorageManager  # noqa: E402
+from tests.behavior.context import BehaviorContext  # noqa: E402
 from tests.conftest import reset_limiter_state, VSS_AVAILABLE  # noqa: E402
 from tests.typing_helpers import TypedFixture
 
@@ -42,7 +43,7 @@ class StorageErrorHandler:
     def attempt_operation(
         self,
         operation: Callable[[], T_co],
-        bdd_context: dict[str, object],
+        bdd_context: BehaviorContext,
         context_key: str = "storage_error",
     ) -> T_co | None:
         """Attempt an operation that might raise an exception."""
@@ -95,7 +96,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 @pytest.fixture
-def test_context() -> TypedFixture[dict[str, object]]:
+def test_context() -> TypedFixture[BehaviorContext]:
     """Mutable mapping for sharing state in behavior tests."""
     return {}
 

--- a/tests/behavior/context.py
+++ b/tests/behavior/context.py
@@ -1,0 +1,168 @@
+"""Shared typing helpers for behavior test context payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping, Sequence
+from dataclasses import dataclass
+from typing import Any, TypeVar, overload
+
+__all__ = [
+    "APICapture",
+    "BehaviorContext",
+    "CLIInvocation",
+    "get_optional",
+    "get_required",
+    "set_value",
+]
+
+# ``MutableMapping`` rather than ``dict`` so fixtures can swap in custom
+# implementations (e.g., ``defaultdict``) without breaking the type contract.
+BehaviorContext = MutableMapping[str, object]
+"""Type alias for the shared mutable context passed between BDD steps."""
+
+T = TypeVar("T")
+
+
+def set_value(context: BehaviorContext, key: str, value: T) -> T:
+    """Store ``value`` in ``context`` and return it.
+
+    Keeping the return value makes it easy to use within expressions::
+
+        result = set_value(bdd_context, "cli_result", runner.invoke(app, ["--help"]))
+
+    Parameters
+    ----------
+    context:
+        The shared scenario context.
+    key:
+        Dictionary key under which the value should be stored.
+    value:
+        The object to persist for later steps.
+    """
+
+    context[key] = value
+    return value
+
+
+@overload
+def get_required(context: BehaviorContext, key: str, /) -> object:
+    ...
+
+
+@overload
+def get_required(
+    context: BehaviorContext,
+    key: str,
+    expected_type: type[T] | tuple[type[T], ...],
+    /,
+) -> T:
+    ...
+
+
+def get_required(
+    context: BehaviorContext,
+    key: str,
+    expected_type: type[T] | tuple[type[T], ...] | None = None,
+) -> T | object:
+    """Retrieve a required value from ``context``.
+
+    Parameters
+    ----------
+    context:
+        Scenario context created by :func:`bdd_context`.
+    key:
+        Name of the value to fetch.
+    expected_type:
+        Optional runtime type check that will raise ``TypeError`` when the stored
+        value does not match. When omitted the raw object is returned.
+
+    Raises
+    ------
+    KeyError
+        If ``key`` is absent from the context.
+    TypeError
+        If ``expected_type`` is provided and the stored value does not match the
+        requested type.
+    """
+
+    value = context[key]
+    if expected_type is not None and not isinstance(value, expected_type):
+        msg = _type_mismatch_message(key, expected_type, value)
+        raise TypeError(msg)
+    return value
+
+
+def get_optional(
+    context: BehaviorContext,
+    key: str,
+    expected_type: type[T] | tuple[type[T], ...] | None = None,
+    default: T | None = None,
+) -> T | object | None:
+    """Fetch an optional value from ``context`` with an optional type check."""
+
+    if key not in context:
+        return default
+    value = context[key]
+    if expected_type is not None and not isinstance(value, expected_type):
+        msg = _type_mismatch_message(key, expected_type, value)
+        raise TypeError(msg)
+    return value
+
+
+def _type_mismatch_message(
+    key: str,
+    expected_type: type[Any] | tuple[type[Any], ...],
+    value: object,
+) -> str:
+    """Build a helpful ``TypeError`` message for accessor helpers."""
+
+    if isinstance(expected_type, tuple):
+        expected = ", ".join(sorted(t.__name__ for t in expected_type))
+    else:
+        expected = expected_type.__name__
+    actual = type(value).__name__
+    return f"Value for '{key}' expected ({expected}) but received {actual}"
+
+
+@dataclass(slots=True)
+class CLIInvocation:
+    """Capture the outcome of invoking a CLI command within a scenario."""
+
+    command: Sequence[str]
+    """Arguments passed to the CLI entrypoint."""
+
+    result: Any
+    """Raw runner result to inspect in assertions (e.g., ``CliRunner`` result)."""
+
+    exit_code: int
+    """Exit code captured from the invocation."""
+
+    stdout: str
+    """Standard output emitted by the CLI."""
+
+    stderr: str | None = None
+    """Standard error output when available."""
+
+
+@dataclass(slots=True)
+class APICapture:
+    """Describe an HTTP interaction recorded during a scenario."""
+
+    method: str
+    """HTTP method used for the request."""
+
+    url: str
+    """Target URL for the request."""
+
+    status_code: int
+    """HTTP status code returned by the API."""
+
+    json_body: Mapping[str, Any] | None = None
+    """JSON response payload when applicable."""
+
+    text_body: str | None = None
+    """Fallback textual response body."""
+
+    headers: Mapping[str, str] | None = None
+    """Subset of HTTP headers retained for assertions."""
+

--- a/tests/behavior/fixtures/__init__.py
+++ b/tests/behavior/fixtures/__init__.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 from typer.testing import CliRunner
 
+from tests.behavior.context import BehaviorContext
 from tests.typing_helpers import TypedFixture
 
 
 @pytest.fixture
-def bdd_context() -> TypedFixture[dict[str, Any]]:
+def bdd_context() -> TypedFixture[BehaviorContext]:
     """Mutable mapping for sharing data between BDD steps."""
-    ctx: dict[str, Any] = {}
+    ctx: BehaviorContext = {}
     yield ctx
     broker = ctx.get("broker")
     if broker and hasattr(broker, "shutdown"):

--- a/tests/behavior/steps/__init__.py
+++ b/tests/behavior/steps/__init__.py
@@ -8,6 +8,15 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from tests.behavior.context import (
+        APICapture,
+        BehaviorContext,
+        CLIInvocation,
+        get_optional,
+        get_required,
+        set_value,
+    )
+
     app_running: Callable[..., None]
     app_running_with_default: Callable[..., None]
     application_running: Callable[..., None]
@@ -20,6 +29,14 @@ else:
     app_running_with_default = _common_steps.app_running_with_default
     application_running = _common_steps.application_running
     cli_app = _common_steps.cli_app
+
+    _context = importlib.import_module("tests.behavior.context")
+    BehaviorContext = _context.BehaviorContext
+    CLIInvocation = _context.CLIInvocation
+    APICapture = _context.APICapture
+    get_required = _context.get_required
+    get_optional = _context.get_optional
+    set_value = _context.set_value
 
 if not TYPE_CHECKING:
     # Import step modules so pytest-bdd discovers them when running the package.
@@ -44,4 +61,10 @@ __all__ = [
     "app_running_with_default",
     "application_running",
     "cli_app",
+    "BehaviorContext",
+    "CLIInvocation",
+    "APICapture",
+    "get_required",
+    "get_optional",
+    "set_value",
 ]


### PR DESCRIPTION
## Summary
- add a reusable behavior context module with typed accessors and payload dataclasses
- update behavior fixtures to return the new context alias and keep cleanup semantics
- re-export the helpers through the steps package for convenient reuse

## Testing
- uv run python -m compileall tests/behavior/context.py

------
https://chatgpt.com/codex/tasks/task_e_68ddaf7e84788333a7e5e52c3b0a751e