### PR TITLE
Refactor orchestrator behavior steps for typed contexts

### DIFF
--- a/tests/behavior/steps/agent_messages_steps.py
+++ b/tests/behavior/steps/agent_messages_steps.py
@@ -13,7 +13,12 @@ from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.models import QueryResponse
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.orchestration.state import QueryState
-from tests.behavior.context import BehaviorContext, get_orchestrator, set_value
+from tests.behavior.context import (
+    BehaviorContext,
+    get_config,
+    get_orchestrator,
+    set_value,
+)
 
 from . import common_steps  # noqa: F401
 
@@ -129,10 +134,10 @@ def setup_agents_no_messaging(
 
 
 @when("I execute a query", target_fixture="response")
-def run_query(config: ConfigModel, bdd_context: BehaviorContext) -> QueryResponse:
+def run_query(bdd_context: BehaviorContext) -> QueryResponse:
     """Execute a simple query and capture the response."""
     orchestrator = get_orchestrator(bdd_context)
-    set_value(bdd_context, "config", config)
+    config = get_config(bdd_context)
     return orchestrator.run_query("ping", config)
 
 
@@ -180,13 +185,10 @@ def setup_coalition(
 
 
 @when("the sender broadcasts to the coalition", target_fixture="response")
-def run_broadcast_query(
-    config: ConfigModel,
-    bdd_context: BehaviorContext,
-) -> QueryResponse:
+def run_broadcast_query(bdd_context: BehaviorContext) -> QueryResponse:
     """Run a query to trigger broadcast messaging."""
     orchestrator = get_orchestrator(bdd_context)
-    set_value(bdd_context, "config", config)
+    config = get_config(bdd_context)
     return orchestrator.run_query("ping", config)
 
 

--- a/tests/behavior/steps/orchestrator_agents_integration_steps.py
+++ b/tests/behavior/steps/orchestrator_agents_integration_steps.py
@@ -5,37 +5,60 @@ the orchestrator and agents, including agent execution order, error handling,
 and execution conditions.
 """
 
-import pytest
-from pytest_bdd import scenario, given, when, then
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
 from unittest.mock import MagicMock, patch
 
-from autoresearch.orchestration.orchestrator import Orchestrator
-from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
+import pytest
+from pytest_bdd import given, scenario, then, when
+
 from autoresearch.config.models import ConfigModel
 from autoresearch.llm import DummyAdapter
+from autoresearch.orchestration.orchestration_utils import OrchestrationUtils
+from tests.behavior.context import (
+    BehaviorContext,
+    get_config,
+    get_orchestrator,
+    set_value,
+)
+
+
+@dataclass(slots=True)
+class OrchestratorScenarioContext:
+    """Typed container for sharing state between behavior steps."""
+
+    config: ConfigModel | None = None
+    agents: list[str] = field(default_factory=list)
+    executed_agents: list[str] = field(default_factory=list)
+    agent_states: dict[str, Any] = field(default_factory=dict)
+    result: Any | None = None
+    errors: list[tuple[str, Exception]] = field(default_factory=list)
+    exception: Exception | None = None
+    original_execute_agent: Callable[..., Any] | None = None
+    original_handle_error: Callable[..., Any] | None = None
+    original_get: Callable[..., Any] | None = None
 
 
 # Fixtures
-@pytest.fixture
-def test_context():
-    """Create a context for storing test state."""
-    return {
-        "config": None,
-        "agents": [],
-        "executed_agents": [],
-        "agent_states": {},
-        "result": None,
-        "errors": [],
-    }
 
 
 @pytest.fixture
-def mock_agent_factory():
+def test_context() -> OrchestratorScenarioContext:
+    """Create a typed context for storing scenario state."""
+
+    return OrchestratorScenarioContext()
+
+
+@pytest.fixture
+def mock_agent_factory() -> MagicMock:
     """Create a mock agent factory for testing."""
-    factory = MagicMock()
-    agents = {}
 
-    def get_agent(name):
+    factory: MagicMock = MagicMock()
+    agents: dict[str, MagicMock] = {}
+
+    def get_agent(name: str) -> MagicMock:
         if name not in agents:
             agent = MagicMock()
             agent.name = name
@@ -52,83 +75,100 @@ def mock_agent_factory():
 
 
 # Scenarios
+
+
 @scenario(
     "../features/orchestrator_agents_integration.feature",
     "Orchestrator executes agents in the correct order",
 )
-def test_orchestrator_executes_agents_in_order():
+def test_orchestrator_executes_agents_in_order() -> None:
     """Test that the orchestrator executes agents in the correct order."""
-    pass
 
 
 @scenario(
     "../features/orchestrator_agents_integration.feature",
     "Orchestrator handles agent errors gracefully",
 )
-def test_orchestrator_handles_agent_errors():
+def test_orchestrator_handles_agent_errors() -> None:
     """Test that the orchestrator handles agent errors gracefully."""
-    pass
 
 
 @scenario(
     "../features/orchestrator_agents_integration.feature",
     "Orchestrator respects agent execution conditions",
 )
-def test_orchestrator_respects_agent_conditions():
+def test_orchestrator_respects_agent_conditions() -> None:
     """Test that the orchestrator respects agent execution conditions."""
-    pass
 
 
 # Background steps
+
+
 @given("the system is configured with multiple agents")
-def system_configured_with_multiple_agents(test_context):
+def system_configured_with_multiple_agents(
+    test_context: OrchestratorScenarioContext,
+    bdd_context: BehaviorContext,
+) -> None:
     """Configure the system with multiple agents."""
-    test_context["config"] = ConfigModel(
+
+    config = ConfigModel(
         agents=["Synthesizer", "Contrarian", "FactChecker"],
         reasoning_mode="dialectical",
         loops=1,
         llm_backend="dummy",
         default_model="dummy-model",
     )
-    test_context["agents"] = ["Synthesizer", "Contrarian", "FactChecker"]
+    test_context.config = config
+    test_context.agents = ["Synthesizer", "Contrarian", "FactChecker"]
+    set_value(bdd_context, "config", config)
 
 
 @given("the system is using a dummy LLM adapter for testing")
-def system_using_dummy_llm_adapter(monkeypatch):
+def system_using_dummy_llm_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
     """Configure the system to use a dummy LLM adapter."""
-    monkeypatch.setattr("autoresearch.llm.get_llm_adapter", lambda name: DummyAdapter())
+
+    monkeypatch.setattr(
+        "autoresearch.llm.get_llm_adapter", lambda name: DummyAdapter()
+    )
 
 
 # Scenario: Orchestrator executes agents in the correct order
-@when("I run a query with the dialectical reasoning mode")
-def run_query_with_dialectical_reasoning(test_context, mock_agent_factory, monkeypatch):
-    """Run a query with the dialectical reasoning mode."""
-    # Store original functions for cleanup verification
-    test_context["original_execute_agent"] = OrchestrationUtils.execute_agent
 
-    # Track executed agents
+
+@when("I run a query with the dialectical reasoning mode")
+def run_query_with_dialectical_reasoning(
+    test_context: OrchestratorScenarioContext,
+    mock_agent_factory: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+) -> None:
+    """Run a query with the dialectical reasoning mode."""
+
+    test_context.original_execute_agent = OrchestrationUtils.execute_agent
+
     original_get = mock_agent_factory.get
 
-    def get_and_track(name):
+    def get_and_track(name: str) -> MagicMock:
         agent = original_get(name)
-        test_context["executed_agents"].append(name)
+        test_context.executed_agents.append(name)
         return agent
 
     mock_agent_factory.get.side_effect = get_and_track
 
-    # Track agent states
     def execute_and_track_state(
-        agent_name,
-        state,
-        config,
-        metrics,
-        callbacks,
-        agent_factory,
-        storage_manager,
-        loop,
-    ):
-        test_context["agent_states"][agent_name] = state.copy()
-        return test_context["original_execute_agent"](
+        agent_name: str,
+        state: Any,
+        config: ConfigModel,
+        metrics: Any,
+        callbacks: Any,
+        agent_factory: Any,
+        storage_manager: Any,
+        loop: int,
+    ) -> Any:
+        test_context.agent_states[agent_name] = state.copy()
+        if test_context.original_execute_agent is None:
+            raise AssertionError("Original execute_agent reference missing")
+        return test_context.original_execute_agent(
             agent_name,
             state,
             config,
@@ -139,72 +179,95 @@ def run_query_with_dialectical_reasoning(test_context, mock_agent_factory, monke
             loop,
         )
 
-    # Use monkeypatch for automatic cleanup
     monkeypatch.setattr(OrchestrationUtils, "execute_agent", execute_and_track_state)
 
-    # Run the query using a context manager for proper cleanup
+    orchestrator = get_orchestrator(bdd_context)
+    config = get_config(bdd_context)
+
     with patch(
         "autoresearch.orchestration.orchestrator.AgentFactory", mock_agent_factory
     ):
         try:
-            test_context["result"] = Orchestrator.run_query(
-                "test query", test_context["config"]
-            )
-        except Exception as e:
-            test_context["exception"] = e
-            # Store the exception as the result for testing
-            test_context["result"] = {"error": str(e)}
+            test_context.result = orchestrator.run_query("test query", config)
+        except Exception as exc:  # noqa: BLE001
+            test_context.exception = exc
+            test_context.result = {"error": str(exc)}
 
 
 @then("the agents should be executed in the correct sequence")
-def agents_executed_in_correct_sequence(test_context):
+def agents_executed_in_correct_sequence(
+    test_context: OrchestratorScenarioContext,
+) -> None:
     """Verify that agents were executed in the correct sequence."""
-    # Surface any error captured during execution
-    if "exception" in test_context:
-        raise test_context["exception"]
 
-    expected_sequence = test_context["agents"]
-    assert test_context["executed_agents"] == expected_sequence
+    if test_context.exception is not None:
+        raise test_context.exception
+
+    assert test_context.executed_agents == test_context.agents
 
 
 @then("each agent should receive the state from previous agents")
-def agents_receive_state_from_previous(test_context):
+def agents_receive_state_from_previous(
+    test_context: OrchestratorScenarioContext,
+) -> None:
     """Verify that each agent received the state from previous agents."""
-    # Surface any error captured during execution
-    if "exception" in test_context:
-        raise test_context["exception"]
 
-    for i, agent_name in enumerate(test_context["executed_agents"]):
-        if i > 0:
-            prev_agent = test_context["executed_agents"][i - 1]
-            assert prev_agent in str(test_context["agent_states"][agent_name])
+    if test_context.exception is not None:
+        raise test_context.exception
+
+    for index, agent_name in enumerate(test_context.executed_agents):
+        if index == 0:
+            continue
+        previous_agent = test_context.executed_agents[index - 1]
+        agent_state = test_context.agent_states.get(agent_name)
+        assert agent_state is not None
+        assert previous_agent in str(agent_state)
 
 
 @then("the final result should include contributions from all agents")
-def result_includes_all_agent_contributions(test_context):
+def result_includes_all_agent_contributions(
+    test_context: OrchestratorScenarioContext,
+) -> None:
     """Verify that the final result includes contributions from all agents."""
-    # Surface any error captured during execution
-    if "exception" in test_context:
-        raise test_context["exception"]
 
-    for agent_name in test_context["agents"]:
-        assert agent_name in str(test_context["result"])
+    if test_context.exception is not None:
+        raise test_context.exception
+
+    for agent_name in test_context.agents:
+        assert agent_name in str(test_context.result)
 
 
 # Scenario: Orchestrator handles agent errors gracefully
+
+
 @given("an agent that will raise an error")
-def agent_that_raises_error(mock_agent_factory, test_context):
+def agent_that_raises_error(
+    mock_agent_factory: MagicMock,
+    test_context: OrchestratorScenarioContext,
+    bdd_context: BehaviorContext,
+) -> None:
     """Configure an agent that will raise an error when executed."""
+
     error_agent = MagicMock()
     error_agent.name = "ErrorAgent"
     error_agent.can_execute.return_value = True
     error_agent.execute.side_effect = ValueError("Test error")
 
-    mock_agent_factory.get.side_effect = (
-        lambda name: error_agent if name == "ErrorAgent" else MagicMock()
-    )
+    def get_agent(name: str) -> MagicMock:
+        if name == "ErrorAgent":
+            return error_agent
+        agent = MagicMock()
+        agent.name = name
+        agent.can_execute.return_value = True
+        agent.execute.return_value = {
+            "agent": name,
+            "result": f"Result from {name}",
+        }
+        return agent
 
-    test_context["config"] = ConfigModel(
+    mock_agent_factory.get.side_effect = get_agent
+
+    config = ConfigModel(
         agents=["ErrorAgent", "Synthesizer"],
         reasoning_mode="direct",
         loops=1,
@@ -212,153 +275,187 @@ def agent_that_raises_error(mock_agent_factory, test_context):
         llm_backend="dummy",
         default_model="dummy-model",
     )
+    test_context.config = config
+    set_value(bdd_context, "config", config)
 
 
 @when("I run a query with that agent")
-def run_query_with_error_agent(test_context, mock_agent_factory, monkeypatch):
+def run_query_with_error_agent(
+    test_context: OrchestratorScenarioContext,
+    mock_agent_factory: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    bdd_context: BehaviorContext,
+) -> None:
     """Run a query with the error-raising agent."""
-    # Store original functions for cleanup verification
-    test_context["original_handle_error"] = OrchestrationUtils.handle_agent_error
 
-    # Track errors
-    def handle_and_track_error(self, error, agent_name, state, config):
-        test_context["errors"].append((agent_name, error))
-        return test_context["original_handle_error"](
+    test_context.original_handle_error = OrchestrationUtils.handle_agent_error
+
+    def handle_and_track_error(
+        self: OrchestrationUtils,
+        error: Exception,
+        agent_name: str,
+        state: Any,
+        config: ConfigModel,
+    ) -> None:
+        test_context.errors.append((agent_name, error))
+        if test_context.original_handle_error is None:
+            raise AssertionError("Original handle_agent_error reference missing")
+        return test_context.original_handle_error(
             self, error, agent_name, state, config
         )
 
-    # Use monkeypatch for automatic cleanup
     monkeypatch.setattr(OrchestrationUtils, "handle_agent_error", handle_and_track_error)
 
-    # Run the query using a context manager for proper cleanup
+    orchestrator = get_orchestrator(bdd_context)
+    config = get_config(bdd_context)
+
     with patch(
         "autoresearch.orchestration.orchestrator.AgentFactory", mock_agent_factory
     ):
         try:
-            test_context["result"] = Orchestrator.run_query(
-                "test query", test_context["config"]
-            )
-        except Exception as e:
-            test_context["exception"] = e
+            test_context.result = orchestrator.run_query("test query", config)
+        except Exception as exc:  # noqa: BLE001
+            test_context.exception = exc
 
 
 @then("the orchestrator should catch and log the error")
-def orchestrator_catches_and_logs_error(test_context):
+def orchestrator_catches_and_logs_error(
+    test_context: OrchestratorScenarioContext,
+) -> None:
     """Verify that the orchestrator caught and logged the error."""
-    # If the error was caught by _handle_agent_error, it will be in the errors list
-    if len(test_context["errors"]) > 0:
-        assert "ErrorAgent" == test_context["errors"][0][0]
-        assert "Test error" in str(test_context["errors"][0][1])
-    # If the error was not caught by _handle_agent_error, it will be in the exception
-    elif "exception" in test_context:
-        assert "error" in str(test_context["exception"]).lower()
-    # If neither, the test fails
+
+    if test_context.errors:
+        agent_name, error = test_context.errors[0]
+        assert agent_name == "ErrorAgent"
+        assert "Test error" in str(error)
+    elif test_context.exception is not None:
+        assert "error" in str(test_context.exception).lower()
     else:
-        assert False, "No error was caught or logged"
+        raise AssertionError("No error was caught or logged")
 
 
 @then("the orchestrator should continue with other agents if possible")
-def orchestrator_continues_with_other_agents(test_context):
+def orchestrator_continues_with_other_agents(
+    test_context: OrchestratorScenarioContext,
+) -> None:
     """Verify that the orchestrator continued with other agents after an error."""
-    # This depends on the max_errors configuration
-    if "exception" not in test_context:
-        assert "Synthesizer" in str(test_context["result"])
+
+    if test_context.exception is None:
+        assert "Synthesizer" in str(test_context.result)
 
 
 @then("the final result should include information about the error")
-def result_includes_error_information(test_context):
+def result_includes_error_information(
+    test_context: OrchestratorScenarioContext,
+) -> None:
     """Verify that the final result includes information about the error."""
-    if "exception" not in test_context:
-        assert "error" in str(test_context["result"]).lower()
+
+    if test_context.exception is None:
+        assert "error" in str(test_context.result).lower()
 
 
 # Scenario: Orchestrator respects agent execution conditions
+
+
 @given("an agent that can only execute under specific conditions")
-def agent_with_specific_execution_conditions(mock_agent_factory, test_context):
+def agent_with_specific_execution_conditions(
+    mock_agent_factory: MagicMock,
+    test_context: OrchestratorScenarioContext,
+    bdd_context: BehaviorContext,
+) -> None:
     """Configure an agent that can only execute under specific conditions."""
+
     conditional_agent = MagicMock()
     conditional_agent.name = "ConditionalAgent"
-    conditional_agent.can_execute.return_value = False  # This agent can't execute
+    conditional_agent.can_execute.return_value = False
 
-    def get_agent(name):
+    def get_agent(name: str) -> MagicMock:
         if name == "ConditionalAgent":
             return conditional_agent
-        else:
-            agent = MagicMock()
-            agent.name = name
-            agent.can_execute.return_value = True
-            agent.execute.return_value = {
-                "agent": name,
-                "result": f"Result from {name}",
-            }
-            return agent
+        agent = MagicMock()
+        agent.name = name
+        agent.can_execute.return_value = True
+        agent.execute.return_value = {
+            "agent": name,
+            "result": f"Result from {name}",
+        }
+        return agent
 
     mock_agent_factory.get.side_effect = get_agent
 
-    test_context["config"] = ConfigModel(
+    config = ConfigModel(
         agents=["ConditionalAgent", "Synthesizer"],
         reasoning_mode="direct",
         loops=1,
         llm_backend="dummy",
         default_model="dummy-model",
     )
+    test_context.config = config
+    set_value(bdd_context, "config", config)
 
 
 @when("I run a query that doesn't meet those conditions")
-def run_query_not_meeting_conditions(test_context, mock_agent_factory, monkeypatch):
+def run_query_not_meeting_conditions(
+    test_context: OrchestratorScenarioContext,
+    mock_agent_factory: MagicMock,
+    bdd_context: BehaviorContext,
+) -> None:
     """Run a query that doesn't meet the conditions for the conditional agent."""
-    # Store original functions for cleanup verification
-    test_context["original_get"] = mock_agent_factory.get
 
-    # Track executed agents
-    def get_and_track(name):
-        agent = test_context["original_get"](name)
+    test_context.original_get = mock_agent_factory.get
+
+    def get_and_track(name: str) -> MagicMock:
+        if test_context.original_get is None:
+            raise AssertionError("Original agent factory getter missing")
+        agent = test_context.original_get(name)
         if agent.can_execute.return_value:
-            test_context["executed_agents"].append(name)
+            test_context.executed_agents.append(name)
         return agent
 
-    # Use side_effect for tracking
     mock_agent_factory.get.side_effect = get_and_track
 
-    # Run the query using a context manager for proper cleanup
+    orchestrator = get_orchestrator(bdd_context)
+    config = get_config(bdd_context)
+
     with patch(
         "autoresearch.orchestration.orchestrator.AgentFactory", mock_agent_factory
     ):
         try:
-            test_context["result"] = Orchestrator.run_query(
-                "test query", test_context["config"]
-            )
-        except Exception as e:
-            test_context["exception"] = e
-            # Store the exception as the result for testing
-            test_context["result"] = {"error": str(e)}
+            test_context.result = orchestrator.run_query("test query", config)
+        except Exception as exc:  # noqa: BLE001
+            test_context.exception = exc
+            test_context.result = {"error": str(exc)}
 
 
 @then("that agent should not be executed")
-def agent_not_executed(test_context):
+def agent_not_executed(test_context: OrchestratorScenarioContext) -> None:
     """Verify that the conditional agent was not executed."""
-    # Surface any error captured during execution
-    if "exception" in test_context:
-        raise test_context["exception"]
 
-    assert "ConditionalAgent" not in test_context["executed_agents"]
+    if test_context.exception is not None:
+        raise test_context.exception
+
+    assert "ConditionalAgent" not in test_context.executed_agents
 
 
 @then("the orchestrator should continue with other agents")
-def orchestrator_continues_with_other_agents_after_skip(test_context):
+def orchestrator_continues_with_other_agents_after_skip(
+    test_context: OrchestratorScenarioContext,
+) -> None:
     """Verify that the orchestrator continued with other agents after skipping one."""
-    # Surface any error captured during execution
-    if "exception" in test_context:
-        raise test_context["exception"]
 
-    assert "Synthesizer" in test_context["executed_agents"]
+    if test_context.exception is not None:
+        raise test_context.exception
+
+    assert "Synthesizer" in test_context.executed_agents
 
 
 @then("the final result should not include contributions from the skipped agent")
-def result_excludes_skipped_agent_contributions(test_context):
+def result_excludes_skipped_agent_contributions(
+    test_context: OrchestratorScenarioContext,
+) -> None:
     """Verify that the final result doesn't include contributions from the skipped agent."""
-    # Surface any error captured during execution
-    if "exception" in test_context:
-        raise test_context["exception"]
 
-    assert "ConditionalAgent" not in str(test_context["result"])
+    if test_context.exception is not None:
+        raise test_context.exception
+
+    assert "ConditionalAgent" not in str(test_context.result)


### PR DESCRIPTION
## Summary
- replace the mutable dict test context in the orchestrator/agents behavior steps with a typed dataclass and move config access through the shared behavior context helpers
- update messaging behavior steps to retrieve configurations via `get_config` before running orchestrator queries

## Testing
- python -m compileall tests/behavior/steps/agent_messages_steps.py tests/behavior/steps/orchestrator_agents_integration_steps.py

------
https://chatgpt.com/codex/tasks/task_e_68ddbcb1b22c8333a019471cf27e210a