### PR TITLE
Improve search cache determinism and fallback placeholders

### DIFF
--- a/docs/search_backends.md
+++ b/docs/search_backends.md
@@ -52,6 +52,18 @@ Changes to the `[search]` section are applied at runtime. The configuration
 watcher updates active search backends and weights without restarting
 services.
 
+## Cache determinism
+
+Search caching relies on a composite key that combines the backend name, the
+normalized query text, and the embedding-related switches (hybrid queries,
+semantic similarity, and the configured embedding backends). This contract
+avoids stale hits when embedding options change during a session.
+
+When every configured backend fails, the fallback backend publishes
+deterministic placeholder results under the `__fallback__` namespace. The
+placeholder URLs encode the query and rank so repeated failures remain
+reproducible and visible in cache diagnostics.
+
 ## Benchmarking
 
 To guard against regressions, run `uv run pytest`

--- a/issues/restore-search-cache-determinism.md
+++ b/issues/restore-search-cache-determinism.md
@@ -17,6 +17,9 @@ backend calls unexpectedly and mutate query text.
   string.
 - All cache-related unit tests pass without monkeypatch workarounds.
 - Telemetry or documentation explains the restored cache semantics.
+- Cache keys include backend identity, normalized queries, and embedding flags.
+- Fallback placeholders expose deterministic URLs under the `__fallback__`
+  namespace.
 
 ## Status
 Open

--- a/tests/unit/test_failure_scenarios.py
+++ b/tests/unit/test_failure_scenarios.py
@@ -1,4 +1,5 @@
 import sys
+from urllib.parse import quote_plus
 
 import pytest
 import requests
@@ -63,6 +64,17 @@ def test_external_lookup_fallback(monkeypatch):
     results = Search.external_lookup("q", max_results=2)
     assert len(results) == 2
     assert results[0]["title"] == "Result 1 for q"
+    encoded = quote_plus("q")
+    assert results[0]["url"] == f"https://example.invalid/search?q={encoded}&rank=1", (
+        "If fallback URLs drift, how would we detect nondeterministic cache placeholders?"
+    )
+    assert results[0]["backend"] == "__fallback__", (
+        "When the fallback backend label changes, who will warn us about cache coverage gaps?"
+    )
+    repeat = Search.external_lookup("q", max_results=2)
+    assert repeat == results, (
+        "If deterministic placeholders vanish, what signal would alert us to fallback regressions?"
+    )
 
 
 def test_get_message_broker_invalid():


### PR DESCRIPTION
## Summary
- add a cache key builder and deterministic fallback placeholder helper to the search core
- extend cache and failure scenario unit tests to cover normalization, embedding flags, and fallback expectations
- document the new cache contract and record the acceptance criteria update in the tracking issue

## Testing
- uv run mypy --strict src tests
- uv run --extra test pytest tests/unit/test_cache.py tests/unit/test_failure_scenarios.py

------
https://chatgpt.com/codex/tasks/task_e_68e05cfd0bb48333996e8a56013736b8