### PR TITLE
Add typed payload helpers for behavior tests

### DIFF
--- a/tests/behavior/steps/api_async_query_steps.py
+++ b/tests/behavior/steps/api_async_query_steps.py
@@ -1,7 +1,7 @@
 """Step definitions for asynchronous query API behavior tests."""
 
 from __future__ import annotations
-from tests.behavior.utils import as_payload
+from tests.behavior.utils import build_async_submission_payload
 
 import asyncio
 import time
@@ -268,12 +268,12 @@ def failing_async_query(failure: str, api_client, monkeypatch):
         )
     if not logs:
         logs.append(strategy_map[failure])
-    return as_payload({
-        "response": status,
-        "recovery_info": recovery_info,
-        "logs": logs,
-        "state": state,
-    })
+    return build_async_submission_payload(
+        response=status,
+        recovery_info=recovery_info,
+        logs=logs,
+        state=state,
+    )
 
 
 @then(parsers.parse('a recovery strategy "{strategy}" should be recorded'))

--- a/tests/behavior/steps/reasoning_mode_api_steps.py
+++ b/tests/behavior/steps/reasoning_mode_api_steps.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
-from tests.behavior.utils import as_payload
+from tests.behavior.utils import (
+    as_payload,
+    build_scout_claim,
+    build_scout_payload,
+)
 from typing import Any
 
 import asyncio
@@ -97,16 +101,16 @@ def send_query(test_context: dict, query: str, mode: str, config: ConfigModel):
             step = len(record) + 1
             record.append(self.name)
             content = f"{self.name}-{step}"
-            return as_payload({
-                "claims": [
-                    {
-                        "id": str(step),
-                        "type": "thought",
-                        "content": content,
-                    }
+            return build_scout_payload(
+                claims=[
+                    build_scout_claim(
+                        claim_id=str(step),
+                        claim_type="thought",
+                        content=content,
+                    )
                 ],
-                "results": {"final_answer": content},
-            })
+                results={"final_answer": content},
+            )
 
     def get_agent(name: str) -> DummyAgent:
         return DummyAgent(name)
@@ -172,16 +176,16 @@ def send_async_query(test_context: dict, query: str, mode: str, config: ConfigMo
             step = len(record) + 1
             record.append(self.name)
             content = f"{self.name}-{step}"
-            return as_payload({
-                "claims": [
-                    {
-                        "id": str(step),
-                        "type": "thought",
-                        "content": content,
-                    }
+            return build_scout_payload(
+                claims=[
+                    build_scout_claim(
+                        claim_id=str(step),
+                        claim_type="thought",
+                        content=content,
+                    )
                 ],
-                "results": {"final_answer": content},
-            })
+                results={"final_answer": content},
+            )
 
     def get_agent(name: str) -> DummyAgent:
         return DummyAgent(name)

--- a/tests/behavior/steps/reasoning_modes_auto_steps.py
+++ b/tests/behavior/steps/reasoning_modes_auto_steps.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
-from tests.behavior.utils import as_payload
+from tests.behavior.utils import (
+    as_payload,
+    build_scout_audit,
+    build_scout_claim,
+    build_scout_metadata,
+    build_scout_payload,
+    build_scout_source,
+)
 
 import json
 from typing import Any, Callable
@@ -94,78 +101,78 @@ def run_auto_planner_cycle(
 
         def execute(self, state: QueryState, cfg: ConfigLike) -> dict[str, Any]:
             self._invocations += 1
-            metadata = {
-                "scout_retrieval_sets": [
+            metadata = build_scout_metadata(
+                retrieval_sets=[
                     ["src-plan", "src-verify"],
                     ["src-verify", "src-analysis"],
                 ],
-                "scout_complexity_features": {
+                complexity_features={
                     "hops": 2,
                     "entities": ["planner", "verifier"],
                     "clauses": 4,
                 },
-                "scout_entailment_scores": [
+                entailment_scores=[
                     {"support": 0.32, "conflict": 0.68},
                     {"support": 0.30, "conflict": 0.70},
                 ],
-            }
+            )
             scout_claims = [
-                {
-                    "id": "c1",
-                    "type": "thesis",
-                    "content": "Planner identifies conflicting statements to verify.",
-                    "audit": {
-                        "claim_id": "c1",
-                        "status": "supported",
-                        "entailment": 0.82,
-                        "sources": ["src-plan"],
-                    },
-                },
-                {
-                    "id": "c2",
-                    "type": "antithesis",
-                    "content": "Follow-up evidence remains unresolved.",
-                },
+                build_scout_claim(
+                    claim_id="c1",
+                    claim_type="thesis",
+                    content="Planner identifies conflicting statements to verify.",
+                    audit=build_scout_audit(
+                        claim_id="c1",
+                        status="supported",
+                        entailment=0.82,
+                        sources=["src-plan"],
+                    ),
+                ),
+                build_scout_claim(
+                    claim_id="c2",
+                    claim_type="antithesis",
+                    content="Follow-up evidence remains unresolved.",
+                ),
             ]
             scout_sources = [
-                {
-                    "source_id": "src-plan",
-                    "title": "Planning memo",
-                    "snippet": "Plan verification tasks",
-                    "backend": "duckduckgo",
-                    "url": "https://example.com/plan",
-                },
-                {
-                    "source_id": "src-verify",
-                    "title": "Verification checklist",
-                    "snippet": "Needs follow-up",
-                    "backend": "serper",
-                    "url": "https://example.com/verify",
-                },
+                build_scout_source(
+                    source_id="src-plan",
+                    title="Planning memo",
+                    snippet="Plan verification tasks",
+                    backend="duckduckgo",
+                    url="https://example.com/plan",
+                ),
+                build_scout_source(
+                    source_id="src-verify",
+                    title="Verification checklist",
+                    snippet="Needs follow-up",
+                    backend="serper",
+                    url="https://example.com/verify",
+                ),
             ]
             if cfg.reasoning_mode == ReasoningMode.DIRECT:
-                return as_payload({
-                    "claims": scout_claims,
-                    "sources": scout_sources,
-                    "metadata": metadata,
-                    "results": {
+                return build_scout_payload(
+                    claims=scout_claims,
+                    sources=scout_sources,
+                    metadata=metadata,
+                    results={
                         "final_answer": "Initial scout summary",
                         "task_graph": task_graph,
                     },
-                })
-            return as_payload({
-                "claims": [
-                    {
-                        "id": "c3",
-                        "type": "synthesis",
-                        "content": "Synthesis integrates planner and verifier evidence.",
-                    }
+                )
+            return build_scout_payload(
+                claims=[
+                    build_scout_claim(
+                        claim_id="c3",
+                        claim_type="synthesis",
+                        content="Synthesis integrates planner and verifier evidence.",
+                    )
                 ],
-                "results": {
+                results={
                     "final_answer": "Verified synthesis with planner context.",
                     "task_graph": task_graph,
                 },
-            })
+            )
 
     class DebateContrarian:
         def __init__(self, name: str, llm_adapter: object | None = None) -> None:
@@ -176,22 +183,22 @@ def run_auto_planner_cycle(
             return True
 
         def execute(self, _state: QueryState, _cfg: ConfigLike) -> dict[str, Any]:
-            return as_payload({
-                "claims": [
-                    {
-                        "id": "c2",
-                        "type": "antithesis",
-                        "content": "Contrarian flags remaining verification gaps.",
-                        "audit": {
-                            "claim_id": "c2",
-                            "status": "needs_review",
-                            "entailment": 0.44,
-                            "sources": ["src-verify"],
-                        },
-                    }
+            return build_scout_payload(
+                claims=[
+                    build_scout_claim(
+                        claim_id="c2",
+                        claim_type="antithesis",
+                        content="Contrarian flags remaining verification gaps.",
+                        audit=build_scout_audit(
+                            claim_id="c2",
+                            status="needs_review",
+                            entailment=0.44,
+                            sources=["src-verify"],
+                        ),
+                    )
                 ],
-                "results": {"contrarian_note": "Verification gaps recorded"},
-            })
+                results={"contrarian_note": "Verification gaps recorded"},
+            )
 
     class VerifierFactChecker:
         def __init__(self, name: str, llm_adapter: object | None = None) -> None:
@@ -203,26 +210,29 @@ def run_auto_planner_cycle(
 
         def execute(self, _state: QueryState, _cfg: ConfigLike) -> dict[str, Any]:
             audits = [
-                {
-                    "claim_id": "c1",
-                    "status": "supported",
-                    "entailment": 0.82,
-                    "stability": 0.91,
-                    "sources": ["src-plan"],
-                },
-                {
-                    "claim_id": "c2",
-                    "status": "needs_review",
-                    "entailment": 0.44,
-                    "stability": 0.50,
-                    "sources": ["src-verify"],
-                },
+                build_scout_audit(
+                    claim_id="c1",
+                    status="supported",
+                    entailment=0.82,
+                    stability=0.91,
+                    sources=["src-plan"],
+                ),
+                build_scout_audit(
+                    claim_id="c2",
+                    status="needs_review",
+                    entailment=0.44,
+                    stability=0.50,
+                    sources=["src-verify"],
+                ),
             ]
-            return as_payload({
-                "claim_audits": audits,
-                "metadata": {"audit_badges": {"supported": 1, "needs_review": 1}},
-                "results": {"verification_summary": "Audit badges recorded"},
-            })
+            metadata = build_scout_metadata(
+                audit_badges={"supported": 1, "needs_review": 1}
+            )
+            return build_scout_payload(
+                claim_audits=audits,
+                metadata=metadata,
+                results={"verification_summary": "Audit badges recorded"},
+            )
 
     agent_builders: dict[str, Callable[[str, object | None], object]] = {
         "Synthesizer": lambda name, adapter: PlannerSynthesizer(name, adapter),

--- a/tests/behavior/utils.py
+++ b/tests/behavior/utils.py
@@ -3,12 +3,83 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping, cast
+from typing import (
+    Any,
+    Iterable,
+    Mapping,
+    MutableMapping,
+    NotRequired,
+    Sequence,
+    TypedDict,
+    cast,
+)
 
 from tests.behavior.context import BehaviorContext
 
 PayloadDict = dict[str, Any]
 """Concrete alias for payload dictionaries shared across steps."""
+
+
+class ScoutClaimAudit(TypedDict):
+    """Schema for audit details attached to scout claims."""
+
+    claim_id: str
+    status: str
+    entailment: float
+    sources: list[str]
+    stability: NotRequired[float]
+
+
+class ScoutClaim(TypedDict):
+    """Structured representation of scout claim payload entries."""
+
+    id: str
+    type: str
+    content: str
+    audit: NotRequired[ScoutClaimAudit]
+
+
+class ScoutSource(TypedDict):
+    """Schema for scout source metadata shared across steps."""
+
+    source_id: str
+    title: str
+    snippet: str
+    backend: str
+    url: str
+
+
+class ScoutComplexityFeatures(TypedDict, total=False):
+    """Complexity metrics captured alongside scout samples."""
+
+    hops: int
+    entities: list[str]
+    clauses: int
+
+
+class ScoutEntailmentScore(TypedDict, total=False):
+    """Per-claim entailment/conflict scores emitted by scout agents."""
+
+    support: float
+    conflict: float
+
+
+class ScoutMetadata(TypedDict, total=False):
+    """Aggregate metadata emitted with scout payloads."""
+
+    scout_retrieval_sets: list[list[str]]
+    scout_complexity_features: ScoutComplexityFeatures
+    scout_entailment_scores: list[ScoutEntailmentScore]
+    audit_badges: Mapping[str, int]
+
+
+class AsyncSubmissionPayload(TypedDict):
+    """Normalized payload returned from async API submissions in tests."""
+
+    response: Any
+    recovery_info: MutableMapping[str, str]
+    logs: list[str]
+    state: MutableMapping[str, Any]
 
 
 def as_payload(payload: Mapping[str, Any] | None = None, /, **values: Any) -> PayloadDict:
@@ -40,6 +111,135 @@ def empty_metrics() -> PayloadDict:
     """Provide a shared empty metrics payload for ``QueryResponse`` objects."""
 
     return cast(PayloadDict, {})
+
+
+def build_scout_audit(
+    *,
+    claim_id: str,
+    status: str,
+    entailment: float,
+    sources: Sequence[str],
+    stability: float | None = None,
+) -> ScoutClaimAudit:
+    """Create a :class:`ScoutClaimAudit` entry with defensive copying."""
+
+    audit: ScoutClaimAudit = {
+        "claim_id": claim_id,
+        "status": status,
+        "entailment": entailment,
+        "sources": list(sources),
+    }
+    if stability is not None:
+        audit["stability"] = stability
+    return audit
+
+
+def build_scout_claim(
+    *,
+    claim_id: str,
+    claim_type: str,
+    content: str,
+    audit: ScoutClaimAudit | Mapping[str, Any] | None = None,
+) -> ScoutClaim:
+    """Create a :class:`ScoutClaim` optionally including audit information."""
+
+    claim: ScoutClaim = {
+        "id": claim_id,
+        "type": claim_type,
+        "content": content,
+    }
+    if audit is not None:
+        claim["audit"] = cast(ScoutClaimAudit, dict(audit))
+    return claim
+
+
+def build_scout_source(
+    *,
+    source_id: str,
+    title: str,
+    snippet: str,
+    backend: str,
+    url: str,
+) -> ScoutSource:
+    """Create a :class:`ScoutSource` entry used in scout payload snapshots."""
+
+    return {
+        "source_id": source_id,
+        "title": title,
+        "snippet": snippet,
+        "backend": backend,
+        "url": url,
+    }
+
+
+def build_scout_metadata(
+    *,
+    retrieval_sets: Sequence[Sequence[str]] | None = None,
+    complexity_features: Mapping[str, Any] | None = None,
+    entailment_scores: Sequence[Mapping[str, float]] | None = None,
+    audit_badges: Mapping[str, int] | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> ScoutMetadata:
+    """Compose :class:`ScoutMetadata` entries with optional components."""
+
+    metadata: ScoutMetadata = {}
+    if retrieval_sets is not None:
+        metadata["scout_retrieval_sets"] = [list(group) for group in retrieval_sets]
+    if complexity_features is not None:
+        metadata["scout_complexity_features"] = cast(
+            ScoutComplexityFeatures, dict(complexity_features)
+        )
+    if entailment_scores is not None:
+        metadata["scout_entailment_scores"] = [
+            cast(ScoutEntailmentScore, dict(score)) for score in entailment_scores
+        ]
+    if audit_badges is not None:
+        metadata["audit_badges"] = dict(audit_badges)
+    if extra is not None:
+        metadata.update(dict(extra))
+    return metadata
+
+
+def build_scout_payload(
+    *,
+    claims: Sequence[ScoutClaim] | None = None,
+    results: Mapping[str, Any] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+    sources: Sequence[ScoutSource] | None = None,
+    claim_audits: Sequence[ScoutClaimAudit] | None = None,
+) -> PayloadDict:
+    """Create a normalized payload for scout agent outputs."""
+
+    payload = as_payload()
+    if claims is not None:
+        payload["claims"] = [dict(claim) for claim in claims]
+    if results is not None:
+        payload["results"] = dict(results)
+    if metadata is not None:
+        payload["metadata"] = dict(metadata)
+    if sources is not None:
+        payload["sources"] = [dict(source) for source in sources]
+    if claim_audits is not None:
+        payload["claim_audits"] = [dict(audit) for audit in claim_audits]
+    return payload
+
+
+def build_async_submission_payload(
+    *,
+    response: Any,
+    recovery_info: Mapping[str, str] | None = None,
+    logs: Iterable[str] | None = None,
+    state: Mapping[str, Any] | None = None,
+) -> AsyncSubmissionPayload:
+    """Construct a normalized payload for async API submission checks."""
+
+    payload: AsyncSubmissionPayload = {
+        "response": response,
+        "recovery_info": dict(recovery_info or {}),
+        "logs": list(logs or []),
+        "state": dict(state or {}),
+    }
+    return payload
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- add Scout payload TypedDicts and async submission helper factories to tests.behavior.utils
- refactor AUTO reasoning and API step definitions to reuse the new helpers for claims, sources, and async results
- ensure metadata helpers cover audit badges and additional telemetry fields

## Testing
- uv run python -m compileall tests/behavior/utils.py tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/reasoning_modes_auto_steps.py tests/behavior/steps/reasoning_modes_auto_cli_cycle_steps.py tests/behavior/steps/reasoning_mode_api_steps.py

------
https://chatgpt.com/codex/tasks/task_e_68deba7e448483339be6a87773270761