### PR TITLE
Ensure storage loader respects deterministic resident default

### DIFF
--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -288,6 +288,10 @@ TestPyPI dry run. Pass `EXTRAS="gpu"` when GPU wheels are staged.
   【F:src/autoresearch/search/core.py†L705-L760】
   【F:src/autoresearch/orchestration/parallel.py†L145-L182】
   【F:tests/stubs/numpy.py†L12-L81】
+- [ ] Storage checklist:
+  - Document that the deterministic resident node floor stays at `2`
+    whenever release configs omit `minimum_deterministic_resident_nodes` so
+    reviewers confirm storage stability without extra overrides.
 - [x] Revalidated the DuckDB vector path now emits two search-phase instance
   lookups plus the direct-only pair (four calls total) while the legacy branch
   stays capped at the direct pair. The refreshed

--- a/src/autoresearch/config/loader.py
+++ b/src/autoresearch/config/loader.py
@@ -308,10 +308,12 @@ class ConfigLoader:
             "use_kuzu": storage_cfg.get("use_kuzu", False),
             "kuzu_path": storage_cfg.get("kuzu_path", "kuzu.db"),
             "deterministic_node_budget": storage_cfg.get("deterministic_node_budget"),
-            "minimum_deterministic_resident_nodes": storage_cfg.get(
-                "minimum_deterministic_resident_nodes"
-            ),
         }
+        minimum_resident_nodes = storage_cfg.get("minimum_deterministic_resident_nodes")
+        if minimum_resident_nodes is not None:
+            storage_settings[
+                "minimum_deterministic_resident_nodes"
+            ] = minimum_resident_nodes
         _merge_dict(storage_settings, storage_env)
 
         api_section = raw.get("api", {})

--- a/tests/unit/config/test_loader_types.py
+++ b/tests/unit/config/test_loader_types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from unittest.mock import patch
 
@@ -49,6 +50,24 @@ def test_env_storage_override_round_trips(tmp_path: Path, monkeypatch: pytest.Mo
 
     assert config.storage.vector_nprobe == 5
     assert config.storage.ontology_reasoner == "owlrl"
+
+
+def test_storage_defaults(tmp_path: Path) -> None:
+    """Loading a minimal config should keep storage defaults intact."""
+
+    config_path = tmp_path / "autoresearch.toml"
+    config_path.write_text("[core]\nloops = 1\n")
+
+    loader = ConfigLoader.new_for_tests(search_paths=[config_path])
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            config = loader.load_config()
+    finally:
+        ConfigLoader.reset_instance()
+
+    assert not caught
+    assert config.storage.minimum_deterministic_resident_nodes == 2
 
 
 def test_normalize_ranking_weights_balances_missing_values() -> None:


### PR DESCRIPTION
## Summary
- avoid overriding the storage model's `minimum_deterministic_resident_nodes` default unless the config sets it explicitly
- add a regression test that loads a minimal config and asserts the default remains 2 without emitting warnings
- document the deterministic resident node default in the release plan storage checklist

## Testing
- uv run --extra test pytest tests/unit/config/test_loader_types.py::test_storage_defaults
- uv run pytest tests/unit/config/test_loader_types.py::test_storage_defaults

------
https://chatgpt.com/codex/tasks/task_e_68de0225c2b88333bd855cf6c3fc9d6a