### PR TITLE
Restore API exports and FastMCP schema

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,27 @@ Once the server is running you can interact with the endpoints described below.
 For details on orchestrator state transitions and the API contract see
 [orchestrator_state.md](orchestrator_state.md).
 
+## Python module surface
+
+The :mod:`autoresearch.api` package re-exports the most frequently used
+entry points so callers can bootstrap servers, rate limiting, and telemetry
+from a single import. The exported symbols include:
+
+- ``app`` and ``create_app`` for integrating with ASGI servers.
+- ``query_endpoint`` and ``query_stream_endpoint`` for synchronous and
+  streaming execution.
+- ``QueryRequestV1``, ``QueryResponseV1``, and the batch plus async variants
+  for schema-aware clients.
+- ``dynamic_limit`` and ``parse`` for converting rate-limit strings alongside
+  ``Limiter`` and ``RateLimitExceeded``.
+- ``FallbackRateLimitMiddleware`` and ``RateLimitMiddleware`` for SlowAPI and
+  stubbed deployments, plus ``AuthMiddleware`` and ``handle_rate_limit``.
+- ``create_request_logger``, ``get_request_logger``, ``reset_request_log``, and
+  ``RequestLogger`` to introspect throttling metrics.
+
+These exports mirror the public REST contract so API consumers and MCP
+adapters stay aligned without reaching into submodules.
+
 Requests and responses are versioned. Include `"version": "1"` in request
 bodies; responses echo the same field to signal the contract in use. The
 `QueryRequestV1` and `QueryResponseV1` models live in

--- a/issues/restore-api-parse-and-fastmcp-handshake.md
+++ b/issues/restore-api-parse-and-fastmcp-handshake.md
@@ -19,4 +19,16 @@
 - Documentation or release notes summarise the API and handshake changes.
 
 ## Status
-Open
+Closed
+
+## Resolution
+- Restored the `autoresearch.api` surface by re-exporting rate-limit helpers,
+  middleware, and the `parse` utility for compatibility with existing
+  integrations.
+- Updated FastMCP adapters to emit and accept `QueryRequestV1` and
+  `QueryResponseV1` payloads, including structured error telemetry for Socratic
+  recovery prompts.
+- Added unit tests that assert success and failure flows for both the REST API
+  and FastMCP handshake while exercising Socratic diagnostics.
+- Documented the consolidated Python exports in `docs/api.md` so downstream
+  clients can rely on the public surface without spelunking submodules.

--- a/src/autoresearch/api/__init__.py
+++ b/src/autoresearch/api/__init__.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 from . import routing
+from .auth_middleware import AuthMiddleware as _AuthMiddleware
+from .errors import handle_rate_limit as _handle_rate_limit
 from .middleware import (
     SLOWAPI_STUB,
+    FallbackRateLimitMiddleware as _FallbackRateLimitMiddleware,
+    RateLimitMiddleware as _RateLimitMiddleware,
 )
 from .middleware import Limiter as _Limiter
 from .middleware import RateLimitExceeded as _RateLimitExceeded
 from .middleware import (
     dynamic_limit,
     get_remote_address,
+    parse as _parse,
 )
 from .models import (
     AsyncQueryResponseV1,
@@ -19,6 +24,7 @@ from .models import (
     QueryRequestV1,
     QueryResponseV1,
 )
+from .streaming import query_stream_endpoint
 from .utils import (
     RequestLogger,
     create_request_logger,
@@ -35,6 +41,11 @@ limiter = routing.limiter
 query_endpoint = routing.query_endpoint
 RateLimitExceeded = _RateLimitExceeded
 Limiter = _Limiter
+parse = _parse
+FallbackRateLimitMiddleware = _FallbackRateLimitMiddleware
+RateLimitMiddleware = _RateLimitMiddleware
+AuthMiddleware = _AuthMiddleware
+handle_rate_limit = _handle_rate_limit
 
 __all__ = [
     "app",
@@ -48,6 +59,7 @@ __all__ = [
     "RateLimitExceeded",
     "Limiter",
     "query_endpoint",
+    "query_stream_endpoint",
     "QueryRequestV1",
     "QueryResponseV1",
     "BatchQueryRequestV1",
@@ -58,4 +70,9 @@ __all__ = [
     "get_request_logger",
     "RequestLogger",
     "reset_request_log",
+    "parse",
+    "FallbackRateLimitMiddleware",
+    "RateLimitMiddleware",
+    "AuthMiddleware",
+    "handle_rate_limit",
 ]

--- a/src/autoresearch/api/middleware.py
+++ b/src/autoresearch/api/middleware.py
@@ -171,4 +171,5 @@ __all__ = [
     "RateLimitExceeded",
     "dynamic_limit",
     "get_remote_address",
+    "parse",
 ]

--- a/src/autoresearch/mcp_interface.py
+++ b/src/autoresearch/mcp_interface.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping, cast
+from collections.abc import Mapping, Sequence
+from enum import Enum
+from typing import Any
 
 import anyio
-from fastmcp import FastMCP, Client
+from fastmcp import Client, FastMCP
 
+from .api.models import QueryRequestV1, QueryResponseV1
 from .config import ConfigLoader
+from .error_utils import format_error_for_api, get_error_info
 from .logging_utils import get_logger
 from .models import QueryResponse
 from .orchestration.orchestrator import Orchestrator
@@ -21,23 +25,22 @@ def create_server(host: str = "127.0.0.1", port: int = 8080) -> FastMCP:
     """Create a FastMCP server exposing the research tool."""
     config = _config_loader.load_config()
     orchestrator = Orchestrator()
-    server: FastMCP = FastMCP("Autoresearch", host=host, port=port)
+    server = _initialise_server(host=host, port=port)
     setattr(server, "orchestrator", orchestrator)
 
     @server.tool
-    async def research(query: str) -> dict[str, Any]:
+    async def research(
+        query: str | Mapping[str, Any],
+        version: str = QueryRequestV1.__version__,
+        **overrides: Any,
+    ) -> dict[str, Any]:
         try:
-            result: QueryResponse = orchestrator.run_query(query, config)
-            response: dict[str, Any] = {
-                "answer": result.answer,
-                "citations": [_serialise_mapping(c) for c in result.citations],
-                "reasoning": result.reasoning,
-                "metrics": result.metrics,
-            }
-            return response
+            request = _build_query_request(query, version=version, overrides=overrides)
+            result = orchestrator.run_query(request.query, config)
+            return _build_success_payload(result)
         except Exception as exc:  # pragma: no cover - network errors
             logger.error("Error processing query", exc_info=exc)
-            return {"error": str(exc)}
+            return _build_error_payload(exc)
 
     return server
 
@@ -51,24 +54,144 @@ def query(
 ) -> dict[str, Any]:
     """Send a query to an MCP server and return the result."""
     target = transport or f"http://{host}:{port}"
+    payload = _build_request_payload(query)
 
     async def _call() -> dict[str, Any]:
         async with Client(target) as client:
-            result = await client.call_tool("research", {"query": query})
-            return cast(dict[str, Any], result)
+            result = await client.call_tool("research", payload)
+            response = QueryResponseV1.model_validate(result)
+            result_payload: dict[str, Any] = response.model_dump(mode="json")
+            return result_payload
 
     return anyio.run(_call)
 
 
-def _serialise_mapping(value: Any) -> dict[str, Any] | Any:
-    """Return a JSON-serialisable representation of ``value``."""
+def _initialise_server(host: str, port: int) -> FastMCP:
+    """Construct a FastMCP server compatible with stubbed environments."""
+
+    constructor_attempts: tuple[tuple[tuple[Any, ...], dict[str, Any]], ...] = (
+        (("Autoresearch",), {"host": host, "port": port}),
+        (("Autoresearch",), {}),
+        (tuple(), {}),
+    )
+    for args, kwargs in constructor_attempts:
+        try:
+            server = FastMCP(*args, **kwargs)
+            break
+        except TypeError:
+            continue
+    else:  # pragma: no cover - defensive fallback
+        server = FastMCP("Autoresearch")
+
+    setattr(server, "host", host)
+    setattr(server, "port", port)
+    return server
+
+
+def _build_request_payload(query: str) -> dict[str, Any]:
+    """Render a versioned MCP payload for the research tool."""
+
+    request = QueryRequestV1.model_validate({"query": query})
+    return request.model_dump(mode="json")
+
+
+def _build_query_request(
+    query: str | Mapping[str, Any],
+    *,
+    version: str,
+    overrides: Mapping[str, Any],
+) -> QueryRequestV1:
+    """Normalise inputs from FastMCP clients into ``QueryRequestV1``."""
+
+    payload: dict[str, Any]
+    if isinstance(query, Mapping):
+        payload = {**_serialise_structure(query)}
+    else:
+        payload = {"query": query}
+    payload.update(_serialise_structure(overrides))
+    payload.setdefault("version", version)
+    return QueryRequestV1.model_validate(payload)
+
+
+def _build_success_payload(result: QueryResponse | Mapping[str, Any]) -> dict[str, Any]:
+    """Serialise orchestrator responses using the public API schema."""
+
+    if not isinstance(result, QueryResponse):
+        result = QueryResponse.model_validate(result)
+    payload = result.model_dump(mode="json")
+    payload.update(
+        {
+            "citations": [
+                _serialise_structure(item) for item in result.citations
+            ],
+            "claim_audits": [
+                _serialise_structure(audit) for audit in result.claim_audits
+            ],
+            "react_traces": [
+                _serialise_structure(trace) for trace in result.react_traces
+            ],
+            "metrics": _serialise_structure(result.metrics),
+        }
+    )
+    response = QueryResponseV1.model_validate(payload)
+    return response.model_dump(mode="json")
+
+
+def _build_error_payload(exc: Exception) -> dict[str, Any]:
+    """Return a structured error response mirroring the API contract."""
+
+    error_info = get_error_info(exc)
+    error_data = format_error_for_api(error_info)
+    reasoning: list[str] = [
+        "An error occurred during MCP query execution.",
+    ]
+    if error_info.suggestions:
+        reasoning.extend(
+            f"Socratic check: {suggestion}" for suggestion in error_info.suggestions
+        )
+    else:
+        reasoning.append("Socratic check: Which configuration caused this failure?")
+
+    response = QueryResponseV1(
+        answer=f"Error: {error_info.message}",
+        citations=[],
+        reasoning=reasoning,
+        metrics={
+            "error": error_info.message,
+            "error_details": _serialise_structure(error_data),
+        },
+    )
+    return response.model_dump(mode="json")
+
+
+def _serialise_structure(value: Any, *, _seen: set[int] | None = None) -> Any:
+    """Convert nested structures into JSON-compatible primitives."""
+
+    if _seen is None:
+        _seen = set()
 
     if hasattr(value, "model_dump") and callable(value.model_dump):
         dumped = value.model_dump(mode="python")
-        return cast(dict[str, Any], dumped)
+        return _serialise_structure(dumped, _seen=_seen)
+    if isinstance(value, Enum):
+        return value.value
+    obj_id = id(value)
+    if obj_id in _seen:
+        return repr(value)
     if isinstance(value, Mapping):
-        return {str(key): val for key, val in value.items()}
+        _seen.add(obj_id)
+        return {
+            str(key): _serialise_structure(val, _seen=_seen) for key, val in value.items()
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        _seen.add(obj_id)
+        return [_serialise_structure(item, _seen=_seen) for item in value]
     attrs = getattr(value, "__dict__", None)
     if isinstance(attrs, Mapping):
-        return {str(key): val for key, val in attrs.items()}
+        _seen.add(obj_id)
+        return {
+            str(key): _serialise_structure(val, _seen=_seen) for key, val in attrs.items()
+        }
+    if callable(value):
+        return repr(value)
     return value

--- a/tests/unit/test_a2a_mcp_handshake.py
+++ b/tests/unit/test_a2a_mcp_handshake.py
@@ -1,18 +1,36 @@
+from types import MethodType
+from typing import Any
+
 import pytest
 from fastmcp import Client, FastMCP
 
 from autoresearch import mcp_interface
+from autoresearch.api.models import QueryResponseV1
+from autoresearch.errors import AgentError
 
 pytestmark = [pytest.mark.unit, pytest.mark.a2a_mcp, pytest.mark.requires_distributed]
 
 
 @pytest.fixture
 def server() -> FastMCP:
-    server = FastMCP("Mock")
+    try:
+        server = FastMCP("Mock")
+    except TypeError:
+        server = FastMCP()
 
     @server.tool
-    async def research(query: str) -> dict:
-        return {"answer": "42"}
+    async def research(query: str, version: str = "1", **overrides: Any) -> dict:
+        _ = overrides  # Exercise kwargs for coverage while staying simple.
+        response = QueryResponseV1(
+            query=query,
+            answer="42",
+            citations=[],
+            reasoning=["Socratic check: Did the handshake complete successfully?"],
+            metrics={"cycles_completed": 1},
+            react_traces=[],
+        )
+        response.version = version
+        return response.model_dump(mode="json")
 
     yield server
     server.tools.clear()
@@ -20,7 +38,15 @@ def server() -> FastMCP:
 
 def test_handshake_success(server: FastMCP) -> None:
     result = mcp_interface.query("hello", transport=server)
-    assert result["answer"] == "42"
+    assert result["answer"] == "42", (
+        "Socratic check: Did the MCP handshake deliver orchestrator output?"
+    )
+    assert any("Socratic check" in step for step in result["reasoning"]), (
+        "Socratic check: Did the response capture reflective guidance?"
+    )
+    assert result["metrics"]["cycles_completed"] == 1, (
+        "Socratic check: Are success metrics surfaced for auditing?"
+    )
 
 
 def test_handshake_timeout(server: FastMCP, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -29,8 +55,12 @@ def test_handshake_timeout(server: FastMCP, monkeypatch: pytest.MonkeyPatch) -> 
 
     monkeypatch.setattr("autoresearch.mcp_interface.Client.call_tool", _timeout)
 
-    with pytest.raises(TimeoutError):
+    with pytest.raises(TimeoutError) as exc_info:
         mcp_interface.query("hello", transport=server)
+
+    assert "timeout" in str(exc_info.value).lower(), (
+        "Socratic check: Did the client propagate timeout diagnostics?"
+    )
 
 
 def test_handshake_recovery(server: FastMCP, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -53,8 +83,39 @@ def test_handshake_recovery(server: FastMCP, monkeypatch: pytest.MonkeyPatch) ->
 
     monkeypatch.setattr("autoresearch.mcp_interface.Client", FlakyClient)
 
-    with pytest.raises(ConnectionError):
+    with pytest.raises(ConnectionError) as exc_info:
         mcp_interface.query("hello", transport=server)
 
+    assert "temporary failure" in str(exc_info.value).lower(), (
+        "Socratic check: Did the retry logic surface the transient failure?"
+    )
+
     result = mcp_interface.query("hello", transport=server)
-    assert result["answer"] == "42"
+    assert result["answer"] == "42", (
+        "Socratic check: Did the client recover after the transient failure?"
+    )
+
+
+def test_handshake_server_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    server = mcp_interface.create_server()
+
+    def fail(self, _query: str, _config: object, **_kwargs: Any) -> QueryResponseV1:
+        raise AgentError("broken", context={"agent": "Handshake"})
+
+    monkeypatch.setattr(
+        server.orchestrator,
+        "run_query",
+        MethodType(fail, server.orchestrator),
+    )
+
+    result = mcp_interface.query("hello", transport=server)
+
+    assert result["answer"].startswith("Error:"), (
+        "Socratic check: Did server failures bubble up as structured errors?"
+    )
+    assert any(step.startswith("Socratic check") for step in result["reasoning"]), (
+        "Socratic check: Are follow-up prompts included for diagnosis?"
+    )
+    assert result["metrics"].get("error"), (
+        "Socratic check: Are error metrics captured for telemetry?"
+    )

--- a/tests/unit/test_mcp_interface.py
+++ b/tests/unit/test_mcp_interface.py
@@ -1,23 +1,88 @@
 from types import MethodType
 
+import pytest
+
 from autoresearch import mcp_interface
 from autoresearch.config.models import ConfigModel
+from autoresearch.errors import AgentError
+from autoresearch.models import QueryResponse
 
 
-def _mock_load_config():
+def _mock_load_config() -> ConfigModel:
     return ConfigModel()
 
 
-def test_client_server_roundtrip(monkeypatch, mock_run_query):
+@pytest.mark.unit
+@pytest.mark.a2a_mcp
+@pytest.mark.requires_distributed
+def test_client_server_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(mcp_interface._config_loader, "load_config", _mock_load_config)
 
     server = mcp_interface.create_server()
+
+    def success(
+        self,
+        query: str,
+        config: ConfigModel,
+        callbacks=None,
+        **_kwargs: object,
+    ) -> QueryResponse:
+        return QueryResponse(
+            answer="ok",
+            citations=[],
+            reasoning=["Socratic check: Did we challenge the initial hypothesis?"],
+            metrics={"m": 1},
+        )
+
     monkeypatch.setattr(
         server.orchestrator,
         "run_query",
-        MethodType(mock_run_query, server.orchestrator),
+        MethodType(success, server.orchestrator),
     )
 
     result = mcp_interface.query("hello", transport=server)
 
-    assert result["answer"] == "ok"
+    assert result["answer"] == "ok", (
+        "Socratic check: Did the MCP transport return successful results?"
+    )
+    assert any("Socratic check" in step for step in result["reasoning"]), (
+        "Socratic check: Are reflective prompts surfaced on success?"
+    )
+    assert result["metrics"]["m"] == 1, (
+        "Socratic check: Were metrics preserved across the handshake?"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.a2a_mcp
+@pytest.mark.requires_distributed
+def test_client_server_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mcp_interface._config_loader, "load_config", _mock_load_config)
+
+    server = mcp_interface.create_server()
+
+    def fail(
+        self,
+        query: str,
+        config: ConfigModel,
+        **_kwargs: object,
+    ) -> QueryResponse:
+        raise AgentError("boom", context={"agent": "Stub"})
+
+    monkeypatch.setattr(
+        server.orchestrator,
+        "run_query",
+        MethodType(fail, server.orchestrator),
+    )
+
+    result = mcp_interface.query("hello", transport=server)
+
+    assert result["answer"].startswith("Error:"), (
+        "Socratic check: Did failure cases propagate structured responses?"
+    )
+    assert any(step.startswith("Socratic check") for step in result["reasoning"]), (
+        "Socratic check: Are diagnostic prompts included on failure?"
+    )
+    assert result["metrics"].get("error"), (
+        "Socratic check: Do metrics expose the failure details?"
+    )


### PR DESCRIPTION
## Summary
- re-export API middleware, streaming, and rate limit helpers from `autoresearch.api`
- align FastMCP adapters with the versioned request/response schema and Socratic error prompts
- document the Python API surface and extend unit tests with success and failure Socratic assertions

## Testing
- uv run mypy --strict src tests
- uv run --extra test pytest tests/unit/test_api.py
- uv run --extra test pytest tests/unit/test_a2a_mcp_handshake.py
- uv run --extra test pytest tests/unit/test_mcp_interface.py

------
https://chatgpt.com/codex/tasks/task_e_68e066ca90608333b9225b19c23d9284