### PR TITLE
Enhance behavior payload storage helper

### DIFF
--- a/tests/behavior/steps/__init__.py
+++ b/tests/behavior/steps/__init__.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
         get_required,
         set_value,
     )
-    from tests.behavior.utils import PayloadDict, as_payload
+    from tests.behavior.utils import PayloadDict, as_payload, store_payload
 
     app_running: Callable[..., None]
     app_running_with_default: Callable[..., None]
@@ -42,6 +42,7 @@ else:
     _utils = importlib.import_module("tests.behavior.utils")
     PayloadDict = _utils.PayloadDict
     as_payload = _utils.as_payload
+    store_payload = _utils.store_payload
 
 if not TYPE_CHECKING:
     # Import step modules so pytest-bdd discovers them when running the package.
@@ -74,4 +75,5 @@ __all__ = [
     "set_value",
     "PayloadDict",
     "as_payload",
+    "store_payload",
 ]

--- a/tests/behavior/utils.py
+++ b/tests/behavior/utils.py
@@ -1,4 +1,4 @@
-"""Typed helpers for behavior test payloads."""
+"""Typed helpers for composing and storing behavior test payloads."""
 
 from __future__ import annotations
 
@@ -90,10 +90,26 @@ def as_payload(payload: Mapping[str, Any] | None = None, /, **values: Any) -> Pa
     return data
 
 
-def store_payload(context: BehaviorContext, key: str, **values: Any) -> PayloadDict:
-    """Update ``context`` with a typed payload dictionary and return it."""
+def store_payload(
+    context: BehaviorContext,
+    key: str,
+    payload: Mapping[str, Any] | None = None,
+    /,
+    **values: Any,
+) -> PayloadDict:
+    """Update ``context`` with a typed payload dictionary and return it.
 
-    payload = as_payload(**values)
+    Args:
+        context: The behavior context being updated.
+        key: The lookup key for the stored payload.
+        payload: Optional base mapping to merge into the stored payload.
+        **values: Additional key-value pairs merged into the payload.
+
+    Returns:
+        The merged payload stored in ``context``.
+    """
+
+    payload = as_payload(payload, **values)
     context[key] = payload
     return payload
 


### PR DESCRIPTION
## Summary
- allow `store_payload` to merge an existing mapping when storing behavior context payloads
- update the behavior step package exports to expose the enhanced helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dedcb53a5483339ce3e18202222fbb