### PR TITLE
Add strict mypy gate task and document manual CI policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,13 @@
 - 
 
 # Testing
+- [ ] `task mypy-strict`
 - [ ] `task check`
 - [ ] `task verify`
 
 # Verification
 - [ ] `uv run task verify EXTRAS="nlp ui vss git distributed analysis llm parsers gpu"` — coverage ___ %
+- [ ] TestPyPI dry run (paused; enable `run_testpypi_dry_run` in CI workflow when needed)
 
 # Spec References
 - docs/orchestrator_state.md#state-transitions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ name: CI
 # via the CLI: `gh workflow run CI`.
 on:
   workflow_dispatch:
+    inputs:
+      run_testpypi_dry_run:
+        description: "Run TestPyPI dry run stage"
+        type: boolean
+        default: false
 
 jobs:
   check-env:
@@ -65,6 +70,8 @@ jobs:
         run: uv run python scripts/check_env.py
       - name: Audit spec files
         run: uv run task lint-specs
+      - name: Run strict mypy gate
+        run: uv run task mypy-strict
       - name: Run task check
         run: uv run task check
       - name: Unit tests with deprecations as errors
@@ -143,6 +150,7 @@ jobs:
   publish-dev-dry-run:
     needs: verify
     runs-on: ubuntu-latest
+    if: inputs.run_testpypi_dry_run == true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,26 @@ checks are required. `task verify` always syncs the `dev-minimal` and `test`
 extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
+## October 3, 2025
+- Manual CI dispatches now expose a `run_testpypi_dry_run` flag that defaults
+  to false, keeping the TestPyPI dry run paused while the verify job runs
+  `task mypy-strict` immediately after spec linting to surface strict typing
+  failures sooner.
+  【F:.github/workflows/ci.yml†L5-L48】【F:.github/workflows/ci.yml†L70-L104】
+- `task mypy-strict` completed at **01:31 UTC**, confirming the repository-wide
+  strict sweep still finishes without diagnostics.
+  【F:baseline/logs/mypy-strict-20251003T013152Z.log†L1-L1】
+- `uv run task verify EXTRAS="nlp ui vss git distributed analysis llm
+  parsers"` continues to fail in the flake8 stage because the behavior,
+  integration, and storage tests retain unused imports, blank-line debt, and
+  undefined helper references; the new log archives the failure details while
+  we triage the lint backlog.【F:baseline/logs/task-verify-20251003T013253Z.log†L1-L22】
+- `uv run task coverage EXTRAS="nlp ui vss git distributed analysis llm
+  parsers"` still halts when `test_scheduler_restarts_existing_timer` observes
+  that the captured `DummyTimer` never marks itself as cancelled, so
+  `coverage.xml` remains unchanged until we address the scheduler regression.
+  【F:baseline/logs/task-coverage-20251003T013422Z.log†L1-L40】
+
 ## October 2, 2025
 - `uv run mypy --strict src tests` completed at **23:57 UTC** with zero
   findings, clearing the 2,114-error backlog logged on October 1 and restoring

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,9 +1,20 @@
-As of **2025-10-02** at 23:57 UTC `uv run mypy --strict src tests` finishes with
-no errors, clearing the 2,114-item backlog logged on October 1. Phase 2 planner
-execution can restart once `task verify` and `task coverage` reruns confirm the
-strict gate stays green alongside the established 92.4 % coverage record cited
-below.
-【F:baseline/logs/mypy-strict-20251002T235732Z.log†L1-L1】
+As of **2025-10-03** at 01:31 UTC `task mypy-strict` completes without
+diagnostics, keeping the automated strict gate green now that Task `check`,
+Task `verify`, and the CI workflow all invoke the target directly. TestPyPI dry
+runs remain opt-in because the new `run_testpypi_dry_run` workflow input
+defaults to false, holding the publish stage until reviewers re-enable it.
+【F:baseline/logs/mypy-strict-20251003T013152Z.log†L1-L1】【F:.github/workflows/ci.yml†L5-L104】
+
+As of **2025-10-03** at 01:32 UTC
+`uv run task verify EXTRAS="nlp ui vss git distributed analysis llm parsers"`
+still fails in the flake8 phase because behavior, integration, and storage
+tests retain unused imports, blank-line debt, and undefined helper references.
+The accompanying coverage sweep at 01:34 UTC stops when
+`test_scheduler_restarts_existing_timer` observes that its dummy timer never
+marks itself as cancelled, so `coverage.xml` remains unchanged while the
+regression stands.
+【F:baseline/logs/task-verify-20251003T013253Z.log†L1-L22】
+【F:baseline/logs/task-coverage-20251003T013422Z.log†L1-L40】
 
 As of **2025-09-30** at 18:19 UTC `uv run task coverage` finishes with the
 92.4 % statement rate after the QueryState registry clone switched to typed

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,9 +59,14 @@ tasks:
     cmds:
       - uv run python scripts/check_release_metadata.py
     desc: "Validate release version and date alignment"
-  mypy:strict-suite:
+  mypy-strict:
     cmds:
       - uv run mypy --strict src tests
+    desc: "Run mypy in strict mode across src and tests"
+
+  mypy:strict-suite:
+    cmds:
+      - task mypy-strict
     desc: "Run mypy in strict mode across src and tests"
 
   mypy:behavior:
@@ -83,7 +88,7 @@ tasks:
             {{if .EXTRAS}}{{range splitList " " .EXTRAS}} --extra {{.}}{{end}}{{end}}
       - task check-env EXTRAS="{{.EXTRAS}}"
       - uv run flake8 src
-      - uv run mypy --strict src tests
+      - task mypy-strict
       - task lint-specs
       - task check-release-metadata
       - uv run python scripts/check_spec_tests.py
@@ -376,10 +381,8 @@ tasks:
           set -eu
           uv run flake8 src tests
           echo "[verify][lint] flake8 passed"
-      - |
-          set -eu
-          uv run mypy --strict src tests
-          echo "[verify][mypy] strict suite passed"
+      - task mypy-strict
+      - echo "[verify][mypy] strict suite passed"
       - task lint-specs
       - echo "[verify][lint] spec lint passed"
       - task check-release-metadata

--- a/baseline/logs/mypy-strict-20251003T013152Z.log
+++ b/baseline/logs/mypy-strict-20251003T013152Z.log
@@ -1,0 +1,1 @@
+Success: no issues found in 783 source files

--- a/baseline/logs/task-coverage-20251003T013422Z.log
+++ b/baseline/logs/task-coverage-20251003T013422Z.log
@@ -1,0 +1,184 @@
+task: [coverage] echo "[coverage] syncing dependencies"
+[coverage] syncing dependencies
+task: [coverage] uv sync \
+   --extra dev-minimal --extra test --extra nlp --extra ui --extra vss --extra git --extra distributed --extra analysis --extra llm --extra parsers \
+  
+
+Resolved 328 packages in 4ms
+Audited 246 packages in 0.59ms
+task: [coverage] echo "[coverage] erasing previous data"
+[coverage] erasing previous data
+task: [coverage] uv run coverage erase
+task: [coverage] echo "[coverage] running unit tests"
+[coverage] running unit tests
+task: [coverage] uv run pytest -vv --maxfail=1 --durations=10 -x tests/unit -m 'not slow' \
+  --cov=src --cov-report=term-missing --cov-append
+
+===================================================== test session starts ======================================================
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /workspace/autoresearch/.venv/bin/python3
+cachedir: .pytest_cache
+hypothesis profile 'default'
+benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+rootdir: /workspace/autoresearch
+configfile: pytest.ini
+plugins: hypothesis-6.140.2, langsmith-0.4.31, httpx-0.35.0, cov-7.0.0, bdd-8.1.0, anyio-4.11.0, benchmark-5.1.0
+collecting ... collected 1085 items / 25 deselected / 1060 selected
+
+tests/unit/config/test_loader_types.py::test_load_config_file_returns_defaults_when_missing PASSED                       [  0%]
+tests/unit/config/test_loader_types.py::test_load_config_file_rejects_non_mapping PASSED                                 [  0%]
+tests/unit/config/test_loader_types.py::test_env_storage_override_round_trips PASSED                                     [  0%]
+tests/unit/config/test_loader_types.py::test_storage_defaults PASSED                                                     [  0%]
+tests/unit/config/test_loader_types.py::test_minimum_resident_nodes_default_without_warning PASSED                       [  0%]
+tests/unit/config/test_loader_types.py::test_normalize_ranking_weights_balances_missing_values PASSED                    [  0%]
+tests/unit/config/test_loader_types.py::test_config_model_deep_copy_preserves_storage_settings PASSED                    [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_election_converges_to_minimum PASSED                        [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_election_requires_identifier PASSED                         [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_election_accepts_strings PASSED                             [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent PASSED                     [  1%]
+tests/unit/distributed/test_coordination_properties.py::test_message_processing_returns_copy PASSED                      [  1%]
+tests/unit/distributed/test_coordination_properties.py::test_module_exports_helpers PASSED                               [  1%]
+tests/unit/distributed/test_coordination_properties.py::test_storage_queue_adapter_accepts_mapping_payloads PASSED       [  1%]
+tests/unit/distributed/test_coordination_properties.py::test_storage_queue_adapter_rejects_incompatible_payloads PASSED  [  1%]
+tests/unit/distributed/test_coordination_properties.py::test_storage_queue_adapter_accepts_broker_queue PASSED           [  1%]
+tests/unit/evaluation/test_harness_typing.py::test_open_duckdb_closes_connection PASSED                                  [  1%]
+tests/unit/evidence/test_stability_utils.py::test_aggregate_entailment_scores_stable PASSED                              [  1%]
+tests/unit/evidence/test_stability_utils.py::test_aggregate_entailment_scores_unstable PASSED                            [  1%]
+tests/unit/evidence/test_stability_utils.py::test_sample_paraphrases_returns_unique_variants PASSED                      [  1%]
+tests/unit/knowledge/test_graph_pipeline.py::test_session_graph_pipeline_ingest_records_provenance PASSED                [  1%]
+tests/unit/knowledge/test_graph_pipeline.py::test_session_graph_pipeline_neighbors_uses_storage PASSED                   [  2%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_decodes_prometheus_payload PASSED                     [  2%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_coerces_bytearray PASSED                              [  2%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_handles_memoryview PASSED                             [  2%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_replaces_invalid_bytes PASSED                         [  2%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_handles_failure PASSED                                [  2%]
+tests/unit/orchestration/test_answer_audit.py::test_answer_auditor_hedges_unsupported_claims PASSED                      [  2%]
+tests/unit/orchestration/test_budgeting_algorithm.py::test_budget_scaled_by_loops_and_limits PASSED                      [  2%]
+tests/unit/orchestration/test_budgeting_algorithm.py::test_budget_minimum_buffer_applied PASSED                          [  2%]
+tests/unit/orchestration/test_budgeting_algorithm.py::test_budget_unchanged_within_bounds PASSED                         [  2%]
+tests/unit/orchestration/test_circuit_breaker_determinism.py::test_circuit_breaker_determinism_and_recovery PASSED       [  3%]
+tests/unit/orchestration/test_circuit_breaker_thresholds.py::test_circuit_breaker_threshold_and_recovery PASSED          [  3%]
+tests/unit/orchestration/test_gate_policy.py::test_scout_gate_reduces_loops_when_signals_low PASSED                      [  3%]
+tests/unit/orchestration/test_gate_policy.py::test_scout_gate_respects_force_debate_override PASSED                      [  3%]
+tests/unit/orchestration/test_gate_policy.py::test_scout_gate_flags_coverage_gap_and_confidence PASSED                   [  3%]
+tests/unit/orchestration/test_gate_policy.py::test_scout_gate_applies_graph_thresholds PASSED                            [  3%]
+tests/unit/orchestration/test_metrics_graph_summary.py::test_graph_summary_uses_typed_floats PASSED                      [  3%]
+tests/unit/orchestration/test_metrics_graph_summary.py::test_graph_build_skips_empty_payload PASSED                      [  3%]
+tests/unit/orchestration/test_metrics_graph_summary.py::test_graph_ingestion_saved_payload_is_sanitized PASSED           [  3%]
+tests/unit/orchestration/test_orchestration_simulations.py::test_circuit_breaker_sim_is_deterministic PASSED             [  3%]
+tests/unit/orchestration/test_orchestration_simulations.py::test_parallel_execution_sim_is_deterministic PASSED          [  3%]
+tests/unit/orchestration/test_orchestration_simulations.py::test_cli_runs_modes PASSED                                   [  4%]
+tests/unit/orchestration/test_orchestrator_auto_mode.py::test_auto_mode_returns_direct_answer_when_gate_exits PASSED     [  4%]
+tests/unit/orchestration/test_orchestrator_auto_mode.py::test_auto_mode_escalates_to_debate_when_gate_requires_loops PASSED [  4%]
+tests/unit/orchestration/test_package_exports.py::test_agent_factory_export PASSED                                       [  4%]
+tests/unit/orchestration/test_package_exports.py::test_agent_registry_export PASSED                                      [  4%]
+tests/unit/orchestration/test_package_exports.py::test_orchestrator_export PASSED                                        [  4%]
+tests/unit/orchestration/test_package_exports.py::test_storage_manager_export PASSED                                     [  4%]
+tests/unit/orchestration/test_parallel_execute.py::test_execute_parallel_query_error_and_timeout PASSED                  [  4%]
+tests/unit/orchestration/test_parallel_execute.py::test_execute_parallel_query_all_fail PASSED                           [  4%]
+tests/unit/orchestration/test_parallel_merge_invariant.py::test_parallel_merge_invariant PASSED                          [  4%]
+tests/unit/orchestration/test_query_state_features.py::test_query_state_cloudpickle_serialization_preserves_fields PASSED [  5%]
+tests/unit/orchestration/test_query_state_features.py::test_query_state_registry_clone_produces_independent_copies PASSED [  5%]
+tests/unit/orchestration/test_query_state_features.py::test_query_state_model_copy_deep_clone_separates_mutable_data PASSED [  5%]
+tests/unit/orchestration/test_query_state_features.py::test_query_state_registry_update_refreshes_snapshots PASSED       [  5%]
+tests/unit/orchestration/test_state_registry.py::test_register_and_clone_preserve_lock_and_metadata_types PASSED         [  5%]
+tests/unit/orchestration/test_state_registry.py::test_config_model_deep_copy_with_embedded_lock PASSED                   [  5%]
+tests/unit/orchestration/test_state_registry.py::test_update_replaces_snapshot_and_preserves_lock_integrity PASSED       [  5%]
+tests/unit/orchestration/test_state_registry.py::test_update_creates_snapshot_when_missing_identifier PASSED             [  5%]
+tests/unit/orchestration/test_state_registry.py::test_registry_round_trip_rehydrates_state_with_fresh_lock PASSED        [  5%]
+tests/unit/orchestration/test_task_coordinator.py::test_task_coordinator_schedules_dependencies PASSED                   [  5%]
+tests/unit/orchestration/test_token_utils.py::test_execute_with_adapter_kwarg PASSED                                     [  5%]
+tests/unit/orchestration/test_token_utils.py::test_execute_with_mutation_hooks_restores_original PASSED                  [  6%]
+tests/unit/orchestration/test_token_utils.py::test_execute_without_adapter_hooks PASSED                                  [  6%]
+tests/unit/orchestration/test_token_utils.py::test_execute_raises_for_non_mapping_result PASSED                          [  6%]
+tests/unit/orchestration/test_token_utils.py::test_type_guards_detect_adapter_features PASSED                            [  6%]
+tests/unit/orchestration/test_token_utils.py::test_is_agent_execution_result_guard PASSED                                [  6%]
+tests/unit/orchestration/test_utils_confidence.py::test_metrics_snapshot_parses_token_usage PASSED                       [  6%]
+tests/unit/orchestration/test_utils_confidence.py::test_confidence_adjusts_with_metrics_payload PASSED                   [  6%]
+tests/unit/orchestration/test_utils_confidence.py::test_graph_metrics_payload_is_sanitized PASSED                        [  6%]
+tests/unit/search/test_property_ranking_monotonicity.py::test_monotonic_ranking PASSED                                   [  6%]
+tests/unit/search/test_query_expansion_convergence.py::test_query_expansion_converges PASSED                             [  6%]
+tests/unit/search/test_query_expansion_convergence.py::test_reset_instance_creates_new_singleton PASSED                  [  6%]
+tests/unit/search/test_query_expansion_convergence.py::test_extract_entities_with_spacy PASSED                           [  7%]
+tests/unit/search/test_query_expansion_convergence.py::test_build_topic_model_with_insufficient_docs PASSED              [  7%]
+tests/unit/search/test_query_expansion_convergence.py::test_try_imports_disabled PASSED                                  [  7%]
+tests/unit/search/test_query_expansion_convergence.py::test_try_import_sentence_transformers_success PASSED              [  7%]
+tests/unit/search/test_query_expansion_convergence.py::test_search_embedding_protocol_prefers_embed PASSED               [  7%]
+tests/unit/search/test_query_expansion_convergence.py::test_search_embedding_protocol_falls_back_to_encode PASSED        [  7%]
+tests/unit/search/test_query_expansion_convergence.py::test_search_sentence_transformer_fallback_cached PASSED           [  7%]
+tests/unit/search/test_query_expansion_convergence.py::test_search_embedding_backend_switches_without_reset PASSED       [  7%]
+tests/unit/search/test_ranking_convergence_simulation.py::test_ranking_converges SKIPPED (CollectorRegistry duplication
+in test environment)                                                                                                     [  7%]
+tests/unit/search/test_ranking_convergence_simulation.py::test_invalid_weights_raise SKIPPED (CollectorRegistry
+duplication in test environment)                                                                                         [  7%]
+tests/unit/search/test_ranking_formula.py::test_combine_scores_weighted_sum PASSED                                       [  8%]
+tests/unit/search/test_ranking_formula.py::test_combine_scores_requires_convex_weights PASSED                            [  8%]
+tests/unit/search/test_ranking_formula.py::test_duckdb_scores_used_without_semantic PASSED                               [  8%]
+tests/unit/search/test_ranking_formula.py::test_rank_results_weighted_combination PASSED                                 [  8%]
+tests/unit/search/test_ranking_formula.py::test_rank_results_weight_fallback PASSED                                      [  8%]
+tests/unit/search/test_session_retry.py::test_http_session_retries_and_reuse PASSED                                      [  8%]
+tests/unit/search/test_session_retry.py::test_http_session_recovery PASSED                                               [  8%]
+tests/unit/search/test_session_retry.py::test_http_session_adapter_failure PASSED                                        [  8%]
+tests/unit/search/test_simulate_rate_limit.py::test_default_backoff PASSED                                               [  8%]
+tests/unit/search/test_simulate_rate_limit.py::test_custom_backoff PASSED                                                [  8%]
+tests/unit/storage/test_backup_scheduler.py::test_scheduler_runs_backup_and_reschedules PASSED                           [  8%]
+tests/unit/storage/test_backup_scheduler.py::test_scheduler_restarts_existing_timer FAILED                               [  9%]
+
+=========================================================== FAILURES ===========================================================
+____________________________________________ test_scheduler_restarts_existing_timer ____________________________________________
+
+scheduler_environment = (<autoresearch.storage_backup.BackupScheduler object at 0x7fa44d11ac30>, [<tests.unit.storage.test_backup_scheduler.sc...ir', 'db.duckdb', 'store.rdf', True, BackupConfig(backup_dir='dir', compress=True, max_backups=5, retention_days=30))])
+
+    def test_scheduler_restarts_existing_timer(
+        scheduler_environment: tuple[
+            BackupScheduler, list["DummyTimer"], list[tuple[str, str, str, bool, BackupConfig]]
+        ],
+    ) -> None:
+        scheduler, timers, backups = scheduler_environment
+    
+        scheduler.schedule("dir", "db.duckdb", "store.rdf", interval_hours=1)
+        previous_timer = timers[-1]
+    
+        scheduler.schedule("dir", "db.duckdb", "store.rdf", interval_hours=2)
+    
+>       assert previous_timer.cancelled is True
+E       assert False is True
+E        +  where False = <tests.unit.storage.test_backup_scheduler.scheduler_environment.<locals>.DummyTimer object at 0x7fa44d11b410>.cancelled
+
+/workspace/autoresearch/tests/unit/storage/test_backup_scheduler.py:112: AssertionError
+----------------------------------------------------- Captured stderr call -----------------------------------------------------
+{"text": "2025-10-03 01:34:49.929 | INFO     | autoresearch.logging_utils:emit:113 - {\"event\": \"Scheduled backups every 1 hours to dir\", \"timestamp\": \"2025-10-03T01:34:49.928846Z\"}\n", "record": {"elapsed": {"repr": "0:00:22.856999", "seconds": 22.856999}, "exception": null, "extra": {}, "file": {"name": "logging_utils.py", "path": "/workspace/autoresearch/src/autoresearch/logging_utils.py"}, "function": "emit", "level": {"icon": "ℹ️", "name": "INFO", "no": 20}, "line": 113, "message": "{\"event\": \"Scheduled backups every 1 hours to dir\", \"timestamp\": \"2025-10-03T01:34:49.928846Z\"}", "module": "logging_utils", "name": "autoresearch.logging_utils", "process": {"id": 4967, "name": "MainProcess"}, "thread": {"id": 140344308382592, "name": "MainThread"}, "time": {"repr": "2025-10-03 01:34:49.929074+00:00", "timestamp": 1759455289.929074}}}
+{"text": "2025-10-03 01:34:49.929 | INFO     | autoresearch.logging_utils:emit:113 - {\"event\": \"Stopped scheduled backups\", \"timestamp\": \"2025-10-03T01:34:49.929466Z\"}\n", "record": {"elapsed": {"repr": "0:00:22.857525", "seconds": 22.857525}, "exception": null, "extra": {}, "file": {"name": "logging_utils.py", "path": "/workspace/autoresearch/src/autoresearch/logging_utils.py"}, "function": "emit", "level": {"icon": "ℹ️", "name": "INFO", "no": 20}, "line": 113, "message": "{\"event\": \"Stopped scheduled backups\", \"timestamp\": \"2025-10-03T01:34:49.929466Z\"}", "module": "logging_utils", "name": "autoresearch.logging_utils", "process": {"id": 4967, "name": "MainProcess"}, "thread": {"id": 140344308382592, "name": "MainThread"}, "time": {"repr": "2025-10-03 01:34:49.929600+00:00", "timestamp": 1759455289.9296}}}
+{"text": "2025-10-03 01:34:49.930 | INFO     | autoresearch.logging_utils:emit:113 - {\"event\": \"Scheduled backups every 2 hours to dir\", \"timestamp\": \"2025-10-03T01:34:49.929970Z\"}\n", "record": {"elapsed": {"repr": "0:00:22.858016", "seconds": 22.858016}, "exception": null, "extra": {}, "file": {"name": "logging_utils.py", "path": "/workspace/autoresearch/src/autoresearch/logging_utils.py"}, "function": "emit", "level": {"icon": "ℹ️", "name": "INFO", "no": 20}, "line": 113, "message": "{\"event\": \"Scheduled backups every 2 hours to dir\", \"timestamp\": \"2025-10-03T01:34:49.929970Z\"}", "module": "logging_utils", "name": "autoresearch.logging_utils", "process": {"id": 4967, "name": "MainProcess"}, "thread": {"id": 140344308382592, "name": "MainThread"}, "time": {"repr": "2025-10-03 01:34:49.930091+00:00", "timestamp": 1759455289.930091}}}
+------------------------------------------------------ Captured log call -------------------------------------------------------
+INFO     autoresearch.storage_backup:storage_backup.py:521 {"event": "Scheduled backups every 1 hours to dir", "timestamp": "2025-10-03T01:34:49.928846Z"}
+INFO     autoresearch.storage_backup:storage_backup.py:530 {"event": "Stopped scheduled backups", "timestamp": "2025-10-03T01:34:49.929466Z"}
+INFO     autoresearch.storage_backup:storage_backup.py:521 {"event": "Scheduled backups every 2 hours to dir", "timestamp": "2025-10-03T01:34:49.929970Z"}
+--------------------------------------------------- Captured stderr teardown ---------------------------------------------------
+{"text": "2025-10-03 01:34:49.945 | INFO     | autoresearch.logging_utils:emit:113 - {\"event\": \"Stopped scheduled backups\", \"timestamp\": \"2025-10-03T01:34:49.945291Z\"}\n", "record": {"elapsed": {"repr": "0:00:22.873474", "seconds": 22.873474}, "exception": null, "extra": {}, "file": {"name": "logging_utils.py", "path": "/workspace/autoresearch/src/autoresearch/logging_utils.py"}, "function": "emit", "level": {"icon": "ℹ️", "name": "INFO", "no": 20}, "line": 113, "message": "{\"event\": \"Stopped scheduled backups\", \"timestamp\": \"2025-10-03T01:34:49.945291Z\"}", "module": "logging_utils", "name": "autoresearch.logging_utils", "process": {"id": 4967, "name": "MainProcess"}, "thread": {"id": 140344308382592, "name": "MainThread"}, "time": {"repr": "2025-10-03 01:34:49.945549+00:00", "timestamp": 1759455289.945549}}}
+{"text": "2025-10-03 01:34:49.955 | INFO     | autoresearch.logging_utils:emit:113 - No configuration file found; using defaults\n", "record": {"elapsed": {"repr": "0:00:22.883079", "seconds": 22.883079}, "exception": null, "extra": {}, "file": {"name": "logging_utils.py", "path": "/workspace/autoresearch/src/autoresearch/logging_utils.py"}, "function": "emit", "level": {"icon": "ℹ️", "name": "INFO", "no": 20}, "line": 113, "message": "No configuration file found; using defaults", "module": "logging_utils", "name": "autoresearch.logging_utils", "process": {"id": 4967, "name": "MainProcess"}, "thread": {"id": 140344308382592, "name": "MainThread"}, "time": {"repr": "2025-10-03 01:34:49.955154+00:00", "timestamp": 1759455289.955154}}}
+---------------------------------------------------- Captured log teardown -----------------------------------------------------
+INFO     autoresearch.storage_backup:storage_backup.py:530 {"event": "Stopped scheduled backups", "timestamp": "2025-10-03T01:34:49.945291Z"}
+INFO     autoresearch.config.loader:loader.py:104 No configuration file found; using defaults
+======================================================= warnings summary =======================================================
+tests/unit/test_main_config_commands.py:4
+  /workspace/autoresearch/tests/unit/test_main_config_commands.py:4: DeprecationWarning: 'importlib.abc.Traversable' is deprecated and slated for removal in Python 3.14
+    from importlib.abc import Traversable
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+===================================================== slowest 10 durations =====================================================
+0.71s call     tests/unit/distributed/test_coordination_properties.py::test_election_converges_to_minimum
+0.51s call     tests/unit/orchestration/test_parallel_execute.py::test_execute_parallel_query_error_and_timeout
+0.29s call     tests/unit/search/test_property_ranking_monotonicity.py::test_monotonic_ranking
+0.11s call     tests/unit/orchestration/test_parallel_merge_invariant.py::test_parallel_merge_invariant
+0.06s call     tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent
+0.06s setup    tests/unit/config/test_loader_types.py::test_storage_defaults
+0.05s call     tests/unit/knowledge/test_graph_pipeline.py::test_session_graph_pipeline_ingest_records_provenance
+0.05s call     tests/unit/orchestration/test_orchestration_simulations.py::test_parallel_execution_sim_is_deterministic
+0.04s setup    tests/unit/search/test_ranking_formula.py::test_rank_results_weighted_combination
+0.03s call     tests/unit/orchestration/test_orchestration_simulations.py::test_cli_runs_modes
+=================================================== short test summary info ====================================================
+FAILED tests/unit/storage/test_backup_scheduler.py::test_scheduler_restarts_existing_timer - assert False is True
+ +  where False = <tests.unit.storage.test_backup_scheduler.scheduler_environment.<locals>.DummyTimer object at 0x7fa44d11b410>.cancelled
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+============================== 1 failed, 93 passed, 2 skipped, 25 deselected, 1 warning in 11.49s ==============================
+task: Failed to run task "coverage": exit status 1

--- a/baseline/logs/task-verify-20251003T013253Z.log
+++ b/baseline/logs/task-verify-20251003T013253Z.log
@@ -1,0 +1,139 @@
+task: [verify] set -eu
+extras="dev-minimal test nlp ui vss git distributed analysis llm parsers"
+export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-600}"
+uv sync \
+  --python-platform x86_64-manylinux_2_28 \
+  $(printf ' --extra %s' $extras) \
+  
+
+Resolved 328 packages in 7ms
+Audited 246 packages in 0.53ms
+task: [verify] task check-env EXTRAS="dev-minimal test nlp ui vss git distributed analysis llm parsers"
+task: [check-env] task --version
+3.45.4
+task: [check-env] uv run python scripts/check_env.py
+Verifying extras: analysis, dev-minimal, distributed, git, llm, nlp, parsers, test, ui, vss
+Python 3.12.10
+Go Task 3.45.4
+uv 0.7.22
+GitPython 3.1.45
+a2a-sdk 0.3.7
+black 25.9.0
+dspy-ai 3.0.3
+duckdb 1.3.2
+duckdb-extension-vss 1.3.2
+fakeredis 2.31.3
+fastembed 0.7.3
+flake8 7.3.0
+freezegun 1.5.5
+hypothesis 6.140.2
+mypy 1.18.2
+networkx 3.5
+owlrl 7.1.4
+pdfminer-six 20250506
+pillow 11.3.0
+polars 1.33.1
+psutil 7.1.0
+pytest 8.4.2
+pytest-bdd 8.1.0
+pytest-benchmark 5.1.0
+pytest-cov 7.0.0
+pytest-httpx 0.35.0
+python-docx 1.2.0
+ray 2.49.2
+redis 6.4.0
+responses 0.25.8
+spacy 3.8.7
+streamlit 1.50.0
+tomli-w 1.2.0
+types-protobuf 6.32.1.20250918
+types-psutil 7.0.0.20250822
+types-requests 2.32.4.20250913
+types-tabulate 0.9.0.20241207
+uvicorn 0.37.0
+task: [verify] set -eu
+uv run flake8 src tests
+echo "[verify][lint] flake8 passed"
+
+tests/analysis/test_agents_sim.py:3:1: F811 redefinition of unused 'cast' from line 1
+tests/analysis/test_distributed_coordination.py:47:1: E303 too many blank lines (4)
+tests/behavior/conftest.py:59:1: E305 expected 2 blank lines after class or function definition, found 1
+tests/behavior/context.py:319:1: W391 blank line at end of file
+tests/behavior/steps/agent_messages_steps.py:15:1: F401 'autoresearch.orchestration.orchestrator.Orchestrator' imported but unused
+tests/behavior/steps/backup_cli_steps.py:180:1: W391 blank line at end of file
+tests/behavior/steps/capabilities_cli_steps.py:42:1: W391 blank line at end of file
+tests/behavior/steps/cli_options_steps.py:18:1: F401 '.common_steps.app_running' imported but unused
+tests/behavior/steps/cli_options_steps.py:18:1: F401 '.common_steps.app_running_with_default' imported but unused
+tests/behavior/steps/cli_options_steps.py:18:1: F401 '.common_steps.application_running' imported but unused
+tests/behavior/steps/config_cli_steps.py:162:1: W391 blank line at end of file
+tests/behavior/steps/distributed_execution_steps.py:24:1: F811 redefinition of unused 'BehaviorContext' from line 5
+tests/behavior/steps/error_recovery_redis_steps.py:4:1: F811 redefinition of unused 'pytest' from line 1
+tests/behavior/steps/error_recovery_workflow_steps.py:23:1: E305 expected 2 blank lines after class or function definition, found 1
+tests/behavior/steps/gui_cli_steps.py:107:1: W391 blank line at end of file
+tests/behavior/steps/interactive_monitor_steps.py:15:1: F401 '.common_steps.app_running' imported but unused
+tests/behavior/steps/interactive_monitor_steps.py:15:1: F401 '.common_steps.app_running_with_default' imported but unused
+tests/behavior/steps/interactive_monitor_steps.py:15:1: F401 '.common_steps.application_running' imported but unused
+tests/behavior/steps/interface_test_cli_steps.py:158:1: W391 blank line at end of file
+tests/behavior/steps/monitor_cli_steps.py:188:1: W391 blank line at end of file
+tests/behavior/steps/orchestration_system_steps.py:4:1: F401 'typing.Callable' imported but unused
+tests/behavior/steps/parallel_group_merging_steps.py:15:1: E302 expected 2 blank lines, found 0
+tests/behavior/steps/query_interface_steps.py:17:1: F401 '.common_steps.app_running' imported but unused
+tests/behavior/steps/query_interface_steps.py:17:1: F401 '.common_steps.app_running_with_default' imported but unused
+tests/behavior/steps/query_interface_steps.py:17:1: F401 '.common_steps.application_running' imported but unused
+tests/behavior/steps/reasoning_mode_cli_steps.py:3:1: F401 'typing.Any' imported but unused
+tests/behavior/steps/search_cli_steps.py:80:1: W391 blank line at end of file
+tests/behavior/steps/sparql_cli_steps.py:82:1: W391 blank line at end of file
+tests/behavior/steps/streamlit_gui_steps.py:10:1: F401 'pytest_bdd.parsers' imported but unused
+tests/behavior/steps/streamlit_gui_steps.py:23:1: F401 '.common_steps.app_running' imported but unused
+tests/behavior/steps/streamlit_gui_steps.py:23:1: F401 '.common_steps.app_running_with_default' imported but unused
+tests/behavior/steps/streamlit_gui_steps.py:23:1: F401 '.common_steps.application_running' imported but unused
+tests/behavior/steps/visualize_metrics_cli_steps.py:42:1: W391 blank line at end of file
+tests/benchmark/test_token_memory.py:18:1: E305 expected 2 blank lines after class or function definition, found 1
+tests/fixtures/protocols.py:74:1: W391 blank line at end of file
+tests/integration/__init__.py:51:9: E731 do not assign a lambda expression, use a def
+tests/integration/__init__.py:53:9: E731 do not assign a lambda expression, use a def
+tests/integration/conftest.py:17:1: F401 'tests.integration._orchestrator_stubs.BrokerQueueStub' imported but unused
+tests/integration/test_cli_http.py:15:1: F401 'autoresearch.orchestration.orchestrator.Orchestrator' imported but unused
+tests/integration/test_cli_progress.py:63:5: F841 local variable 'cfg' is assigned to but never used
+tests/integration/test_distributed_process_storage.py:73:1: E305 expected 2 blank lines after class or function definition, found 0
+tests/integration/test_orchestrator_search_storage.py:203:1: W293 blank line contains whitespace
+tests/integration/test_query_performance.py:3:1: F404 from __future__ imports must occur at the beginning of the file
+tests/integration/test_query_performance.py:5:1: F811 redefinition of unused 'time' from line 1
+tests/integration/test_query_performance.py:6:1: F811 redefinition of unused 'contextmanager' from line 2
+tests/integration/test_query_performance_benchmark.py:7:1: F404 from __future__ imports must occur at the beginning of the file
+tests/integration/test_query_performance_benchmark.py:10:1: F811 redefinition of unused 'json' from line 2
+tests/integration/test_query_performance_benchmark.py:11:1: F811 redefinition of unused 'Path' from line 3
+tests/integration/test_query_performance_benchmark.py:14:1: F811 redefinition of unused 'pytest' from line 5
+tests/integration/test_query_performance_benchmark.py:120:1: W293 blank line contains whitespace
+tests/integration/test_query_with_reasoning.py:5:1: F811 redefinition of unused 'rdflib' from line 1
+tests/integration/test_ranking_formula_consistency.py:5:1: F811 redefinition of unused 'patch' from line 1
+tests/integration/test_rdf_persistence.py:61:5: E306 expected 1 blank line before a nested definition, found 0
+tests/integration/test_rdf_persistence.py:95:5: E306 expected 1 blank line before a nested definition, found 0
+tests/integration/test_rdf_persistence.py:116:5: E306 expected 1 blank line before a nested definition, found 0
+tests/integration/test_rdf_persistence.py:143:5: E306 expected 1 blank line before a nested definition, found 0
+tests/integration/test_redis_broker.py:27:26: W291 trailing whitespace
+tests/integration/test_redis_broker.py:64:5: E306 expected 1 blank line before a nested definition, found 0
+tests/integration/test_search_duckdb_semantic_merge.py:25:1: E302 expected 2 blank lines, found 0
+tests/integration/test_search_score_normalization.py:18:1: E302 expected 2 blank lines, found 0
+tests/integration/test_semantic_similarity.py:2:1: F811 redefinition of unused 'importlib' from line 1
+tests/integration/test_semantic_similarity.py:38:1: E302 expected 2 blank lines, found 0
+tests/integration/test_simple_orchestration.py:7:1: F401 'autoresearch.agents.registry.AgentFactory' imported but unused
+tests/integration/test_storage_baseline.py:22:5: E306 expected 1 blank line before a nested definition, found 0
+tests/integration/test_storage_baseline.py:68:5: E301 expected 1 blank line, found 0
+tests/integration/test_storage_concurrency.py:22:1: W293 blank line contains whitespace
+tests/integration/test_storage_eviction.py:21:1: W293 blank line contains whitespace
+tests/stubs/slowapi.py:5:1: F401 'inspect' imported but unused
+tests/stubs/slowapi.py:45:1: E303 too many blank lines (3)
+tests/stubs/slowapi.py:149:1: E302 expected 2 blank lines, found 0
+tests/targeted/test_extras_codepaths.py:25:1: F401 'autoresearch.distributed.broker.StorageBrokerQueueProtocol' imported but unused
+tests/targeted/test_extras_codepaths.py:178:5: F811 redefinition of unused 'StorageBrokerQueueProtocol' from line 25
+tests/unit/storage/test_backup_scheduler.py:21:34: F821 undefined name 'DummyTimer'
+tests/unit/storage/test_backup_scheduler.py:78:31: F821 undefined name 'DummyTimer'
+tests/unit/storage/test_backup_scheduler.py:102:31: F821 undefined name 'DummyTimer'
+tests/unit/storage/test_backup_scheduler.py:119:31: F821 undefined name 'DummyTimer'
+tests/unit/test_cache.py:210:5: E301 expected 1 blank line, found 0
+tests/unit/test_check_env_warnings.py:94:5: E301 expected 1 blank line, found 0
+tests/unit/test_search.py:361:1: W293 blank line contains whitespace
+tests/unit/test_streamlit_ui_helpers.py:12:5: E306 expected 1 blank line before a nested definition, found 0
+tests/unit/typing_helpers.py:294:1: W391 blank line at end of file
+task: Failed to run task "verify": exit status 1

--- a/docs/review_guidelines.md
+++ b/docs/review_guidelines.md
@@ -5,3 +5,7 @@
   or pull request triggers.
 - Move obsolete or unneeded workflows to `.github/workflows.disabled/`
   to keep the active directory minimal.
+- Confirm the automated `task mypy-strict` gate runs early in manual CI
+  workflows so strict typing regressions fail fast.
+- Leave the TestPyPI dry run paused unless the `run_testpypi_dry_run`
+  input is explicitly enabled during `workflow_dispatch` execution.


### PR DESCRIPTION
## Summary
- add a reusable `mypy-strict` Taskfile target and invoke it from the fast `check` and full `verify` sweeps
- run the strict gate earlier in the manual CI workflow, gate the TestPyPI dry run behind a new dispatch input, and surface the policy in the PR template, status docs, and review guidance
- archive fresh strict, verify, and coverage logs from the 2025-10-03 runs to baseline/logs

## Testing
- `uv run task mypy-strict`
- `uv run task verify EXTRAS="nlp ui vss git distributed analysis llm parsers"` *(fails: existing flake8 violations in tests)*
- `uv run task coverage EXTRAS="nlp ui vss git distributed analysis llm parsers"` *(fails: `test_scheduler_restarts_existing_timer` regression)*

------
https://chatgpt.com/codex/tasks/task_e_68df2638fcd48333a44106d46af245d4