### PR TITLE
Annotate CLI/API behavior steps with typed helpers

### DIFF
--- a/tests/behavior/steps/agent_messages_steps.py
+++ b/tests/behavior/steps/agent_messages_steps.py
@@ -1,11 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
 from pytest_bdd import given, scenario, then, when
 
 from autoresearch.agents.base import Agent, AgentRole
 from autoresearch.agents.messages import MessageProtocol
 from autoresearch.agents.registry import AgentFactory
 from autoresearch.config.models import ConfigModel, StorageConfig
+from autoresearch.models import QueryResponse
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.orchestration.state import QueryState
+from tests.behavior.context import BehaviorContext, get_orchestrator, set_value
 
 from . import common_steps  # noqa: F401
 
@@ -14,7 +22,7 @@ class Sender(Agent):
     role: AgentRole = AgentRole.SPECIALIST
     name: str = "Sender"
 
-    def execute(self, state: QueryState, config: ConfigModel):
+    def execute(self, state: QueryState, config: ConfigModel) -> dict[str, Any]:
         self.send_message(state, "hi", to="Receiver")
         return {}
 
@@ -23,7 +31,7 @@ class Broadcaster(Agent):
     role: AgentRole = AgentRole.SPECIALIST
     name: str = "Sender"
 
-    def execute(self, state: QueryState, config: ConfigModel):
+    def execute(self, state: QueryState, config: ConfigModel) -> dict[str, Any]:
         self.broadcast(state, "hello team", "team")
         return {}
 
@@ -32,7 +40,7 @@ class Receiver(Agent):
     role: AgentRole = AgentRole.SPECIALIST
     name: str = "Receiver"
 
-    def execute(self, state: QueryState, config: ConfigModel):
+    def execute(self, state: QueryState, config: ConfigModel) -> dict[str, Any]:
         msgs = self.get_messages(state, from_agent="Sender")
         content = msgs[0].content if msgs else None
         state.results["received"] = content
@@ -42,7 +50,7 @@ class Receiver(Agent):
 class TeamReceiver(Agent):
     role: AgentRole = AgentRole.SPECIALIST
 
-    def execute(self, state: QueryState, config: ConfigModel):
+    def execute(self, state: QueryState, config: ConfigModel) -> dict[str, Any]:
         msgs = self.get_messages(
             state,
             from_agent="Sender",
@@ -56,24 +64,29 @@ class TeamReceiver(Agent):
 @scenario(
     "../features/agent_messages.feature", "Agents share data through the orchestrator"
 )
-def test_agent_message_exchange():
+def test_agent_message_exchange() -> None:
     pass
 
 
 @scenario("../features/agent_messages.feature", "Coalition broadcast communication")
-def test_coalition_broadcast():
+def test_coalition_broadcast() -> None:
     pass
 
 
 @scenario(
     "../features/agent_messages.feature", "Messaging disabled prevents communication"
 )
-def test_messaging_disabled():
+def test_messaging_disabled() -> None:
     pass
 
 
 @given("two communicating agents", target_fixture="config")
-def setup_agents(monkeypatch, tmp_path, config_model):
+def setup_agents(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_model: ConfigModel,
+    bdd_context: BehaviorContext,
+) -> ConfigModel:
     """Configure a simple pair of communicating agents."""
     db_path = tmp_path / "kg.duckdb"
     cfg = config_model.model_copy()
@@ -83,15 +96,21 @@ def setup_agents(monkeypatch, tmp_path, config_model):
     cfg.storage = StorageConfig(duckdb_path=str(db_path))
     monkeypatch.setenv("DUCKDB_PATH", str(db_path))
 
-    def get_agent(name: str):
+    def get_agent(name: str) -> Agent:
         return Sender() if name == "Sender" else Receiver()
 
     monkeypatch.setattr(AgentFactory, "get", staticmethod(get_agent))
+    set_value(bdd_context, "config", cfg)
     return cfg
 
 
 @given("two communicating agents without messaging", target_fixture="config")
-def setup_agents_no_messaging(monkeypatch, tmp_path, config_model):
+def setup_agents_no_messaging(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_model: ConfigModel,
+    bdd_context: BehaviorContext,
+) -> ConfigModel:
     """Configure agents with messaging disabled."""
     db_path = tmp_path / "kg.duckdb"
     cfg = config_model.model_copy()
@@ -101,33 +120,41 @@ def setup_agents_no_messaging(monkeypatch, tmp_path, config_model):
     cfg.storage = StorageConfig(duckdb_path=str(db_path))
     monkeypatch.setenv("DUCKDB_PATH", str(db_path))
 
-    def get_agent(name: str):
+    def get_agent(name: str) -> Agent:
         return Sender() if name == "Sender" else Receiver()
 
     monkeypatch.setattr(AgentFactory, "get", staticmethod(get_agent))
+    set_value(bdd_context, "config", cfg)
     return cfg
 
 
 @when("I execute a query", target_fixture="response")
-def run_query(config):
+def run_query(config: ConfigModel, bdd_context: BehaviorContext) -> QueryResponse:
     """Execute a simple query and capture the response."""
-    return Orchestrator.run_query("ping", config)
+    orchestrator = get_orchestrator(bdd_context)
+    set_value(bdd_context, "config", config)
+    return orchestrator.run_query("ping", config)
 
 
 @then("the receiver should process the message")
-def receiver_got_message(response):
+def receiver_got_message(response: QueryResponse) -> None:
     metrics = response.metrics
     assert metrics["delivered_messages"]["Receiver"][0]["content"] == "hi"
 
 
 @then("the receiver should have no messages")
-def receiver_no_message(response):
+def receiver_no_message(response: QueryResponse) -> None:
     metrics = response.metrics
     assert "Receiver" not in metrics.get("delivered_messages", {})
 
 
 @given("a coalition with a sender and two receivers", target_fixture="config")
-def setup_coalition(monkeypatch, tmp_path, config_model):
+def setup_coalition(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_model: ConfigModel,
+    bdd_context: BehaviorContext,
+) -> ConfigModel:
     """Set up a coalition for broadcast testing."""
     db_path = tmp_path / "kg.duckdb"
     cfg = config_model.model_copy()
@@ -142,23 +169,29 @@ def setup_coalition(monkeypatch, tmp_path, config_model):
     AgentFactory.register("R1", TeamReceiver)
     AgentFactory.register("R2", TeamReceiver)
 
-    def get_agent(name: str):
+    def get_agent(name: str) -> Agent:
         if name == "Sender":
             return Broadcaster()
         return TeamReceiver(name=name)
 
     monkeypatch.setattr(AgentFactory, "get", staticmethod(get_agent))
+    set_value(bdd_context, "config", cfg)
     return cfg
 
 
 @when("the sender broadcasts to the coalition", target_fixture="response")
-def run_broadcast_query(config):
+def run_broadcast_query(
+    config: ConfigModel,
+    bdd_context: BehaviorContext,
+) -> QueryResponse:
     """Run a query to trigger broadcast messaging."""
-    return Orchestrator.run_query("ping", config)
+    orchestrator = get_orchestrator(bdd_context)
+    set_value(bdd_context, "config", config)
+    return orchestrator.run_query("ping", config)
 
 
 @then("both receivers should process the broadcast")
-def receivers_got_broadcast(response):
+def receivers_got_broadcast(response: QueryResponse) -> None:
     metrics = response.metrics
     msgs_r1 = metrics["delivered_messages"]["R1"][0]
     msgs_r2 = metrics["delivered_messages"]["R2"][0]

--- a/tests/behavior/steps/cli_options_steps.py
+++ b/tests/behavior/steps/cli_options_steps.py
@@ -1,38 +1,88 @@
-# flake8: noqa
-import json
-import pytest
-from pytest_bdd import scenario, when, then, parsers
+from __future__ import annotations
 
-from .common_steps import app_running, app_running_with_default, application_running, cli_app
-from autoresearch.config.models import ConfigModel
+from dataclasses import dataclass
+from typing import Callable
+
+import pytest
+from click.testing import CliRunner, Result
+from pytest_bdd import parsers, scenario, then, when
+
 from autoresearch.config.loader import ConfigLoader
-from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.config.models import ConfigModel
 from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import Orchestrator
+from tests.behavior.context import BehaviorContext, get_required, set_value
+
+from . import common_steps  # noqa: F401
+from .common_steps import (
+    app_running,
+    app_running_with_default,
+    application_running,
+    cli_app,
+)
+
+
+@dataclass(slots=True)
+class CLIExecution:
+    """Capture a CLI invocation and the resulting configuration."""
+
+    config: ConfigModel
+    result: Result
+
+
+@dataclass(slots=True)
+class ParallelExecution:
+    """Capture parallel CLI invocation metadata."""
+
+    result: Result
+    groups: list[list[str]]
 
 
 @scenario("../features/cli_options.feature", "Set loops and token budget via CLI")
-def test_token_budget_loops(bdd_context):
+def test_token_budget_loops(bdd_context: BehaviorContext) -> None:
     pass
 
 
 @scenario("../features/cli_options.feature", "Choose specific agents via CLI")
-def test_choose_agents(bdd_context):
+def test_choose_agents(bdd_context: BehaviorContext) -> None:
     pass
 
 
 @scenario("../features/cli_options.feature", "Run agent groups in parallel via CLI")
-def test_parallel_groups(bdd_context):
+def test_parallel_groups(bdd_context: BehaviorContext) -> None:
     pass
 
 
 @scenario("../features/cli_options.feature", "Override reasoning mode via CLI")
-def test_cli_reasoning_mode(bdd_context):
+def test_cli_reasoning_mode(bdd_context: BehaviorContext) -> None:
     pass
 
 
 @scenario("../features/cli_options.feature", "Override primus start via CLI")
-def test_cli_primus_start(bdd_context):
+def test_cli_primus_start(bdd_context: BehaviorContext) -> None:
     pass
+
+
+def _install_query_stub(
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+) -> Callable[[str, ConfigModel, object | None], QueryResponse]:
+    """Install an orchestrator stub that records the provided config."""
+
+    def mock_run_query(
+        query: str,
+        cfg: ConfigModel,
+        callbacks: object | None = None,
+        *,
+        agent_factory: object | None = None,
+        storage_manager: object | None = None,
+    ) -> QueryResponse:
+        set_value(bdd_context, "captured_config", cfg)
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+
+    monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
+    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: ConfigModel())
+    return mock_run_query
 
 
 @when(
@@ -40,65 +90,72 @@ def test_cli_primus_start(bdd_context):
         'I run `autoresearch search "{query}" --loops {loops:d} --token-budget {budget:d} --no-ontology-reasoning`'
     )
 )
-def run_with_budget(query, loops, budget, monkeypatch, cli_runner, bdd_context):
+def run_with_budget(
+    query: str,
+    loops: int,
+    budget: int,
+    monkeypatch: pytest.MonkeyPatch,
+    cli_runner: CliRunner,
+    bdd_context: BehaviorContext,
+) -> None:
     ConfigLoader.reset_instance()
-    def mock_run_query(
-        q,
-        cfg,
-        callbacks=None,
-        *,
-        agent_factory=None,
-        storage_manager=None,
-    ):
-        bdd_context["cfg"] = cfg
-        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
-
-    monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: ConfigModel())
+    _install_query_stub(monkeypatch, bdd_context)
     result = cli_runner.invoke(
         cli_app,
-        ["search", query, "--loops", str(loops), "--token-budget", str(budget), "--no-ontology-reasoning"],
+        [
+            "search",
+            query,
+            "--loops",
+            str(loops),
+            "--token-budget",
+            str(budget),
+            "--no-ontology-reasoning",
+        ],
     )
-    bdd_context["result"] = result
+    config = get_required(bdd_context, "captured_config", ConfigModel)
+    execution = CLIExecution(config=config, result=result)
+    set_value(bdd_context, "cli_execution", execution)
 
 
 @then(parsers.parse("the search config should have loops {loops:d} and token budget {budget:d}"))
-def check_budget_config(bdd_context, loops, budget):
-    cfg = bdd_context.get("cfg")
+def check_budget_config(
+    bdd_context: BehaviorContext,
+    loops: int,
+    budget: int,
+) -> None:
+    execution = get_required(bdd_context, "cli_execution", CLIExecution)
+    cfg = execution.config
     assert cfg.loops == loops
     assert cfg.token_budget == budget
-    result = bdd_context["result"]
+    result = execution.result
     assert result.exit_code == 0
     assert result.stdout != ""
     assert result.stderr == ""
 
 
 @when(parsers.parse('I run `autoresearch search "{query}" --agents {agents}`'))
-def run_with_agents(query, agents, monkeypatch, cli_runner, bdd_context):
+def run_with_agents(
+    query: str,
+    agents: str,
+    monkeypatch: pytest.MonkeyPatch,
+    cli_runner: CliRunner,
+    bdd_context: BehaviorContext,
+) -> None:
     ConfigLoader.reset_instance()
-    def mock_run_query(
-        q,
-        cfg,
-        callbacks=None,
-        *,
-        agent_factory=None,
-        storage_manager=None,
-    ):
-        bdd_context["cfg"] = cfg
-        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
-
-    monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: ConfigModel())
+    _install_query_stub(monkeypatch, bdd_context)
     result = cli_runner.invoke(cli_app, ["search", query, "--agents", agents])
-    bdd_context["result"] = result
+    config = get_required(bdd_context, "captured_config", ConfigModel)
+    execution = CLIExecution(config=config, result=result)
+    set_value(bdd_context, "cli_execution", execution)
 
 
 @then(parsers.parse('the search config should list agents "{agents}"'))
-def check_agents_config(bdd_context, agents):
-    cfg = bdd_context.get("cfg")
+def check_agents_config(bdd_context: BehaviorContext, agents: str) -> None:
+    execution = get_required(bdd_context, "cli_execution", CLIExecution)
+    cfg = execution.config
     expected = [a.strip() for a in agents.split(",")]
     assert cfg.agents == expected
-    result = bdd_context["result"]
+    result = execution.result
     assert result.exit_code == 0
     assert result.stdout != ""
     assert result.stderr == ""
@@ -109,11 +166,23 @@ def check_agents_config(bdd_context, agents):
         r'^I run `autoresearch search --parallel --agent-groups "(?P<g1>.+)" "(?P<g2>.+)" "(?P<query>.+)"`$'
     )
 )
-def run_parallel_cli(g1, g2, query, monkeypatch, cli_runner, bdd_context):
+def run_parallel_cli(
+    g1: str,
+    g2: str,
+    query: str,
+    monkeypatch: pytest.MonkeyPatch,
+    cli_runner: CliRunner,
+    bdd_context: BehaviorContext,
+) -> None:
     ConfigLoader.reset_instance()
     groups = [[a.strip() for a in g1.split(",")], [a.strip() for a in g2.split(",")]]
 
-    def mock_parallel(q, cfg, agent_groups):
+    def mock_parallel(
+        q: str,
+        cfg: ConfigModel,
+        agent_groups: list[list[str]],
+    ) -> QueryResponse:
+        set_value(bdd_context, "captured_config", cfg)
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
     monkeypatch.setattr(Orchestrator, "run_parallel_query", mock_parallel)
@@ -122,77 +191,74 @@ def run_parallel_cli(g1, g2, query, monkeypatch, cli_runner, bdd_context):
         cli_app,
         ["search", "--parallel", "--agent-groups", g1, "--agent-groups", g2, query],
     )
-    bdd_context["result"] = result
-    bdd_context["groups"] = groups
+    parallel = ParallelExecution(result=result, groups=groups)
+    set_value(bdd_context, "parallel_execution", parallel)
 
 
 @when(parsers.parse('I run `autoresearch search "{query}" --reasoning-mode {mode}`'))
-def run_with_reasoning(query, mode, monkeypatch, cli_runner, bdd_context):
+def run_with_reasoning(
+    query: str,
+    mode: str,
+    monkeypatch: pytest.MonkeyPatch,
+    cli_runner: CliRunner,
+    bdd_context: BehaviorContext,
+) -> None:
     ConfigLoader.reset_instance()
-
-    def mock_run_query(
-        q,
-        cfg,
-        callbacks=None,
-        *,
-        agent_factory=None,
-        storage_manager=None,
-    ):
-        bdd_context["cfg"] = cfg
-        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
-
-    monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: ConfigModel())
+    _install_query_stub(monkeypatch, bdd_context)
     result = cli_runner.invoke(cli_app, ["search", query, "--reasoning-mode", mode])
-    bdd_context["result"] = result
+    config = get_required(bdd_context, "captured_config", ConfigModel)
+    execution = CLIExecution(config=config, result=result)
+    set_value(bdd_context, "cli_execution", execution)
 
 
 @then(parsers.parse('the search config should use reasoning mode "{mode}"'))
-def check_reasoning_mode(bdd_context, mode):
-    cfg = bdd_context.get("cfg")
+def check_reasoning_mode(bdd_context: BehaviorContext, mode: str) -> None:
+    execution = get_required(bdd_context, "cli_execution", CLIExecution)
+    cfg = execution.config
     assert cfg.reasoning_mode.value == mode
-    result = bdd_context["result"]
+    result = execution.result
     assert result.exit_code == 0
     assert result.stdout != ""
     assert result.stderr == ""
 
 
 @when(parsers.parse('I run `autoresearch search "{query}" --primus-start {index:d}`'))
-def run_with_primus(query, index, monkeypatch, cli_runner, bdd_context):
+def run_with_primus(
+    query: str,
+    index: int,
+    monkeypatch: pytest.MonkeyPatch,
+    cli_runner: CliRunner,
+    bdd_context: BehaviorContext,
+) -> None:
     ConfigLoader.reset_instance()
-
-    def mock_run_query(
-        q,
-        cfg,
-        callbacks=None,
-        *,
-        agent_factory=None,
-        storage_manager=None,
-    ):
-        bdd_context["cfg"] = cfg
-        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
-
-    monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: ConfigModel())
+    _install_query_stub(monkeypatch, bdd_context)
     result = cli_runner.invoke(cli_app, ["search", query, "--primus-start", str(index)])
-    bdd_context["result"] = result
+    config = get_required(bdd_context, "captured_config", ConfigModel)
+    execution = CLIExecution(config=config, result=result)
+    set_value(bdd_context, "cli_execution", execution)
 
 
 @then(parsers.parse('the search config should have primus start {index:d}'))
-def check_primus_start(bdd_context, index):
-    cfg = bdd_context.get("cfg")
+def check_primus_start(bdd_context: BehaviorContext, index: int) -> None:
+    execution = get_required(bdd_context, "cli_execution", CLIExecution)
+    cfg = execution.config
     assert cfg.primus_start == index
-    result = bdd_context["result"]
+    result = execution.result
     assert result.exit_code == 0
     assert result.stdout != ""
     assert result.stderr == ""
 
 
 @then(parsers.parse('the parallel query should use groups "{g1}" and "{g2}"'))
-def check_parallel_groups(bdd_context, g1, g2):
+def check_parallel_groups(
+    bdd_context: BehaviorContext,
+    g1: str,
+    g2: str,
+) -> None:
+    parallel = get_required(bdd_context, "parallel_execution", ParallelExecution)
     expected = [[a.strip() for a in g1.split(",")], [a.strip() for a in g2.split(",")]]
-    assert bdd_context.get("groups") == expected
-    result = bdd_context["result"]
+    assert parallel.groups == expected
+    result = parallel.result
     assert result.exit_code == 0
     assert result.stdout != ""
     assert result.stderr == ""

--- a/tests/behavior/steps/common_steps.py
+++ b/tests/behavior/steps/common_steps.py
@@ -23,6 +23,7 @@ from autoresearch.storage import set_delegate as set_storage_delegate
 from autoresearch.storage import teardown as storage_teardown
 from click.testing import Result
 from tests.behavior.context import (
+    BehaviorContext,
     get_cli_result,
     set_cli_invocation,
     set_cli_result,
@@ -217,13 +218,13 @@ def application_running(temp_config: Path) -> None:
 @when(parsers.parse("I run `{command}`"))
 def run_cli_command(
     cli_runner: CliRunner,
-    bdd_context: dict[str, object],
+    bdd_context: BehaviorContext,
     command: str,
     _isolate_network: None,
     _restore_environment: None,
 ) -> None:
     args = shlex.split(command)
-    trimmed_args = args
+    trimmed_args: list[str] = args
     if args and args[0] == "uv":
         remainder = args[1:]
         if remainder and remainder[0] == "run":
@@ -242,13 +243,13 @@ def run_cli_command(
 
 
 @then("the CLI should exit successfully")
-def cli_should_exit_successfully(bdd_context: dict[str, object]) -> None:
+def cli_should_exit_successfully(bdd_context: BehaviorContext) -> None:
     result = get_cli_result(bdd_context, key="result")
     assert_cli_success(result)
 
 
 @then("the CLI should report an error")
-def cli_should_report_error(bdd_context: dict[str, object]) -> None:
+def cli_should_report_error(bdd_context: BehaviorContext) -> None:
     result = get_cli_result(bdd_context, key="result")
     assert_cli_error(result)
 

--- a/tests/behavior/steps/interactive_monitor_steps.py
+++ b/tests/behavior/steps/interactive_monitor_steps.py
@@ -1,78 +1,121 @@
-# flake8: noqa
-from pytest_bdd import scenario, when, then, parsers
+from __future__ import annotations
 
-from .common_steps import app_running, app_running_with_default, application_running, cli_app
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from click.testing import CliRunner, Result
+from pytest_bdd import parsers, scenario, then, when
+
+from autoresearch.models import QueryResponse
+from autoresearch.orchestration.orchestrator import Orchestrator
+from tests.behavior.context import BehaviorContext, get_required, set_value
+
+from .common_steps import (
+    app_running,
+    app_running_with_default,
+    application_running,
+    cli_app,
+)
 
 
 @when(parsers.parse('I start `autoresearch monitor run` and enter "{text}"'))
-def start_monitor(text, monkeypatch, bdd_context, cli_runner):
-    responses = iter([text, "", "q"])
-    monkeypatch.setattr("autoresearch.main.Prompt.ask", lambda *a, **k: next(responses))
-    monkeypatch.setattr("autoresearch.monitor.Prompt.ask", lambda *a, **k: next(responses))
+def start_monitor(
+    text: str,
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+    cli_runner: CliRunner,
+) -> None:
+    responses: Iterator[str] = iter([text, "", "q"])
+    monkeypatch.setattr(
+        "autoresearch.main.Prompt.ask", lambda *args, **kwargs: next(responses)
+    )
+    monkeypatch.setattr(
+        "autoresearch.monitor.Prompt.ask", lambda *args, **kwargs: next(responses)
+    )
     result = cli_runner.invoke(cli_app, ["monitor", "run"])
-    bdd_context["monitor_result"] = result
+    set_value(bdd_context, "monitor_result", result)
 
 
 @when('I run `autoresearch monitor metrics`')
-def run_metrics(monkeypatch, bdd_context, cli_runner):
+def run_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+    cli_runner: CliRunner,
+) -> None:
+    metrics_payload: dict[str, float] = {"cpu_percent": 10.0, "memory_percent": 5.0}
     monkeypatch.setattr(
         "autoresearch.monitor._collect_system_metrics",
-        lambda: {"cpu_percent": 10.0, "memory_percent": 5.0},
+        lambda: metrics_payload,
     )
     result = cli_runner.invoke(cli_app, ["monitor", "metrics"])
-    bdd_context["monitor_result"] = result
+    set_value(bdd_context, "monitor_result", result)
 
 
 @when('I run `autoresearch monitor graph`')
-def run_graph(monkeypatch, bdd_context, cli_runner):
+def run_graph(
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+    cli_runner: CliRunner,
+) -> None:
+    graph_data: dict[str, list[str]] = {"A": ["B", "C"]}
     monkeypatch.setattr(
-        "autoresearch.monitor._collect_graph_data",
-        lambda: {"A": ["B", "C"]},
+        "autoresearch.monitor._collect_graph_data", lambda: graph_data
     )
     result = cli_runner.invoke(cli_app, ["monitor", "graph"])
-    bdd_context["monitor_result"] = result
+    set_value(bdd_context, "monitor_result", result)
 
 
 @when('I run `autoresearch monitor graph --tui`')
-def run_graph_tui(monkeypatch, bdd_context, cli_runner):
+def run_graph_tui(
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+    cli_runner: CliRunner,
+) -> None:
+    graph_data: dict[str, list[str]] = {"A": ["B", "C"]}
     monkeypatch.setattr(
-        "autoresearch.monitor._collect_graph_data",
-        lambda: {"A": ["B", "C"]},
+        "autoresearch.monitor._collect_graph_data", lambda: graph_data
     )
     result = cli_runner.invoke(cli_app, ["monitor", "graph", "--tui"])
-    bdd_context["monitor_result"] = result
+    set_value(bdd_context, "monitor_result", result)
 
 
 @when(parsers.parse('I run `autoresearch search "{query}" --visualize`'))
-def run_search_visualize(query, monkeypatch, bdd_context, cli_runner):
-    from autoresearch.orchestration.orchestrator import Orchestrator
-    from autoresearch.models import QueryResponse
-
+def run_search_visualize(
+    query: str,
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+    cli_runner: CliRunner,
+) -> None:
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    graph_data: dict[str, list[str]] = {"A": ["B"]}
     monkeypatch.setattr(
-        "autoresearch.monitor._collect_graph_data",
-        lambda: {"A": ["B"]},
+        "autoresearch.monitor._collect_graph_data", lambda: graph_data
     )
 
-    def dummy_run_query(*args, **kwargs):
+    def dummy_run_query(*_args: Any, **_kwargs: Any) -> QueryResponse:
         return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
 
     monkeypatch.setattr(Orchestrator, "run_query", dummy_run_query)
     result = cli_runner.invoke(cli_app, ["search", query, "--visualize"])
-    bdd_context["visual_result"] = result
+    set_value(bdd_context, "visual_result", result)
 
 
 @when('I run `autoresearch monitor resources --duration 1`')
-def run_monitor_resources(monkeypatch, bdd_context, cli_runner):
+def run_monitor_resources(
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+    cli_runner: CliRunner,
+) -> None:
     class DummyMetrics:
-        def record_system_resources(self):
-            pass
+        def record_system_resources(self) -> None:
+            return None
 
-        def get_summary(self):
-            return {
+        def get_summary(self) -> dict[str, list[dict[str, float]]]:
+            summary: dict[str, list[dict[str, float]]] = {
                 "resource_usage": [
                     {
-                        "timestamp": 0,
+                        "timestamp": 0.0,
                         "cpu_percent": 10.0,
                         "memory_mb": 5.0,
                         "gpu_percent": 0.0,
@@ -80,6 +123,7 @@ def run_monitor_resources(monkeypatch, bdd_context, cli_runner):
                     }
                 ]
             }
+            return summary
 
     monkeypatch.setattr(
         "autoresearch.monitor.orch_metrics.OrchestrationMetrics", lambda: DummyMetrics()
@@ -88,112 +132,117 @@ def run_monitor_resources(monkeypatch, bdd_context, cli_runner):
     result = cli_runner.invoke(
         cli_app, ["monitor", "resources", "--duration", "1"]
     )
-    bdd_context["monitor_result"] = result
+    set_value(bdd_context, "monitor_result", result)
 
 
 @when('I run `autoresearch monitor start --interval 0.1`')
-def run_monitor_start(monkeypatch, bdd_context, cli_runner):
+def run_monitor_start(
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+    cli_runner: CliRunner,
+) -> None:
     monkeypatch.setattr(
-        "autoresearch.monitor.ResourceMonitor.start", lambda self, prometheus_port=None: None
+        "autoresearch.monitor.ResourceMonitor.start",
+        lambda self, prometheus_port=None: None,
     )
     monkeypatch.setattr("autoresearch.monitor.ResourceMonitor.stop", lambda self: None)
     monkeypatch.setattr("autoresearch.monitor.SystemMonitor.start", lambda self: None)
     monkeypatch.setattr("autoresearch.monitor.SystemMonitor.stop", lambda self: None)
 
-    def _raise(_):
+    def _raise(_: float) -> None:
         raise KeyboardInterrupt()
 
     monkeypatch.setattr("time.sleep", _raise)
     result = cli_runner.invoke(cli_app, ["monitor", "start", "--interval", "0.1"])
-    bdd_context["monitor_result"] = result
+    set_value(bdd_context, "monitor_result", result)
 
 
 @then("the monitor should exit successfully")
-def monitor_exit_successfully(bdd_context):
-    result = bdd_context["monitor_result"]
+def monitor_exit_successfully(bdd_context: BehaviorContext) -> None:
+    result = get_required(bdd_context, "monitor_result", Result)
     assert result.exit_code == 0
     assert result.stdout != ""
     assert result.stderr == ""
 
 
 @then("the monitor output should display system metrics")
-def monitor_output_contains_metrics(bdd_context):
-    output = bdd_context["monitor_result"].stdout
+def monitor_output_contains_metrics(bdd_context: BehaviorContext) -> None:
+    output = get_required(bdd_context, "monitor_result", Result).stdout
     assert "System Metrics" in output
     assert "cpu_percent" in output
     assert "memory_percent" in output
 
 
 @then("the monitor output should display graph data")
-def monitor_output_contains_graph(bdd_context):
-    output = bdd_context["monitor_result"].stdout
+def monitor_output_contains_graph(bdd_context: BehaviorContext) -> None:
+    output = get_required(bdd_context, "monitor_result", Result).stdout
     assert "Knowledge Graph" in output
     assert "A" in output
 
 
 @then("the search command should exit successfully")
-def search_exit_successfully(bdd_context):
-    result = bdd_context["visual_result"]
+def search_exit_successfully(bdd_context: BehaviorContext) -> None:
+    result = get_required(bdd_context, "visual_result", Result)
     assert result.exit_code == 0
     assert result.stdout != ""
     assert result.stderr == ""
 
 
 @then("the search output should display graph data")
-def search_output_contains_graph(bdd_context):
-    output = bdd_context["visual_result"].stdout
+def search_output_contains_graph(bdd_context: BehaviorContext) -> None:
+    output = get_required(bdd_context, "visual_result", Result).stdout
     assert "Knowledge Graph" in output
     assert "Answer" in output
 
 
 @then("the monitor output should display resource usage")
-def monitor_output_contains_resources(bdd_context):
-    output = bdd_context["monitor_result"].stdout
+def monitor_output_contains_resources(bdd_context: BehaviorContext) -> None:
+    output = get_required(bdd_context, "monitor_result", Result).stdout
     assert "Resource Usage" in output
     assert "CPU %" in output
 
 
 @then("the monitor output should indicate it started")
-def monitor_output_started(bdd_context):
-    output = bdd_context["monitor_result"].stdout
+def monitor_output_started(bdd_context: BehaviorContext) -> None:
+    output = get_required(bdd_context, "monitor_result", Result).stdout
     assert "Monitoring started" in output
 
 
 @scenario("../features/interactive_monitor.feature", "Interactive monitoring")
-def test_interactive_monitor(bdd_context):
-    assert bdd_context["monitor_result"].exit_code == 0
+def test_interactive_monitor(bdd_context: BehaviorContext) -> None:
+    assert get_required(bdd_context, "monitor_result", Result).exit_code == 0
 
 
 @scenario("../features/interactive_monitor.feature", "Exit immediately")
-def test_monitor_exit_immediately(bdd_context):
-    assert bdd_context["monitor_result"].exit_code == 0
+def test_monitor_exit_immediately(bdd_context: BehaviorContext) -> None:
+    assert get_required(bdd_context, "monitor_result", Result).exit_code == 0
 
 
 @scenario("../features/interactive_monitor.feature", "Display metrics")
-def test_monitor_metrics(bdd_context):
-    assert bdd_context["monitor_result"].exit_code == 0
+def test_monitor_metrics(bdd_context: BehaviorContext) -> None:
+    assert get_required(bdd_context, "monitor_result", Result).exit_code == 0
 
 
 @scenario("../features/interactive_monitor.feature", "Display graph")
-def test_monitor_graph(bdd_context):
-    assert bdd_context["monitor_result"].exit_code == 0
+def test_monitor_graph(bdd_context: BehaviorContext) -> None:
+    assert get_required(bdd_context, "monitor_result", Result).exit_code == 0
 
 
 @scenario("../features/interactive_monitor.feature", "Display TUI graph")
-def test_monitor_graph_tui(bdd_context):
-    assert bdd_context["monitor_result"].exit_code == 0
+def test_monitor_graph_tui(bdd_context: BehaviorContext) -> None:
+    assert get_required(bdd_context, "monitor_result", Result).exit_code == 0
 
 
 @scenario("../features/interactive_monitor.feature", "Visualize search results")
-def test_search_visualization(bdd_context):
-    assert bdd_context["visual_result"].exit_code == 0
+def test_search_visualization(bdd_context: BehaviorContext) -> None:
+    assert get_required(bdd_context, "visual_result", Result).exit_code == 0
 
 
 @scenario("../features/interactive_monitor.feature", "Record resource usage")
-def test_monitor_resources(bdd_context):
-    assert bdd_context["monitor_result"].exit_code == 0
+def test_monitor_resources(bdd_context: BehaviorContext) -> None:
+    assert get_required(bdd_context, "monitor_result", Result).exit_code == 0
 
 
 @scenario("../features/interactive_monitor.feature", "Start monitoring service")
-def test_monitor_start_service(bdd_context):
-    assert bdd_context["monitor_result"].exit_code == 0
+def test_monitor_start_service(bdd_context: BehaviorContext) -> None:
+    assert get_required(bdd_context, "monitor_result", Result).exit_code == 0

--- a/tests/behavior/steps/query_interface_steps.py
+++ b/tests/behavior/steps/query_interface_steps.py
@@ -1,48 +1,95 @@
-# flake8: noqa
-import json
-import pytest
-from pytest_bdd import given, scenario, when, then, parsers
+from __future__ import annotations
 
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from click.testing import CliRunner, Result
+from httpx import Client, Response
+from pytest_bdd import given, parsers, scenario, then, when
+
+from autoresearch.models import QueryResponse
+from tests.behavior.context import BehaviorContext, get_required, set_value
+
+from . import common_steps  # noqa: F401
 from .common_steps import (
     app_running,
     app_running_with_default,
     application_running,
     cli_app,
 )
-from . import common_steps  # noqa: F401
+
+
+@dataclass(slots=True)
+class CLIExpectation:
+    """Capture a CLI invocation alongside its expected response."""
+
+    result: Result
+    expected: QueryResponse
+
+
+@dataclass(slots=True)
+class HTTPExpectation:
+    """Capture an HTTP response with the associated expected payload."""
+
+    response: Response
+    expected: QueryResponse
+
+
+@dataclass(slots=True)
+class VisualizationResult:
+    """Capture CLI visualization execution details."""
+
+    result: Result
+    path: Path
 
 
 @given("the Autoresearch application is running")
-def _app_running():
+def _app_running() -> None:
     """Background step placeholder for feature scenarios."""
-    return
+    return None
 
 
 @when(parsers.parse('I run `autoresearch search "{query}"` in a terminal'))
-def run_cli_query(query, monkeypatch, bdd_context, cli_runner, dummy_query_response):
+def run_cli_query(
+    query: str,
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+    cli_runner: CliRunner,
+    dummy_query_response: QueryResponse,
+) -> None:
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     result = cli_runner.invoke(cli_app, ["search", query])
-    bdd_context.update({"cli_result": result, "expected": dummy_query_response})
+    expectation = CLIExpectation(result=result, expected=dummy_query_response)
+    set_value(bdd_context, "cli_expectation", expectation)
 
 
 @when(parsers.parse('I run `autoresearch search "{query}" --reasoning-mode {mode}` in a terminal'))
 def run_cli_query_with_mode(
-    query, mode, monkeypatch, bdd_context, cli_runner, dummy_query_response
-):
+    query: str,
+    mode: str,
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+    cli_runner: CliRunner,
+    dummy_query_response: QueryResponse,
+) -> None:
     """Run CLI search specifying a reasoning mode."""
 
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     result = cli_runner.invoke(cli_app, ["search", query, "--reasoning-mode", mode])
-    bdd_context.update({"cli_result": result, "expected": dummy_query_response})
+    expectation = CLIExpectation(result=result, expected=dummy_query_response)
+    set_value(bdd_context, "cli_expectation", expectation)
 
 
 @then(
-    "I should receive a readable Markdown answer with `answer`, `citations`, "
-    "`reasoning`, and `metrics` sections",
+    "I should receive a readable Markdown answer with `answer`, `citations`, `reasoning`, and `metrics` sections",
 )
-def check_cli_output(bdd_context):
-    result = bdd_context["cli_result"]
-    expected = bdd_context["expected"]
+def check_cli_output(bdd_context: BehaviorContext) -> None:
+    expectation = get_required(bdd_context, "cli_expectation", CLIExpectation)
+    result = expectation.result
+    expected = expectation.expected
     assert result.exit_code == 0
     assert result.stderr == ""
     out = result.stdout
@@ -60,17 +107,24 @@ def check_cli_output(bdd_context):
 
 
 @when(parsers.parse('I send a POST request to `/query` with JSON `{ "query": "{query}" }`'))
-def send_http_query(query, bdd_context, api_client, dummy_query_response):
+def send_http_query(
+    query: str,
+    bdd_context: BehaviorContext,
+    api_client: Client,
+    dummy_query_response: QueryResponse,
+) -> None:
     response = api_client.post("/query", json={"query": query})
-    bdd_context.update({"http_response": response, "expected": dummy_query_response})
+    expectation = HTTPExpectation(response=response, expected=dummy_query_response)
+    set_value(bdd_context, "http_expectation", expectation)
 
 
 @then(
     "the response should be a valid JSON document with keys `answer`, `citations`, `reasoning`, and `metrics`",
 )
-def check_http_response(bdd_context):
-    response = bdd_context["http_response"]
-    expected = bdd_context["expected"]
+def check_http_response(bdd_context: BehaviorContext) -> None:
+    expectation = get_required(bdd_context, "http_expectation", HTTPExpectation)
+    response = expectation.response
+    expected = expectation.expected
     assert response.status_code == 200
     data = response.json()
     expected_dict = expected.model_dump()
@@ -80,53 +134,82 @@ def check_http_response(bdd_context):
 
 
 @when(parsers.re(r'I run `autoresearch\.search\("(?P<query>.+)"\)` via the MCP CLI'))
-def run_mcp_cli_query(query, monkeypatch, bdd_context, cli_runner, dummy_query_response):
+def run_mcp_cli_query(
+    query: str,
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+    cli_runner: CliRunner,
+    dummy_query_response: QueryResponse,
+) -> None:
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     result = cli_runner.invoke(cli_app, ["search", query])
-    bdd_context.update({"mcp_result": result, "expected": dummy_query_response})
+    expectation = CLIExpectation(result=result, expected=dummy_query_response)
+    set_value(bdd_context, "mcp_expectation", expectation)
 
 
 @when(parsers.parse('I run `autoresearch search "{query}" -i` and refine to "{refined}" then exit'))
 def run_interactive_query(
-    query, refined, monkeypatch, bdd_context, cli_runner, dummy_query_response
-):
-    from autoresearch.config.models import ConfigModel
+    query: str,
+    refined: str,
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+    cli_runner: CliRunner,
+    dummy_query_response: QueryResponse,
+) -> None:
     from autoresearch.config.loader import ConfigLoader
+    from autoresearch.config.models import ConfigModel
 
     monkeypatch.setattr(
         ConfigLoader,
         "load_config",
         lambda self: ConfigModel(loops=2),
     )
-    responses = iter([refined, "q"])
+    responses: Iterator[str] = iter([refined, "q"])
     monkeypatch.setattr("autoresearch.main.Prompt.ask", lambda *a, **k: next(responses))
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     result = cli_runner.invoke(cli_app, ["search", query, "--interactive"])
-    bdd_context.update({"cli_result": result, "expected": dummy_query_response})
+    expectation = CLIExpectation(result=result, expected=dummy_query_response)
+    set_value(bdd_context, "cli_expectation", expectation)
 
 
 @when(parsers.re(r'I run `autoresearch visualize "(?P<query>.+)" (?P<file>.+)`'))
-def run_visualize_cli(query, file, tmp_path, bdd_context, cli_runner, dummy_query_response):
+def run_visualize_cli(
+    query: str,
+    file: str,
+    tmp_path: Path,
+    bdd_context: BehaviorContext,
+    cli_runner: CliRunner,
+    dummy_query_response: QueryResponse,
+) -> None:
     out = tmp_path / file
     result = cli_runner.invoke(cli_app, ["visualize", query, str(out)])
-    bdd_context.update({"viz_result": result, "viz_path": out, "expected": dummy_query_response})
+    visualization = VisualizationResult(result=result, path=out)
+    set_value(bdd_context, "visualization", visualization)
+    expectation = CLIExpectation(result=result, expected=dummy_query_response)
+    set_value(bdd_context, "cli_expectation", expectation)
 
 
 @when(parsers.re(r"I run `autoresearch visualize-rdf (?P<file>.+)`"))
-def run_visualize_rdf_cli(file, tmp_path, bdd_context, cli_runner):
+def run_visualize_rdf_cli(
+    file: str,
+    tmp_path: Path,
+    bdd_context: BehaviorContext,
+    cli_runner: CliRunner,
+) -> None:
     out = tmp_path / file
     result = cli_runner.invoke(cli_app, ["visualize-rdf", str(out)])
-    bdd_context["viz_result"] = result
-    bdd_context["viz_path"] = out
+    visualization = VisualizationResult(result=result, path=out)
+    set_value(bdd_context, "visualization", visualization)
 
 
 @then(parsers.parse('the visualization file "{file}" should exist'))
-def check_viz_file(file, bdd_context):
-    path = bdd_context["viz_path"]
+def check_viz_file(file: str, bdd_context: BehaviorContext) -> None:
+    visualization = get_required(bdd_context, "visualization", VisualizationResult)
+    path = visualization.path
     assert path.exists() and path.stat().st_size > 0
     path.unlink()
-    result = bdd_context["viz_result"]
+    result = visualization.result
     assert result.exit_code == 0
     assert result.stderr == ""
 
@@ -134,9 +217,10 @@ def check_viz_file(file, bdd_context):
 @then(
     "I should receive a JSON output matching the defined schema for `answer`, `citations`, `reasoning`, and `metrics`",
 )
-def check_mcp_cli_output(bdd_context):
-    result = bdd_context["mcp_result"]
-    expected = bdd_context["expected"]
+def check_mcp_cli_output(bdd_context: BehaviorContext) -> None:
+    expectation = get_required(bdd_context, "mcp_expectation", CLIExpectation)
+    result = expectation.result
+    expected = expectation.expected
     assert result.exit_code == 0
     assert result.stderr == ""
     lines = result.stdout.splitlines()
@@ -152,33 +236,33 @@ def check_mcp_cli_output(bdd_context):
 
 
 @scenario("../features/query_interface.feature", "Submit query via CLI")
-def test_cli_query():
+def test_cli_query() -> None:
     pass
 
 
 @scenario("../features/query_interface.feature", "Submit query via HTTP API")
-def test_http_query():
+def test_http_query() -> None:
     pass
 
 
 @pytest.mark.skip(reason="MCP CLI not required for minimal verify")
 @scenario("../features/query_interface.feature", "Submit query via MCP tool")
-def test_mcp_query():
+def test_mcp_query() -> None:
     pass
 
 
 @scenario("../features/query_interface.feature", "Refine query interactively via CLI")
-def test_interactive_query():
+def test_interactive_query() -> None:
     pass
 
 
 @scenario("../features/query_interface.feature", "Visualize query results via CLI")
-def test_visualize_query():
+def test_visualize_query() -> None:
     pass
 
 
 @scenario("../features/query_interface.feature", "Visualize RDF graph via CLI")
-def test_visualize_rdf_cli():
+def test_visualize_rdf_cli() -> None:
     pass
 
 
@@ -186,6 +270,6 @@ def test_visualize_rdf_cli():
     "../features/query_interface.feature",
     "Submit query via CLI with reasoning mode",
 )
-def test_cli_query_with_reasoning_mode():
+def test_cli_query_with_reasoning_mode() -> None:
     """CLI query works when specifying reasoning mode."""
     pass


### PR DESCRIPTION
## Summary
- add explicit BehaviorContext usage to common CLI helpers
- introduce typed dataclasses and annotations across CLI/API behavior step modules
- switch agent message steps to orchestrator helpers and tighten temporary data typing

## Testing
- `uv run mypy --strict tests/behavior` *(fails: pre-existing typing errors across other step modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb4aee7388333b12b920a63280a7a