### PR TITLE
Add adaptive search telemetry and configuration knobs

### DIFF
--- a/docs/deep_research_upgrade_plan.md
+++ b/docs/deep_research_upgrade_plan.md
@@ -102,6 +102,11 @@ coverage rerun showing the FastEmbed fallback failure after the registry fix.
    - Surface contradiction checks to the scout gate through
      `SearchContext.get_contradiction_signal()` while exposing neighbour
      and path queries to agents for multi-hop reasoning.
+   - Extend `SearchContext` with on-demand query rewriting, adaptive fetch
+     planning, and search self-critique telemetry so retrieval gaps can close
+     before debate. These signals surface through `ScoutGateDecision.telemetry`
+     when `gate_capture_query_strategy` and
+     `gate_capture_self_critique` remain enabled.
    - Instrument `OrchestrationMetrics` with Prometheus-backed
      `graph_ingestion` telemetry (entity, relation, contradiction, neighbour,
      and latency aggregates) guarded by `search.context_aware` toggles so

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -147,6 +147,10 @@ repository without reprocessing unchanged commits.
 Queries against these local indexes leverage DuckDB vector search. Matches
 return the snippet, file path, and commit hash when applicable so every result
 is fully attributable.
+- When retrieval coverage is insufficient, on-demand query rewriting expands
+  the search focus using context entities and heuristics. Adaptive fetch
+  planning increases per-backend `k` until coverage gaps shrink. Configure
+  these behaviours with `[search.query_rewrite]` and `[search.adaptive_k]`.
 - Results from all backends are persisted via `storage.py` and inserted into the
   knowledge graph for later reasoning.
 
@@ -171,6 +175,10 @@ is fully attributable.
   totals, contradiction scores, sampled planner neighbors, and storage
   latency. Toggle the feed with `search.context_aware.enabled` and
   `search.context_aware.graph_pipeline_enabled`.
+- Adaptive search telemetry is exposed when `gate_capture_query_strategy` and
+  `gate_capture_self_critique` remain enabled. The gate decision payload and
+  `scout_stage` metrics include fetch plan attempts, query rewrites, and search
+  self-critique markers for auditability.
 
 ## 9. Adaptive Orchestration
 

--- a/tests/behavior/features/reasoning_modes/auto_planner_cycle.feature
+++ b/tests/behavior/features/reasoning_modes/auto_planner_cycle.feature
@@ -12,3 +12,11 @@ Feature: AUTO reasoning integrates planner, scout gate, and verification
     And the planner task graph snapshot should include verification goals
     And the AUTO metrics should record scout samples and agreement
     And the AUTO metrics should include planner depth and routing deltas
+
+  Scenario: AUTO telemetry captures adaptive search strategy improvements
+    Given loops is set to 2 in configuration
+    And reasoning mode is "auto"
+    And the planner proposes verification tasks
+    And the scout metadata includes adaptive search strategy signals
+    When I run the auto planner cycle for query "adaptive telemetry rehearsal"
+    Then the auto planner cycle should surface search strategy telemetry

--- a/tests/helpers/config.py
+++ b/tests/helpers/config.py
@@ -30,10 +30,32 @@ class ContextAwareSearchConfigDump(TypedDict):
     planner_graph_conditioning: bool
 
 
+class QueryRewriteConfigDump(TypedDict):
+    """Serialized representation of :class:`QueryRewriteConfigStub`."""
+
+    enabled: bool
+    max_attempts: int
+    min_results: int
+    min_unique_sources: int
+    coverage_gap_threshold: float
+
+
+class AdaptiveKConfigDump(TypedDict):
+    """Serialized representation of :class:`AdaptiveKConfigStub`."""
+
+    enabled: bool
+    min_k: int
+    max_k: int
+    step: int
+    coverage_gap_threshold: float
+
+
 class SearchConfigDump(TypedDict):
     """Serialized representation of :class:`SearchConfigStub`."""
 
     context_aware: ContextAwareSearchConfigDump
+    query_rewrite: QueryRewriteConfigDump
+    adaptive_k: AdaptiveKConfigDump
 
 
 class ConfigModelDump(TypedDict):
@@ -46,6 +68,8 @@ class ConfigModelDump(TypedDict):
     search: SearchConfigDump
     gate_graph_contradiction_threshold: float
     gate_graph_similarity_threshold: float
+    gate_capture_query_strategy: bool
+    gate_capture_self_critique: bool
     agents: list[str]
     reasoning_mode: Optional[str]
     llm_backend: str
@@ -74,6 +98,34 @@ class SearchConfigStub:
     context_aware: ContextAwareSearchConfigStub = field(
         default_factory=ContextAwareSearchConfigStub
     )
+    query_rewrite: "QueryRewriteConfigStub" = field(
+        default_factory=lambda: QueryRewriteConfigStub()
+    )
+    adaptive_k: "AdaptiveKConfigStub" = field(
+        default_factory=lambda: AdaptiveKConfigStub()
+    )
+
+
+@dataclass(slots=True)
+class QueryRewriteConfigStub:
+    """Subset of query rewrite settings required in tests."""
+
+    enabled: bool = True
+    max_attempts: int = 2
+    min_results: int = 3
+    min_unique_sources: int = 3
+    coverage_gap_threshold: float = 0.45
+
+
+@dataclass(slots=True)
+class AdaptiveKConfigStub:
+    """Subset of adaptive fetch configuration for tests."""
+
+    enabled: bool = True
+    min_k: int = 5
+    max_k: int = 12
+    step: int = 3
+    coverage_gap_threshold: float = 0.4
 
 
 @dataclass(slots=True)
@@ -87,6 +139,8 @@ class ConfigModelStub:
     search: SearchConfigStub = field(default_factory=SearchConfigStub)
     gate_graph_contradiction_threshold: float = 0.25
     gate_graph_similarity_threshold: float = 0.0
+    gate_capture_query_strategy: bool = True
+    gate_capture_self_critique: bool = True
     agents: list[str] = field(default_factory=list)
     reasoning_mode: ReasoningMode | None = None
     llm_backend: str = "lmstudio"
@@ -119,11 +173,33 @@ class ConfigModelStub:
                         self.search.context_aware.planner_graph_conditioning
                     ),
                 },
+                "query_rewrite": {
+                    "enabled": self.search.query_rewrite.enabled,
+                    "max_attempts": self.search.query_rewrite.max_attempts,
+                    "min_results": self.search.query_rewrite.min_results,
+                    "min_unique_sources": (
+                        self.search.query_rewrite.min_unique_sources
+                    ),
+                    "coverage_gap_threshold": (
+                        self.search.query_rewrite.coverage_gap_threshold
+                    ),
+                },
+                "adaptive_k": {
+                    "enabled": self.search.adaptive_k.enabled,
+                    "min_k": self.search.adaptive_k.min_k,
+                    "max_k": self.search.adaptive_k.max_k,
+                    "step": self.search.adaptive_k.step,
+                    "coverage_gap_threshold": (
+                        self.search.adaptive_k.coverage_gap_threshold
+                    ),
+                },
             },
             "gate_graph_contradiction_threshold": (
                 self.gate_graph_contradiction_threshold
             ),
             "gate_graph_similarity_threshold": self.gate_graph_similarity_threshold,
+            "gate_capture_query_strategy": self.gate_capture_query_strategy,
+            "gate_capture_self_critique": self.gate_capture_self_critique,
             "agents": list(self.agents),
             "reasoning_mode": (
                 self.reasoning_mode.value
@@ -163,11 +239,33 @@ def make_search_config(
     *,
     context_overrides: Mapping[str, ContextOverrideValue] | None = None,
     overrides: Mapping[str, SearchOverrideValue] | None = None,
+    query_rewrite_overrides: Mapping[str, SearchOverrideValue] | None = None,
+    adaptive_overrides: Mapping[str, SearchOverrideValue] | None = None,
 ) -> SearchConfigStub:
     """Construct a search configuration stub for unit tests."""
 
     context_cfg = make_context_aware_config(context_overrides)
-    search_cfg = SearchConfigStub(context_aware=context_cfg)
+    query_rewrite_cfg = QueryRewriteConfigStub()
+    if query_rewrite_overrides:
+        for key, value in query_rewrite_overrides.items():
+            if not hasattr(query_rewrite_cfg, key):
+                raise AttributeError(
+                    f"QueryRewriteConfigStub has no attribute '{key}' to override"
+                )
+            setattr(query_rewrite_cfg, key, value)
+    adaptive_cfg = AdaptiveKConfigStub()
+    if adaptive_overrides:
+        for key, value in adaptive_overrides.items():
+            if not hasattr(adaptive_cfg, key):
+                raise AttributeError(
+                    f"AdaptiveKConfigStub has no attribute '{key}' to override"
+                )
+            setattr(adaptive_cfg, key, value)
+    search_cfg = SearchConfigStub(
+        context_aware=context_cfg,
+        query_rewrite=query_rewrite_cfg,
+        adaptive_k=adaptive_cfg,
+    )
     if overrides:
         for key, value in overrides.items():
             if key == "context_aware":
@@ -190,11 +288,16 @@ def make_config_model(
     adaptive_min_buffer: int = 10,
     search_overrides: Mapping[str, SearchOverrideValue] | None = None,
     context_overrides: Mapping[str, ContextOverrideValue] | None = None,
+    query_rewrite_overrides: Mapping[str, SearchOverrideValue] | None = None,
+    adaptive_overrides: Mapping[str, SearchOverrideValue] | None = None,
 ) -> ConfigModelStub:
     """Create a :class:`ConfigModelStub` with explicit overrides when needed."""
 
     search_cfg = make_search_config(
-        context_overrides=context_overrides, overrides=search_overrides
+        context_overrides=context_overrides,
+        overrides=search_overrides,
+        query_rewrite_overrides=query_rewrite_overrides,
+        adaptive_overrides=adaptive_overrides,
     )
     return ConfigModelStub(
         token_budget=token_budget,

--- a/tests/integration/test_query_performance.py
+++ b/tests/integration/test_query_performance.py
@@ -1,5 +1,3 @@
-import time
-from contextlib import contextmanager
 from __future__ import annotations
 
 import time

--- a/tests/integration/test_query_performance_benchmark.py
+++ b/tests/integration/test_query_performance_benchmark.py
@@ -1,12 +1,7 @@
-import importlib.util
-import json
-from pathlib import Path
-
-import pytest
-
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import json
 from pathlib import Path
 from typing import Callable, Mapping


### PR DESCRIPTION
## Summary
- add adaptive search retries, query rewrites, and self-critique telemetry surfaced through `SearchContext` and `Search.external_lookup`
- expose new query rewrite and adaptive-k configuration controls plus scout telemetry toggles and propagate them through the orchestration layer
- cover adaptive search behaviour with unit and behaviour tests and document the new capabilities

## Testing
- uv run --extra test pytest tests/unit/search/test_adaptive_rewrite.py
- uv run --extra test pytest tests/behavior -k auto_planner_cycle

------
https://chatgpt.com/codex/tasks/task_e_68df45c3ccc88333ac0ec89d1e836eae