### PR TITLE
Refine distributed execution behavior steps with typed context

### DIFF
--- a/tests/behavior/steps/distributed_execution_steps.py
+++ b/tests/behavior/steps/distributed_execution_steps.py
@@ -1,17 +1,46 @@
 """Step definitions for distributed execution feature."""
 
-import os
+from __future__ import annotations
+
 import importlib.util
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TypeAlias
 
 import pytest
-from pytest_bdd import scenario, given, when, then
+from pytest_bdd import given, scenario, then, when
 
-from autoresearch.distributed import RayExecutor, ProcessExecutor
 from autoresearch.config.models import ConfigModel, DistributedConfig, StorageConfig
-from autoresearch.storage import StorageManager
+from autoresearch.distributed import ProcessExecutor, RayExecutor
+from autoresearch.models import QueryResponse
 from autoresearch.orchestration.orchestrator import AgentFactory
 from autoresearch.orchestration.state import QueryState
-from autoresearch.models import QueryResponse
+from autoresearch.storage import StorageManager
+
+
+BehaviorContext: TypeAlias = dict[str, Any]
+ExecutorClass: TypeAlias = type[ProcessExecutor] | type[RayExecutor]
+
+
+@dataclass
+class DistributedArtifacts:
+    """Container for distributed execution state shared across steps."""
+
+    config: ConfigModel
+    executor_cls: ExecutorClass
+    db_path: str
+    response: QueryResponse | None = None
+    pids: list[int] = field(default_factory=list)
+
+
+def _get_distributed_artifacts(bdd_context: BehaviorContext) -> DistributedArtifacts:
+    """Retrieve distributed execution artifacts from the behavior context."""
+
+    artifacts = bdd_context.get("distributed")
+    if not isinstance(artifacts, DistributedArtifacts):  # pragma: no cover - safety net
+        raise AssertionError("Distributed artifacts not configured")
+    return artifacts
 
 
 # Scenarios
@@ -33,13 +62,12 @@ def test_process_executor(bdd_context):
 
 # Fixtures and steps
 @pytest.fixture
-def pids(bdd_context):
-    bdd_context["pids"] = []
-    return bdd_context["pids"]
+def pids() -> list[int]:
+    return []
 
 
 @given("mock agents that persist claims")
-def mock_agents(monkeypatch, pids):
+def mock_agents(monkeypatch: pytest.MonkeyPatch, pids: list[int]) -> None:
     class ClaimAgent:
         def __init__(self, name: str, pid_list: list[int]):
             self.name = name
@@ -48,7 +76,12 @@ def mock_agents(monkeypatch, pids):
         def can_execute(self, state: QueryState, config: ConfigModel) -> bool:  # pragma: no cover - dummy
             return True
 
-        def execute(self, state: QueryState, config: ConfigModel, **_: object) -> dict:
+        def execute(
+            self,
+            state: QueryState,
+            config: ConfigModel,
+            **_: object,
+        ) -> dict[str, Any]:
             self._pids.append(os.getpid())
             claim = {"id": self.name, "type": "fact", "content": self.name}
             StorageManager.persist_claim(claim)
@@ -59,7 +92,7 @@ def mock_agents(monkeypatch, pids):
 
 
 @given("a distributed configuration using Ray")
-def config_ray(tmp_path, bdd_context, monkeypatch):
+def config_ray(tmp_path: Path, bdd_context: BehaviorContext, pids: list[int]) -> None:
     if importlib.util.find_spec("ray") is None:
         pytest.skip("Ray not installed")
     if not os.getenv("ENABLE_DISTRIBUTED_TESTS"):
@@ -75,11 +108,16 @@ def config_ray(tmp_path, bdd_context, monkeypatch):
     import ray as ray_module
     if not hasattr(ray_module, "put"):
         pytest.skip("Ray not available in test environment")
-    bdd_context.update({"cfg": cfg, "executor_cls": RayExecutor, "db_path": cfg.storage.duckdb_path})
+    bdd_context["distributed"] = DistributedArtifacts(
+        config=cfg,
+        executor_cls=RayExecutor,
+        db_path=cfg.storage.duckdb_path,
+        pids=pids,
+    )
 
 
 @given("a distributed configuration using multiprocessing")
-def config_process(tmp_path, bdd_context):
+def config_process(tmp_path: Path, bdd_context: BehaviorContext, pids: list[int]) -> None:
     if not os.getenv("ENABLE_DISTRIBUTED_TESTS"):
         pytest.skip("Distributed tests are disabled")
     cfg = ConfigModel(
@@ -89,30 +127,35 @@ def config_process(tmp_path, bdd_context):
         distributed_config=DistributedConfig(enabled=True, num_cpus=2, message_broker="memory"),
         storage=StorageConfig(duckdb_path=str(tmp_path / "kg.duckdb")),
     )
-    bdd_context.update({"cfg": cfg, "executor_cls": ProcessExecutor, "db_path": cfg.storage.duckdb_path})
+    bdd_context["distributed"] = DistributedArtifacts(
+        config=cfg,
+        executor_cls=ProcessExecutor,
+        db_path=cfg.storage.duckdb_path,
+        pids=pids,
+    )
 
 
 @when("I run a distributed query")
-def run_distributed_query(bdd_context):
-    cfg = bdd_context["cfg"]
-    executor_cls = bdd_context["executor_cls"]
-    executor = executor_cls(cfg)
+def run_distributed_query(bdd_context: BehaviorContext) -> None:
+    artifacts = _get_distributed_artifacts(bdd_context)
+    executor = artifacts.executor_cls(artifacts.config)
     resp = executor.run_query("q")
     assert isinstance(resp, QueryResponse)
     os.environ["RAY_IGNORE_UNHANDLED_ERRORS"] = "1"
     executor.shutdown()
-    bdd_context["response"] = resp
+    artifacts.response = resp
 
 
 @then("the claims should be persisted for each agent")
-def claims_persisted(bdd_context):
-    StorageManager.setup(bdd_context["db_path"])
+def claims_persisted(bdd_context: BehaviorContext) -> None:
+    artifacts = _get_distributed_artifacts(bdd_context)
+    StorageManager.setup(artifacts.db_path)
     conn = StorageManager.get_duckdb_conn()
     rows = conn.execute("SELECT id FROM nodes ORDER BY id").fetchall()
     assert [r[0] for r in rows] == ["A", "B"]
 
 
 @then("more than one process should execute")
-def multiple_processes_used(bdd_context):
-    pids = bdd_context.get("pids", [])
-    assert len(set(pids)) > 1
+def multiple_processes_used(bdd_context: BehaviorContext) -> None:
+    artifacts = _get_distributed_artifacts(bdd_context)
+    assert len(set(artifacts.pids)) > 1


### PR DESCRIPTION
## Summary
- introduce a `DistributedArtifacts` dataclass to store shared distributed execution state in behavior tests
- update fixtures and steps to rely on the typed container instead of raw dictionary keys
- tighten helper annotations for mock agents to satisfy mypy strict expectations

## Testing
- `uv run --extra test pytest tests/behavior/steps/distributed_execution_steps.py`


------
https://chatgpt.com/codex/tasks/task_e_68ddbe53e3f88333a15be2a6cc334e0b