### PR TITLE
Finalize behavior typing and AUTO reasoning regression suite

### DIFF
--- a/tests/behavior/steps/common_steps.py
+++ b/tests/behavior/steps/common_steps.py
@@ -154,6 +154,15 @@ def isolate_network(monkeypatch: pytest.MonkeyPatch) -> TypedFixture[None]:
     return None
 
 
+@pytest.fixture(name="_isolate_network")
+def alias_isolate_network(
+    isolate_network: TypedFixture[None],
+) -> TypedFixture[None]:
+    """Provide a backwards-compatible alias for the network isolation fixture."""
+
+    return isolate_network
+
+
 @pytest.fixture
 def restore_environment() -> TypedFixture[None]:
     """Snapshot ``os.environ`` and restore it after the test."""
@@ -165,6 +174,15 @@ def restore_environment() -> TypedFixture[None]:
         os.environ.clear()
         os.environ.update(original)
     return None
+
+
+@pytest.fixture(name="_restore_environment")
+def alias_restore_environment(
+    restore_environment: TypedFixture[None],
+) -> TypedFixture[None]:
+    """Expose ``restore_environment`` under a private fixture name."""
+
+    return restore_environment
 
 
 def assert_cli_success(result: Result) -> None:

--- a/tests/behavior/steps/error_recovery_workflow_steps.py
+++ b/tests/behavior/steps/error_recovery_workflow_steps.py
@@ -1,4 +1,3 @@
-from pytest_bdd import given, when, then, scenarios, parsers
 from __future__ import annotations
 
 from typing import Any, TypedDict

--- a/tests/behavior/steps/hybrid_search_steps.py
+++ b/tests/behavior/steps/hybrid_search_steps.py
@@ -1,4 +1,3 @@
-from pytest_bdd import parsers, scenario, then, when
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/behavior/steps/orchestration_system_steps.py
+++ b/tests/behavior/steps/orchestration_system_steps.py
@@ -1,12 +1,10 @@
-from pytest_bdd import scenario, given, when, then
-import pytest
 from __future__ import annotations
 
 from typing import Any, Callable, MutableMapping, cast
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pytest_bdd import given, scenario, then, when
-from unittest.mock import MagicMock, patch
 
 from autoresearch.config.models import ConfigModel
 from autoresearch.models import QueryResponse

--- a/tests/behavior/steps/ui_accessibility_steps.py
+++ b/tests/behavior/steps/ui_accessibility_steps.py
@@ -1,16 +1,12 @@
-from pytest_bdd import scenario, given, when, then, parsers
-from unittest.mock import patch
-import pytest
-
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Callable, cast
+from unittest.mock import MagicMock, patch
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from pytest_bdd import given, parsers, scenario, then, when
-from unittest.mock import MagicMock, patch
 
 from autoresearch.cli_utils import format_error, format_info, format_success
 

--- a/tests/behavior/steps/visualization_cli_steps.py
+++ b/tests/behavior/steps/visualization_cli_steps.py
@@ -1,18 +1,13 @@
-from pathlib import Path
-from pytest_bdd import scenario, when, then
-
-from autoresearch.main import app as cli_app
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Protocol, cast
 
 from _pytest.monkeypatch import MonkeyPatch
 from pytest_bdd import scenario, then, when
-from typing import Protocol, cast
 from typer.testing import CliRunner
 
 from autoresearch.main import app as cli_app
-
 from tests.behavior.context import BehaviorContext, get_cli_result, set_cli_result
 
 

--- a/tests/helpers/config.py
+++ b/tests/helpers/config.py
@@ -11,8 +11,11 @@ structure produced by :meth:`ConfigModelStub.model_dump`.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from copy import copy, deepcopy
 from dataclasses import dataclass, field
 from typing import Optional, TypedDict
+
+from autoresearch.orchestration import ReasoningMode
 
 
 class ContextAwareSearchConfigDump(TypedDict):
@@ -43,6 +46,9 @@ class ConfigModelDump(TypedDict):
     search: SearchConfigDump
     gate_graph_contradiction_threshold: float
     gate_graph_similarity_threshold: float
+    agents: list[str]
+    reasoning_mode: Optional[str]
+    llm_backend: str
 
 
 ContextOverrideValue = bool | float | int
@@ -81,6 +87,9 @@ class ConfigModelStub:
     search: SearchConfigStub = field(default_factory=SearchConfigStub)
     gate_graph_contradiction_threshold: float = 0.25
     gate_graph_similarity_threshold: float = 0.0
+    agents: list[str] = field(default_factory=list)
+    reasoning_mode: ReasoningMode | None = None
+    llm_backend: str = "lmstudio"
 
     def model_dump(self) -> ConfigModelDump:
         """Return a dictionary representation mirroring ``BaseModel``."""
@@ -115,7 +124,19 @@ class ConfigModelStub:
                 self.gate_graph_contradiction_threshold
             ),
             "gate_graph_similarity_threshold": self.gate_graph_similarity_threshold,
+            "agents": list(self.agents),
+            "reasoning_mode": (
+                self.reasoning_mode.value
+                if isinstance(self.reasoning_mode, ReasoningMode)
+                else self.reasoning_mode
+            ),
+            "llm_backend": self.llm_backend,
         }
+
+    def model_copy(self, *, deep: bool = False) -> ConfigModelStub:
+        """Mimic ``BaseModel.model_copy`` for orchestration helpers."""
+
+        return deepcopy(self) if deep else copy(self)
 
 
 def make_context_aware_config(


### PR DESCRIPTION
## Summary
- record evaluation behavior telemetry via the captured Rich tables and tolerate truncated run IDs
- align AUTO CLI TLDR expectations with the updated caution messaging and add a reasoning-mode Given step
- extend the ConfigModelStub with agent metadata, llm backend details, and a model_copy helper used by orchestrator state snapshots

## Testing
- uv run --extra test pytest tests/behavior -m "not requires_distributed and not requires_llm"
- uv run mypy --strict tests/behavior

------
https://chatgpt.com/codex/tasks/task_e_68ddf2a95ae48333af315ec607061559