### PR TITLE
Annotate orchestrator integration tests with storage typings

### DIFF
--- a/tests/integration/test_orchestrator_concurrency.py
+++ b/tests/integration/test_orchestrator_concurrency.py
@@ -1,13 +1,12 @@
 import asyncio
 import time
 from dataclasses import asdict, dataclass, field
-from typing import cast
-
 import pytest
 from autoresearch.config.models import ConfigModel
 from autoresearch.orchestration import orchestrator as orch_mod
 from autoresearch.orchestration.reasoning import ReasoningMode
 from autoresearch.orchestration.state import QueryState
+from autoresearch.storage_typing import JSONDict
 
 from tests.integration._orchestrator_stubs import AgentDouble, patch_agent_factory_get
 
@@ -41,10 +40,10 @@ class SleepAgentDouble(AgentDouble):
         state: QueryState,
         config: ConfigModel,
         **_: object,
-    ) -> dict[str, object]:
+    ) -> JSONDict:
         self.starts.append(time.perf_counter())
         time.sleep(self.delay)
-        payload = cast(dict[str, object], {"results": {self.name: "ok"}})
+        payload: JSONDict = {"results": {self.name: "ok"}}
         state.update(payload)
         state.results["final_answer"] = "ok"
         return payload

--- a/tests/integration/test_orchestrator_registered_pairs.py
+++ b/tests/integration/test_orchestrator_registered_pairs.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import itertools
-from typing import Any
 
 import pytest
 
@@ -9,6 +8,8 @@ from autoresearch.agents.registry import AgentRegistry
 from autoresearch.config.models import ConfigModel
 from autoresearch.models import QueryResponse
 from autoresearch.orchestration.orchestrator import Orchestrator
+from autoresearch.orchestration.state import QueryState
+from autoresearch.storage_typing import JSONDict
 from pytest import MonkeyPatch
 from tests.integration._orchestrator_stubs import (
     AgentDouble,
@@ -40,12 +41,12 @@ def test_orchestrator_all_registered_pairs(
         double = AgentDouble(name=agent_name)
 
         def result_factory(
-            state: Any,
+            state: QueryState,
             config: ConfigModel,
             *,
             name: str = agent_name,
             stub: AgentDouble = double,
-        ) -> dict[str, Any]:
+        ) -> JSONDict:
             original_factory = stub.result_factory
             stub.result_factory = None
             try:


### PR DESCRIPTION
## Summary
- add explicit JSONDict/QueryState type annotations to orchestrator integration test fixtures and helpers
- normalize storage claim stubs to use typed JSON payloads across search and combination scenarios
- ensure concurrency helpers return JSONDict payloads for SleepAgentDouble

## Testing
- uv run task check

------
https://chatgpt.com/codex/tasks/task_e_68dea181182483339a4aa94a9ce34f0a