### PR TITLE
Refresh v0.1.0a1 readiness plan with latest pytest triage

### DIFF
--- a/CODE_COMPLETE_PLAN.md
+++ b/CODE_COMPLETE_PLAN.md
@@ -5,19 +5,19 @@ Based on a thorough analysis of the Autoresearch codebase, I've developed a comp
 
 ## Status
 
-As of **October 3, 2025 at 14:52 UTC** the strict typing gate remains green:
-`uv run mypy --strict src tests` completes without diagnostics across
-application and test modules. The new preflight plan captures the follow-on
-telemetry work needed to keep AUTO mode and planner upgrades measurable.
-【4b1e56†L1-L2】【F:docs/v0.1.0a1_preflight_plan.md†L1-L113】
+As of **October 3, 2025 at 22:37 UTC** the strict typing gate remains green:
+`uv run mypy --strict src tests` again reported “Success: no issues found in
+787 source files”, confirming the repository-wide strict baseline holds.
+【d70b9a†L1-L2】
 
-The pytest suite is still red. A repository-wide `uv run --extra test pytest`
-execution surfaces failures in reverification defaults, storage backup
-rotation, search cache determinism, API parsing exports, FastMCP constructor
-shims, and cache-backed query preservation. These regressions block fresh
-coverage evidence and must be resolved before the 92.4 % statement gate can be
-revalidated.
-【7be155†L104-L262】【F:docs/v0.1.0a1_preflight_plan.md†L115-L173】
+The pytest suite is still red. The latest `uv run --extra test pytest`
+execution finished with 26 failures and five errors spanning reverification
+defaults, backup scheduler rotation, search cache determinism, API parsing
+exports, FastMCP constructor shims, orchestrator error handling, planner
+metadata, storage contracts, and environment metadata checks. These
+regressions block fresh coverage evidence and must be resolved before the
+92.4 % statement gate can be revalidated.
+【ce87c2†L81-L116】【F:docs/v0.1.0a1_preflight_plan.md†L80-L239】
 
 The alpha release issue, roadmap, and task progress log now point to the
 preflight plan for a consistent summary of the recovery path. TestPyPI remains
@@ -29,17 +29,28 @@ restored.
 
 - [ ] Ship **PR-A** – normalize FactChecker defaults and update
   reverification fixtures so the reverification unit test suite passes
-  again.
+  while preserving opt-out coverage.
 - [ ] Ship **PR-B** – repair backup scheduler restart semantics and rotation
-  policy to satisfy `tests/unit/storage/test_backup_scheduler.py`.
+  policy to satisfy `tests/unit/storage/test_backup_scheduler.py` without
+  introducing timing flakiness.
 - [ ] Ship **PR-C** – restore search cache determinism and stub behaviour so
   cache-related unit tests stop over-fetching and preserve query text.
-- [ ] Ship **PR-D** – expose `autoresearch.api.parse`, fix FastMCP adapter
+- [ ] Ship **PR-D** – expose `autoresearch.api.parse`, align FastMCP adapter
   construction, and unblock the API and MCP handshake suites.
-- [ ] After PR-A through PR-D land, capture a fresh coverage run (PR-G) and
+- [ ] Ship **PR-E** – normalise orchestrator error claim payloads and
+  parallel timeout messaging so error-handling suites regain mapping-based
+  claims.
+- [ ] Ship **PR-F** – stabilise storage initialisation and migration
+  contracts to satisfy incremental update and DuckDB migration tests.
+- [ ] Ship **PR-G** – provide planner metadata adapters and refreshed
+  docstrings so planner metadata and documentation hygiene suites pass.
+- [ ] Ship **PR-H** – supply environment metadata fixtures and telemetry
+  guards for the `check_env_warnings` and `formattemplate_metrics` tests.
+- [ ] Ship **PR-I** – rerun `task coverage` after PR-A through PR-H land and
   update release documentation with the new evidence.
-- [ ] Track AUTO telemetry and planner prompt upgrades (PR-E and PR-F) once the
-  suite is green to keep orchestration improvements measurable.
+- [ ] Ship **PR-J** – add AUTO mode telemetry once the suite is green.
+- [ ] Ship **PR-K** – layer dependency-aware planner prompts with Socratic
+  self-checks building on PR-J outputs.
 - [ ] Complete the
   [prepare-first-alpha-release](issues/prepare-first-alpha-release.md)
   milestones with the refreshed coverage data and updated documentation set.

--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,15 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
 ## October 3, 2025
+- `uv run mypy --strict src tests` succeeded again at **22:37 UTC**,
+  reporting “Success: no issues found in 787 source files” and confirming
+  the strict gate remains green while we triage the pytest regressions.
+  【d70b9a†L1-L2】
+- `uv run --extra test pytest` at **22:37 UTC** finished with 26 failures
+  and five errors across reverification defaults, backup scheduling,
+  cache determinism, FastMCP adapters, orchestrator error handling,
+  planner metadata, storage migrations, and environment metadata checks.
+  【ce87c2†L81-L116】
 - Documented the v0.1.0a1 preflight readiness plan, capturing strict
   typing success, current pytest failures, and the PR slices required to
   restore coverage.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,11 +1,17 @@
-As of **2025-10-03 at 14:52 UTC** the strict typing gate remains green while the
-pytest suite is red. `uv run mypy --strict src tests` finishes without
-diagnostics, but `uv run --extra test pytest` still fails across
-reverification defaults, backup scheduling, search cache determinism, API
-parsing exports, and FastMCP shims. The new preflight plan captures the
-remediation path and splits the work into review-sized PRs so release
-preparation can continue once the suite is green again.
-【4b1e56†L1-L2】【7be155†L104-L262】【F:docs/v0.1.0a1_preflight_plan.md†L1-L173】
+As of **2025-10-03 at 22:37 UTC** the strict typing gate is still green and
+the pytest suite remains red. `uv run mypy --strict src tests` reported
+“Success: no issues found in 787 source files”, confirming the strict
+baseline remains stable, while `uv run --extra test pytest` finished with 26
+failures and five errors across FactChecker defaults, backup scheduling,
+search cache determinism, FastMCP adapters, orchestrator error handling,
+planner metadata, storage contracts, and environment metadata checks.
+【d70b9a†L1-L2】【ce87c2†L81-L116】
+
+The refreshed [v0.1.0a1 preflight readiness plan](docs/v0.1.0a1_preflight_plan.md)
+now breaks the regression clusters into PR-A through PR-H with dialectical
+assessments, then sequences telemetry and planner enhancements as PR-I
+through PR-K once the suite is green.
+【F:docs/v0.1.0a1_preflight_plan.md†L1-L239】
 
 As of **2025-10-03** the deterministic storage resident-floor documentation is
 published at `docs/storage_resident_floor.md`, closing the alpha checklist note

--- a/docs/v0.1.0a1_preflight_plan.md
+++ b/docs/v0.1.0a1_preflight_plan.md
@@ -8,14 +8,17 @@ pull request.
 
 ## Evidence snapshot
 
-- `uv run mypy --strict src tests` returns success, confirming the
-  strict typing gate is green across application and test modules.
-  【4b1e56†L1-L2】
-- `uv run --extra test pytest` currently fails across verification,
-  storage, API, MCP, and search caching tests. The failures highlight
-  gaps in fact-checker configuration, backup rotation, cache invalidity,
-  FastMCP construction, and API parsing utilities.
-  【7be155†L104-L170】【7be155†L201-L262】
+- `uv run mypy --strict src tests` continues to pass. The
+  October 3, 2025 at 22:37 UTC sweep reported “Success: no issues found”,
+  keeping the strict typing gate green across source and test modules.
+  【d70b9a†L1-L2】
+- `uv run --extra test pytest` on October 3, 2025 at 22:37 UTC surfaced
+  26 failing tests and five errors across reverification defaults,
+  storage rotation, cache determinism, FastMCP adapters, API exports,
+  orchestrator error handling, planner metadata, and docstring quality.
+  These failures block fresh coverage evidence and the alpha release
+  sign-off until the regressions are resolved.
+  【ce87c2†L81-L116】
 
 The plan below assumes strict typing remains green and focuses on the
 fastest path to a green test suite, refreshed coverage evidence, and the
@@ -97,17 +100,141 @@ next step.
   consistency checks plus provenance guards once persistence is
   reliable.
 
+## Fresh pytest diagnostics (2025-10-03 22:37 UTC)
+
+### FactChecker defaults
+
+- **Representative failures:**
+  - `tests/unit/orchestration/test_reverify.py`:
+    - `test_reverify_extracts_claims_and_retries`
+- **Assumption:** Restoring default FactChecker configuration should
+  unblock reverification retries.
+- **Support:** The regression surfaces as a validation error complaining
+  about missing configuration.
+- **Counterpoint:** Hard-coding defaults without fixture opt-outs could
+  hide legitimate misconfiguration.
+- **Synthesis:** Provide explicit defaults in configuration factories
+  while updating fixtures to assert opt-in overrides so tests can verify
+  both configured and default flows.
+
+### Backup scheduler
+
+- **Representative failures:**
+  - `tests/unit/storage/test_backup_scheduler.py`:
+    - `test_scheduler_restarts_existing_timer`
+    - `test_rotation_policy_removes_excess_and_stale_backups`
+- **Assumption:** The scheduler should restart timers and prune backups
+  deterministically.
+- **Support:** Tests assert observed behaviour (missing cancellation,
+  stale cleanup) and currently fail.
+- **Counterpoint:** Simplistic fixes risk race conditions in production
+  timers.
+- **Synthesis:** Introduce deterministic timer handles in the scheduler
+  abstraction and extend tests with Socratic prompts questioning
+  cancellation semantics before touching production concurrency paths.
+
+### Search cache and stubs
+
+- **Representative failures:**
+  - `tests/unit/test_cache.py::*`
+  - `tests/unit/test_core_modules_additional.py::*`
+  - `tests/unit/test_failure_scenarios.py::test_external_lookup_fallback`
+- **Assumption:** Cache metadata drift stems from regressions in backend
+  keys and stub fallbacks.
+- **Support:** Assertions expect per-backend isolation and stub fallback
+  responses.
+- **Counterpoint:** Over-fitting to tests may reduce runtime resilience
+  if fallback semantics change.
+- **Synthesis:** Refactor cache keys via a dedicated helper, add
+  Socratic checklists in tests to challenge fallback behaviour, and
+  document backend contracts so runtime changes stay auditable.
+
+### API and FastMCP
+
+- **Representative failures:**
+  - `tests/unit/test_api.py::test_fallback_multiple_ips`
+  - `tests/unit/test_a2a_mcp_handshake.py::*`
+  - `tests/unit/test_mcp_interface.py::test_client_server_roundtrip`
+- **Assumption:** Missing exports and constructor signatures break API
+  clients.
+- **Support:** Attribute errors and unexpected kwargs confirm the
+  breakage.
+- **Counterpoint:** Re-exporting without integration coverage could
+  reintroduce stale adapters.
+- **Synthesis:** Restore exports through the package `__all__`, align
+  FastMCP constructors with documented schemas, and add behaviour
+  coverage for handshake retries.
+
+### Orchestrator error handling
+
+- **Representative failures:**
+  - `tests/unit/test_orchestrator_errors.py::*`
+  - `tests/unit/test_parallel_query_timeout_claims`
+- **Assumption:** Error fallback should emit structured claim mappings.
+- **Support:** Type errors show the pipeline now injects strings instead
+  of mappings.
+- **Counterpoint:** Tightening the schema could mask debugging strings.
+- **Synthesis:** Update error-handling helpers to normalise claim
+  payloads, retain debugging metadata under explicit keys, and add
+  Socratic prompts in tests to question claim structure expectations.
+
+### Planner metadata and documentation hygiene
+
+- **Representative failures:**
+  - `tests/unit/test_advanced_agents.py::test_planner_metadata`
+  - `tests/unit/test_models_docstrings.py::test_class_docstrings`
+- **Assumption:** Planner outputs and documentation lost required
+  context during refactors.
+- **Support:** Attribute errors and docstring assertions fail.
+- **Counterpoint:** Reintroducing heavy fixtures may slow planner
+  iterations.
+- **Synthesis:** Provide lightweight metadata adapters in planner mocks
+  and refresh docstrings with concise yet auditable descriptions,
+  capturing trade-offs in documentation.
+
+### Storage contracts
+
+- **Representative failures:**
+  - `tests/unit/test_incremental_updates.py`:
+    - `test_persist_claim_triggers_index_refresh`
+  - `tests/unit/test_duckdb_storage_backend.py`:
+    - `TestDuckDBStorageBackend::test_run_migrations`
+- **Assumption:** Storage initialisation and migrations drifted from
+  deterministic expectations.
+- **Support:** Tests observe missing knowledge graph initialisation and
+  redundant migration writes.
+- **Counterpoint:** Forcing eager initialisation may regress lazy-loading
+  performance.
+- **Synthesis:** Add guard rails ensuring test fixtures bootstrap
+  storage deterministically while keeping production lazy paths
+  documented and monitored.
+
+### Environment and telemetry
+
+- **Representative failures:**
+  - `tests/unit/test_check_env_warnings.py::*`
+  - `tests/unit/test_more_coverage.py::test_formattemplate_metrics`
+- **Assumption:** Environment checks and telemetry helpers depend on
+  metadata that recent refactors removed.
+- **Support:** Errors cite missing package metadata and claim audit
+  fields.
+- **Counterpoint:** Reintroducing metadata blindly may duplicate build
+  steps.
+- **Synthesis:** Provide fixture-supplied metadata hooks, question each
+  field’s provenance, and document the expected telemetry surface in
+  specs.
+
 ## Highest-impact priorities
 
-1. Restore a green pytest suite by fixing configuration and caching
-   regressions in verification, storage backups, API utilities, and
-   search caching.
-2. Refresh coverage evidence after the test suite is green, keeping the
-   92.4% gate enforceable ahead of alpha tagging.
-3. Instrument AUTO mode and planner output with the telemetry required
-   to tune adaptive debate and PRDV upgrades without guesswork.
-4. Document routing, verification, and retrieval decisions so reviewers
-   can audit improvements without external context.
+1. Restore a green pytest suite by fixing the clustered regressions above,
+   starting with FactChecker defaults, storage rotation, cache determinism,
+   API adapters, and orchestrator error handling.
+2. Refresh coverage evidence after the suite is green, keeping the 92.4%
+   gate enforceable ahead of alpha tagging.
+3. Instrument AUTO mode and planner output with the telemetry required to
+   tune adaptive debate and PRDV upgrades without guesswork.
+4. Document routing, verification, and retrieval decisions so reviewers can
+   audit improvements without external context.
 
 ## Planned PR slices
 
@@ -115,30 +242,45 @@ Each bullet is scoped for a fast review cycle and can ship
 independently.
 
 1. **PR-A:** Normalize FactChecker defaults and update reverification
-   fixtures so `test_reverify_extracts_claims_and_retries` passes.
-2. **PR-B:** Fix backup scheduler restart logic and rotation policy to
-   satisfy `tests/unit/storage/test_backup_scheduler.py`.
-3. **PR-C:** Repair search cache and stub behaviours, ensuring backend
-   selection and query preservation match expectations.
-4. **PR-D:** Restore `autoresearch.api.parse` exports and FastMCP
-   adapter construction so API and MCP handshake tests pass.
-5. **PR-E:** Add AUTO mode telemetry, capturing skip/escalate decisions
-   and evidence coverage for tuning.
-6. **PR-F:** Introduce dependency-aware planner prompts with Socratic
-   self-checks and regression coverage.
-7. **PR-G:** Refresh `task coverage` evidence once PR-A through PR-D
-   land, updating release documentation with the new report.
+   fixtures so `test_reverify_extracts_claims_and_retries` passes while
+   preserving opt-out coverage.
+2. **PR-B:** Repair backup scheduler restart logic and rotation policy to
+   satisfy `tests/unit/storage/test_backup_scheduler.py` without
+   introducing timing flakiness.
+3. **PR-C:** Refactor search cache key derivation, backend isolation, and
+   stub fallback handling so cache and stub suites pass with deterministic
+   query preservation.
+4. **PR-D:** Restore `autoresearch.api.parse` exports and align FastMCP
+   adapter construction with handshake tests, covering both API and MCP
+   suites.
+5. **PR-E:** Normalise orchestrator error claim payloads and parallel
+   timeout messaging so error-handling suites reintroduce mapping-based
+   claims and clear reasoning trails.
+6. **PR-F:** Stabilise storage initialisation and migration contracts,
+   ensuring knowledge-graph setup and migration idempotency satisfy the
+   incremental update and DuckDB tests.
+7. **PR-G:** Provide planner metadata adapters and refreshed docstrings so
+   planner metadata and documentation hygiene suites pass without slowing
+   planner iterations.
+8. **PR-H:** Supply environment metadata fixtures and telemetry guards for
+   `check_env_warnings` and `formattemplate_metrics` coverage tests.
+9. **PR-I:** After PR-A through PR-H land, capture a fresh coverage run
+   and update release documentation with the new evidence.
+10. **PR-J:** Add AUTO mode telemetry, capturing skip/escalate decisions
+    and evidence coverage for tuning once the suite is green.
+11. **PR-K:** Introduce dependency-aware planner prompts with Socratic
+    self-checks and regression coverage building on PR-J outputs.
 
 ## Coverage and behaviour follow-up
 
-- After PRs A–D, rerun `uv run task verify EXTRAS="nlp ui vss git
+- After PRs A–H, rerun `uv run task verify EXTRAS="nlp ui vss git
   distributed analysis llm parsers"` to confirm lint, mypy, and pytest
   gates are green.
 - When the suite passes, capture a fresh `task coverage` log and update
   `docs/release_plan.md`, `STATUS.md`, `TASK_PROGRESS.md`, and
   `CODE_COMPLETE_PLAN.md` with the new evidence.
 - Expand behaviour coverage by adding scenarios under the
-  `reasoning_modes` tag that exercise AUTO telemetry once PR-E merges.
+  `reasoning_modes` tag that exercise AUTO telemetry once PR-J merges.
 
 ## Documentation actions
 

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -1,14 +1,19 @@
 # Prepare first alpha release
 
 ## Context
-As of **October 3, 2025 at 14:52 UTC** the strict typing gate is green but the
-pytest suite remains red. `uv run mypy --strict src tests` finishes without
-findings, while `uv run --extra test pytest` fails across reverification
-configuration, backup scheduling, search caching, API parsing, and FastMCP
-handshake fixtures. The [v0.1.0a1 preflight readiness plan](../docs/v0.1.0a1_preflight_plan.md)
-summarises the remediation work and maps it to review-sized PRs so we can refresh
-coverage evidence and restart the release pipeline.
-【4b1e56†L1-L2】【7be155†L104-L262】
+As of **October 3, 2025 at 22:37 UTC** the strict typing gate remains green but
+the pytest suite is still red. `uv run mypy --strict src tests` again reported
+“Success: no issues found in 787 source files”, while
+`uv run --extra test pytest` finished with 26 failures and five errors spanning
+FactChecker defaults, backup scheduling, search cache determinism, API parsing
+exports, FastMCP handshake fixtures, orchestrator error handling, planner
+metadata, storage contracts, and environment metadata checks. The
+[v0.1.0a1 preflight readiness plan](../docs/v0.1.0a1_preflight_plan.md) now
+captures these regression clusters as PR-A through PR-H and sequences telemetry
+and planner enhancements as PR-I through PR-K once the suite is green, keeping
+each change review-sized so we can refresh coverage evidence and restart the
+release pipeline.
+【d70b9a†L1-L2】【ce87c2†L81-L116】【F:docs/v0.1.0a1_preflight_plan.md†L1-L239】
 
 TestPyPI dry runs remain paused by default. Once PR-A through PR-D in the
 preflight plan land and the suite is green, we will capture fresh verify and
@@ -16,10 +21,10 @@ coverage runs before re-enabling the publish stage.
 【F:docs/v0.1.0a1_preflight_plan.md†L115-L173】
 
 ## Tasks
-- [ ] Ship PR-A through PR-D from the preflight plan to restore a green
-  pytest suite.
-- [ ] Capture fresh verify and coverage logs once the suite passes and
-  update release documentation.
+- [ ] Ship PR-A through PR-H from the refreshed preflight plan to restore a
+  green pytest suite.
+- [ ] Capture fresh verify and coverage logs once the suite passes and update
+  release documentation.
 - [ ] Re-enable the TestPyPI dry run and document the result after the
   gates are green.
 - [ ] Run the release sign-off review with updated evidence and record


### PR DESCRIPTION
## Summary
- capture the 2025-10-03 22:37 UTC mypy strict success and pytest failure set, then document the clustered regressions in the v0.1.0a1 preflight readiness plan
- expand the preflight PR roadmap to cover new regression clusters and align CODE_COMPLETE_PLAN, STATUS, TASK_PROGRESS, and the alpha release issue with the updated plan

## Testing
- uv run mypy --strict src tests
- uv run --extra test pytest

------
https://chatgpt.com/codex/tasks/task_e_68e04fc6d724833389ead54b8101bd8f