### PR TITLE
Refine typing for storage and extras fixtures

### DIFF
--- a/tests/fixtures/extras.py
+++ b/tests/fixtures/extras.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import importlib.util
+from importlib import import_module
 from importlib.machinery import ModuleSpec
 from types import ModuleType
 from typing import Final
 
 import pytest
+
+
+from .protocols import ExtraProbe, ModuleLoader
 
 
 def _module_available(name: str) -> bool:
@@ -18,56 +22,87 @@ def _module_available(name: str) -> bool:
     return spec is not None
 
 
+def _load_module(name: str) -> ModuleType | None:
+    """Attempt to import ``name`` while suppressing ImportError cascades."""
+
+    try:
+        if not _module_available(name):
+            return None
+        return import_module(name)
+    except Exception:  # pragma: no cover - defensive import safety
+        return None
+
+
+def _git_validator(module: ModuleType) -> bool:
+    """Verify Git extras expose the expected surface area."""
+
+    repo_attr: Final[object | None] = getattr(module, "Repo", None)
+    version_attr: Final[object | None] = getattr(module, "__version__", None)
+    return repo_attr is not None and version_attr is not None
+
+
+EXTRA_PROBES: Final[dict[str, ExtraProbe]] = {
+    "ui": ExtraProbe(modules=("streamlit",)),
+    "vss": ExtraProbe(modules=("duckdb_extension_vss",)),
+    "git": ExtraProbe(modules=("git",), validator=_git_validator),
+    "distributed": ExtraProbe(modules=("ray",)),
+    "analysis": ExtraProbe(modules=("polars",)),
+    "nlp": ExtraProbe(modules=("spacy",)),
+    "llm": ExtraProbe(modules=("fastembed",)),
+    "parsers": ExtraProbe(modules=("pdfminer",)),
+}
+
+
+def _extra_available(name: str, loader: ModuleLoader = _load_module) -> bool:
+    """Helper resolving extras through shared probes."""
+
+    probe = EXTRA_PROBES[name]
+    return probe.available(loader)
+
+
 @pytest.fixture
 def has_ui() -> bool:
     """Return True if the UI extra is installed."""
-    return _module_available("streamlit")
+    return _extra_available("ui")
 
 
 @pytest.fixture
 def has_vss() -> bool:
     """Return True if the DuckDB VSS extension is available."""
-    return _module_available("duckdb_extension_vss")
+    return _extra_available("vss")
 
 
 @pytest.fixture
 def has_git() -> bool:
     """Return True if GitPython is installed."""
-    try:
-        import git as git_module  # type: ignore[import-untyped]
-    except Exception:
-        return False
-    git_module_typed: ModuleType = git_module
-    repo_attr: Final[object | None] = getattr(git_module_typed, "Repo", None)
-    version_attr: Final[object | None] = getattr(git_module_typed, "__version__", None)
-    return repo_attr is not None and version_attr is not None
+    return _extra_available("git")
 
 
 @pytest.fixture
 def has_distributed() -> bool:
     """Return True if distributed extras are installed."""
-    return _module_available("ray")
+    return _extra_available("distributed")
 
 
 @pytest.fixture
 def has_analysis() -> bool:
     """Return True if analysis extras are installed."""
-    return _module_available("polars")
+    return _extra_available("analysis")
 
 
 @pytest.fixture
 def has_nlp() -> bool:
     """Return True if NLP extras are installed."""
-    return _module_available("spacy")
+    return _extra_available("nlp")
 
 
 @pytest.fixture
 def has_llm() -> bool:
     """Return True if LLM extras are installed."""
-    return _module_available("fastembed")
+    return _extra_available("llm")
 
 
 @pytest.fixture
 def has_parsers() -> bool:
     """Return True if parser extras are installed."""
-    return _module_available("pdfminer")
+    return _extra_available("parsers")

--- a/tests/fixtures/protocols.py
+++ b/tests/fixtures/protocols.py
@@ -1,0 +1,74 @@
+"""Shared typing utilities for fixture stubs.
+
+This module centralises lightweight protocols and dataclasses used by
+``tests/fixtures`` so individual fixtures can share well-typed helpers
+without re-declaring structural contracts.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Any, Protocol
+
+
+JSONMapping = Mapping[str, Any]
+
+
+class StorageManagerProtocol(Protocol):
+    """Protocol describing the subset of ``StorageManager`` used in tests."""
+
+    @staticmethod
+    def persist_claim(claim: JSONMapping) -> None: ...
+
+    @staticmethod
+    def setup(
+        *,
+        db_path: str | None = ...,  # pragma: no cover - typing helper
+        context: object | None = ...,  # pragma: no cover - typing helper
+        state: object | None = ...,  # pragma: no cover - typing helper
+    ) -> "StorageManagerProtocol": ...
+
+
+StorageSetup = Callable[..., StorageManagerProtocol]
+
+
+class StorageModuleProtocol(Protocol):
+    """Protocol for the dynamically-created ``autoresearch.storage`` module."""
+
+    StorageManager: type[StorageManagerProtocol]
+    setup: StorageSetup
+
+
+@dataclass(slots=True)
+class StorageHandle:
+    """Dataclass capturing the exported handles from the storage stub."""
+
+    module: ModuleType
+    manager: type[StorageManagerProtocol]
+    setup: StorageSetup
+
+
+ModuleLoader = Callable[[str], ModuleType | None]
+ExtraValidator = Callable[[ModuleType], bool]
+
+
+@dataclass(frozen=True, slots=True)
+class ExtraProbe:
+    """Describe how to detect whether an optional extra is available."""
+
+    modules: Sequence[str]
+    validator: ExtraValidator | None = None
+
+    def available(self, loader: ModuleLoader) -> bool:
+        """Return ``True`` when all modules load and validators pass."""
+
+        for module_name in self.modules:
+            module = loader(module_name)
+            if module is None:
+                return False
+            if self.validator is not None and not self.validator(module):
+                return False
+        return True
+

--- a/tests/targeted/test_storage_eviction.py
+++ b/tests/targeted/test_storage_eviction.py
@@ -13,6 +13,7 @@ from autoresearch.storage import (  # noqa: E402
     StorageState,
     initialize_storage,
 )
+from autoresearch.storage_backends import DuckDBStorageBackend  # noqa: E402
 
 
 def test_initialize_storage_idempotent() -> None:
@@ -20,9 +21,13 @@ def test_initialize_storage_idempotent() -> None:
     ctx = StorageContext()
     st = StorageState()
     initialize_storage(db_path=":memory:", context=ctx, state=st)
-    first = ctx.db_backend._conn.execute("show tables").fetchall()
+    db_backend = ctx.db_backend
+    assert isinstance(db_backend, DuckDBStorageBackend)
+    first = db_backend._conn.execute("show tables").fetchall()
     initialize_storage(db_path=":memory:", context=ctx, state=st)
-    second = ctx.db_backend._conn.execute("show tables").fetchall()
+    db_backend_second = ctx.db_backend
+    assert isinstance(db_backend_second, DuckDBStorageBackend)
+    second = db_backend_second._conn.execute("show tables").fetchall()
     assert first == second
     StorageManager.teardown(remove_db=True, context=ctx, state=st)
     StorageManager.state = StorageState()

--- a/tests/unit/test_storage_persistence.py
+++ b/tests/unit/test_storage_persistence.py
@@ -69,7 +69,9 @@ def test_initialize_handles_missing_extension(tmp_path, monkeypatch):
     storage.teardown(remove_db=True)
     ctx = storage.initialize_storage(str(db_file))
     assert db_file.exists()
-    assert ctx.db_backend.has_vss() is False
+    db_backend = ctx.db_backend
+    assert isinstance(db_backend, storage.DuckDBStorageBackend)
+    assert db_backend.has_vss() is False
     assert called["count"] >= 1
-    ctx.db_backend._conn.execute("SELECT 1 FROM nodes LIMIT 1")
+    db_backend._conn.execute("SELECT 1 FROM nodes LIMIT 1")
     storage.teardown(remove_db=True, context=ctx)


### PR DESCRIPTION
## Summary
- add shared protocols/dataclasses for storage and extras fixtures
- tighten dummy storage and extras fixtures around the new shared typing utilities
- assert DuckDB backend availability before touching private connections in storage tests

## Testing
- uv run mypy --strict tests/fixtures tests/targeted/test_storage_eviction.py

------
https://chatgpt.com/codex/tasks/task_e_68deec5940708333b62dc129896455df