### PR TITLE
Improve semantic fallback caching and storage defaults

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -48,6 +48,16 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   sentence-transformers fallback. The log records the new failure mode while the
   TestPyPI dry run stays deferred under the alpha directive.
   【F:baseline/logs/task-coverage-20251001T152708Z.log†L60-L166】
+- Hardened the search embedding fallback so fastembed stubs are cleared, the
+  sentence-transformers import runs once, and AUTO mode logs why the fallback
+  failed when applicable. The paired regression stubs both libraries to assert
+  the cached fallback returns the expected vector, while storage loading now
+  coerces `minimum_deterministic_resident_nodes` back to its baseline so AUTO
+  mode keeps deterministic graph budgets without warnings.
+  【F:src/autoresearch/search/core.py†L100-L215】
+  【F:tests/unit/search/test_query_expansion_convergence.py†L120-L230】
+  【F:src/autoresearch/config/loader.py†L300-L320】
+  【F:tests/unit/config/test_loader_types.py†L1-L120】
 
 ## September 29, 2025
 - Reran `uv run task release:alpha` at 00:08 UTC; extras synced before

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -29,12 +29,18 @@ in place.
 【F:baseline/logs/task-coverage-20250930T181947Z.log†L1-L21】
 
 Semantic fallback detection now honours the runtime configuration before
-loading `sentence_transformers`, and the unit regression asserts the encode
-fallback activates once fastembed is unavailable. The same configuration guard
-ensures strict typing sweeps can execute without tripping import-time errors
-while we work through the remaining fixture annotations recorded below.
-【F:src/autoresearch/search/core.py†L147-L199】
-【F:tests/unit/search/test_query_expansion_convergence.py†L154-L206】
+loading `sentence_transformers`, caches the fallback class when fastembed is
+missing, and logs the import error so AUTO mode keeps the search pipeline
+efficient. The regression suite stubs both libraries to confirm the cached
+fallback returns the expected vector and prevents fastembed stubs from
+resurfacing once the runtime falls back to `sentence_transformers`. Storage
+defaults now coerce `minimum_deterministic_resident_nodes` back to the model
+baseline when files or environment overrides pass `null`, so AUTO mode keeps
+its deterministic graph budget without emitting warnings.
+【F:src/autoresearch/search/core.py†L100-L215】
+【F:tests/unit/search/test_query_expansion_convergence.py†L120-L230】
+【F:src/autoresearch/config/loader.py†L300-L320】
+【F:tests/unit/config/test_loader_types.py†L1-L120】
 【F:baseline/logs/mypy-strict-20251001T143959Z.log†L2358-L2377】
 
 The alpha checklist still tracks the open storage documentation note, deferred

--- a/src/autoresearch/config/loader.py
+++ b/src/autoresearch/config/loader.py
@@ -316,6 +316,15 @@ class ConfigLoader:
             ] = minimum_resident_nodes
         _merge_dict(storage_settings, storage_env)
 
+        default_minimum_nodes = cast(
+            int,
+            StorageConfig.model_fields[
+                "minimum_deterministic_resident_nodes"
+            ].default,
+        )
+        if storage_settings.get("minimum_deterministic_resident_nodes") is None:
+            storage_settings["minimum_deterministic_resident_nodes"] = default_minimum_nodes
+
         api_section = raw.get("api", {})
         api_settings: ConfigInitDict = dict(api_section) if isinstance(api_section, Mapping) else {}
         distributed_section = raw.get("distributed", {})


### PR DESCRIPTION
## Summary
- cache the sentence-transformers fallback import, reset stale fastembed stubs, and log import failures in the search embedding pipeline
- cover the fallback caching and storage minimum defaults with targeted regression tests and update release/status notes
- coerce `minimum_deterministic_resident_nodes` back to the model baseline when overrides pass `None`

## Testing
- uv run pytest tests/unit/search/test_query_expansion_convergence.py tests/unit/config/test_loader_types.py

------
https://chatgpt.com/codex/tasks/task_e_68df00e18b64833380939db49afc5445