### PR TITLE
Refactor integration config fixtures and add typed RDF graph helpers

### DIFF
--- a/tests/integration/test_local_file_backend_pdf.py
+++ b/tests/integration/test_local_file_backend_pdf.py
@@ -6,7 +6,7 @@ import pytest
 
 
 @pytest.mark.requires_parsers
-def test_local_file_backend_pdf(tmp_path, monkeypatch):
+def test_local_file_backend_pdf(tmp_path, monkeypatch, config_factory):
     """_local_file_backend should parse PDFs using pdfminer."""
     dummy_pdf = tmp_path / "sample.pdf"
     dummy_pdf.write_text("content")
@@ -16,12 +16,17 @@ def test_local_file_backend_pdf(tmp_path, monkeypatch):
     from autoresearch.search import core
     importlib.reload(core)
 
-    class Cfg:
-        class search:
-            class local_file:
-                path = str(tmp_path)
-                file_types = ["pdf"]
-
-    monkeypatch.setattr(core, "get_config", lambda: Cfg)
+    cfg = config_factory(
+        {
+            "search": {
+                "local_file": {
+                    "path": str(tmp_path),
+                    "file_types": ["pdf"],
+                }
+            }
+        }
+    )
+    monkeypatch.setattr(core, "get_config", lambda: cfg)
     results = core._local_file_backend("dummy")
-    assert results and results[0]["snippet"] == "dummy snippet"
+    assert results, "local_file backend should return at least one match"
+    assert results[0]["snippet"] == "dummy snippet"

--- a/tests/integration/test_local_git_backend.py
+++ b/tests/integration/test_local_git_backend.py
@@ -6,7 +6,6 @@ import pytest
 
 from tests.optional_imports import import_or_skip
 
-from autoresearch.config.models import ConfigModel
 from autoresearch.search.core import _local_git_backend
 from autoresearch.storage import StorageManager
 
@@ -25,7 +24,7 @@ def _dummy_connection():
 
 
 @pytest.mark.requires_git
-def test_local_git_backend_finds_file_content(tmp_path, monkeypatch):
+def test_local_git_backend_finds_file_content(tmp_path, monkeypatch, config_factory):
     git = import_or_skip("git", reason="git extra not installed")
     repo_path = tmp_path / "repo"
     repo = git.Repo.init(repo_path)
@@ -34,11 +33,18 @@ def test_local_git_backend_finds_file_content(tmp_path, monkeypatch):
     repo.index.add([str(file_path)])
     repo.index.commit("add data")
 
-    cfg = ConfigModel()
-    cfg.search.local_git.repo_path = str(repo_path)
-    cfg.search.local_git.branches = [repo.active_branch.name]
-    cfg.search.local_git.history_depth = 5
-    cfg.search.local_file.file_types = ["txt"]
+    cfg = config_factory(
+        {
+            "search": {
+                "local_git": {
+                    "repo_path": str(repo_path),
+                    "branches": [repo.active_branch.name],
+                    "history_depth": 5,
+                },
+                "local_file": {"file_types": ["txt"]},
+            }
+        }
+    )
     monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
     monkeypatch.setattr("autoresearch.search.core.Repo", git.Repo)
     monkeypatch.setattr(StorageManager, "connection", staticmethod(_dummy_connection))
@@ -48,7 +54,7 @@ def test_local_git_backend_finds_file_content(tmp_path, monkeypatch):
 
 
 @pytest.mark.requires_git
-def test_local_git_backend_finds_commit_message(tmp_path, monkeypatch):
+def test_local_git_backend_finds_commit_message(tmp_path, monkeypatch, config_factory):
     git = import_or_skip("git", reason="git extra not installed")
     repo_path = tmp_path / "repo"
     repo = git.Repo.init(repo_path)
@@ -60,11 +66,18 @@ def test_local_git_backend_finds_commit_message(tmp_path, monkeypatch):
     repo.index.add([str(file_path)])
     repo.index.commit("feature commitmarker")
 
-    cfg = ConfigModel()
-    cfg.search.local_git.repo_path = str(repo_path)
-    cfg.search.local_git.branches = [repo.active_branch.name]
-    cfg.search.local_git.history_depth = 5
-    cfg.search.local_file.file_types = ["txt"]
+    cfg = config_factory(
+        {
+            "search": {
+                "local_git": {
+                    "repo_path": str(repo_path),
+                    "branches": [repo.active_branch.name],
+                    "history_depth": 5,
+                },
+                "local_file": {"file_types": ["txt"]},
+            }
+        }
+    )
     monkeypatch.setattr("autoresearch.search.core.get_config", lambda: cfg)
     monkeypatch.setattr("autoresearch.search.core.Repo", git.Repo)
     monkeypatch.setattr(StorageManager, "connection", staticmethod(_dummy_connection))

--- a/tests/integration/test_ontology_reasoning.py
+++ b/tests/integration/test_ontology_reasoning.py
@@ -9,14 +9,15 @@ from autoresearch.storage import StorageManager, teardown
 from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.kg_reasoning import register_reasoner
+from autoresearch.storage_utils import graph_add, graph_subject_objects, graph_triples
 
 
 def _simple_rdfs(graph: rdflib.Graph) -> None:
     """Tiny RDFS subclass reasoner used for integration tests."""
 
-    for subj, obj in graph.subject_objects(rdflib.RDF.type):
-        for _s, _p, super_cls in graph.triples((obj, rdflib.RDFS.subClassOf, None)):
-            graph.add((subj, rdflib.RDF.type, super_cls))
+    for subj, obj in graph_subject_objects(graph, rdflib.RDF.type):
+        for _s, _p, super_cls in graph_triples(graph, (obj, rdflib.RDFS.subClassOf, None)):
+            graph_add(graph, (subj, rdflib.RDF.type, super_cls))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_search_storage.py
+++ b/tests/integration/test_search_storage.py
@@ -172,7 +172,7 @@ def clean_storage(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None
 
 
 def _config_without_network() -> ConfigModel:
-    cfg = ConfigModel()
+    cfg = ConfigModel.model_validate({})
     cfg.search.backends = []
     cfg.search.embedding_backends = ["duckdb"]
     cfg.search.context_aware.enabled = False


### PR DESCRIPTION
## Summary
- add typed rdflib graph utilities and adopt them in storage manager and ontology tests
- provide a config_factory fixture and update storage/search integrations to build real ConfigModels
- align search backend tests and local backend integrations with validated configs and stronger assertions

## Testing
- uv run mypy --strict tests/integration

------
https://chatgpt.com/codex/tasks/task_e_68df0ca659648333814e031a1c9b5457