### PR TITLE
Normalize planner metadata for coordinator telemetry

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -9,13 +9,18 @@ while retaining thread safety and reproducible telemetry.
   `PlannerPromptBuilder` instructs the LLM to emit JSON including
   `objectives`, `tool_affinity`, `exit_criteria`, and `explanation` for each
   task. These fields are mapped onto the runtime `TaskNode` data structure.
+- Planner metadata (for example `metadata.version`, `metadata.notes`, and
+  planner-specified tags) is normalised into JSON-safe dictionaries. The
+  metadata is surfaced through `result.metadata['task_graph']` so downstream
+  services can reason about planner intent without re-parsing the raw plan.
 - `QueryState.set_task_graph` captures planner telemetry, aggregating the
   objectives, exit criteria, and per-task affinity/explanation data. The
   telemetry is serialisation-safe and restored with the state.
 - `TaskCoordinator` converts planner payloads into `TaskGraphNode` snapshots.
   Nodes sort by readiness, affinity, dependency depth, then identifier. Every
   ReAct step records the scheduler snapshot so downstream tools can replay the
-  decision trail.
+  decision trail. Coordinator telemetry now echoes `task_metadata` alongside
+  scheduler candidates to preserve planner hints such as priority or budgets.
 - Planner and coordinator metadata flow into the `react_log`, agent results,
   and behaviour scenarios for observability.
 

--- a/issues/planner-coordinator-react-upgrade.md
+++ b/issues/planner-coordinator-react-upgrade.md
@@ -51,6 +51,8 @@ telemetry hooks so decomposition quality and routing choices remain auditable.
   **14:55 UTC** `task verify` failures clear.
 - [x] Update `docs/pseudocode.md` with the PRDV verification loop and expanded
   `EvaluationSummary` fields to align planner telemetry with verification docs.
+- [x] Normalise planner metadata into result payloads and coordinator traces so
+  `task_metadata` mirrors planner hints without bespoke adapters.
 - [ ] Resume implementation after the **October 1, 2025** strict and coverage
   sweeps confirm the `_thread.RLock` clone and typed `EvaluationSummary`
   fixtures are green again.

--- a/src/autoresearch/orchestration/task_graph.py
+++ b/src/autoresearch/orchestration/task_graph.py
@@ -103,6 +103,7 @@ class TaskGraphNode:
     tools: List[str] = field(default_factory=list)
     criteria: List[str] = field(default_factory=list)
     explanation: str | None = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
     def max_affinity(self) -> float:
         """Return the maximum affinity score across known tools."""
@@ -138,6 +139,7 @@ class TaskGraphNode:
             "criteria": list(self.criteria),
             "explanation": self.explanation,
             "max_affinity": self.max_affinity(),
+            "metadata": dict(self.metadata),
         }
 
 


### PR DESCRIPTION
## Summary
- normalise planner metadata, surface it in agent results, and adapt coordinator traces to include task metadata snapshots
- extend TaskGraphNode snapshots with metadata payloads and ensure planner metadata parsing coerces nested structures
- refresh orchestration docs, issue checklist, and QueryResponse docstrings to describe the new metadata fields

## Testing
- `uv run mypy --strict src tests`
- `uv run --extra test pytest tests/unit/test_advanced_agents.py tests/unit/test_models_docstrings.py`


------
https://chatgpt.com/codex/tasks/task_e_68e072bae37483339c6542256f2205f6