### PR TITLE
Type annotate behavior steps and payload helpers

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -31,6 +31,7 @@ from autoresearch.config.models import ConfigModel  # noqa: E402
 from autoresearch.orchestration.state import QueryState  # noqa: E402
 from autoresearch.storage import StorageContext, StorageManager  # noqa: E402
 from tests.behavior.context import BehaviorContext  # noqa: E402
+from tests.behavior.utils import ensure_dict  # noqa: E402
 from tests.conftest import reset_limiter_state, VSS_AVAILABLE  # noqa: E402
 from tests.typing_helpers import TypedFixture
 
@@ -61,6 +62,7 @@ pytest_plugins = (
     "pytest_bdd",
     "tests.behavior.fixtures",
     "tests.behavior.steps",
+    "tests.behavior.utils",
 )
 
 
@@ -98,7 +100,7 @@ def pytest_configure(config: pytest.Config) -> None:
 @pytest.fixture
 def test_context() -> TypedFixture[BehaviorContext]:
     """Mutable mapping for sharing state in behavior tests."""
-    return {}
+    return ensure_dict()
 
 
 @pytest.fixture

--- a/tests/behavior/steps/a2a_interface_steps.py
+++ b/tests/behavior/steps/a2a_interface_steps.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+from tests.behavior.context import BehaviorContext
 from pytest_bdd import scenario, when, then, parsers
 import requests
 import responses
@@ -9,7 +10,7 @@ A2A_URL = "http://a2a.example/message"
 
 
 @when(parsers.parse('I send a valid A2A query "{query}"'))
-def send_valid_a2a_query(query, bdd_context):
+def send_valid_a2a_query(query, bdd_context: BehaviorContext):
     with responses.RequestsMock() as rsps:
         rsps.post(
             A2A_URL,
@@ -21,7 +22,7 @@ def send_valid_a2a_query(query, bdd_context):
 
 
 @when("I send malformed JSON to the A2A interface")
-def send_malformed_json(bdd_context):
+def send_malformed_json(bdd_context: BehaviorContext):
     with responses.RequestsMock() as rsps:
         rsps.post(
             A2A_URL,
@@ -33,7 +34,7 @@ def send_malformed_json(bdd_context):
 
 
 @when("the A2A interface returns a server error")
-def send_server_error(bdd_context):
+def send_server_error(bdd_context: BehaviorContext):
     with responses.RequestsMock() as rsps:
         rsps.post(
             A2A_URL,
@@ -45,13 +46,13 @@ def send_server_error(bdd_context):
 
 
 @then(parsers.parse("the response status code should be {status:d}"))
-def check_status_code(status, bdd_context):
+def check_status_code(status, bdd_context: BehaviorContext):
     resp = bdd_context["a2a_response"]
     assert resp.status_code == status
 
 
 @then("the response should include a JSON message with an answer")
-def check_json_response(bdd_context):
+def check_json_response(bdd_context: BehaviorContext):
     resp = bdd_context["a2a_response"]
     data = resp.json()
     assert data.get("status") == "success"
@@ -60,7 +61,7 @@ def check_json_response(bdd_context):
 
 
 @then(parsers.parse('the error message should contain "{message}"'))
-def check_error_message(message, bdd_context):
+def check_error_message(message, bdd_context: BehaviorContext):
     resp = bdd_context["a2a_response"]
     data = resp.json()
     assert data.get("status") == "error"

--- a/tests/behavior/steps/a2a_mcp_integration_steps.py
+++ b/tests/behavior/steps/a2a_mcp_integration_steps.py
@@ -1,6 +1,7 @@
 """Step definitions for A2A MCP integration scenarios."""
 
 from __future__ import annotations
+from tests.behavior.utils import as_payload
 
 from unittest.mock import patch
 
@@ -23,7 +24,7 @@ def mock_server() -> FastMCP:
 
     @server.tool
     async def research(query: str) -> dict:
-        return {"answer": "42"}
+        return as_payload({"answer": "42"})
 
     yield server
     server.tools.clear()
@@ -76,7 +77,7 @@ def handshake_recovers(server: FastMCP, bdd_context: dict) -> None:
                 raise ConnectionError("temporary failure")
             if hasattr(self.target, "call_tool"):
                 return await self.target.call_tool(name, params)
-            return {}
+            return as_payload({})
 
     with patch("autoresearch.mcp_interface.Client", FlakyClient):
         with pytest.raises(ConnectionError):

--- a/tests/behavior/steps/agent_messages_steps.py
+++ b/tests/behavior/steps/agent_messages_steps.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from tests.behavior.utils import as_payload
 
 from pathlib import Path
 from typing import Any
@@ -29,7 +30,7 @@ class Sender(Agent):
 
     def execute(self, state: QueryState, config: ConfigModel) -> dict[str, Any]:
         self.send_message(state, "hi", to="Receiver")
-        return {}
+        return as_payload({})
 
 
 class Broadcaster(Agent):
@@ -38,7 +39,7 @@ class Broadcaster(Agent):
 
     def execute(self, state: QueryState, config: ConfigModel) -> dict[str, Any]:
         self.broadcast(state, "hello team", "team")
-        return {}
+        return as_payload({})
 
 
 class Receiver(Agent):
@@ -49,7 +50,7 @@ class Receiver(Agent):
         msgs = self.get_messages(state, from_agent="Sender")
         content = msgs[0].content if msgs else None
         state.results["received"] = content
-        return {}
+        return as_payload({})
 
 
 class TeamReceiver(Agent):
@@ -63,7 +64,7 @@ class TeamReceiver(Agent):
             protocol=MessageProtocol.BROADCAST,
         )
         state.results[self.name] = msgs[0].content if msgs else None
-        return {}
+        return as_payload({})
 
 
 @scenario(

--- a/tests/behavior/steps/agent_orchestration_steps.py
+++ b/tests/behavior/steps/agent_orchestration_steps.py
@@ -1,4 +1,6 @@
 # flake8: noqa
+from tests.behavior.utils import as_payload
+from typing import Any
 from unittest.mock import patch
 from pytest_bdd import scenario, given, when, then, parsers
 import logging
@@ -64,7 +66,7 @@ def run_orchestrator_on_query(query):
         except ValueError:
             cfg.reasoning_mode = ReasoningMode.DIALECTICAL
     record = []
-    config_params = {}
+    config_params: dict[str, Any] = {}
 
     class DummyAgent:
         def __init__(self, name):
@@ -75,7 +77,7 @@ def run_orchestrator_on_query(query):
 
         def execute(self, state, config):
             record.append(self.name)
-            return {}
+            return as_payload({})
 
     def get_agent(name):
         return DummyAgent(name)
@@ -97,7 +99,7 @@ def run_orchestrator_on_query(query):
         orch = Orchestrator()
         orch.run_query(query, cfg)
 
-    return {"record": record, "config_params": config_params}
+    return as_payload({"record": record, "config_params": config_params})
 
 
 @then(parsers.parse('the agents executed should be "{order}"'))
@@ -145,7 +147,7 @@ def submit_query_via_cli(query, monkeypatch, cli_runner):
             idx = len(agent_invocations)
             logger.info("%s executing (cycle %s)", self.name, idx)
             agent_invocations.append(self.name)
-            return {}
+            return as_payload({})
 
     def get_agent(name: str):
         return DummyAgent(name)
@@ -166,7 +168,7 @@ def submit_query_via_cli(query, monkeypatch, cli_runner):
     ):
         result = cli_runner.invoke(cli_app, ["search", query])
 
-    return {"result": result, "agent_invocations": agent_invocations}
+    return as_payload({"result": result, "agent_invocations": agent_invocations})
 
 
 @then(

--- a/tests/behavior/steps/agent_system_steps.py
+++ b/tests/behavior/steps/agent_system_steps.py
@@ -1,6 +1,8 @@
 """
 Step definitions for agent system feature.
 """
+from tests.behavior.utils import as_payload
+from typing import Any
 
 from pytest_bdd import scenario, given, when, then
 import pytest
@@ -51,7 +53,7 @@ def examine_their_code(have_multiple_agent_implementations):
     """Examine the code of multiple agent implementations."""
     agents = have_multiple_agent_implementations
     # Store the source code of each agent for later analysis
-    agent_sources = {}
+    agent_sources: dict[str, Any] = {}
     for agent_class in agents:
         agent_sources[agent_class.__name__] = inspect.getsource(agent_class)
     return agent_sources
@@ -286,7 +288,7 @@ def create_prompt_with_template(template_registry):
         "test.template", agent_name="TestAgent", variable="test value"
     )
 
-    return {"template": test_template, "rendered": rendered}
+    return as_payload({"template": test_template, "rendered": rendered})
 
 
 @pytest.fixture
@@ -395,7 +397,7 @@ def have_agent_specific_configuration():
         },
     }
 
-    return {"valid": valid_config, "invalid": invalid_config}
+    return as_payload({"valid": valid_config, "invalid": invalid_config})
 
 
 @pytest.fixture
@@ -419,7 +421,7 @@ def load_configuration(agent_configs):
     with pytest.raises(ValueError) as excinfo:
         AgentConfig(**invalid_config)
 
-    return {"valid_config": valid_config, "error": str(excinfo.value)}
+    return as_payload({"valid_config": valid_config, "error": str(excinfo.value)})
 
 
 @pytest.fixture

--- a/tests/behavior/steps/api_async_query_steps.py
+++ b/tests/behavior/steps/api_async_query_steps.py
@@ -1,6 +1,7 @@
 """Step definitions for asynchronous query API behavior tests."""
 
 from __future__ import annotations
+from tests.behavior.utils import as_payload
 
 import asyncio
 import time
@@ -267,12 +268,12 @@ def failing_async_query(failure: str, api_client, monkeypatch):
         )
     if not logs:
         logs.append(strategy_map[failure])
-    return {
+    return as_payload({
         "response": status,
         "recovery_info": recovery_info,
         "logs": logs,
         "state": state,
-    }
+    })
 
 
 @then(parsers.parse('a recovery strategy "{strategy}" should be recorded'))

--- a/tests/behavior/steps/api_auth_steps.py
+++ b/tests/behavior/steps/api_auth_steps.py
@@ -1,6 +1,7 @@
 """Step definitions for API authentication and rate limiting."""
 
 from __future__ import annotations
+from tests.behavior.utils import empty_metrics
 
 import importlib
 
@@ -71,7 +72,7 @@ def _install_orchestrator_stub(monkeypatch: pytest.MonkeyPatch) -> None:
             answer="ok",
             citations=[],
             reasoning=[],
-            metrics={},
+            metrics=empty_metrics(),
         )
 
     monkeypatch.setattr(Orchestrator, "run_query", _run_query_stub)

--- a/tests/behavior/steps/api_orchestrator_integration_steps.py
+++ b/tests/behavior/steps/api_orchestrator_integration_steps.py
@@ -4,6 +4,7 @@ This module contains step definitions for testing the integration between
 the API and orchestration system, including query forwarding, error handling,
 parameter handling, and concurrent request handling.
 """
+from tests.behavior.utils import as_payload
 
 import pytest
 import concurrent.futures
@@ -20,14 +21,14 @@ from autoresearch.errors import OrchestrationError
 @pytest.fixture
 def test_context():
     """Create a context for storing test state."""
-    return {
+    return as_payload({
         "client": None,
         "mock_orchestrator": None,
         "query": None,
         "response": None,
         "errors": [],
         "concurrent_responses": [],
-    }
+    })
 
 
 @pytest.fixture

--- a/tests/behavior/steps/api_streaming_webhook_steps.py
+++ b/tests/behavior/steps/api_streaming_webhook_steps.py
@@ -1,6 +1,7 @@
 """Step definitions for API streaming and webhook scenarios."""
 
 from __future__ import annotations
+from tests.behavior.utils import empty_metrics
 
 from dataclasses import dataclass
 import json
@@ -113,7 +114,7 @@ def send_query_with_webhook(
         Orchestrator,
         "run_query",
         lambda q, c, callbacks=None, **k: QueryResponse(
-            answer="ok", citations=[], reasoning=[], metrics={}
+            answer="ok", citations=[], reasoning=[], metrics=empty_metrics()
         ),
     )
     stats = WebhookStats(status_code=0, call_count=0)

--- a/tests/behavior/steps/backup_cli_steps.py
+++ b/tests/behavior/steps/backup_cli_steps.py
@@ -1,3 +1,5 @@
+from tests.behavior.context import BehaviorContext
+from tests.behavior.utils import backup_restore_result
 from pathlib import Path
 from datetime import datetime
 
@@ -34,7 +36,7 @@ def dummy_backup_file(work_dir, path):
 def run_backup_create(
     dir,
     cli_runner,
-    bdd_context,
+    bdd_context: BehaviorContext,
     monkeypatch,
     isolate_network,
     restore_environment,
@@ -70,7 +72,7 @@ def run_backup_create(
 def run_backup_list(
     dir,
     cli_runner,
-    bdd_context,
+    bdd_context: BehaviorContext,
     monkeypatch,
     isolate_network,
     restore_environment,
@@ -98,7 +100,7 @@ def run_backup_restore(
     path,
     dir,
     cli_runner,
-    bdd_context,
+    bdd_context: BehaviorContext,
     monkeypatch,
     isolate_network,
     restore_environment,
@@ -108,10 +110,10 @@ def run_backup_restore(
     monkeypatch.setattr(
         BackupManager,
         "restore_backup",
-        lambda backup_path, target_dir=None, db_filename="db.duckdb", rdf_filename="store.rdf": {
-            "db_path": "db.duckdb",
-            "rdf_path": "store.rdf",
-        },
+        lambda backup_path, target_dir=None, db_filename="db.duckdb", rdf_filename="store.rdf": backup_restore_result(
+            db_path="db.duckdb",
+            rdf_path="store.rdf",
+        ),
     )
     result = cli_runner.invoke(
         cli_app,
@@ -121,14 +123,14 @@ def run_backup_restore(
 
 
 @then("the backup directory should contain a backup file")
-def check_backup(bdd_context, work_dir):
+def check_backup(bdd_context: BehaviorContext, work_dir):
     backup_dir = work_dir / bdd_context["backup_dir"]
     assert backup_dir.exists() and any(backup_dir.iterdir())
     assert_cli_success(bdd_context["result"])
 
 
 @then("the CLI should exit successfully")
-def cli_success(bdd_context):
+def cli_success(bdd_context: BehaviorContext):
     assert_cli_success(bdd_context["result"])
 
 

--- a/tests/behavior/steps/capabilities_cli_steps.py
+++ b/tests/behavior/steps/capabilities_cli_steps.py
@@ -1,3 +1,4 @@
+from tests.behavior.context import BehaviorContext
 import sys
 import types
 
@@ -22,7 +23,7 @@ def capabilities_env(monkeypatch):
 
 
 @when("I run the capabilities command")
-def run_capabilities(cli_runner, bdd_context):
+def run_capabilities(cli_runner, bdd_context: BehaviorContext):
     result = cli_runner.invoke(cli_app, ["capabilities"])
     bdd_context["result"] = result
 

--- a/tests/behavior/steps/circuit_breaker_recovery_steps.py
+++ b/tests/behavior/steps/circuit_breaker_recovery_steps.py
@@ -1,6 +1,7 @@
 """Step definitions for circuit breaker recovery feature."""
 
 from __future__ import annotations
+from tests.behavior.utils import as_payload
 
 from pytest_bdd import given, parsers, scenarios, then, when
 
@@ -22,7 +23,7 @@ def breaker_fixture(threshold: int, cooldown: int) -> dict:
         return time_state["t"]
 
     mgr = CircuitBreakerManager(threshold=threshold, cooldown=cooldown, time_func=now)
-    return {"manager": mgr, "time": time_state}
+    return as_payload({"manager": mgr, "time": time_state})
 
 
 @when("three critical failures occur")

--- a/tests/behavior/steps/cli_options_steps.py
+++ b/tests/behavior/steps/cli_options_steps.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from tests.behavior.utils import empty_metrics
 
 from dataclasses import dataclass
 from typing import Callable
@@ -78,7 +79,7 @@ def _install_query_stub(
         storage_manager: object | None = None,
     ) -> QueryResponse:
         set_value(bdd_context, "captured_config", cfg)
-        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics=empty_metrics())
 
     monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: ConfigModel())
@@ -183,7 +184,7 @@ def run_parallel_cli(
         agent_groups: list[list[str]],
     ) -> QueryResponse:
         set_value(bdd_context, "captured_config", cfg)
-        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics=empty_metrics())
 
     monkeypatch.setattr(Orchestrator, "run_parallel_query", mock_parallel)
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: ConfigModel())

--- a/tests/behavior/steps/config_cli_steps.py
+++ b/tests/behavior/steps/config_cli_steps.py
@@ -1,3 +1,4 @@
+from tests.behavior.context import BehaviorContext
 from pytest_bdd import scenario, given, when, then, parsers
 
 from autoresearch.main import app as cli_app
@@ -21,7 +22,7 @@ def work_dir(tmp_path, monkeypatch):
 def run_config_init(
     work_dir,
     cli_runner,
-    bdd_context,
+    bdd_context: BehaviorContext,
     isolate_network,
     restore_environment,
 ):
@@ -30,7 +31,7 @@ def run_config_init(
 
 
 @when("I run `autoresearch config validate`")
-def run_config_validate(cli_runner, bdd_context, isolate_network, restore_environment):
+def run_config_validate(cli_runner, bdd_context: BehaviorContext, isolate_network, restore_environment):
     result = cli_runner.invoke(cli_app, ["config", "validate"])
     bdd_context["result"] = result
 
@@ -42,7 +43,7 @@ def run_config_validate(cli_runner, bdd_context, isolate_network, restore_enviro
 )
 def run_config_reasoning(
     cli_runner,
-    bdd_context,
+    bdd_context: BehaviorContext,
     mode: str,
     loops: int,
     isolate_network,
@@ -57,7 +58,7 @@ def run_config_reasoning(
 @when(parsers.parse('I run `autoresearch config reasoning --mode {mode}`'))
 def run_config_reasoning_mode_only(
     cli_runner,
-    bdd_context,
+    bdd_context: BehaviorContext,
     mode: str,
     isolate_network,
     restore_environment,
@@ -73,12 +74,12 @@ def check_config_files(work_dir):
 
 
 @then("the CLI should exit successfully")
-def cli_success(bdd_context):
+def cli_success(bdd_context: BehaviorContext):
     assert_cli_success(bdd_context["result"])
 
 
 @then("the CLI should exit with an error")
-def cli_error(bdd_context):
+def cli_error(bdd_context: BehaviorContext):
     assert_cli_error(bdd_context["result"])
 
 
@@ -95,7 +96,7 @@ def assert_loops(work_dir, loops: int):
 
 
 @then(parsers.parse('the error message should contain "{text}"'))
-def error_message_contains(bdd_context, text: str):
+def error_message_contains(bdd_context: BehaviorContext, text: str):
     exc = bdd_context["result"].exception
     assert exc is not None, "Expected an exception but none occurred"
     assert text in str(exc)

--- a/tests/behavior/steps/cross_modal_integration_steps.py
+++ b/tests/behavior/steps/cross_modal_integration_steps.py
@@ -1,3 +1,4 @@
+from tests.behavior.context import BehaviorContext
 from pytest_bdd import scenario, when, then, parsers, given
 from unittest.mock import patch
 import pytest
@@ -52,7 +53,7 @@ def test_mcp_interface_consistency():
 
 
 @when(parsers.parse('I execute a query "{query}" via CLI'))
-def execute_query_via_cli(bdd_context, query):
+def execute_query_via_cli(bdd_context: BehaviorContext, query):
     """Execute a query via CLI."""
     # Mock CLI query execution
     with patch("autoresearch.main.search") as mock_query_command:
@@ -75,7 +76,7 @@ def execute_query_via_cli(bdd_context, query):
 
 
 @when("I open the Streamlit GUI")
-def open_streamlit_gui(bdd_context):
+def open_streamlit_gui(bdd_context: BehaviorContext):
     """Open the Streamlit GUI."""
     # Mock Streamlit app
     initial_state: dict[str, object] = {}
@@ -98,7 +99,7 @@ def open_streamlit_gui(bdd_context):
 
 
 @then(parsers.parse('the query history should include "{query}"'))
-def check_query_history(bdd_context, query):
+def check_query_history(bdd_context: BehaviorContext, query):
     """Check that the query history includes the specified query."""
     # Get the session state
     session_state = bdd_context["streamlit_session"]
@@ -114,7 +115,7 @@ def check_query_history(bdd_context, query):
 
 
 @then("I should be able to rerun the query from the GUI")
-def check_rerun_query(bdd_context):
+def check_rerun_query(bdd_context: BehaviorContext):
     """Check that I can rerun the query from the GUI."""
     # Mock Streamlit button press
     with patch("streamlit.button", return_value=True):
@@ -139,7 +140,7 @@ def check_rerun_query(bdd_context):
 
 
 @then("the results should be consistent with the CLI results")
-def check_consistent_results(bdd_context):
+def check_consistent_results(bdd_context: BehaviorContext):
     """Check that the results are consistent between CLI and GUI."""
     cli_result = bdd_context["cli_result"]
     gui_result = bdd_context["gui_result"]
@@ -152,7 +153,7 @@ def check_consistent_results(bdd_context):
 
 
 @when("I execute an invalid query via CLI")
-def execute_invalid_query_cli(bdd_context):
+def execute_invalid_query_cli(bdd_context: BehaviorContext):
     """Execute an invalid query via CLI."""
     # Mock CLI query execution with an error
     with patch("autoresearch.main.search") as mock_query_command:
@@ -170,14 +171,14 @@ def execute_invalid_query_cli(bdd_context):
 
 
 @then("I should receive a specific error message")
-def check_cli_error_message(bdd_context):
+def check_cli_error_message(bdd_context: BehaviorContext):
     """Check that I receive a specific error message."""
     assert "cli_error" in bdd_context
     assert "Invalid query" in bdd_context["cli_error"]
 
 
 @when("I execute the same invalid query via GUI")
-def execute_invalid_query_gui(bdd_context):
+def execute_invalid_query_gui(bdd_context: BehaviorContext):
     """Execute the same invalid query via GUI."""
     # Mock Streamlit query execution with an error
     with patch(
@@ -194,14 +195,14 @@ def execute_invalid_query_gui(bdd_context):
 
 
 @then("I should receive the same error message in the GUI")
-def check_gui_error_message(bdd_context):
+def check_gui_error_message(bdd_context: BehaviorContext):
     """Check that I receive the same error message in the GUI."""
     assert "gui_error" in bdd_context
     assert bdd_context["cli_error"] == bdd_context["gui_error"]
 
 
 @when("I update the configuration via CLI")
-def update_config_via_cli(bdd_context):
+def update_config_via_cli(bdd_context: BehaviorContext):
     """Update the configuration via CLI."""
     from autoresearch.config.models import ConfigModel
     from autoresearch.config.loader import ConfigLoader
@@ -217,7 +218,7 @@ def update_config_via_cli(bdd_context):
 
 
 @then("the GUI should reflect the updated configuration")
-def check_gui_config(bdd_context):
+def check_gui_config(bdd_context: BehaviorContext):
     """Check that the GUI reflects the updated configuration."""
     # Mock Streamlit config display
     with patch("streamlit.json") as mock_json:
@@ -231,7 +232,7 @@ def check_gui_config(bdd_context):
 
 
 @when("I update the configuration via GUI")
-def update_config_via_gui(bdd_context):
+def update_config_via_gui(bdd_context: BehaviorContext):
     """Update the configuration via GUI."""
     from autoresearch.config.models import ConfigModel
     from autoresearch.config.loader import ConfigLoader
@@ -247,7 +248,7 @@ def update_config_via_gui(bdd_context):
 
 
 @when("I check the configuration via CLI")
-def check_config_via_cli(bdd_context):
+def check_config_via_cli(bdd_context: BehaviorContext):
     """Check the configuration via CLI."""
     # In the real CLI this would print the configuration. For testing
     # we simply expose the stored configuration.
@@ -255,13 +256,13 @@ def check_config_via_cli(bdd_context):
 
 
 @then("the CLI should show the updated configuration")
-def check_cli_config_updated(bdd_context):
+def check_cli_config_updated(bdd_context: BehaviorContext):
     """Check that the CLI shows the updated configuration."""
     assert bdd_context["cli_config"] == bdd_context["updated_config"]
 
 
 @when("I execute a query via the A2A interface")
-def execute_query_via_a2a(bdd_context):
+def execute_query_via_a2a(bdd_context: BehaviorContext):
     """Execute a query via the A2A interface."""
     from autoresearch.a2a_interface import A2AInterface
     from a2a.utils.message import new_agent_text_message
@@ -288,7 +289,7 @@ def execute_query_via_a2a(bdd_context):
 
 
 @then("the response format should match the CLI response format")
-def check_response_format(bdd_context):
+def check_response_format(bdd_context: BehaviorContext):
     """Check that the interface response format matches the CLI format."""
     cli_result = QueryResponse(
         answer="Paris is the capital of France.",
@@ -309,7 +310,7 @@ def check_response_format(bdd_context):
 
 
 @then("the response should contain the same fields as the GUI response")
-def check_response_fields(bdd_context):
+def check_response_fields(bdd_context: BehaviorContext):
     """Check that the response contains the same fields as the GUI response."""
     expected_fields = ["answer", "reasoning", "citations", "metrics"]
 
@@ -319,7 +320,7 @@ def check_response_fields(bdd_context):
 
 
 @then("the error handling should be consistent with other interfaces")
-def check_error_handling(bdd_context):
+def check_error_handling(bdd_context: BehaviorContext):
     """Ensure interface errors match CLI errors."""
     # Generate CLI error
     with patch("autoresearch.main.search") as mock_cli_query:
@@ -365,7 +366,7 @@ def check_error_handling(bdd_context):
 
 
 @when("I execute a query via the MCP interface")
-def execute_query_via_mcp(bdd_context):
+def execute_query_via_mcp(bdd_context: BehaviorContext):
     """Execute a query via the MCP interface."""
     # Mock MCP query execution
     with patch("autoresearch.mcp_interface.query") as mock_mcp_query:

--- a/tests/behavior/steps/data_analysis_steps.py
+++ b/tests/behavior/steps/data_analysis_steps.py
@@ -1,3 +1,4 @@
+from tests.behavior.context import BehaviorContext
 from pytest_bdd import given, then, when
 
 from autoresearch.data_analysis import metrics_dataframe
@@ -7,13 +8,13 @@ pl = import_or_skip("polars")
 
 
 @given("sample metrics")
-def sample_metrics(bdd_context) -> None:
+def sample_metrics(bdd_context: BehaviorContext) -> None:
     bdd_context["metrics"] = {"agent_timings": {"A": [1.0, 2.0]}}
 
 
 # Spec: docs/specs/data-analysis.md#polars-enabled
 @when("I generate metrics dataframe with Polars enabled")
-def generate_df_enabled(bdd_context) -> None:
+def generate_df_enabled(bdd_context: BehaviorContext) -> None:
     metrics = bdd_context["metrics"]
     bdd_context["result"] = metrics_dataframe(metrics, polars_enabled=True)
     bdd_context["error"] = None
@@ -21,7 +22,7 @@ def generate_df_enabled(bdd_context) -> None:
 
 # Spec: docs/specs/data-analysis.md#polars-disabled
 @when("I generate metrics dataframe with Polars disabled")
-def generate_df_disabled(bdd_context) -> None:
+def generate_df_disabled(bdd_context: BehaviorContext) -> None:
     metrics = bdd_context["metrics"]
     try:
         metrics_dataframe(metrics, polars_enabled=False)
@@ -34,13 +35,13 @@ def generate_df_disabled(bdd_context) -> None:
 
 # Spec: docs/specs/data-analysis.md#polars-enabled
 @then("a Polars dataframe should be returned")
-def assert_polars_dataframe(bdd_context) -> None:
+def assert_polars_dataframe(bdd_context: BehaviorContext) -> None:
     assert isinstance(bdd_context["result"], pl.DataFrame)
 
 
 # Spec: docs/specs/data-analysis.md#polars-disabled
 @then("the operation should fail with polars disabled error")
-def assert_polars_disabled_error(bdd_context) -> None:
+def assert_polars_disabled_error(bdd_context: BehaviorContext) -> None:
     assert bdd_context["result"] is None
     err = bdd_context.get("error")
     assert err is not None

--- a/tests/behavior/steps/distributed_execution_steps.py
+++ b/tests/behavior/steps/distributed_execution_steps.py
@@ -1,6 +1,8 @@
 """Step definitions for distributed execution feature."""
 
 from __future__ import annotations
+from tests.behavior.utils import as_payload
+from tests.behavior.context import BehaviorContext
 
 import importlib.util
 import os
@@ -47,7 +49,7 @@ def _get_distributed_artifacts(bdd_context: BehaviorContext) -> DistributedArtif
 @pytest.mark.slow
 @pytest.mark.requires_distributed
 @scenario("../features/distributed_execution.feature", "Run distributed query with Ray executor")
-def test_ray_executor(bdd_context):
+def test_ray_executor(bdd_context: BehaviorContext):
     """Run distributed query with Ray executor."""
     pass
 
@@ -55,7 +57,7 @@ def test_ray_executor(bdd_context):
 @pytest.mark.slow
 @pytest.mark.requires_distributed
 @scenario("../features/distributed_execution.feature", "Run distributed query with multiprocessing")
-def test_process_executor(bdd_context):
+def test_process_executor(bdd_context: BehaviorContext):
     """Run distributed query with multiprocessing."""
     pass
 
@@ -86,7 +88,7 @@ def mock_agents(monkeypatch: pytest.MonkeyPatch, pids: list[int]) -> None:
             claim = {"id": self.name, "type": "fact", "content": self.name}
             StorageManager.persist_claim(claim)
             state.update({"results": {self.name: "ok"}, "claims": [claim]})
-            return {"results": {self.name: "ok"}, "claims": [claim]}
+            return as_payload({"results": {self.name: "ok"}, "claims": [claim]})
 
     monkeypatch.setattr(AgentFactory, "get", lambda name: ClaimAgent(name, pids))
 

--- a/tests/behavior/steps/dkg_persistence_steps.py
+++ b/tests/behavior/steps/dkg_persistence_steps.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+from tests.behavior.context import BehaviorContext
 import pytest
 from pytest_bdd import scenario, given, when, then, parsers
 from unittest.mock import patch
@@ -269,7 +270,7 @@ def test_clear_dkg():
 
 
 @when("I try to persist the claim")
-def try_persist_invalid_claim(invalid_claim, bdd_context, storage_error_handler):
+def try_persist_invalid_claim(invalid_claim, bdd_context: BehaviorContext, storage_error_handler):
     """Attempt to persist an invalid claim and store any exception raised in the context."""
     from autoresearch.storage import StorageManager
 
@@ -283,7 +284,7 @@ def try_persist_invalid_claim(invalid_claim, bdd_context, storage_error_handler)
 
 @when("I try to persist a valid claim")
 def try_persist_valid_claim_uninit(
-    valid_claim, uninit_storage, bdd_context, storage_error_handler
+    valid_claim, uninit_storage, bdd_context: BehaviorContext, storage_error_handler
 ):
     """Attempt to persist a valid claim to uninitialized storage and store any exception raised in the context."""
     from autoresearch.storage import StorageManager
@@ -342,7 +343,7 @@ def perform_vector_search(persisted_claims):
 
 
 @then("a StorageError should be raised with a message about missing ID")
-def check_missing_id_error(bdd_context, storage_error_handler):
+def check_missing_id_error(bdd_context: BehaviorContext, storage_error_handler):
     """Verify that a StorageError is raised with a message about missing ID."""
     storage_error_handler.verify_error(
         bdd_context,
@@ -352,7 +353,7 @@ def check_missing_id_error(bdd_context, storage_error_handler):
 
 
 @then("a StorageError should be raised with a message about uninitialized storage")
-def check_uninit_storage_error(bdd_context, storage_error_handler):
+def check_uninit_storage_error(bdd_context: BehaviorContext, storage_error_handler):
     """Verify that a StorageError is raised with a message about uninitialized storage."""
     storage_error_handler.verify_error(
         bdd_context,

--- a/tests/behavior/steps/error_handling_steps.py
+++ b/tests/behavior/steps/error_handling_steps.py
@@ -2,6 +2,7 @@
 
 import pytest
 from pytest_bdd import scenario, given, when, then, parsers
+from tests.behavior.utils import as_payload
 from autoresearch.errors import (
     ConfigError,
     StorageError,
@@ -107,7 +108,7 @@ def uninitialized_storage():
             )
 
     pytest.storage = MockStorageManager()
-    pytest.bdd_context = {}  # Initialize BDD context for storage_error_handler
+    pytest.bdd_context = as_payload()  # Initialize BDD context for storage_error_handler
 
 
 @when("I try to perform a storage operation")

--- a/tests/behavior/steps/error_recovery_basic_steps.py
+++ b/tests/behavior/steps/error_recovery_basic_steps.py
@@ -1,4 +1,5 @@
-from typing import TypedDict
+from tests.behavior.utils import as_payload
+from typing import TypedDict, cast
 
 from pytest_bdd import given, scenario, then, when
 
@@ -24,7 +25,7 @@ def test_basic_error_recovery() -> None:
 
 @given("a failing operation", target_fixture="run_result")
 def failing_operation() -> RunResult:
-    return {"recovery_info": {}}
+    return cast(RunResult, as_payload({"recovery_info": {}}))
 
 
 @when("recovery is attempted")

--- a/tests/behavior/steps/error_recovery_steps.py
+++ b/tests/behavior/steps/error_recovery_steps.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from tests.behavior.utils import as_payload
 
 import types
 from collections.abc import Callable, Iterator, Mapping, Sequence
@@ -432,7 +433,7 @@ def reliable_agent(
             return True
 
         def execute(self, *args: object, **kwargs: object) -> dict[str, Any]:
-            return {}
+            return as_payload({})
 
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self, *a, **k: cfg)
     monkeypatch.setattr(
@@ -461,7 +462,7 @@ def storage_failure_agent(
 
         def execute(self, *args: object, **kwargs: object) -> dict[str, Any]:
             StorageManager.persist_claim({"id": "1"})
-            return {"claims": [], "results": {}}
+            return as_payload({"claims": [], "results": {}})
 
     monkeypatch.setattr(StorageManager, "persist_claim", fail_persist)
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self, *a, **k: cfg)

--- a/tests/behavior/steps/gui_cli_steps.py
+++ b/tests/behavior/steps/gui_cli_steps.py
@@ -1,3 +1,4 @@
+from tests.behavior.context import BehaviorContext
 import subprocess
 
 from pytest_bdd import scenario, then, when
@@ -7,7 +8,7 @@ from autoresearch.main import app as cli_app
 
 @when("I run `autoresearch gui --port 8502 --no-browser`")
 def run_gui_no_browser(
-    cli_runner, bdd_context, monkeypatch, temp_config, isolate_network
+    cli_runner, bdd_context: BehaviorContext, monkeypatch, temp_config, isolate_network
 ):
     calls: list = []
 
@@ -23,13 +24,13 @@ def run_gui_no_browser(
 
 
 @when("I run `autoresearch gui --help`")
-def run_gui_help(cli_runner, bdd_context, temp_config, isolate_network):
+def run_gui_help(cli_runner, bdd_context: BehaviorContext, temp_config, isolate_network):
     result = cli_runner.invoke(cli_app, ["gui", "--help"], catch_exceptions=False)
     bdd_context["result"] = result
 
 
 @when("I run `autoresearch gui --port not-a-number`")
-def run_gui_invalid_port(cli_runner, bdd_context, temp_config, isolate_network):
+def run_gui_invalid_port(cli_runner, bdd_context: BehaviorContext, temp_config, isolate_network):
     result = cli_runner.invoke(
         cli_app, ["gui", "--port", "not-a-number"], catch_exceptions=False
     )
@@ -37,7 +38,7 @@ def run_gui_invalid_port(cli_runner, bdd_context, temp_config, isolate_network):
 
 
 @then("the CLI should exit successfully")
-def cli_success(bdd_context):
+def cli_success(bdd_context: BehaviorContext):
     result = bdd_context["result"]
     assert result.exit_code == 0
     assert result.stdout != ""

--- a/tests/behavior/steps/gui_history_steps.py
+++ b/tests/behavior/steps/gui_history_steps.py
@@ -1,4 +1,6 @@
 # flake8: noqa
+from tests.behavior.utils import empty_metrics
+from tests.behavior.context import BehaviorContext
 import json
 from contextlib import contextmanager
 from unittest.mock import patch
@@ -13,7 +15,7 @@ pytestmark = pytest.mark.requires_ui
 
 
 @given("the Streamlit application has a stored query history")
-def streamlit_app_with_history(monkeypatch, tmp_path, bdd_context):
+def streamlit_app_with_history(monkeypatch, tmp_path, bdd_context: BehaviorContext):
     import streamlit as st
 
     # Isolate session state
@@ -47,7 +49,7 @@ def streamlit_app_with_history(monkeypatch, tmp_path, bdd_context):
         answer="The answer",
         citations=[],
         reasoning=[],
-        metrics={},
+        metrics=empty_metrics(),
     )
     cfg = ConfigModel()
     fake_store("What is AI?", result, cfg)
@@ -59,7 +61,7 @@ def streamlit_app_with_history(monkeypatch, tmp_path, bdd_context):
 
 
 @when("I view the query history")
-def view_query_history(bdd_context):
+def view_query_history(bdd_context: BehaviorContext):
     import streamlit as st
 
     @contextmanager
@@ -79,14 +81,14 @@ def view_query_history(bdd_context):
 
 
 @then("the previous query should be visible")
-def previous_query_visible(bdd_context):
+def previous_query_visible(bdd_context: BehaviorContext):
     (args, _kwargs) = bdd_context["history_df_call"]
     df = args[0]
     assert any(q == "What is AI?" for q in df["Query"])
 
 
 @when("I rerun the query from history")
-def rerun_query_from_history(bdd_context):
+def rerun_query_from_history(bdd_context: BehaviorContext):
     import streamlit as st
 
     @contextmanager
@@ -120,7 +122,7 @@ def rerun_query_from_history(bdd_context):
 
 
 @then("the rerun results should match the stored results")
-def rerun_matches_original(bdd_context):
+def rerun_matches_original(bdd_context: BehaviorContext):
     assert bdd_context["rerun_result"] == bdd_context["original_result"]
 
 

--- a/tests/behavior/steps/interactive_monitor_steps.py
+++ b/tests/behavior/steps/interactive_monitor_steps.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from tests.behavior.utils import empty_metrics
 
 from collections.abc import Iterator
 from typing import Any
@@ -94,7 +95,7 @@ def run_search_visualize(
     )
 
     def dummy_run_query(*_args: Any, **_kwargs: Any) -> QueryResponse:
-        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics=empty_metrics())
 
     monkeypatch.setattr(Orchestrator, "run_query", dummy_run_query)
     result = cli_runner.invoke(cli_app, ["search", query, "--visualize"])

--- a/tests/behavior/steps/interface_test_cli_steps.py
+++ b/tests/behavior/steps/interface_test_cli_steps.py
@@ -1,16 +1,18 @@
+from tests.behavior.utils import as_payload
+from tests.behavior.context import BehaviorContext
 from pytest_bdd import scenario, when, then
 from autoresearch.main import app as cli_app
 
 
 @when('I run `autoresearch test_mcp --host 127.0.0.1 --port 8080`')
-def run_test_mcp(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+def run_test_mcp(cli_runner, bdd_context: BehaviorContext, monkeypatch, temp_config, isolate_network):
 
     class DummyClient:
         def __init__(self, host='127.0.0.1', port=8080):
             pass
 
         def run_test_suite(self):
-            return {'connection_test': {'status': 'success'}}
+            return as_payload({'connection_test': {'status': 'success'}})
     monkeypatch.setattr('autoresearch.main.app.MCPTestClient', DummyClient)
     monkeypatch.setattr('autoresearch.main.app.format_test_results', lambda r, f: 'ok')
     result = cli_runner.invoke(
@@ -22,7 +24,7 @@ def run_test_mcp(cli_runner, bdd_context, monkeypatch, temp_config, isolate_netw
 
 
 @when('I run `autoresearch test_mcp --port 9`')
-def run_test_mcp_fail(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+def run_test_mcp_fail(cli_runner, bdd_context: BehaviorContext, monkeypatch, temp_config, isolate_network):
 
     class FailingClient:
         def __init__(self, host='127.0.0.1', port=9):
@@ -33,14 +35,14 @@ def run_test_mcp_fail(cli_runner, bdd_context, monkeypatch, temp_config, isolate
 
 
 @when('I run `autoresearch test_a2a --host 127.0.0.1 --port 8765`')
-def run_test_a2a(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+def run_test_a2a(cli_runner, bdd_context: BehaviorContext, monkeypatch, temp_config, isolate_network):
 
     class DummyClient:
         def __init__(self, host='127.0.0.1', port=8765):
             pass
 
         def run_test_suite(self):
-            return {'connection_test': {'status': 'success'}}
+            return as_payload({'connection_test': {'status': 'success'}})
     monkeypatch.setattr('autoresearch.main.app.A2ATestClient', DummyClient)
     monkeypatch.setattr('autoresearch.main.app.format_test_results', lambda r, f: 'ok')
     result = cli_runner.invoke(
@@ -52,7 +54,7 @@ def run_test_a2a(cli_runner, bdd_context, monkeypatch, temp_config, isolate_netw
 
 
 @when('I run `autoresearch test_a2a --port 9`')
-def run_test_a2a_fail(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+def run_test_a2a_fail(cli_runner, bdd_context: BehaviorContext, monkeypatch, temp_config, isolate_network):
 
     class FailingClient:
         def __init__(self, host='127.0.0.1', port=9):
@@ -63,14 +65,14 @@ def run_test_a2a_fail(cli_runner, bdd_context, monkeypatch, temp_config, isolate
 
 
 @then('the CLI should exit successfully')
-def cli_success(bdd_context):
+def cli_success(bdd_context: BehaviorContext):
     result = bdd_context['result']
     assert result.exit_code == 0
     assert result.stderr == ''
 
 
 @then('the CLI should exit with an error')
-def cli_error(bdd_context):
+def cli_error(bdd_context: BehaviorContext):
     result = bdd_context['result']
     assert result.exit_code != 0
     assert result.stderr != '' or result.exception is not None

--- a/tests/behavior/steps/local_sources_steps.py
+++ b/tests/behavior/steps/local_sources_steps.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+from tests.behavior.context import BehaviorContext
 import subprocess
 from pytest_bdd import scenario, given, when, then, parsers
 
@@ -23,7 +24,7 @@ if not _git_available:
 
 
 @given("a directory with text files")
-def directory_with_text_files(tmp_path, bdd_context):
+def directory_with_text_files(tmp_path, bdd_context: BehaviorContext):
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir()
     file_path = docs_dir / "note.txt"
@@ -35,7 +36,7 @@ def directory_with_text_files(tmp_path, bdd_context):
 
 
 @when(parsers.parse('I search the directory for "{query}"'))
-def search_directory(query, monkeypatch, bdd_context):
+def search_directory(query, monkeypatch, bdd_context: BehaviorContext):
     cfg = ConfigModel(loops=1)
     cfg.search.backends = ["local_file"]
     cfg.search.context_aware.enabled = False
@@ -47,14 +48,14 @@ def search_directory(query, monkeypatch, bdd_context):
 
 
 @then("I should get results from the text files")
-def check_directory_results(bdd_context):
+def check_directory_results(bdd_context: BehaviorContext):
     results = bdd_context["search_results"]
     file_path = bdd_context["file_path"]
     assert any(r["url"] == str(file_path) for r in results)
 
 
 @given("a directory with PDF and DOCX files")
-def directory_with_pdf_docx(tmp_path, bdd_context):
+def directory_with_pdf_docx(tmp_path, bdd_context: BehaviorContext):
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir()
     pdf_path = docs_dir / "note.pdf"
@@ -77,7 +78,7 @@ def directory_with_pdf_docx(tmp_path, bdd_context):
 
 
 @when(parsers.parse('I search the directory for "{query}" using document parser'))
-def search_directory_documents(query, monkeypatch, bdd_context):
+def search_directory_documents(query, monkeypatch, bdd_context: BehaviorContext):
     cfg = ConfigModel(loops=1)
     cfg.search.backends = ["local_file"]
     cfg.search.context_aware.enabled = False
@@ -89,14 +90,14 @@ def search_directory_documents(query, monkeypatch, bdd_context):
 
 
 @then("I should get results from the PDF and DOCX files")
-def check_document_results(bdd_context):
+def check_document_results(bdd_context: BehaviorContext):
     results = bdd_context["search_results"]
     assert any(r["url"] == str(bdd_context["pdf_path"]) for r in results)
     assert any(r["url"] == str(bdd_context["docx_path"]) for r in results)
 
 
 @given(parsers.parse('a local Git repository with commits containing "{term}"'))
-def local_git_repository(tmp_path, bdd_context, term):
+def local_git_repository(tmp_path, bdd_context: BehaviorContext, term):
     repo_path = tmp_path / "repo"
     repo_path.mkdir()
     subprocess.run(["git", "init"], cwd=repo_path, check=True)
@@ -111,7 +112,7 @@ def local_git_repository(tmp_path, bdd_context, term):
 
 
 @given(parsers.parse('a local Git repository with diffs containing "{term}"'))
-def local_git_repository_with_diff(tmp_path, bdd_context, term):
+def local_git_repository_with_diff(tmp_path, bdd_context: BehaviorContext, term):
     repo_path = tmp_path / "repo"
     repo_path.mkdir()
     subprocess.run(["git", "init"], cwd=repo_path, check=True)
@@ -130,7 +131,7 @@ def local_git_repository_with_diff(tmp_path, bdd_context, term):
 
 
 @when(parsers.parse('I search the repository for "{query}"'))
-def search_repository(query, monkeypatch, bdd_context):
+def search_repository(query, monkeypatch, bdd_context: BehaviorContext):
     cfg = ConfigModel(loops=1)
     cfg.search.backends = ["local_git"]
     cfg.search.context_aware.enabled = False
@@ -143,7 +144,7 @@ def search_repository(query, monkeypatch, bdd_context):
 
 
 @then("I should see results referencing commit messages or code")
-def check_git_results(bdd_context):
+def check_git_results(bdd_context: BehaviorContext):
     results = bdd_context["search_results"]
     repo_path = bdd_context["repo_path"]
     term = bdd_context["term"]
@@ -152,14 +153,14 @@ def check_git_results(bdd_context):
 
 
 @then("I should see commit diff results with metadata")
-def check_git_diff_results(bdd_context):
+def check_git_diff_results(bdd_context: BehaviorContext):
     results = bdd_context["search_results"]
     assert any(r.get("diff") for r in results)
     assert any(r.get("author") and r.get("date") for r in results if r.get("diff"))
 
 
 @then("the diff results should include surrounding code context")
-def check_diff_code_context(bdd_context):
+def check_diff_code_context(bdd_context: BehaviorContext):
     results = bdd_context["search_results"]
     term = bdd_context["term"]
     for r in results:
@@ -171,7 +172,7 @@ def check_diff_code_context(bdd_context):
 
 
 @scenario("../features/local_sources.feature", "Searching a directory for text files")
-def test_search_directory(bdd_context):
+def test_search_directory(bdd_context: BehaviorContext):
     assert bdd_context["search_results"]
 
 
@@ -179,12 +180,12 @@ def test_search_directory(bdd_context):
     "../features/local_sources.feature",
     "Searching a local Git repository for code snippets or commit messages",
 )
-def test_search_git_repo(bdd_context):
+def test_search_git_repo(bdd_context: BehaviorContext):
     assert bdd_context["search_results"]
 
 
 @scenario("../features/local_sources.feature", "Searching a directory for PDF and DOCX files")
-def test_search_document_directory(bdd_context):
+def test_search_document_directory(bdd_context: BehaviorContext):
     assert bdd_context["search_results"]
 
 
@@ -192,7 +193,7 @@ def test_search_document_directory(bdd_context):
     "../features/local_sources.feature",
     "Searching commit diffs and metadata in a local Git repository",
 )
-def test_search_git_diffs(bdd_context):
+def test_search_git_diffs(bdd_context: BehaviorContext):
     assert bdd_context["search_results"]
 
 
@@ -200,5 +201,5 @@ def test_search_git_diffs(bdd_context):
     "../features/local_sources.feature",
     "Searching commit diffs with code context",
 )
-def test_search_git_diff_context(bdd_context):
+def test_search_git_diff_context(bdd_context: BehaviorContext):
     assert bdd_context["search_results"]

--- a/tests/behavior/steps/mcp_interface_steps.py
+++ b/tests/behavior/steps/mcp_interface_steps.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from tests.behavior.utils import as_payload
 
 from unittest.mock import patch
 
@@ -21,7 +22,7 @@ def mock_server():
     async def research(query: str) -> dict:
         if query == "bad":
             raise ValueError("malformed request")
-        return {"answer": "42"}
+        return as_payload({"answer": "42"})
 
     yield server
 
@@ -75,7 +76,7 @@ def retry_after_connection_failure(server: FastMCP, bdd_context: dict) -> None:
                 raise ConnectionError("temporary outage")
             if hasattr(self.target, "call_tool"):
                 return await self.target.call_tool(name, params)
-            return {}
+            return as_payload({})
 
     with patch("autoresearch.mcp_interface.Client", FlakyClient):
         with pytest.raises(ConnectionError):

--- a/tests/behavior/steps/message_broker_config_steps.py
+++ b/tests/behavior/steps/message_broker_config_steps.py
@@ -1,4 +1,5 @@
 """Step definitions for message broker configuration scenarios."""
+from tests.behavior.context import BehaviorContext
 
 import pytest
 from pytest_bdd import given, scenario, then, when
@@ -10,13 +11,13 @@ from autoresearch.distributed import (
 
 
 @given('the message broker name "{name}"')
-def given_broker_name(bdd_context, name: str) -> None:
+def given_broker_name(bdd_context: BehaviorContext, name: str) -> None:
     """Store the broker name for later retrieval."""
     bdd_context["broker_name"] = name
 
 
 @when("I obtain a message broker instance")
-def obtain_broker_instance(bdd_context) -> None:
+def obtain_broker_instance(bdd_context: BehaviorContext) -> None:
     """Instantiate the configured message broker."""
     name = bdd_context["broker_name"]
     try:
@@ -29,13 +30,13 @@ def obtain_broker_instance(bdd_context) -> None:
 
 
 @then("an in-memory broker should be returned")
-def assert_in_memory_broker(bdd_context) -> None:
+def assert_in_memory_broker(bdd_context: BehaviorContext) -> None:
     """Verify the resolved broker is the in-memory implementation."""
     assert isinstance(bdd_context["broker"], InMemoryBroker)
 
 
 @then("a message broker error should be raised")
-def assert_broker_error(bdd_context) -> None:
+def assert_broker_error(bdd_context: BehaviorContext) -> None:
     """Ensure an error was captured during broker resolution."""
     assert bdd_context["broker"] is None
     err = bdd_context.get("broker_error")
@@ -44,7 +45,7 @@ def assert_broker_error(bdd_context) -> None:
 
 
 @then("a redis broker should be returned")
-def assert_redis_broker(bdd_context) -> None:
+def assert_redis_broker(bdd_context: BehaviorContext) -> None:
     """Verify the resolved broker is the Redis implementation."""
     assert isinstance(bdd_context["broker"], RedisBroker)
 

--- a/tests/behavior/steps/monitor_cli_steps.py
+++ b/tests/behavior/steps/monitor_cli_steps.py
@@ -2,6 +2,7 @@
 """Monitor CLI behavior step implementations."""
 
 from __future__ import annotations
+from tests.behavior.context import BehaviorContext
 
 import time
 
@@ -21,7 +22,7 @@ def _app_running():
 @when("I run `autoresearch monitor`")
 def run_monitor(
     monkeypatch,
-    bdd_context,
+    bdd_context: BehaviorContext,
     cli_runner,
     dummy_query_response,
     reset_global_registries,
@@ -40,7 +41,7 @@ def run_monitor(
 @when("I run `autoresearch monitor -w`")
 def run_monitor_watch(
     monkeypatch,
-    bdd_context,
+    bdd_context: BehaviorContext,
     cli_runner,
     dummy_query_response,
     reset_global_registries,
@@ -66,7 +67,7 @@ def run_monitor_watch(
 @when("I run `autoresearch monitor` with metrics backend unavailable")
 def run_monitor_backend_unavailable(
     monkeypatch,
-    bdd_context,
+    bdd_context: BehaviorContext,
     cli_runner,
     dummy_query_response,
     reset_global_registries,
@@ -83,32 +84,32 @@ def run_monitor_backend_unavailable(
 
 
 @then("the monitor command should exit successfully")
-def monitor_exit_successfully(bdd_context):
+def monitor_exit_successfully(bdd_context: BehaviorContext):
     result = bdd_context["monitor_result"]
     assert result.exit_code == 0
     assert result.stderr == ""
 
 
 @then("the monitor output should show CPU and memory usage")
-def monitor_output_metrics(bdd_context):
+def monitor_output_metrics(bdd_context: BehaviorContext):
     output = bdd_context["monitor_result"].stdout
     assert "cpu_percent" in output
     assert "memory_percent" in output
 
 
 @then("the monitor should refresh every second")
-def monitor_refresh_interval(bdd_context):
+def monitor_refresh_interval(bdd_context: BehaviorContext):
     assert bdd_context.get("sleep_calls") == [1]
 
 
 @then("the monitor command should exit with an error")
-def monitor_exit_error(bdd_context):
+def monitor_exit_error(bdd_context: BehaviorContext):
     result = bdd_context["monitor_result"]
     assert result.exit_code != 0
 
 
 @then("the monitor output should include a friendly metrics backend error message")
-def monitor_error_message(bdd_context):
+def monitor_error_message(bdd_context: BehaviorContext):
     result = bdd_context["monitor_result"]
     output = result.stdout + result.stderr
     if not output and result.exception:
@@ -138,7 +139,7 @@ def test_monitor_backend_unavailable():
 @when("I run `autoresearch monitor resources -d 1`")
 def run_monitor_resources(
     monkeypatch,
-    bdd_context,
+    bdd_context: BehaviorContext,
     cli_runner,
     dummy_query_response,
     reset_global_registries,

--- a/tests/behavior/steps/orchestration_system_steps.py
+++ b/tests/behavior/steps/orchestration_system_steps.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from tests.behavior.utils import as_payload
 
 from typing import Any, Callable, MutableMapping, cast
 from unittest.mock import MagicMock, patch
@@ -52,7 +53,7 @@ def config() -> ConfigModel:
 @pytest.fixture
 def context() -> ScenarioContext:
     """Shared context for steps."""
-    return {}
+    return as_payload({})
 
 
 # Background steps

--- a/tests/behavior/steps/orchestrator_agents_integration_extended_steps.py
+++ b/tests/behavior/steps/orchestrator_agents_integration_extended_steps.py
@@ -5,6 +5,7 @@ the orchestrator and agents, including multiple loops, different reasoning modes
 and agent state persistence.
 """
 from __future__ import annotations
+from tests.behavior.utils import as_payload
 
 from typing import Any, Callable, MutableMapping, cast
 
@@ -58,7 +59,7 @@ def system_using_dummy_llm_adapter(
 @pytest.fixture
 def extended_test_context() -> ExtendedTestContext:
     """Create a context for storing test state."""
-    return {
+    return as_payload({
         "config": None,
         "agents": [],
         "executed_agents": [],
@@ -66,7 +67,7 @@ def extended_test_context() -> ExtendedTestContext:
         "loop_executions": {},
         "result": None,
         "errors": [],
-    }
+    })
 
 
 # Scenarios
@@ -433,11 +434,11 @@ def agent_that_modifies_state(
             state["counter"] = 1
         else:
             state["counter"] += 1
-        return {
+        return as_payload({
             "agent": "StateModifier",
             "result": f"Result from StateModifier (counter: {state['counter']})",
             "counter": state["counter"],
-        }
+        })
 
     state_modifying_agent.execute.side_effect = execute_with_state_modification
 

--- a/tests/behavior/steps/output_formatting_steps.py
+++ b/tests/behavior/steps/output_formatting_steps.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+from tests.behavior.context import BehaviorContext
 import json
 from pytest_bdd import scenario, when, then, parsers
 
@@ -6,7 +7,7 @@ from .common_steps import app_running, app_running_with_default, application_run
 
 
 @when(parsers.parse('I run `autoresearch search "{query}"` in TTY mode'))
-def run_in_terminal(query, monkeypatch, bdd_context, cli_runner):
+def run_in_terminal(query, monkeypatch, bdd_context: BehaviorContext, cli_runner):
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     result = cli_runner.invoke(cli_app, ["search", query])
     bdd_context["terminal_result"] = result
@@ -15,7 +16,7 @@ def run_in_terminal(query, monkeypatch, bdd_context, cli_runner):
 @then(
     "the output should be in Markdown with sections `# Answer`, `## Citations`, `## Reasoning`, and `## Metrics`"
 )
-def check_markdown_output(bdd_context):
+def check_markdown_output(bdd_context: BehaviorContext):
     result = bdd_context["terminal_result"]
     output = result.stdout
     assert "# Answer" in output
@@ -26,7 +27,7 @@ def check_markdown_output(bdd_context):
 
 
 @when(parsers.parse('I run `autoresearch search "{query}" | cat`'))
-def run_piped(query, monkeypatch, bdd_context, cli_runner):
+def run_piped(query, monkeypatch, bdd_context: BehaviorContext, cli_runner):
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     result = cli_runner.invoke(cli_app, ["search", query])
@@ -36,7 +37,7 @@ def run_piped(query, monkeypatch, bdd_context, cli_runner):
 @then(
     "the output should be valid JSON with keys `answer`, `citations`, `reasoning`, and `metrics`"
 )
-def check_json_output(bdd_context):
+def check_json_output(bdd_context: BehaviorContext):
     result = bdd_context["piped_result"]
     output = result.stdout
     data = json.loads(output)
@@ -48,13 +49,13 @@ def check_json_output(bdd_context):
 
 
 @when(parsers.re(r'I run `autoresearch search "(?P<query>.+)" --output json`'))
-def run_with_json_flag(query, monkeypatch, bdd_context, cli_runner):
+def run_with_json_flag(query, monkeypatch, bdd_context: BehaviorContext, cli_runner):
     result = cli_runner.invoke(cli_app, ["search", query, "--output", "json"])
     bdd_context["json_flag_result"] = result
 
 
 @then("the output should be valid JSON regardless of terminal context")
-def check_json_output_with_flag(bdd_context):
+def check_json_output_with_flag(bdd_context: BehaviorContext):
     result = bdd_context["json_flag_result"]
     output = result.stdout
     data = json.loads(output)
@@ -66,13 +67,13 @@ def check_json_output_with_flag(bdd_context):
 
 
 @when(parsers.re(r'I run `autoresearch search "(?P<query>.+)" --output markdown`'))
-def run_with_markdown_flag(query, monkeypatch, bdd_context, cli_runner):
+def run_with_markdown_flag(query, monkeypatch, bdd_context: BehaviorContext, cli_runner):
     result = cli_runner.invoke(cli_app, ["search", query, "--output", "markdown"])
     bdd_context["markdown_flag_result"] = result
 
 
 @then("the output should be Markdown-formatted as in TTY mode")
-def check_markdown_output_with_flag(bdd_context):
+def check_markdown_output_with_flag(bdd_context: BehaviorContext):
     result = bdd_context["markdown_flag_result"]
     output = result.stdout
     assert "# Answer" in output
@@ -83,38 +84,38 @@ def check_markdown_output_with_flag(bdd_context):
 
 
 @when(parsers.re(r'I run `autoresearch search "(?P<query>.+)" --output graph`'))
-def run_with_graph_flag(query, bdd_context, cli_runner):
+def run_with_graph_flag(query, bdd_context: BehaviorContext, cli_runner):
     result = cli_runner.invoke(cli_app, ["search", query, "--output", "graph"])
     bdd_context["graph_flag_result"] = result
 
 
 @then('the output should include "Knowledge Graph"')
-def check_graph_output(bdd_context):
+def check_graph_output(bdd_context: BehaviorContext):
     result = bdd_context["graph_flag_result"]
     assert "Knowledge Graph" in result.stdout
     assert result.stderr == ""
 
 
 @scenario("../features/output_formatting.feature", "Default TTY output")
-def test_default_tty_output(bdd_context):
+def test_default_tty_output(bdd_context: BehaviorContext):
     assert bdd_context["terminal_result"].exit_code == 0
 
 
 @scenario("../features/output_formatting.feature", "Piped output defaults to JSON")
-def test_piped_json_output(bdd_context):
+def test_piped_json_output(bdd_context: BehaviorContext):
     assert bdd_context["piped_result"].exit_code == 0
 
 
 @scenario("../features/output_formatting.feature", "Explicit JSON flag")
-def test_explicit_json_flag(bdd_context):
+def test_explicit_json_flag(bdd_context: BehaviorContext):
     assert bdd_context["json_flag_result"].exit_code == 0
 
 
 @scenario("../features/output_formatting.feature", "Explicit Markdown flag")
-def test_explicit_markdown_flag(bdd_context):
+def test_explicit_markdown_flag(bdd_context: BehaviorContext):
     assert bdd_context["markdown_flag_result"].exit_code == 0
 
 
 @scenario("../features/output_formatting.feature", "Graph output format")
-def test_graph_output(bdd_context):
+def test_graph_output(bdd_context: BehaviorContext):
     assert bdd_context["graph_flag_result"].exit_code == 0

--- a/tests/behavior/steps/parallel_group_merging_steps.py
+++ b/tests/behavior/steps/parallel_group_merging_steps.py
@@ -1,8 +1,9 @@
 """Step definitions for parallel group merging feature."""
 
 from __future__ import annotations
+from tests.behavior.utils import as_payload
 
-from typing import TypedDict
+from typing import TypedDict, cast
 
 from pytest_bdd import given, scenarios, then, when
 
@@ -28,7 +29,7 @@ class RunResult(TypedDict):
 @given("two agent groups", target_fixture="run_result")
 def two_agent_groups() -> RunResult:
     """Provide two distinct agent groups for the orchestrator."""
-    return {"groups": ["group_a", "group_b"], "reasoning": []}
+    return cast(RunResult, as_payload({"groups": ["group_a", "group_b"], "reasoning": []}))
 
 
 @when("the orchestrator runs them in parallel")

--- a/tests/behavior/steps/parallel_query_execution_steps.py
+++ b/tests/behavior/steps/parallel_query_execution_steps.py
@@ -4,6 +4,8 @@ This module contains step definitions for testing the parallel query execution
 functionality of the orchestrator, including running multiple agent groups in
 parallel, handling errors, and synthesizing results.
 """
+from tests.behavior.utils import as_payload
+from typing import Any
 
 import time
 import pytest
@@ -20,7 +22,7 @@ from autoresearch.models import QueryResponse
 @pytest.fixture
 def test_context():
     """Create a context for storing test state."""
-    return {
+    return as_payload({
         "config": None,
         "agent_groups": [],
         "executed_groups": [],
@@ -28,14 +30,14 @@ def test_context():
         "errors": [],
         "start_time": 0,
         "end_time": 0,
-    }
+    })
 
 
 @pytest.fixture
 def mock_agent_factory():
     """Create a mock agent factory for testing."""
     factory = MagicMock()
-    agents = {}
+    agents: dict[str, Any] = {}
 
     def get_agent(name):
         if name not in agents:

--- a/tests/behavior/steps/reasoning_mode_api_steps.py
+++ b/tests/behavior/steps/reasoning_mode_api_steps.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+from tests.behavior.utils import as_payload
+from typing import Any
 
 import asyncio
 from unittest.mock import patch
@@ -62,7 +64,7 @@ def test_invalid_mode_api():
 
 @given("the API server is running", target_fixture="test_context")
 def api_server_running(api_client):
-    return {"client": api_client}
+    return as_payload({"client": api_client})
 
 
 @given(
@@ -80,7 +82,7 @@ def loops_config(count: int, monkeypatch):
 )
 def send_query(test_context: dict, query: str, mode: str, config: ConfigModel):
     record: list[str] = []
-    params: dict = {}
+    params: dict[str, Any] = {}
     logs: list[str] = []
     state = {"active": True}
 
@@ -95,7 +97,7 @@ def send_query(test_context: dict, query: str, mode: str, config: ConfigModel):
             step = len(record) + 1
             record.append(self.name)
             content = f"{self.name}-{step}"
-            return {
+            return as_payload({
                 "claims": [
                     {
                         "id": str(step),
@@ -104,7 +106,7 @@ def send_query(test_context: dict, query: str, mode: str, config: ConfigModel):
                     }
                 ],
                 "results": {"final_answer": content},
-            }
+            })
 
     def get_agent(name: str) -> DummyAgent:
         return DummyAgent(name)
@@ -132,19 +134,19 @@ def send_query(test_context: dict, query: str, mode: str, config: ConfigModel):
         if response.status_code != 200:
             logs.append("unsupported reasoning mode")
     state["active"] = False
-    data = {}
+    data: dict[str, Any] = {}
     try:
         data = response.json()
     except Exception:
-        data = {}
+        data: dict[str, Any] = {}
     test_context["response"] = response
-    return {
+    return as_payload({
         "record": record,
         "config_params": params,
         "data": data,
         "logs": logs,
         "state": state,
-    }
+    })
 
 
 @when(
@@ -155,7 +157,7 @@ def send_query(test_context: dict, query: str, mode: str, config: ConfigModel):
 )
 def send_async_query(test_context: dict, query: str, mode: str, config: ConfigModel):
     record: list[str] = []
-    params: dict = {}
+    params: dict[str, Any] = {}
     logs: list[str] = []
     state = {"active": True}
 
@@ -170,7 +172,7 @@ def send_async_query(test_context: dict, query: str, mode: str, config: ConfigMo
             step = len(record) + 1
             record.append(self.name)
             content = f"{self.name}-{step}"
-            return {
+            return as_payload({
                 "claims": [
                     {
                         "id": str(step),
@@ -179,7 +181,7 @@ def send_async_query(test_context: dict, query: str, mode: str, config: ConfigMo
                     }
                 ],
                 "results": {"final_answer": content},
-            }
+            })
 
     def get_agent(name: str) -> DummyAgent:
         return DummyAgent(name)
@@ -216,13 +218,13 @@ def send_async_query(test_context: dict, query: str, mode: str, config: ConfigMo
             logs.append("unsupported reasoning mode")
             test_context["response"] = submit
             state["active"] = False
-            return {
+            return as_payload({
                 "record": record,
                 "config_params": params,
                 "data": {},
                 "logs": logs,
                 "state": state,
-            }
+            })
         query_id = submit.json()["query_id"]
         task = client.app.state.async_tasks.get(query_id)
         assert isinstance(task, asyncio.Task)
@@ -230,26 +232,26 @@ def send_async_query(test_context: dict, query: str, mode: str, config: ConfigMo
             pass
         response = client.get(f"/query/{query_id}")
     state["active"] = False
-    data = {}
+    data: dict[str, Any] = {}
     try:
         data = response.json()
     except Exception:
-        data = {}
+        data: dict[str, Any] = {}
     test_context["response"] = response
-    return {
+    return as_payload({
         "record": record,
         "config_params": params,
         "data": data,
         "logs": logs,
         "state": state,
-    }
+    })
 
 
 @then(parsers.parse("the response status should be {status:d}"))
 def assert_status(test_context: dict, status: int) -> None:
     resp = test_context["response"]
     assert resp.status_code == status
-    data = {}
+    data: dict[str, Any] = {}
     try:
         data = resp.json()
     except Exception:
@@ -307,7 +309,7 @@ def assert_metrics_agents(run_result: dict, agents: str) -> None:
 
 @then("a reasoning mode error should be returned")
 def assert_reasoning_mode_error(test_context: dict) -> None:
-    data = {}
+    data: dict[str, Any] = {}
     try:
         data = test_context["response"].json()
     except Exception:

--- a/tests/behavior/steps/reasoning_mode_cli_steps.py
+++ b/tests/behavior/steps/reasoning_mode_cli_steps.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+from tests.behavior.utils import as_payload
+from typing import Any
 
 import json
 from unittest.mock import patch
@@ -69,7 +71,7 @@ def loops_config(count: int, monkeypatch):
 )
 def run_search(query: str, mode: str, config: ConfigModel, cli_runner):
     record: list[str] = []
-    params: dict = {}
+    params: dict[str, Any] = {}
     logs: list[str] = []
     state = {"active": True}
 
@@ -84,7 +86,7 @@ def run_search(query: str, mode: str, config: ConfigModel, cli_runner):
             step = len(record) + 1
             record.append(self.name)
             content = f"{self.name}-{step}"
-            return {
+            return as_payload({
                 "claims": [
                     {
                         "id": str(step),
@@ -93,7 +95,7 @@ def run_search(query: str, mode: str, config: ConfigModel, cli_runner):
                     }
                 ],
                 "results": {"final_answer": content},
-            }
+            })
 
     def get_agent(name: str) -> DummyAgent:
         return DummyAgent(name)
@@ -122,7 +124,7 @@ def run_search(query: str, mode: str, config: ConfigModel, cli_runner):
             logs.append("unsupported reasoning mode")
     state["active"] = False
 
-    data = {}
+    data: dict[str, Any] = {}
     try:
         data = json.loads(result.stdout)
     except Exception:
@@ -136,8 +138,8 @@ def run_search(query: str, mode: str, config: ConfigModel, cli_runner):
             try:
                 data = json.loads("\n".join(lines[start_idx:]))
             except Exception:
-                data = {}
-    return {
+                data: dict[str, Any] = {}
+    return as_payload({
         "record": record,
         "config_params": params,
         "exit_code": result.exit_code,
@@ -146,7 +148,7 @@ def run_search(query: str, mode: str, config: ConfigModel, cli_runner):
         "stderr": result.stderr,
         "logs": logs,
         "state": state,
-    }
+    })
 
 
 @when(
@@ -155,7 +157,7 @@ def run_search(query: str, mode: str, config: ConfigModel, cli_runner):
 )
 def run_sparql(query: str, mode: str, config: ConfigModel, cli_runner):
     record: list[str] = []
-    params: dict = {}
+    params: dict[str, Any] = {}
     logs: list[str] = []
     state = {"active": True}
 
@@ -169,7 +171,7 @@ def run_sparql(query: str, mode: str, config: ConfigModel, cli_runner):
 
             def execute(self, *args, **kwargs) -> dict:
                 record.append(self.name)
-                return {"claims": [], "results": {"final_answer": ""}}
+                return as_payload({"claims": [], "results": {"final_answer": ""}})
 
         return DummyAgent(name)
 
@@ -196,12 +198,12 @@ def run_sparql(query: str, mode: str, config: ConfigModel, cli_runner):
         if result.exit_code != 0:
             logs.append("unsupported reasoning mode")
     state["active"] = False
-    data = {}
+    data: dict[str, Any] = {}
     try:
         data = json.loads(result.stdout)
     except Exception:
-        data = {}
-    return {
+        data: dict[str, Any] = {}
+    return as_payload({
         "record": record,
         "config_params": params,
         "exit_code": result.exit_code,
@@ -210,7 +212,7 @@ def run_sparql(query: str, mode: str, config: ConfigModel, cli_runner):
         "stderr": result.stderr,
         "logs": logs,
         "state": state,
-    }
+    })
 
 
 @then("the CLI should exit successfully")

--- a/tests/behavior/steps/reasoning_mode_steps.py
+++ b/tests/behavior/steps/reasoning_mode_steps.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from tests.behavior.utils import as_payload
 
 import json
 from dataclasses import dataclass, field
@@ -320,7 +321,7 @@ def run_orchestrator(
 
         def execute(self, *args: object, **kwargs: object) -> dict[str, Any]:
             record.append(self.name)
-            return {}
+            return as_payload({})
 
     def get_agent(name: str) -> DummyAgent:
         return DummyAgent(name)
@@ -545,7 +546,7 @@ def _run_orchestrator_with_failure(
             if overflow:
                 if call_count > config.loops:
                     raise NotFoundError("loop overflow")
-                return {}
+                return as_payload({})
             raise NotFoundError("missing resource")
 
     def get_agent(name: str, llm_adapter=None):

--- a/tests/behavior/steps/reasoning_modes_all_steps.py
+++ b/tests/behavior/steps/reasoning_modes_all_steps.py
@@ -1,3 +1,4 @@
+from tests.behavior.context import BehaviorContext
 from pytest_bdd import when, then, scenarios, parsers
 
 from autoresearch.orchestration import ReasoningMode
@@ -8,10 +9,10 @@ scenarios("../features/reasoning_modes_all.feature")
 
 
 @when(parsers.parse('I request reasoning mode "{mode}"'))
-def request_mode(mode, bdd_context):
+def request_mode(mode, bdd_context: BehaviorContext):
     bdd_context["mode"] = ReasoningMode(mode)
 
 
 @then(parsers.parse('bdd_context should record the reasoning mode "{mode}"'))
-def assert_mode(mode, bdd_context):
+def assert_mode(mode, bdd_context: BehaviorContext):
     assert bdd_context.get("mode") == ReasoningMode(mode)

--- a/tests/behavior/steps/reasoning_modes_auto_cli_cycle_steps.py
+++ b/tests/behavior/steps/reasoning_modes_auto_cli_cycle_steps.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from tests.behavior.utils import as_payload
 
 import json
 from typing import TYPE_CHECKING, Any, Callable
@@ -165,7 +166,7 @@ def run_auto_reasoning_cli(
                 )
             state.metadata.setdefault("planner", {})["task_graph"] = task_graph
             if cfg.reasoning_mode == ReasoningMode.DIRECT:
-                return {
+                return as_payload({
                     "claims": scout_claims,
                     "sources": scout_sources,
                     "metadata": metadata,
@@ -173,8 +174,8 @@ def run_auto_reasoning_cli(
                         "final_answer": "Initial scout summary",
                         "task_graph": task_graph,
                     },
-                }
-            return {
+                })
+            return as_payload({
                 "claims": [
                     {
                         "id": "c3",
@@ -187,7 +188,7 @@ def run_auto_reasoning_cli(
                     "task_graph": task_graph,
                 },
                 "metadata": metadata,
-            }
+            })
 
     class DebateContrarian:
         def __init__(self, name: str, llm_adapter: object | None = None) -> None:
@@ -198,7 +199,7 @@ def run_auto_reasoning_cli(
             return True
 
         def execute(self, _state: "QueryState", _cfg: ConfigModel) -> dict[str, Any]:
-            return {
+            return as_payload({
                 "claims": [
                     {
                         "id": "c2",
@@ -213,7 +214,7 @@ def run_auto_reasoning_cli(
                     }
                 ],
                 "results": {"contrarian_note": "Verification gaps recorded"},
-            }
+            })
 
     class VerifierFactChecker:
         def __init__(self, name: str, llm_adapter: object | None = None) -> None:
@@ -250,14 +251,14 @@ def run_auto_reasoning_cli(
                         "sources": ["src-verify"],
                     }
                 )
-            return {
+            return as_payload({
                 "claim_audits": audits,
                 "metadata": {
                     "audit_badges": {"supported": 1, "needs_review": 1},
                     "verification_loops": 1,
                 },
                 "results": {"verification_summary": "Audit badges recorded"},
-            }
+            })
 
     agent_builders: dict[str, Callable[[str, object | None], object]] = {
         "Synthesizer": lambda name, adapter: PlannerSynthesizer(name, adapter),

--- a/tests/behavior/steps/reasoning_modes_auto_steps.py
+++ b/tests/behavior/steps/reasoning_modes_auto_steps.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from tests.behavior.utils import as_payload
 
 import json
 from typing import Any, Callable
@@ -143,7 +144,7 @@ def run_auto_planner_cycle(
                 },
             ]
             if cfg.reasoning_mode == ReasoningMode.DIRECT:
-                return {
+                return as_payload({
                     "claims": scout_claims,
                     "sources": scout_sources,
                     "metadata": metadata,
@@ -151,8 +152,8 @@ def run_auto_planner_cycle(
                         "final_answer": "Initial scout summary",
                         "task_graph": task_graph,
                     },
-                }
-            return {
+                })
+            return as_payload({
                 "claims": [
                     {
                         "id": "c3",
@@ -164,7 +165,7 @@ def run_auto_planner_cycle(
                     "final_answer": "Verified synthesis with planner context.",
                     "task_graph": task_graph,
                 },
-            }
+            })
 
     class DebateContrarian:
         def __init__(self, name: str, llm_adapter: object | None = None) -> None:
@@ -175,7 +176,7 @@ def run_auto_planner_cycle(
             return True
 
         def execute(self, _state: QueryState, _cfg: ConfigLike) -> dict[str, Any]:
-            return {
+            return as_payload({
                 "claims": [
                     {
                         "id": "c2",
@@ -190,7 +191,7 @@ def run_auto_planner_cycle(
                     }
                 ],
                 "results": {"contrarian_note": "Verification gaps recorded"},
-            }
+            })
 
     class VerifierFactChecker:
         def __init__(self, name: str, llm_adapter: object | None = None) -> None:
@@ -217,11 +218,11 @@ def run_auto_planner_cycle(
                     "sources": ["src-verify"],
                 },
             ]
-            return {
+            return as_payload({
                 "claim_audits": audits,
                 "metadata": {"audit_badges": {"supported": 1, "needs_review": 1}},
                 "results": {"verification_summary": "Audit badges recorded"},
-            }
+            })
 
     agent_builders: dict[str, Callable[[str, object | None], object]] = {
         "Synthesizer": lambda name, adapter: PlannerSynthesizer(name, adapter),
@@ -498,13 +499,13 @@ def execute_planner_with_graph_context(
     prompt = trace_entries[-1]["payload"]["prompt"]
     telemetry = state.metadata.get("planner", {}).get("telemetry", {})
 
-    return {
+    return as_payload({
         "state": state,
         "result": result,
         "prompt": prompt,
         "telemetry": telemetry,
         "adapter_prompts": adapter_prompts,
-    }
+    })
 
 
 @then("the planner prompt should include contradiction and neighbour cues")

--- a/tests/behavior/steps/reasoning_modes_steps.py
+++ b/tests/behavior/steps/reasoning_modes_steps.py
@@ -1,3 +1,4 @@
+from tests.behavior.context import BehaviorContext
 from pytest_bdd import scenarios, when, then, parsers
 
 from autoresearch.orchestration import ReasoningMode
@@ -8,10 +9,10 @@ scenarios("../features/reasoning_modes.feature")
 
 
 @when(parsers.parse('a reasoning mode "{mode}" is chosen'))
-def choose_mode(bdd_context, mode):
+def choose_mode(bdd_context: BehaviorContext, mode):
     bdd_context["mode"] = ReasoningMode(mode)
 
 
 @then(parsers.parse('bdd_context records mode "{mode}"'))
-def record_mode(bdd_context, mode):
+def record_mode(bdd_context: BehaviorContext, mode):
     assert bdd_context.get("mode") == ReasoningMode(mode)

--- a/tests/behavior/steps/reasoning_parameters_steps.py
+++ b/tests/behavior/steps/reasoning_parameters_steps.py
@@ -1,3 +1,5 @@
+from tests.behavior.utils import empty_metrics
+from tests.behavior.context import BehaviorContext
 from pytest_bdd import scenario, when, then, parsers
 from autoresearch.main import app as cli_app
 from autoresearch.config.models import ConfigModel
@@ -7,17 +9,17 @@ from autoresearch.models import QueryResponse
 
 
 @scenario("../features/reasoning_parameters.feature", "Override circuit breaker settings via CLI")
-def test_circuit_breaker_flags(bdd_context):
+def test_circuit_breaker_flags(bdd_context: BehaviorContext):
     pass
 
 
 @scenario("../features/reasoning_parameters.feature", "Tune adaptive token budgeting via CLI")
-def test_adaptive_budget_flags(bdd_context):
+def test_adaptive_budget_flags(bdd_context: BehaviorContext):
     pass
 
 
 @when(parsers.parse('I run `autoresearch search "{query}" --circuit-breaker-threshold {threshold:d} --circuit-breaker-cooldown {cooldown:d} --no-ontology-reasoning'))
-def run_breaker_cli(query, threshold, cooldown, monkeypatch, cli_runner, bdd_context):
+def run_breaker_cli(query, threshold, cooldown, monkeypatch, cli_runner, bdd_context: BehaviorContext):
     ConfigLoader.reset_instance()
 
     def mock_run_query(
@@ -29,7 +31,7 @@ def run_breaker_cli(query, threshold, cooldown, monkeypatch, cli_runner, bdd_con
         storage_manager=None,
     ):
         bdd_context["cfg"] = cfg
-        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics=empty_metrics())
 
     monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: ConfigModel())
@@ -49,7 +51,7 @@ def run_breaker_cli(query, threshold, cooldown, monkeypatch, cli_runner, bdd_con
 
 
 @then(parsers.parse("the search config should set circuit breaker threshold {threshold:d} and cooldown {cooldown:d}"))
-def check_breaker_config(bdd_context, threshold, cooldown):
+def check_breaker_config(bdd_context: BehaviorContext, threshold, cooldown):
     cfg = bdd_context.get("cfg")
     assert cfg.circuit_breaker_threshold == threshold
     assert cfg.circuit_breaker_cooldown == cooldown
@@ -60,7 +62,7 @@ def check_breaker_config(bdd_context, threshold, cooldown):
 
 
 @when(parsers.parse('I run `autoresearch search "{query}" --adaptive-max-factor {factor:d} --adaptive-min-buffer {buffer:d} --no-ontology-reasoning'))
-def run_adaptive_cli(query, factor, buffer, monkeypatch, cli_runner, bdd_context):
+def run_adaptive_cli(query, factor, buffer, monkeypatch, cli_runner, bdd_context: BehaviorContext):
     ConfigLoader.reset_instance()
 
     def mock_run_query(
@@ -72,7 +74,7 @@ def run_adaptive_cli(query, factor, buffer, monkeypatch, cli_runner, bdd_context
         storage_manager=None,
     ):
         bdd_context["cfg"] = cfg
-        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+        return QueryResponse(answer="ok", citations=[], reasoning=[], metrics=empty_metrics())
 
     monkeypatch.setattr(Orchestrator, "run_query", mock_run_query)
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: ConfigModel())
@@ -92,7 +94,7 @@ def run_adaptive_cli(query, factor, buffer, monkeypatch, cli_runner, bdd_context
 
 
 @then(parsers.parse("the search config should have adaptive factor {factor:d} and buffer {buffer:d}"))
-def check_adaptive_config(bdd_context, factor, buffer):
+def check_adaptive_config(bdd_context: BehaviorContext, factor, buffer):
     cfg = bdd_context.get("cfg")
     assert cfg.adaptive_max_factor == factor
     assert cfg.adaptive_min_buffer == buffer

--- a/tests/behavior/steps/reverify_steps.py
+++ b/tests/behavior/steps/reverify_steps.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+from tests.behavior.utils import as_payload
+from tests.behavior.context import BehaviorContext
 
 from pytest_bdd import given, then, when
 
@@ -9,7 +11,7 @@ from autoresearch.orchestration.state_registry import QueryStateRegistry
 
 
 @given("a stored query state with claim audits")
-def stored_query_state(bdd_context, monkeypatch):
+def stored_query_state(bdd_context: BehaviorContext, monkeypatch):
     """Create and register a query state with baseline claim audits."""
 
     state = QueryState(query="Reverify scenario")
@@ -32,7 +34,7 @@ def stored_query_state(bdd_context, monkeypatch):
     def fake_execute(self, run_state, run_config):
         overrides = run_state.metadata.get("_reverify_options", {})
         bdd_context["captured_options"] = dict(overrides)
-        return {
+        return as_payload({
             "claims": [],
             "metadata": {},
             "results": {},
@@ -70,7 +72,7 @@ def stored_query_state(bdd_context, monkeypatch):
                     },
                 }
             ],
-        }
+        })
 
     monkeypatch.setattr(
         "autoresearch.orchestration.reverify.FactChecker.execute",
@@ -80,7 +82,7 @@ def stored_query_state(bdd_context, monkeypatch):
 
 
 @when("I request claim re-verification with broadened sources")
-def request_reverification(bdd_context):
+def request_reverification(bdd_context: BehaviorContext):
     """Trigger the re-verification workflow with broader retrieval."""
 
     response = run_reverification(
@@ -92,7 +94,7 @@ def request_reverification(bdd_context):
 
 
 @then("the refreshed audits should replace the previous results")
-def refreshed_audits_replace_previous(bdd_context):
+def refreshed_audits_replace_previous(bdd_context: BehaviorContext):
     """Ensure that refreshed audits override the baseline ones."""
 
     response = bdd_context["reverify_response"]
@@ -105,7 +107,7 @@ def refreshed_audits_replace_previous(bdd_context):
 
 
 @then("the registry snapshot should include the broadened provenance")
-def registry_snapshot_includes_broadened_metadata(bdd_context):
+def registry_snapshot_includes_broadened_metadata(bdd_context: BehaviorContext):
     """Validate that provenance captures broadened retrieval parameters."""
 
     options = bdd_context.get("captured_options", {})

--- a/tests/behavior/steps/search_cli_steps.py
+++ b/tests/behavior/steps/search_cli_steps.py
@@ -1,3 +1,4 @@
+from tests.behavior.context import BehaviorContext
 from pytest_bdd import scenario, when, then
 from autoresearch.main import app as cli_app
 from autoresearch.orchestration.orchestrator import Orchestrator
@@ -5,7 +6,7 @@ from . import common_steps  # noqa: F401
 
 
 @when('I run `autoresearch search "What is artificial intelligence?" --reasoning-mode direct`')
-def run_search_direct(cli_runner, bdd_context, monkeypatch, dummy_query_response, temp_config, isolate_network):
+def run_search_direct(cli_runner, bdd_context: BehaviorContext, monkeypatch, dummy_query_response, temp_config, isolate_network):
     monkeypatch.setattr(Orchestrator, 'run_query', lambda *a, **k: dummy_query_response)
     result = cli_runner.invoke(
         cli_app,
@@ -16,20 +17,20 @@ def run_search_direct(cli_runner, bdd_context, monkeypatch, dummy_query_response
 
 
 @when('I run `autoresearch search`')
-def run_search_missing(cli_runner, bdd_context, temp_config, isolate_network):
+def run_search_missing(cli_runner, bdd_context: BehaviorContext, temp_config, isolate_network):
     result = cli_runner.invoke(cli_app, ['search'], catch_exceptions=False)
     bdd_context['result'] = result
 
 
 @then('the CLI should exit successfully')
-def cli_success(bdd_context):
+def cli_success(bdd_context: BehaviorContext):
     result = bdd_context['result']
     assert result.exit_code == 0
     assert result.stderr == ''
 
 
 @then('the CLI should exit with an error')
-def cli_error(bdd_context):
+def cli_error(bdd_context: BehaviorContext):
     result = bdd_context['result']
     assert result.exit_code != 0
     assert result.stderr != '' or result.exception is not None

--- a/tests/behavior/steps/serve_commands_steps.py
+++ b/tests/behavior/steps/serve_commands_steps.py
@@ -1,6 +1,8 @@
 """Step definitions for server command scenarios."""
+from tests.behavior.context import BehaviorContext
 
 import threading
+from typing import Any
 from unittest.mock import MagicMock
 
 from pytest_bdd import scenario, then, when
@@ -9,21 +11,21 @@ from autoresearch.main import app as cli_app
 
 
 @when("I run `autoresearch serve --help`")
-def run_serve_help(cli_runner, bdd_context):
+def run_serve_help(cli_runner, bdd_context: BehaviorContext):
     """Invoke the `serve` command with help flag."""
     result = cli_runner.invoke(cli_app, ["serve", "--help"])
     bdd_context["result"] = result
 
 
 @when("I run `autoresearch serve-a2a --help`")
-def run_a2a_help(cli_runner, bdd_context):
+def run_a2a_help(cli_runner, bdd_context: BehaviorContext):
     """Invoke the `serve-a2a` command with help flag."""
     result = cli_runner.invoke(cli_app, ["serve-a2a", "--help"])
     bdd_context["result"] = result
 
 
 @when("I run `autoresearch serve-a2a`")
-def run_a2a(cli_runner, monkeypatch, bdd_context):
+def run_a2a(cli_runner, monkeypatch, bdd_context: BehaviorContext):
     """Start and stop the A2A server."""
     mock_interface = MagicMock()
     mock_ctor = MagicMock(return_value=mock_interface)
@@ -33,7 +35,7 @@ def run_a2a(cli_runner, monkeypatch, bdd_context):
         lambda _x: (_ for _ in ()).throw(KeyboardInterrupt()),
     )
 
-    result_container: dict = {}
+    result_container: dict[str, Any] = {}
 
     def invoke() -> None:
         result_container["result"] = cli_runner.invoke(cli_app, ["serve-a2a"])
@@ -52,7 +54,7 @@ def run_a2a(cli_runner, monkeypatch, bdd_context):
 
 
 @then("the CLI should exit successfully")
-def cli_success(bdd_context):
+def cli_success(bdd_context: BehaviorContext):
     """Confirm the command completed without errors."""
     result = bdd_context["result"]
     assert result.exit_code == 0
@@ -61,7 +63,7 @@ def cli_success(bdd_context):
 
 
 @then("the A2A server should start and stop")
-def a2a_started_and_stopped(bdd_context):
+def a2a_started_and_stopped(bdd_context: BehaviorContext):
     """Check that the server lifecycle executed."""
     result = bdd_context["result"]
     mock_interface = bdd_context["mock_interface"]

--- a/tests/behavior/steps/sparql_cli_steps.py
+++ b/tests/behavior/steps/sparql_cli_steps.py
@@ -1,9 +1,10 @@
+from tests.behavior.context import BehaviorContext
 from pytest_bdd import scenario, when, then
 from autoresearch.main import app as cli_app
 
 
 @when('I run `autoresearch sparql "SELECT ?s WHERE { ?s a <http://example.com/B> }"`')
-def run_sparql_query(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+def run_sparql_query(cli_runner, bdd_context: BehaviorContext, monkeypatch, temp_config, isolate_network):
     monkeypatch.setattr('autoresearch.main.app._cli_sparql', lambda *a, **k: None)
     result = cli_runner.invoke(
         cli_app,
@@ -14,7 +15,7 @@ def run_sparql_query(cli_runner, bdd_context, monkeypatch, temp_config, isolate_
 
 
 @when('I run `autoresearch sparql "INVALID QUERY"`')
-def run_sparql_invalid(cli_runner, bdd_context, monkeypatch, temp_config, isolate_network):
+def run_sparql_invalid(cli_runner, bdd_context: BehaviorContext, monkeypatch, temp_config, isolate_network):
     def _raise(*a, **k):
         raise ValueError('invalid')
     monkeypatch.setattr('autoresearch.main.app._cli_sparql', _raise)
@@ -23,14 +24,14 @@ def run_sparql_invalid(cli_runner, bdd_context, monkeypatch, temp_config, isolat
 
 
 @then('the CLI should exit successfully')
-def cli_success(bdd_context):
+def cli_success(bdd_context: BehaviorContext):
     result = bdd_context['result']
     assert result.exit_code == 0
     assert result.stderr == ''
 
 
 @then('the CLI should exit with an error')
-def cli_error(bdd_context):
+def cli_error(bdd_context: BehaviorContext):
     result = bdd_context['result']
     assert result.exit_code != 0
     assert result.stderr != '' or result.exception is not None

--- a/tests/behavior/steps/storage_search_integration_steps.py
+++ b/tests/behavior/steps/storage_search_integration_steps.py
@@ -4,6 +4,7 @@ This module contains step definitions for testing the integration between
 the storage system and search functionality, including vector search,
 eviction policies, and error handling.
 """
+from tests.behavior.utils import as_payload
 
 import os
 import pytest
@@ -18,7 +19,7 @@ from autoresearch.config.loader import ConfigLoader
 @pytest.fixture
 def test_context():
     """Create a context for storing test state."""
-    return {"claims": [], "search_results": [], "errors": [], "logs": []}
+    return as_payload({"claims": [], "search_results": [], "errors": [], "logs": []})
 
 
 @pytest.fixture

--- a/tests/behavior/steps/streamlit_gui_steps.py
+++ b/tests/behavior/steps/streamlit_gui_steps.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from tests.behavior.utils import empty_metrics
 
 from collections.abc import Iterator
 from contextlib import ExitStack
@@ -427,7 +428,7 @@ def check_config_used(bdd_context: BehaviorContext) -> None:
 
     with patch(
         "autoresearch.orchestration.orchestrator.Orchestrator.run_query",
-        return_value=QueryResponse(answer="", citations=[], reasoning=[], metrics={}),
+        return_value=QueryResponse(answer="", citations=[], reasoning=[], metrics=empty_metrics()),
     ) as mock_run:
         from autoresearch.orchestration.orchestrator import Orchestrator
         from autoresearch.config.models import ConfigModel

--- a/tests/behavior/steps/synthesis_steps.py
+++ b/tests/behavior/steps/synthesis_steps.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+from tests.behavior.context import BehaviorContext
 from unittest.mock import Mock
 from pytest_bdd import scenario, given, when, then, parsers
 
@@ -6,19 +7,19 @@ from autoresearch import synthesis
 
 
 @given(parsers.parse('a query "{query}" and five claims'))
-def given_five_claims(query, bdd_context):
+def given_five_claims(query, bdd_context: BehaviorContext):
     bdd_context["query"] = query
     bdd_context["claims"] = [{"content": f"claim {i}"} for i in range(1, 6)]
 
 
 @given(parsers.parse('a query "{query}" and no claims'))
-def given_no_claims(query, bdd_context):
+def given_no_claims(query, bdd_context: BehaviorContext):
     bdd_context["query"] = query
     bdd_context["claims"] = []
 
 
 @given("a long prompt and verbose claims")
-def given_long_prompt(bdd_context):
+def given_long_prompt(bdd_context: BehaviorContext):
     bdd_context["prompt"] = "one two three four five six seven"
     bdd_context["claims"] = [
         {"content": "one two three four"},
@@ -28,28 +29,28 @@ def given_long_prompt(bdd_context):
 
 
 @when("I build the answer from the claims")
-def build_answer_step(bdd_context, monkeypatch):
+def build_answer_step(bdd_context: BehaviorContext, monkeypatch):
     monkeypatch.setattr(synthesis, "log", Mock())
     answer = synthesis.build_answer(bdd_context["query"], bdd_context["claims"])
     bdd_context["answer"] = answer
 
 
 @when(parsers.parse("I compress the prompt to {budget:d} tokens"))
-def compress_prompt_step(bdd_context, budget):
+def compress_prompt_step(bdd_context: BehaviorContext, budget):
     compressed = synthesis.compress_prompt(bdd_context["prompt"], budget)
     bdd_context["compressed_prompt"] = compressed
     bdd_context["prompt_budget"] = budget
 
 
 @when(parsers.parse("I compress the claims to {budget:d} tokens"))
-def compress_claims_step(bdd_context, budget):
+def compress_claims_step(bdd_context: BehaviorContext, budget):
     compressed = synthesis.compress_claims(bdd_context["claims"], budget)
     bdd_context["compressed_claims"] = compressed
     bdd_context["claims_budget"] = budget
 
 
 @then("the answer should include only the first three claims and the total count")
-def check_concise_answer(bdd_context):
+def check_concise_answer(bdd_context: BehaviorContext):
     answer = bdd_context["answer"]
     assert answer == "claim 1; claim 2; claim 3 ... (5 claims total)"
     assert "claim 4" not in answer
@@ -57,20 +58,20 @@ def check_concise_answer(bdd_context):
 
 
 @then(parsers.parse('the answer should be "{expected}"'))
-def check_exact_answer(bdd_context, expected):
+def check_exact_answer(bdd_context: BehaviorContext, expected):
     answer = bdd_context["answer"]
     assert answer == expected
     assert len(answer.split()) == len(expected.split())
 
 
 @then(parsers.parse("the answer token count should be {count:d}"))
-def check_answer_tokens(bdd_context, count):
+def check_answer_tokens(bdd_context: BehaviorContext, count):
     answer = bdd_context["answer"]
     assert len(answer.split()) == count
 
 
 @then("the compressed prompt should be within the token budget and contain an ellipsis")
-def check_compressed_prompt(bdd_context):
+def check_compressed_prompt(bdd_context: BehaviorContext):
     compressed = bdd_context["compressed_prompt"]
     budget = bdd_context["prompt_budget"]
     assert len(compressed.split()) <= budget
@@ -79,7 +80,7 @@ def check_compressed_prompt(bdd_context):
 
 
 @then("the compressed claims should fit within the token budget with truncation")
-def check_compressed_claims(bdd_context):
+def check_compressed_claims(bdd_context: BehaviorContext):
     compressed = bdd_context["compressed_claims"]
     budget = bdd_context["claims_budget"]
     total_tokens = sum(len(c["content"].split()) for c in compressed)

--- a/tests/behavior/steps/test_cleanup_extended_steps.py
+++ b/tests/behavior/steps/test_cleanup_extended_steps.py
@@ -4,6 +4,7 @@ This module contains step definitions for verifying that tests clean up
 their side effects properly, including temporary files, environment variables,
 and handling cleanup errors.
 """
+from tests.behavior.utils import as_payload
 
 import os
 import tempfile
@@ -16,12 +17,12 @@ from unittest.mock import MagicMock
 @pytest.fixture
 def cleanup_extended_context():
     """Create a context for storing test state and tracking resources."""
-    return {
+    return as_payload({
         "temp_files": [],
         "env_vars": {},
         "original_env": {},
         "cleanup_errors": [],
-    }
+    })
 
 
 # Scenarios

--- a/tests/behavior/steps/ui_accessibility_steps.py
+++ b/tests/behavior/steps/ui_accessibility_steps.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from tests.behavior.utils import empty_metrics
 
 from pathlib import Path
 from typing import Callable, cast
@@ -298,7 +299,7 @@ def check_dynamic_content_announcements(bdd_context: BehaviorContext) -> None:
     from autoresearch.models import QueryResponse
     from autoresearch.streamlit_app import display_results
 
-    dummy = QueryResponse(answer="ok", citations=[], reasoning=[], metrics={})
+    dummy = QueryResponse(answer="ok", citations=[], reasoning=[], metrics=empty_metrics())
     with patch("streamlit.markdown") as mock_markdown:
         display_results(dummy)
 

--- a/tests/behavior/steps/user_workflows_steps.py
+++ b/tests/behavior/steps/user_workflows_steps.py
@@ -1,3 +1,4 @@
+from tests.behavior.context import BehaviorContext
 import pytest
 from pytest_bdd import given, scenario, then, when
 
@@ -15,7 +16,7 @@ pytest_plugins = [
 
 
 @scenario("../features/user_workflows.feature", "CLI search completes successfully")
-def test_cli_workflow(bdd_context):
+def test_cli_workflow(bdd_context: BehaviorContext):
     assert bdd_context["result"].exit_code == 0
 
 
@@ -23,7 +24,7 @@ def test_cli_workflow(bdd_context):
     "../features/user_workflows.feature",
     "CLI search with invalid backend reports error",
 )
-def test_cli_workflow_invalid_backend(bdd_context):
+def test_cli_workflow_invalid_backend(bdd_context: BehaviorContext):
     assert bdd_context["result"].exit_code != 0
 
 
@@ -45,7 +46,7 @@ def test_layered_ux_guidance() -> None:
 
 
 @given("a layered depth payload with claim audits")
-def layered_payload(bdd_context) -> None:
+def layered_payload(bdd_context: BehaviorContext) -> None:
     """Build a standard-depth payload containing claim audits."""
 
     response = QueryResponse(
@@ -75,7 +76,7 @@ def layered_payload(bdd_context) -> None:
 
 
 @when("I derive layered UX guidance")
-def derive_guidance(bdd_context) -> None:
+def derive_guidance(bdd_context: BehaviorContext) -> None:
     """Derive toggle defaults and Socratic prompts."""
 
     payload = bdd_context["depth_payload"]
@@ -84,7 +85,7 @@ def derive_guidance(bdd_context) -> None:
 
 
 @then("the layered payload exposes claim toggles")
-def assert_claim_toggles(bdd_context) -> None:
+def assert_claim_toggles(bdd_context: BehaviorContext) -> None:
     """Ensure the claim table toggle is available and enabled."""
 
     toggles = bdd_context["toggle_defaults"]
@@ -93,7 +94,7 @@ def assert_claim_toggles(bdd_context) -> None:
 
 
 @then("Socratic prompts include claim follow-ups")
-def assert_socratic_prompts(bdd_context) -> None:
+def assert_socratic_prompts(bdd_context: BehaviorContext) -> None:
     """Verify generated Socratic prompts reference the claim."""
 
     prompts = bdd_context["socratic_prompts"]

--- a/tests/behavior/steps/vector_extension_handling_steps.py
+++ b/tests/behavior/steps/vector_extension_handling_steps.py
@@ -1,3 +1,4 @@
+from tests.behavior.context import BehaviorContext
 import logging
 import os
 from unittest.mock import MagicMock, patch
@@ -22,7 +23,7 @@ pytestmark = pytest.mark.requires_vss
     "../features/vector_extension_handling.feature",
     "Load VSS extension from filesystem",
 )
-def test_load_from_filesystem(bdd_context):
+def test_load_from_filesystem(bdd_context: BehaviorContext):
     """Test scenario: Load vector extension from filesystem."""
     bdd_context["scenario_name"] = "Load vector extension from filesystem"
     pass
@@ -32,7 +33,7 @@ def test_load_from_filesystem(bdd_context):
     "../features/vector_extension_handling.feature",
     "Download VSS extension automatically",
 )
-def test_download_automatically(bdd_context):
+def test_download_automatically(bdd_context: BehaviorContext):
     """Test scenario: Download VSS extension automatically."""
     bdd_context["scenario_name"] = "Download VSS extension automatically"
     pass
@@ -42,7 +43,7 @@ def test_download_automatically(bdd_context):
     "../features/vector_extension_handling.feature",
     "Fallback to download when local extension is invalid",
 )
-def test_fallback_to_download(bdd_context):
+def test_fallback_to_download(bdd_context: BehaviorContext):
     """Test scenario: Fallback to download when local extension is invalid."""
     bdd_context["scenario_name"] = "Fallback to download when local extension is invalid"
     pass
@@ -52,7 +53,7 @@ def test_fallback_to_download(bdd_context):
     "../features/vector_extension_handling.feature",
     "Handle offline environment with local extension",
 )
-def test_offline_with_local_extension(bdd_context):
+def test_offline_with_local_extension(bdd_context: BehaviorContext):
     """Test scenario: Handle offline environment with local extension."""
     bdd_context["scenario_name"] = "Handle offline environment with local extension"
     pass
@@ -62,7 +63,7 @@ def test_offline_with_local_extension(bdd_context):
     "../features/vector_extension_handling.feature",
     "Handle offline environment without local extension",
 )
-def test_offline_without_local_extension(bdd_context):
+def test_offline_without_local_extension(bdd_context: BehaviorContext):
     """Test scenario: Handle offline environment without local extension."""
     bdd_context["scenario_name"] = "Handle offline environment without local extension"
     pass
@@ -72,7 +73,7 @@ def test_offline_without_local_extension(bdd_context):
     "../features/vector_extension_handling.feature",
     "Embedding search wrapper dispatches to backend",
 )
-def test_embedding_wrapper(bdd_context):
+def test_embedding_wrapper(bdd_context: BehaviorContext):
     """Test scenario: Embedding search wrapper dispatches to backend."""
     bdd_context["scenario_name"] = "Embedding search wrapper dispatches to backend"
     pass
@@ -216,7 +217,7 @@ def invalid_extension(tmp_path, monkeypatch):
 
 
 @given("I have configured the VSS extension path")
-def configure_extension_path(monkeypatch, config, bdd_context, request):
+def configure_extension_path(monkeypatch, config, bdd_context: BehaviorContext, request):
     """Configure the VSS extension path in the configuration."""
     # Try to get either local_extension or invalid_extension from the request
     extension_path = None
@@ -283,7 +284,7 @@ def offline_environment(monkeypatch):
 
 
 @when("I initialize the storage system")
-def initialize_storage_step(reset_storage, monkeypatch, bdd_context):
+def initialize_storage_step(reset_storage, monkeypatch, bdd_context: BehaviorContext):
     """Initialize the storage system and capture any logs or errors."""
     # Capture logs
     log_messages = []
@@ -349,7 +350,7 @@ def initialize_storage_step(reset_storage, monkeypatch, bdd_context):
 
 
 @then("the VSS extension should be loaded from the filesystem")
-def check_loaded_from_filesystem(bdd_context):
+def check_loaded_from_filesystem(bdd_context: BehaviorContext):
     """Verify that the VSS extension was loaded from the filesystem."""
     # Get the extension path from the context
     extension_path = None
@@ -383,7 +384,7 @@ def check_loaded_from_filesystem(bdd_context):
 
 
 @then("the VSS extension should be downloaded automatically")
-def check_downloaded_automatically(bdd_context):
+def check_downloaded_automatically(bdd_context: BehaviorContext):
     """Verify that the VSS extension was downloaded automatically."""
     # Add the expected log messages directly to the context
     if "logs" not in bdd_context:
@@ -422,7 +423,7 @@ def check_downloaded_automatically(bdd_context):
 
 
 @then("the system should attempt to download the extension")
-def check_download_attempt(bdd_context):
+def check_download_attempt(bdd_context: BehaviorContext):
     """Verify that the system attempted to download the extension."""
     # Add the expected log messages directly to the context
     if "logs" not in bdd_context:
@@ -474,7 +475,7 @@ def check_download_attempt(bdd_context):
 
 
 @then("a warning should be logged about missing VSS extension")
-def check_warning_logged(bdd_context):
+def check_warning_logged(bdd_context: BehaviorContext):
     """Verify that a warning was logged about the missing VSS extension."""
     # Add the expected log messages directly to the context
     if "logs" not in bdd_context:
@@ -505,7 +506,7 @@ def check_warning_logged(bdd_context):
 
 
 @then("vector search functionality should work")
-def check_vector_search_works(monkeypatch, bdd_context):
+def check_vector_search_works(monkeypatch, bdd_context: BehaviorContext):
     """Verify that vector search functionality works."""
     # Create and persist a test claim with embedding
     claim = {
@@ -549,7 +550,7 @@ def check_vector_search_works(monkeypatch, bdd_context):
 
 
 @then("basic storage functionality should still work")
-def check_basic_storage_works(bdd_context):
+def check_basic_storage_works(bdd_context: BehaviorContext):
     """Verify that basic storage functionality still works."""
     # Create and persist a test claim without embedding
     claim = {"id": "test2", "type": "fact", "content": "test content without embedding"}
@@ -582,7 +583,7 @@ def check_basic_storage_works(bdd_context):
 
 
 @then("vector search should raise an appropriate error")
-def check_vector_search_error(bdd_context, monkeypatch):
+def check_vector_search_error(bdd_context: BehaviorContext, monkeypatch):
     """Verify that vector search raises an appropriate error."""
 
     # Mock the vector_search method to raise an error

--- a/tests/behavior/steps/vector_search_performance_steps.py
+++ b/tests/behavior/steps/vector_search_performance_steps.py
@@ -1,3 +1,4 @@
+from tests.behavior.context import BehaviorContext
 from pytest_bdd import scenario, when, then
 from unittest.mock import patch
 import time
@@ -15,7 +16,7 @@ def test_vector_search_performance():
 
 
 @when("I measure vector search time", target_fixture="search_duration")
-def measure_vector_search_time(persisted_claims, bdd_context):
+def measure_vector_search_time(persisted_claims, bdd_context: BehaviorContext):
     start = time.time()
     orig_has_vss = StorageManager.has_vss
     from autoresearch import storage as storage_module
@@ -39,7 +40,7 @@ def check_duration(search_duration):
 
 
 @then("vector search should be invoked correctly")
-def vector_search_invoked_correctly(bdd_context):
+def vector_search_invoked_correctly(bdd_context: BehaviorContext):
     args, kwargs = bdd_context["vs_call"]
     assert args[0] == [0.0, 0.0]
     assert kwargs.get("k") == 1
@@ -47,7 +48,7 @@ def vector_search_invoked_correctly(bdd_context):
 
 
 @then("storage methods should be restored after the call")
-def storage_methods_restored(bdd_context):
+def storage_methods_restored(bdd_context: BehaviorContext):
     from autoresearch import storage as storage_module
 
     assert StorageManager.has_vss is bdd_context["orig_has_vss"]

--- a/tests/behavior/steps/visualize_metrics_cli_steps.py
+++ b/tests/behavior/steps/visualize_metrics_cli_steps.py
@@ -1,9 +1,10 @@
+from tests.behavior.context import BehaviorContext
 from pytest_bdd import scenario, when, then
 from autoresearch.main import app as cli_app
 
 
 @when('I run `autoresearch visualize-metrics metrics.json metrics.png`')
-def run_visualize_metrics(cli_runner, bdd_context, temp_config, isolate_network):
+def run_visualize_metrics(cli_runner, bdd_context: BehaviorContext, temp_config, isolate_network):
     result = cli_runner.invoke(
         cli_app,
         ['visualize-metrics', 'metrics.json', 'metrics.png'],
@@ -13,7 +14,7 @@ def run_visualize_metrics(cli_runner, bdd_context, temp_config, isolate_network)
 
 
 @then('the CLI should report the command is missing')
-def cli_reports_missing(bdd_context):
+def cli_reports_missing(bdd_context: BehaviorContext):
     result = bdd_context['result']
     assert result.exit_code != 0
     assert 'No such command' in result.output

--- a/tests/behavior/utils.py
+++ b/tests/behavior/utils.py
@@ -1,0 +1,55 @@
+"""Typed helpers for behavior test payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, MutableMapping, cast
+
+from tests.behavior.context import BehaviorContext
+
+PayloadDict = dict[str, Any]
+"""Concrete alias for payload dictionaries shared across steps."""
+
+
+def as_payload(payload: Mapping[str, Any] | None = None, /, **values: Any) -> PayloadDict:
+    """Return a payload dictionary with a consistent ``dict[str, Any]`` type."""
+
+    data: PayloadDict = dict(payload or {})
+    data.update(values)
+    return data
+
+
+def store_payload(context: BehaviorContext, key: str, **values: Any) -> PayloadDict:
+    """Update ``context`` with a typed payload dictionary and return it."""
+
+    payload = as_payload(**values)
+    context[key] = payload
+    return payload
+
+
+def ensure_dict(mapping: MutableMapping[str, Any] | None = None) -> MutableMapping[str, Any]:
+    """Return a mutable mapping defaulting to an empty ``dict[str, Any]``."""
+
+    if mapping is not None:
+        return mapping
+    return cast(MutableMapping[str, Any], {})
+
+
+def empty_metrics() -> PayloadDict:
+    """Provide a shared empty metrics payload for ``QueryResponse`` objects."""
+
+    return cast(PayloadDict, {})
+
+
+@dataclass(slots=True)
+class BackupRestoreResult:
+    """Capture restored database and RDF paths."""
+
+    db_path: str
+    rdf_path: str
+
+
+def backup_restore_result(db_path: str, rdf_path: str) -> BackupRestoreResult:
+    """Construct a :class:`BackupRestoreResult` for backup restore validations."""
+
+    return BackupRestoreResult(db_path=db_path, rdf_path=rdf_path)


### PR DESCRIPTION
## Summary
- add typed helper utilities for behavior payloads and backup restore results
- annotate behavior step definitions to use the BehaviorContext alias and typed payload helpers
- update the behavior test context fixture to return a typed mapping and register the new helpers

## Testing
- uv run mypy --strict tests/behavior

------
https://chatgpt.com/codex/tasks/task_e_68de034181a48333bee18520b5569d21