### PR TITLE
Fix backup scheduler timer races and deterministic rotation

### DIFF
--- a/issues/fix-backup-scheduler-rotation-regressions.md
+++ b/issues/fix-backup-scheduler-rotation-regressions.md
@@ -20,5 +20,13 @@ backups piled up and coverage blocked.
   flakiness.
 - Release documentation notes the restored behaviour.
 
+## Progress
+- Scheduler now replaces timers atomically using a generation guard that stops
+  cancelled callbacks from re-arming new timers.
+- Rotation policy deletes expired backups by timestamp and path order so the
+  surviving set is deterministic.
+- Documentation outlines the immediate execution guarantee and the graceful
+  shutdown semantics added to the scheduler.
+
 ## Status
-Open
+In Review


### PR DESCRIPTION
## Summary
- ensure `BackupScheduler` replaces active timers atomically with a generation guard
- enforce deterministic rotation order when pruning expired backups
- expand scheduler tests, update documentation, and record progress in the issue

## Testing
- uv run mypy --strict src tests
- uv run --extra test pytest tests/unit/storage/test_backup_scheduler.py

------
https://chatgpt.com/codex/tasks/task_e_68e05ad8dfa48333856865166f12d903