### PR TITLE
Refine distributed broker test typing

### DIFF
--- a/tests/integration/test_extra_usage.py
+++ b/tests/integration/test_extra_usage.py
@@ -98,10 +98,10 @@ def test_fakeredis_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
         "pid": 4321,
     }
     broker.publish(message)
-    queue = cast(StorageBrokerQueueProtocol, broker.queue)
+    queue: StorageBrokerQueueProtocol = cast(StorageBrokerQueueProtocol, broker.queue)
     queue_protocol: MessageQueueProtocol = queue
     queued_message: BrokerMessage = queue_protocol.get()
-    assert queued_message == message
+    assert cast(AgentResultMessage, queued_message) == message
     broker.shutdown()
 
 

--- a/tests/targeted/test_storage_eviction.py
+++ b/tests/targeted/test_storage_eviction.py
@@ -1,5 +1,6 @@
 """Targeted tests for storage eviction and schema initialization."""
 
+from pathlib import Path
 from threading import Thread
 
 import pytest  # noqa: E402
@@ -28,7 +29,9 @@ def test_initialize_storage_idempotent() -> None:
     StorageManager.context = StorageContext()
 
 
-def test_ram_budget_eviction(tmp_path, monkeypatch) -> None:
+def test_ram_budget_eviction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Concurrent writers respect the configured RAM budget."""
     cfg = ConfigModel(
         storage=StorageConfig(
@@ -63,7 +66,9 @@ def test_ram_budget_eviction(tmp_path, monkeypatch) -> None:
     ConfigLoader()._config = None
 
 
-def test_deterministic_eviction_across_runs(tmp_path, monkeypatch) -> None:
+def test_deterministic_eviction_across_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Eviction leaves a deterministic graph across runs."""
     cfg = ConfigModel(
         storage=StorageConfig(


### PR DESCRIPTION
## Summary
- ensure distributed broker helpers return typed AgentResultMessage/BrokerMessage payloads
- cast broker queues to StorageBrokerQueueProtocol and MessageQueueProtocol in integration and targeted tests
- annotate pytest fixtures and Redis stubs with explicit typing for monkeypatch-based helpers

## Testing
- uv run task check

------
https://chatgpt.com/codex/tasks/task_e_68dea6743c7083339a18886885eecbb1