### PR TITLE
test: type cleanup steps and extend AUTO verification coverage

### DIFF
--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -120,9 +120,15 @@ Tests are organized into four categories:
 2. **Integration Tests** (`tests/integration/`): Test interactions between
    components
 3. **Behavior Tests** (`tests/behavior/`): BDD-style tests using Gherkin syntax
-4. **Targeted Tests** (`tests/targeted/`): Temporary tests for specific issues.
+   4. **Targeted Tests** (`tests/targeted/`): Temporary tests for specific issues.
    Run them manually and migrate to unit or integration suites once
    validated.
+
+Behavior scenarios covering AUTO reasoning now exercise the PRDV verification
+loop telemetry end-to-end. The `reasoning_modes/auto_cli_verify_loop.feature`
+suite adds "AUTO mode completes the configured PRDV verification loops" to
+assert that CLI payloads, orchestrator metrics, and audit rollups report the
+configured loop count consistently.
 
 During `task coverage`, targeted smoke tests execute once per optional extra.
 The task iterates over `ALL_EXTRAS` and runs `pytest tests/targeted -m

--- a/tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature
+++ b/tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature
@@ -12,6 +12,13 @@ Feature: AUTO CLI reasoning captures planner, scout gate, and verification loop
     And the CLI output should record verification loop metrics
     And the AUTO metrics should record scout samples and agreement
 
+  Scenario: AUTO mode completes the configured PRDV verification loops
+    When I run the AUTO reasoning CLI for query "prdv verification rehearsal"
+    Then the CLI scout gate decision should escalate to debate
+    And the CLI output should record verification loop metrics
+    And the CLI verification loops should match the configured count
+    And the AUTO metrics should record scout samples and agreement
+
   Scenario: AUTO mode CLI run exits directly when the scout gate declines debate
     Given the scout gate will force a direct exit
     When I run the AUTO reasoning CLI for query "scout gate direct exit rehearsal"

--- a/tests/behavior/steps/evaluation_steps.py
+++ b/tests/behavior/steps/evaluation_steps.py
@@ -12,6 +12,7 @@ from rich.table import Table as RichTable
 
 from autoresearch.cli_evaluation import EvaluationHarness
 from autoresearch.evaluation import EvaluationSummary
+from tests.behavior.context import BehaviorContext
 from tests.unit.typing_helpers import build_summary_fixture
 
 from . import common_steps  # noqa: F401  # Import shared steps
@@ -94,7 +95,7 @@ def stubbed_summaries(tmp_path: Path) -> tuple[EvaluationSummary, EvaluationSumm
 @given("the evaluation harness runner is stubbed for telemetry")
 def stub_evaluation_harness(
     monkeypatch: pytest.MonkeyPatch,
-    bdd_context: dict,
+    bdd_context: BehaviorContext,
     stubbed_summaries: tuple[EvaluationSummary, EvaluationSummary],
 ) -> None:
     """Patch the evaluation harness to return predictable telemetry."""
@@ -121,7 +122,7 @@ def stub_evaluation_harness(
 
 
 @then("the evaluation summary output should list the stubbed telemetry")
-def assert_summary_output(bdd_context: dict) -> None:
+def assert_summary_output(bdd_context: BehaviorContext) -> None:
     """Verify that the CLI output includes the telemetry table with metrics."""
 
     result = bdd_context["result"]
@@ -165,7 +166,7 @@ def assert_summary_output(bdd_context: dict) -> None:
 
 
 @then("the evaluation summary table should include the metric columns")
-def assert_summary_columns(bdd_context: dict) -> None:
+def assert_summary_columns(bdd_context: BehaviorContext) -> None:
     """Ensure the rendered summary table exposes each metric column header."""
 
     stdout = bdd_context["result"].stdout
@@ -202,7 +203,7 @@ def assert_summary_columns(bdd_context: dict) -> None:
 
 
 @then("the evaluation artifacts should reference the stubbed paths")
-def assert_artifact_listing(bdd_context: dict) -> None:
+def assert_artifact_listing(bdd_context: BehaviorContext) -> None:
     """Ensure artifact paths from the stubbed summary are printed."""
 
     result = bdd_context["result"]

--- a/tests/behavior/steps/reasoning_modes_auto_steps.py
+++ b/tests/behavior/steps/reasoning_modes_auto_steps.py
@@ -28,6 +28,7 @@ from autoresearch.orchestration.orchestration_utils import (
 from autoresearch.orchestration.state import QueryState
 from autoresearch.search.context import SearchContext
 
+from tests.behavior.context import BehaviorContext
 from tests.helpers import ConfigModelStub, make_config_model
 
 ConfigLike = ConfigModel | ConfigModelStub
@@ -57,7 +58,7 @@ def configure_reasoning_mode(config: ConfigLike, mode: str) -> ConfigLike:
 
 
 @given("the planner proposes verification tasks")
-def planner_verification_tasks(bdd_context: dict[str, Any]) -> None:
+def planner_verification_tasks(bdd_context: BehaviorContext) -> None:
     bdd_context["task_graph"] = {
         "tasks": [
             {
@@ -86,7 +87,7 @@ def planner_verification_tasks(bdd_context: dict[str, Any]) -> None:
 def run_auto_planner_cycle(
     query: str,
     config: ConfigLike,
-    bdd_context: dict[str, Any],
+    bdd_context: BehaviorContext,
 ) -> dict[str, Any]:
     task_graph: dict[str, Any] = bdd_context["task_graph"]
 
@@ -342,7 +343,7 @@ def assert_audit_badges(
 
 @then("the planner task graph snapshot should include verification goals")
 def assert_planner_snapshot(
-    auto_cycle_result: dict[str, Any], bdd_context: dict[str, Any]
+    auto_cycle_result: dict[str, Any], bdd_context: BehaviorContext
 ) -> None:
     response: QueryResponse = auto_cycle_result["response"]
     assert response.task_graph is not None
@@ -377,7 +378,7 @@ def enable_planner_graph_conditioning(config: ConfigModel) -> ConfigModel:
 
 
 @given("the knowledge graph metadata includes contradictions and neighbours")
-def configure_graph_metadata(bdd_context: dict[str, Any]) -> None:
+def configure_graph_metadata(bdd_context: BehaviorContext) -> None:
     stage_metadata = {
         "contradictions": {
             "raw_score": 0.8,
@@ -443,7 +444,7 @@ def configure_graph_metadata(bdd_context: dict[str, Any]) -> None:
 def execute_planner_with_graph_context(
     query: str,
     config: ConfigLike,
-    bdd_context: dict[str, Any],
+    bdd_context: BehaviorContext,
     monkeypatch,
 ) -> dict[str, Any]:
     stage_metadata = bdd_context["graph_stage_metadata"]


### PR DESCRIPTION
## Summary
- annotate cleanup and AUTO reasoning step modules with explicit BehaviorContext typing and shared payload helpers
- replace manual tempfile monkeypatching with the pytest monkeypatch fixture and introduce typed cleanup payload records
- extend AUTO-mode verification scenarios and document PRDV loop coverage expectations in the testing guidelines

## Testing
- uv run --extra test pytest tests/behavior/steps/test_cleanup_extended_steps.py tests/behavior/steps/a2a_mcp_integration_steps.py tests/behavior/steps/evaluation_steps.py tests/behavior/steps/reasoning_modes_auto_cli_cycle_steps.py tests/behavior/steps/reasoning_modes_auto_steps.py


------
https://chatgpt.com/codex/tasks/task_e_68df06edc4788333a17c78d0e205f02c