### PR TITLE
Fix flake8 issues in test helpers and stubs

### DIFF
--- a/tests/analysis/test_agents_sim.py
+++ b/tests/analysis/test_agents_sim.py
@@ -1,7 +1,5 @@
 from typing import cast
 
-from typing import cast
-
 from scripts.agents_sim import _simulate
 
 

--- a/tests/analysis/test_distributed_coordination.py
+++ b/tests/analysis/test_distributed_coordination.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
+import multiprocessing
+from multiprocessing.managers import ListProxy
 from types import SimpleNamespace
 from typing import Any, cast
 
-import multiprocessing
 import pytest
 
-from autoresearch.distributed import coordinator as dist_coordinator
 from autoresearch.config.models import ConfigModel
-from multiprocessing.managers import ListProxy
-
+from autoresearch.distributed import coordinator as dist_coordinator
 from autoresearch.distributed.broker import AgentResultMessage
 
 from tests.analysis.distributed_coordination_analysis import run
@@ -40,8 +39,6 @@ class RecordedEvent:
     def wait(self) -> bool:
         self.wait_calls += 1
         return True
-
-
 
 
 @pytest.fixture

--- a/tests/benchmark/test_token_memory.py
+++ b/tests/benchmark/test_token_memory.py
@@ -15,6 +15,7 @@ class TokenMetrics(TypedDict):
     memory_delta_mb: float
     tokens: dict[str, dict[str, int]]
 
+
 ensure_stub_module("docx", {"Document": object})
 ensure_stub_module(
     "pdfminer.high_level", {"extract_text": lambda *a, **k: ""}

--- a/tests/stubs/slowapi.py
+++ b/tests/stubs/slowapi.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 import threading
 from collections import Counter
 from collections.abc import Awaitable, Callable, MutableMapping, Sequence
@@ -39,7 +38,6 @@ class RateLimitExceeded(Exception):
 TRequest = TypeVar("TRequest", bound="RequestProtocol")
 P = ParamSpec("P")
 ResultT = TypeVar("ResultT")
-
 
 
 class RequestState(Protocol):
@@ -146,6 +144,8 @@ class ReceiveCallable(Protocol):
 
 class SendCallable(Protocol):
     def __call__(self, message: Message) -> Awaitable[None]: ...
+
+
 class ASGIApp(Protocol):
     def __call__(
         self, scope: Scope, receive: ReceiveCallable, send: SendCallable

--- a/tests/targeted/test_extras_codepaths.py
+++ b/tests/targeted/test_extras_codepaths.py
@@ -26,6 +26,7 @@ from autoresearch.distributed.broker import (
     AgentResultMessage,
     BrokerMessage,
     MessageQueueProtocol,
+    RedisBroker,
     StorageBrokerQueueProtocol,
 )
 from tests.targeted.helpers.distributed import build_agent_result_message
@@ -175,7 +176,6 @@ def test_redis_broker_publish(monkeypatch: pytest.MonkeyPatch) -> None:
     import_or_skip("redis")
     import fakeredis
     import redis
-    from autoresearch.distributed.broker import RedisBroker, StorageBrokerQueueProtocol
 
     fake = fakeredis.FakeRedis()
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -207,6 +207,7 @@ def test_cache_is_backend_specific_without_embeddings(
         "calculate_bm25_scores",
         staticmethod(assert_bm25_signature),
     )
+
     def _no_transformer() -> None:
         return None
 

--- a/tests/unit/test_check_env_warnings.py
+++ b/tests/unit/test_check_env_warnings.py
@@ -91,6 +91,7 @@ def test_main_reports_missing_metadata(
 ) -> None:
     monkeypatch.setattr(check_env, "EXTRA_REQUIREMENTS", {"fakepkg": "1.0"})
     dummy = check_env.CheckResult("ok", "1", "1")
+
     def _check_python() -> check_env.CheckResult:
         return dummy
 

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -358,7 +358,7 @@ def test_external_lookup_returns_handles(
     with Search.temporary_state() as search_instance:
         search_state: Search = search_instance
         search_state.cache.clear()
-        
+
         def vector_backend_func(
             embedding: Sequence[float], k: int = 5
         ) -> list[SearchPayload]:

--- a/tests/unit/test_streamlit_ui_helpers.py
+++ b/tests/unit/test_streamlit_ui_helpers.py
@@ -9,6 +9,7 @@ from autoresearch.streamlit_ui import apply_theme_settings
 
 def test_apply_theme_settings_dark(monkeypatch: pytest.MonkeyPatch) -> None:
     m = MagicMock()
+
     def apply_markdown(*_args: Any, **_kwargs: Any) -> None:
         m(*_args, **_kwargs)
 


### PR DESCRIPTION
## Summary
- remove duplicate and unused imports across analysis, targeted, and stub tests
- hoist DummyTimer to module scope and clean helper spacing to resolve F821/E30x errors
- normalize blank lines and annotations in affected unit, benchmark, and stub tests

## Testing
- uv run task check *(fails: existing lint issues in src/autoresearch/search/core.py)*
- uv run flake8 tests/analysis/test_agents_sim.py tests/analysis/test_distributed_coordination.py tests/benchmark/test_token_memory.py tests/stubs/slowapi.py tests/targeted/test_extras_codepaths.py tests/unit/storage/test_backup_scheduler.py tests/unit/test_cache.py tests/unit/test_check_env_warnings.py tests/unit/test_streamlit_ui_helpers.py tests/unit/test_search.py


------
https://chatgpt.com/codex/tasks/task_e_68dffdbd593883339150160f8bb80b0b