### PR TITLE
Standardize BehaviorContext usage in API BDD steps

### DIFF
--- a/tests/behavior/steps/api_async_query_steps.py
+++ b/tests/behavior/steps/api_async_query_steps.py
@@ -1,11 +1,9 @@
 """Step definitions for asynchronous query API behavior tests."""
 
 from __future__ import annotations
-from tests.behavior.utils import build_async_submission_payload
 
 import asyncio
 import time
-from typing import Any
 from unittest.mock import patch
 
 from pytest_bdd import given, parsers, scenario, then, when
@@ -16,8 +14,10 @@ from autoresearch.config.models import APIConfig, ConfigModel
 from autoresearch.errors import AgentError, TimeoutError
 from autoresearch.models import QueryResponse
 from autoresearch.orchestration.orchestrator import Orchestrator
-from . import common_steps  # noqa: F401
+from tests.behavior.context import BehaviorContext
+from tests.behavior.utils import build_async_submission_payload
 
+from . import common_steps  # noqa: F401
 from .error_recovery_steps import (  # noqa: F401
     assert_error_category,
     assert_logs,
@@ -28,7 +28,7 @@ from .error_recovery_steps import (  # noqa: F401
 
 @given("the API server is running")
 def api_server_running(
-    bdd_context: dict[str, Any],
+    bdd_context: BehaviorContext,
     api_client,
     temp_config,
     restore_environment,
@@ -41,7 +41,7 @@ def api_server_running(
 @when(parsers.parse('I submit an async query "{query}"'))
 def submit_async_query(
     query: str,
-    bdd_context: dict[str, Any],
+    bdd_context: BehaviorContext,
     monkeypatch,
     dummy_query_response: QueryResponse,
     temp_config,
@@ -67,7 +67,7 @@ def submit_async_query(
 
 
 @then("the response should include a query ID")
-def check_query_id(bdd_context: dict[str, Any]) -> None:
+def check_query_id(bdd_context: BehaviorContext) -> None:
     """Ensure the async submission returned an identifier."""
 
     resp = bdd_context["submit_response"]
@@ -77,7 +77,7 @@ def check_query_id(bdd_context: dict[str, Any]) -> None:
 
 
 @when("I request the status for that query ID")
-def request_status(bdd_context: dict[str, Any], monkeypatch) -> None:
+def request_status(bdd_context: BehaviorContext, monkeypatch) -> None:
     """Retrieve the result for the previously submitted query."""
 
     monkeypatch.setattr(time, "sleep", lambda *_: None)
@@ -92,7 +92,7 @@ def request_status(bdd_context: dict[str, Any], monkeypatch) -> None:
 
 
 @then("the response should contain an answer")
-def check_answer(bdd_context: dict[str, Any]) -> None:
+def check_answer(bdd_context: BehaviorContext) -> None:
     """Verify the async query returned an answer."""
 
     resp = bdd_context["status_response"]
@@ -104,7 +104,7 @@ def check_answer(bdd_context: dict[str, Any]) -> None:
 
 @given("an async query has been submitted")
 def async_query_submitted(
-    bdd_context: dict[str, Any],
+    bdd_context: BehaviorContext,
     api_client,
     monkeypatch,
     dummy_query_response: QueryResponse,
@@ -130,7 +130,7 @@ def async_query_submitted(
 
 
 @when("I cancel the async query")
-def cancel_async_query(bdd_context: dict[str, Any]) -> None:
+def cancel_async_query(bdd_context: BehaviorContext) -> None:
     """Cancel the previously submitted asynchronous query."""
 
     query_id = bdd_context["query_id"]
@@ -140,7 +140,7 @@ def cancel_async_query(bdd_context: dict[str, Any]) -> None:
 
 
 @then("the response should indicate cancellation")
-def check_cancellation(bdd_context: dict[str, Any]) -> None:
+def check_cancellation(bdd_context: BehaviorContext) -> None:
     """Ensure the async query was cancelled and cleaned up."""
 
     resp = bdd_context["cancel_response"]

--- a/tests/behavior/steps/api_auth_steps.py
+++ b/tests/behavior/steps/api_auth_steps.py
@@ -1,6 +1,7 @@
 """Step definitions for API authentication and rate limiting."""
 
 from __future__ import annotations
+from tests.behavior.context import BehaviorContext
 from tests.behavior.utils import empty_metrics
 
 import importlib
@@ -78,7 +79,7 @@ def _install_orchestrator_stub(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Orchestrator, "run_query", _run_query_stub)
 
 
-def _get_response(test_context: dict[str, object], key: str) -> HttpResponse:
+def _get_response(test_context: BehaviorContext, key: str) -> HttpResponse:
     """Retrieve and type-cast a stored HTTP response from the context."""
 
     return cast(HttpResponse, test_context[key])
@@ -139,7 +140,7 @@ def require_api_key_no_permissions(
 )
 def send_query_with_header(
     api_client_factory: ApiClientFactory,
-    test_context: dict[str, object],
+    test_context: BehaviorContext,
     query: str,
     header: str,
     value: str,
@@ -152,7 +153,7 @@ def send_query_with_header(
 @when(parsers.parse('I send a query "{query}" without credentials'))
 def send_query_without_credentials(
     api_client_factory: ApiClientFactory,
-    test_context: dict[str, object],
+    test_context: BehaviorContext,
     query: str,
 ) -> None:
     client = api_client_factory(None)
@@ -162,7 +163,7 @@ def send_query_without_credentials(
 
 @when("I send two queries to the API")
 def send_two_queries(
-    api_client_factory: ApiClientFactory, test_context: dict[str, object]
+    api_client_factory: ApiClientFactory, test_context: BehaviorContext
 ) -> None:
     client = api_client_factory(None)
     test_context["resp1"] = client.post("/query", json={"query": "q"})
@@ -170,7 +171,7 @@ def send_two_queries(
 
 
 @then(parsers.parse("the response status should be {status:d}"))
-def check_status(test_context: dict[str, object], status: int) -> None:
+def check_status(test_context: BehaviorContext, status: int) -> None:
     response = _get_response(test_context, "response")
     assert response.status_code == status
     data = response.json()
@@ -184,7 +185,7 @@ def check_status(test_context: dict[str, object], status: int) -> None:
     parsers.parse('the response should include header "{header}" with value "{value}"')
 )
 def check_response_header(
-    test_context: dict[str, object], header: str, value: str
+    test_context: BehaviorContext, header: str, value: str
 ) -> None:
     response = _get_response(test_context, "response")
     assert header in response.headers
@@ -192,7 +193,7 @@ def check_response_header(
 
 
 @then(parsers.parse("the first response status should be {status:d}"))
-def check_first_status(test_context: dict[str, object], status: int) -> None:
+def check_first_status(test_context: BehaviorContext, status: int) -> None:
     response = _get_response(test_context, "resp1")
     assert response.status_code == status
     data = response.json()
@@ -201,7 +202,7 @@ def check_first_status(test_context: dict[str, object], status: int) -> None:
 
 
 @then(parsers.parse("the second response status should be {status:d}"))
-def check_second_status(test_context: dict[str, object], status: int) -> None:
+def check_second_status(test_context: BehaviorContext, status: int) -> None:
     response = _get_response(test_context, "resp2")
     assert response.status_code == status
     if status == 429:

--- a/tests/behavior/steps/api_config_steps.py
+++ b/tests/behavior/steps/api_config_steps.py
@@ -1,10 +1,14 @@
 from pytest_bdd import given, when, then, scenario
+
 from autoresearch.config.models import ConfigModel, APIConfig
 from autoresearch.config.loader import ConfigLoader
+from tests.behavior.context import BehaviorContext
 
 
 @given("the API server is running with config permissions")
-def api_server_with_permissions(test_context, api_client, monkeypatch):
+def api_server_with_permissions(
+    test_context: BehaviorContext, api_client, monkeypatch
+) -> None:
     cfg = ConfigModel(api=APIConfig())
     cfg.api.role_permissions["anonymous"].append("config")
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
@@ -12,66 +16,66 @@ def api_server_with_permissions(test_context, api_client, monkeypatch):
 
 
 @when("I request the config endpoint")
-def request_config(test_context):
+def request_config(test_context: BehaviorContext) -> None:
     client = test_context["client"]
     test_context["response"] = client.get("/config")
 
 
 @when("I update loops to 2 via the config endpoint")
-def update_config(test_context):
+def update_config(test_context: BehaviorContext) -> None:
     client = test_context["client"]
     test_context["response"] = client.put("/config", json={"loops": 2})
 
 
 @when("I replace the configuration via the config endpoint")
-def replace_config(test_context):
+def replace_config(test_context: BehaviorContext) -> None:
     client = test_context["client"]
     current = client.get("/config").json()
     test_context["response"] = client.post("/config", json=current)
 
 
 @when("I reload the configuration")
-def reload_config(test_context):
+def reload_config(test_context: BehaviorContext) -> None:
     client = test_context["client"]
     test_context["response"] = client.delete("/config")
 
 
 @then("the response status should be 200")
-def response_ok(test_context):
+def response_ok(test_context: BehaviorContext) -> None:
     resp = test_context["response"]
     assert resp.status_code == 200
     assert "error" not in resp.json()
 
 
 @then('the response body should contain "reasoning_mode"')
-def body_has_reasoning_mode(test_context):
+def body_has_reasoning_mode(test_context: BehaviorContext) -> None:
     data = test_context["response"].json()
     assert "reasoning_mode" in data
 
 
 @then("the response body should show loops 2")
-def body_shows_loops(test_context):
+def body_shows_loops(test_context: BehaviorContext) -> None:
     data = test_context["response"].json()
     assert data.get("loops") == 2
 
 
 @scenario("../features/api_config.feature", "Retrieve current configuration")
-def test_get_config():
+def test_get_config() -> None:
     pass
 
 
 @scenario("../features/api_config.feature", "Update loops via the config endpoint")
-def test_update_config():
+def test_update_config() -> None:
     pass
 
 
 @scenario(
     "../features/api_config.feature", "Replace configuration via the config endpoint"
 )
-def test_replace_config():
+def test_replace_config() -> None:
     pass
 
 
 @scenario("../features/api_config.feature", "Reload configuration")
-def test_reload_config():
+def test_reload_config() -> None:
     pass

--- a/tests/behavior/steps/api_documentation_steps.py
+++ b/tests/behavior/steps/api_documentation_steps.py
@@ -2,20 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from fastapi.openapi.docs import get_swagger_ui_html
 from pytest_bdd import given, parsers, scenario, then, when
 
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import APIConfig, ConfigModel
+from tests.behavior.context import BehaviorContext
 
 pytest_plugins = ["tests.behavior.steps.common_steps"]
 
 
 @given("the API server is running")
 def api_server_running(
-    bdd_context: dict[str, Any],
+    bdd_context: BehaviorContext,
     api_client,
     monkeypatch,
     temp_config,
@@ -40,7 +39,7 @@ def api_server_running(
 
 
 @when("I request the docs endpoint")
-def request_docs(bdd_context: dict[str, Any]) -> None:
+def request_docs(bdd_context: BehaviorContext) -> None:
     """Send a GET request to the Swagger UI endpoint."""
 
     client = bdd_context["client"]
@@ -48,7 +47,7 @@ def request_docs(bdd_context: dict[str, Any]) -> None:
 
 
 @when("I request the openapi endpoint")
-def request_openapi(bdd_context: dict[str, Any]) -> None:
+def request_openapi(bdd_context: BehaviorContext) -> None:
     """Send a GET request to the OpenAPI schema endpoint."""
 
     client = bdd_context["client"]
@@ -56,14 +55,14 @@ def request_openapi(bdd_context: dict[str, Any]) -> None:
 
 
 @then("the response status should be 200")
-def check_status_ok(bdd_context: dict[str, Any]) -> None:
+def check_status_ok(bdd_context: BehaviorContext) -> None:
     """Assert that the HTTP status code is 200."""
 
     assert bdd_context["response"].status_code == 200
 
 
 @then(parsers.parse('the response body should contain "{text}"'))
-def check_body_contains(text: str, bdd_context: dict[str, Any]) -> None:
+def check_body_contains(text: str, bdd_context: BehaviorContext) -> None:
     """Verify that the response body contains the expected substring."""
     body = bdd_context["response"].text.lower().replace(" ", "").replace("-", "")
     expected = text.lower().replace(" ", "").replace("-", "")

--- a/tests/behavior/steps/api_edge_cases_steps.py
+++ b/tests/behavior/steps/api_edge_cases_steps.py
@@ -1,18 +1,20 @@
 """Step definitions for API edge case scenarios."""
 
 from pytest_bdd import scenario, given, when, then, parsers
+
 from autoresearch.config.models import ConfigModel
 from autoresearch.config.loader import ConfigLoader
+from tests.behavior.context import BehaviorContext
 
 
 @given("the API server is running")
-def api_server_running(test_context, api_client):
+def api_server_running(test_context: BehaviorContext, api_client) -> None:
     """Store an API client for requests."""
     test_context["client"] = api_client
 
 
 @when("I send invalid JSON to the API")
-def send_invalid_json(test_context):
+def send_invalid_json(test_context: BehaviorContext) -> None:
     """Post malformed JSON payload to the API."""
     client = test_context["client"]
     resp = client.post(
@@ -24,7 +26,7 @@ def send_invalid_json(test_context):
 
 
 @when("I request the metrics endpoint")
-def request_metrics(test_context, monkeypatch):
+def request_metrics(test_context: BehaviorContext, monkeypatch) -> None:
     """Request metrics without proper permissions."""
     cfg = ConfigModel()
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
@@ -34,7 +36,7 @@ def request_metrics(test_context, monkeypatch):
 
 
 @then("the response status should be 422")
-def assert_status_422(test_context):
+def assert_status_422(test_context: BehaviorContext) -> None:
     """Ensure the API returned a 422 status code."""
     resp = test_context["response"]
     assert resp.status_code == 422
@@ -43,7 +45,7 @@ def assert_status_422(test_context):
 
 
 @then("the response status should be 403")
-def assert_status_403(test_context):
+def assert_status_403(test_context: BehaviorContext) -> None:
     """Ensure the API returned a 403 status code."""
     resp = test_context["response"]
     assert resp.status_code == 403
@@ -52,7 +54,7 @@ def assert_status_403(test_context):
 
 
 @when(parsers.parse('I submit a query with deprecated version "{version}"'))
-def submit_deprecated_version(version, test_context):
+def submit_deprecated_version(version: str, test_context: BehaviorContext) -> None:
     """Send a query using an outdated API schema version."""
     client = test_context["client"]
     resp = client.post("/query", json={"version": version, "query": "test"})
@@ -60,7 +62,7 @@ def submit_deprecated_version(version, test_context):
 
 
 @then("the response status should be 410")
-def assert_status_410(test_context):
+def assert_status_410(test_context: BehaviorContext) -> None:
     """Ensure the API rejected a deprecated version."""
     resp = test_context["response"]
     assert resp.status_code == 410
@@ -69,7 +71,7 @@ def assert_status_410(test_context):
 
 
 @scenario("../features/api_edge_cases.feature", "Invalid JSON returns 422")
-def test_invalid_json():
+def test_invalid_json() -> None:
     """Scenario: invalid JSON payload is rejected."""
     pass
 
@@ -78,7 +80,7 @@ def test_invalid_json():
     "../features/api_edge_cases.feature",
     "Permission denied for metrics endpoint",
 )
-def test_permission_denied_metrics():
+def test_permission_denied_metrics() -> None:
     """Scenario: accessing metrics without permissions fails."""
     pass
 
@@ -87,6 +89,6 @@ def test_permission_denied_metrics():
     "../features/api_edge_cases.feature",
     "Deprecated API version rejected",
 )
-def test_deprecated_version():
+def test_deprecated_version() -> None:
     """Scenario: server rejects deprecated API versions."""
     pass

--- a/tests/behavior/steps/api_metrics_steps.py
+++ b/tests/behavior/steps/api_metrics_steps.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pytest_bdd import given, when, then, scenario, parsers
 
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import APIConfig, ConfigModel
+from tests.behavior.context import BehaviorContext
 
 
 @given("the API server is running")
 def api_server_running(
-    bdd_context: dict[str, Any],
+    bdd_context: BehaviorContext,
     api_client,
     monkeypatch,
     temp_config,
@@ -27,7 +26,7 @@ def api_server_running(
 
 @when("I request the metrics endpoint with authorization")
 def request_metrics_authorized(
-    bdd_context: dict[str, Any],
+    bdd_context: BehaviorContext,
     monkeypatch,
     temp_config,
     restore_environment,
@@ -46,7 +45,7 @@ def request_metrics_authorized(
 
 @when("I request the metrics endpoint")
 def request_metrics_denied(
-    bdd_context: dict[str, Any],
+    bdd_context: BehaviorContext,
     monkeypatch,
     temp_config,
     restore_environment,
@@ -60,21 +59,21 @@ def request_metrics_denied(
 
 
 @then("the response status should be 200")
-def check_status_ok(bdd_context: dict[str, Any]) -> None:
+def check_status_ok(bdd_context: BehaviorContext) -> None:
     """Assert that the HTTP response was successful."""
 
     assert bdd_context["response"].status_code == 200
 
 
 @then("the response status should be 403")
-def check_status_forbidden(bdd_context: dict[str, Any]) -> None:
+def check_status_forbidden(bdd_context: BehaviorContext) -> None:
     """Assert that access was forbidden."""
 
     assert bdd_context["response"].status_code == 403
 
 
 @then(parsers.parse('the response body should contain "{text}"'))
-def check_body_contains(text: str, bdd_context: dict[str, Any]) -> None:
+def check_body_contains(text: str, bdd_context: BehaviorContext) -> None:
     """Verify that the metrics output includes the expected metric name."""
 
     assert text in bdd_context["response"].text

--- a/tests/behavior/steps/api_misc_steps.py
+++ b/tests/behavior/steps/api_misc_steps.py
@@ -2,10 +2,13 @@ from pytest_bdd import scenario, given, when, then
 
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel, APIConfig
+from tests.behavior.context import BehaviorContext
 
 
 @given("the API server is running")
-def api_server_running(test_context, api_client, monkeypatch):
+def api_server_running(
+    test_context: BehaviorContext, api_client, monkeypatch
+) -> None:
     cfg = ConfigModel(api=APIConfig())
     cfg.api.role_permissions["anonymous"].append("health")
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
@@ -13,14 +16,14 @@ def api_server_running(test_context, api_client, monkeypatch):
 
 
 @when("I request the health endpoint")
-def request_health(test_context):
+def request_health(test_context: BehaviorContext) -> None:
     client = test_context["client"]
     resp = client.get("/health")
     test_context["response"] = resp
 
 
 @then('the response body should contain "status" "ok"')
-def check_health_body(test_context):
+def check_health_body(test_context: BehaviorContext) -> None:
     resp = test_context["response"]
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
@@ -28,14 +31,14 @@ def check_health_body(test_context):
 
 
 @then("the response status should be 200")
-def assert_status_200(test_context):
+def assert_status_200(test_context: BehaviorContext) -> None:
     resp = test_context["response"]
     assert resp.status_code == 200
     assert "error" not in resp.json()
 
 
 @when("I request the capabilities endpoint")
-def request_capabilities(test_context, monkeypatch):
+def request_capabilities(test_context: BehaviorContext, monkeypatch) -> None:
     cfg = ConfigModel(api=APIConfig())
     cfg.api.role_permissions["anonymous"].append("capabilities")
     monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
@@ -44,7 +47,7 @@ def request_capabilities(test_context, monkeypatch):
 
 
 @then("the response should include supported reasoning modes")
-def check_capabilities(test_context):
+def check_capabilities(test_context: BehaviorContext) -> None:
     resp = test_context["response"]
     assert resp.status_code == 200
     data = resp.json()
@@ -55,10 +58,10 @@ def check_capabilities(test_context):
 
 
 @scenario("../features/api_misc.feature", "Health endpoint returns status")
-def test_health_endpoint():
+def test_health_endpoint() -> None:
     pass
 
 
 @scenario("../features/api_misc.feature", "Capabilities endpoint lists reasoning modes")
-def test_capabilities_endpoint():
+def test_capabilities_endpoint() -> None:
     pass


### PR DESCRIPTION
## Summary
- update API-related behavior step modules to depend on the shared BehaviorContext typing and add explicit return annotations
- use store_payload/PayloadDict helpers when persisting structured payloads into the shared context
- tighten the orchestrator integration fixture to emit a typed BehaviorContext payload

## Testing
- uv run python -m compileall tests/behavior/steps/api_async_query_steps.py tests/behavior/steps/api_auth_steps.py tests/behavior/steps/api_batch_query_steps.py tests/behavior/steps/api_config_steps.py tests/behavior/steps/api_documentation_steps.py tests/behavior/steps/api_edge_cases_steps.py tests/behavior/steps/api_metrics_steps.py tests/behavior/steps/api_misc_steps.py tests/behavior/steps/api_orchestrator_integration_steps.py

------
https://chatgpt.com/codex/tasks/task_e_68dedeec8d388333a123b4a452422d6e