### PR TITLE
Add Socratic planner schema and coordinator dependency scheduling

### DIFF
--- a/docs/diagrams/orchestration.puml
+++ b/docs/diagrams/orchestration.puml
@@ -1,153 +1,63 @@
 @startuml
-title Orchestration Component
+skinparam monochrome true
+skinparam dpi 150
+title PRDV Orchestration Overview
 
-package "Orchestration" {
-  class Orchestrator {
-    + {static} run_query(query, config, callbacks, agent_factory, storage_manager): QueryResponse
-    + {static} run_parallel_query(query, config, agent_groups): QueryResponse
-    - {static} _parse_config(config): Dict
+package "Planning" {
+  class PlannerPromptBuilder {
+    +build(): str
+    -base_prompt: str
+    -dependency_overview: List
+    -socratic_checks: List
   }
 
-  class OrchestrationUtils {
-    + {static} get_agent(agent_name, agent_factory): Agent
-    + {static} check_agent_can_execute(agent, agent_name, state, config): bool
-    + {static} log_agent_execution(agent_name, state, loop): void
-    + {static} call_agent_start_callback(agent_name, state, callbacks): void
-    + {static} execute_agent_with_token_counting(agent, agent_name, state, config, metrics): Dict
-    + {static} handle_agent_completion(agent_name, result, state, metrics, callbacks, duration, loop): void
-    + {static} log_sources(agent_name, result): void
-    + {static} persist_claims(agent_name, result, storage_manager): void
-    + {static} handle_agent_error(agent_name, e, state, metrics): void
-    + {static} execute_agent(agent_name, state, config, metrics, callbacks, agent_factory, storage_manager, loop): void
-    + {static} execute_cycle(loop, loops, agents, primus_index, max_errors, state, config, metrics, callbacks, agent_factory, storage_manager, tracer): int
-    + {static} execute_with_adapter(agent, state, config, adapter): Dict
-    + {static} rotate_list(items, start_idx): List
-    + {static} capture_token_usage(agent_name, metrics, config): Iterator
-    + {static} categorize_error(exc): str
-    + {static} apply_recovery_strategy(agent, category, exc, state): Dict
-    + {static} apply_adaptive_token_budget(config, query): void
-    + {static} get_memory_usage(): float
-    + {static} calculate_result_confidence(result): float
-  }
-
-  class QueryState {
-    + query: str
-    + cycle: int
-    + primus_index: int
-    + results: Dict
-    + metadata: Dict
-    + error_count: int
-    + update(result): void
-    + add_error(error_info): void
-    + synthesize(): QueryResponse
-  }
-
-  class OrchestrationMetrics {
-    + start_cycle(): void
-    + end_cycle(): void
-    + record_agent_timing(agent_name, duration): void
-    + record_token_usage(agent_name, tokens): void
-    + record_error(agent_name): void
-    + get_summary(): Dict
-  }
-
-  enum ReasoningMode {
-    DIRECT
-    DIALECTICAL
-    CHAIN_OF_THOUGHT
-  }
-
-  class ChainOfThoughtStrategy {
-    + run_query(query, config, agent_factory): QueryResponse
-  }
-  class RayExecutor {
-    + run_query(query, callbacks): QueryResponse
+  class TaskGraph {
+    +from_planner_output(payload)
+    +tasks: List[TaskNode]
+    +metadata: Dict
+    +dependency_overview: List
   }
 }
 
-package "Agents" {
-  interface Agent {
-    + execute(state, config): Dict
-    + can_execute(state, config): bool
+package "Execution" {
+  class TaskCoordinator {
+    +schedule_next(preferred_tool)
+    +record_react_step(...)
+    -_provided_depth: Dict
+    -_affinity_map: Dict
   }
 
-  class AgentFactory {
-    + {static} get(agent_name): Agent
-  }
-}
-
-package "Storage" {
-  class StorageManager {
-    + persist_claim(claim): void
-  }
-
-  class KGReasoning {
-    + run_ontology_reasoner(store, engine): None
+  class PRDVLoop {
+    +plan()
+    +research()
+    +debate()
+    +validate()
   }
 }
 
-package "Models" {
-  class QueryResponse {
-    + answer: str
-    + citations: List
-    + reasoning: List
-    + metrics: Dict
-  }
-
-  class Visualization {
-    + save_knowledge_graph(result, path): None
-  }
+class QueryState {
+  +set_task_graph(graph)
+  +metadata: Dict
+  +react_traces: List
 }
 
-package "LLM" {
-  class TokenCountingAdapter {
-    + generate(prompt, model, temperature): str
-  }
-}
+PlannerPromptBuilder --> TaskGraph : emits JSON
+TaskGraph --> QueryState : normalised
+QueryState --> TaskCoordinator : hydrates nodes
+TaskCoordinator --> PRDVLoop : schedules phases
+PRDVLoop --> QueryState : records telemetry
 
-package "Errors" {
-  class OrchestrationError
-  class AgentError
-  class NotFoundError
-  class TimeoutError
-}
+note right of PlannerPromptBuilder
+  Emits dependency_overview and
+  socratic_checks to stress-test
+  each task before execution.
+end note
 
-' Relationships
-Orchestrator --> QueryState: creates and updates
-Orchestrator --> OrchestrationMetrics: records metrics
-Orchestrator --> ReasoningMode: uses
-Orchestrator --> ChainOfThoughtStrategy: delegates to
-Orchestrator --> Agent: executes
-Orchestrator --> AgentFactory: gets agents from
-Orchestrator --> StorageManager: persists claims
-StorageManager --> KGReasoning: run_ontology_reasoner
-Orchestrator --> KGReasoning: run_reasoner
-Orchestrator --> QueryResponse: returns
-Orchestrator --> TokenCountingAdapter: uses for token counting
-Orchestrator --> Visualization: visualize_results
-Orchestrator --> OrchestrationError: throws
-Orchestrator --> AgentError: throws
-Orchestrator --> NotFoundError: throws
-Orchestrator --> TimeoutError: throws
-RayExecutor --> QueryState: maintains state
-RayExecutor --> AgentFactory: gets agents from
-RayExecutor --> Agent: executes
-
-QueryState --> QueryResponse: synthesizes
-
-' Execution flow
-note right of Orchestrator
-  Execution Flow:
-  1. run_query() parses config and initializes state
-  2. For each loop:
-     a. _execute_cycle() rotates agents and executes them
-     b. For each agent:
-        i. _execute_agent() gets agent and checks if it can execute
-        ii. _execute_agent_with_token_counting() executes agent with token counting
-        iii. _handle_agent_completion() processes result
-        iv. _persist_claims() stores claims
-        v. run_reverification() extracts claims, retries audits, and persists updates
-  3. State is synthesized into QueryResponse
+note right of TaskCoordinator
+  Combines planner-provided
+  dependency_depth with live
+  readiness checks and tool
+  affinity preferences.
 end note
 
 @enduml

--- a/docs/diagrams/orchestrator_state.puml
+++ b/docs/diagrams/orchestrator_state.puml
@@ -2,11 +2,15 @@
 skinparam dpi 150
 skinparam monochrome true
 
+title PRDV Loop State Machine
+
 [*] --> Idle
-Idle --> Preparing : start()
-Preparing --> Running : launch()
-Running --> Complete : finish()
-Running --> Error : fail()
+Idle --> Planning : start()
+Planning --> Researching : planner_complete
+Researching --> Debating : evidence_conflict
+Researching --> Validating : evidence_sufficient
+Debating --> Validating : consensus_reached
+Validating --> Complete : criteria_met
+Validating --> Researching : needs_more_evidence
 Complete --> [*]
-Error --> [*]
 @enduml

--- a/issues/planner-coordinator-react-upgrade.md
+++ b/issues/planner-coordinator-react-upgrade.md
@@ -1,12 +1,13 @@
 # Planner coordinator react upgrade
 
 ## Context
-Phase 2 of the deep research program promotes the planner output into a
-Phase 2 now depends on the registry clone fix that deep-copies QueryState
-snapshots with typed memo support and on the semantic fallback guard that
-keeps coverage green when fastembed is absent. The regression suites cover
-register/update/round-trip flows plus the encode fallback, so planner
-telemetry can rely on restored coverage while strict typing proceeds.
+Phase 2 of the deep research program promotes the planner output into a typed
+task graph that captures dependency depth and Socratic self-check prompts. The
+registry clone fix that deep-copies QueryState snapshots with typed memo support
+and the semantic fallback guard that keeps coverage green when fastembed is
+absent both landed earlier. The regression suites cover register/update/round-
+trip flows plus the encode fallback, so planner telemetry can rely on restored
+coverage while strict typing proceeds.
 【F:src/autoresearch/orchestration/state_registry.py†L18-L148】
 【F:tests/unit/orchestration/test_state_registry.py†L21-L138】
 【F:baseline/logs/task-coverage-20250930T181947Z.log†L1-L21】
@@ -34,16 +35,18 @@ telemetry hooks so decomposition quality and routing choices remain auditable.
 
 ## Acceptance Criteria
 - Planner prompt templates request objectives, tool affinity scores, exit
-  criteria, and rationale, emitting structured data the coordinator can ingest
-  without additional parsing.
-- TaskCoordinator honors tool affinity scores, enforces dependency ordering, and
-  records routing decisions plus ReAct steps with task identifiers.
+  criteria, dependency depth, and Socratic self-check prompts, emitting
+  structured data the coordinator can ingest without additional parsing.
+- TaskCoordinator honors tool affinity scores, planner-provided dependency
+  depth, and records routing decisions plus ReAct steps with task identifiers
+  and dependency rationale.
 - QueryState persists the canonical task graph and exposes planner/coordinator
   telemetry for replay.
 - Unit, integration, and behavior tests cover planner output normalization,
   scheduler tie-breakers, and ReAct log persistence.
-- Documentation updates in `docs/orchestration.md` and `docs/pseudocode.md`
-  explain the new data structures and replay workflow.
+- Documentation updates in `docs/orchestration.md`, `docs/pseudocode.md`, and
+  refreshed diagrams explain the PRDV flow, dependency depth, and replay
+  workflow.
 
 ## Checklist
 - [x] Capture the strict typing prerequisite for Phase 2 in
@@ -53,7 +56,7 @@ telemetry hooks so decomposition quality and routing choices remain auditable.
   `EvaluationSummary` fields to align planner telemetry with verification docs.
 - [x] Normalise planner metadata into result payloads and coordinator traces so
   `task_metadata` mirrors planner hints without bespoke adapters.
-- [ ] Resume implementation after the **October 1, 2025** strict and coverage
+- [x] Resume implementation after the **October 1, 2025** strict and coverage
   sweeps confirm the `_thread.RLock` clone and typed `EvaluationSummary`
   fixtures are green again.
   【F:baseline/logs/mypy-strict-20251001T143959Z.log†L2358-L2377】

--- a/src/autoresearch/agents/specialized/planner.py
+++ b/src/autoresearch/agents/specialized/planner.py
@@ -81,6 +81,19 @@ class PlannerPromptBuilder:
                                 "type": "array",
                                 "items": {"type": "string"},
                             },
+                            "dependency_depth": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "description": (
+                                    "Planner-estimated depth relative to root tasks."
+                                ),
+                            },
+                            "dependency_rationale": {
+                                "type": "string",
+                                "description": (
+                                    "Short justification for declared dependencies."
+                                ),
+                            },
                             "criteria": {
                                 "type": "array",
                                 "items": {"type": "string"},
@@ -92,6 +105,19 @@ class PlannerPromptBuilder:
                                 "description": "Alias for criteria.",
                             },
                             "explanation": {"type": "string"},
+                            "socratic_checks": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": (
+                                    "Self-question prompts that stress-test assumptions."
+                                ),
+                            },
+                            "self_check": {
+                                "type": "object",
+                                "description": (
+                                    "Alias for socratic_checks when structured."
+                                ),
+                            },
                             "metadata": {"type": "object"},
                         },
                     },
@@ -116,7 +142,43 @@ class PlannerPromptBuilder:
                     "properties": {
                         "version": {"type": "integer"},
                         "notes": {"type": "string"},
+                        "dependency_overview": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "task": {"type": "string"},
+                                    "depends_on": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                    },
+                                    "depth": {"type": "integer", "minimum": 0},
+                                    "rationale": {"type": "string"},
+                                },
+                            },
+                            "description": (
+                                "Explicit dependency depth summary for coordinator telemetry."
+                            ),
+                        },
                     },
+                },
+                "dependency_overview": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "task": {"type": "string"},
+                            "depends_on": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "depth": {"type": "integer", "minimum": 0},
+                            "rationale": {"type": "string"},
+                        },
+                    },
+                    "description": (
+                        "Planner-declared dependency depths mirrored in metadata.dependency_overview."
+                    ),
                 },
             },
         }
@@ -130,10 +192,14 @@ class PlannerPromptBuilder:
             notes = dedent(
                 """
                 You must respond with JSON that validates against the schema below.
+                - Derive dependency depth per task and mirror it in "dependency_overview".
                 - Populate ``sub_questions`` with decomposed prompts for each task.
                 - Store numeric tool scores in ``affinity`` with values in ``[0, 1]``.
                 - Provide concrete ``criteria`` that confirm completion.
                 - Summarise rationale for the task in "explanation".
+                - Add at least two "socratic_checks" that challenge risky assumptions.
+                - Use "dependency_rationale" to explain why predecessors are required.
+                - Before finalising, double-check the graph consistency against your plan.
                 - Avoid prose outside the JSON object.
                 """
             ).strip()

--- a/tests/unit/orchestration/test_task_graph_enhancements.py
+++ b/tests/unit/orchestration/test_task_graph_enhancements.py
@@ -1,0 +1,140 @@
+"""Unit tests for enhanced planner task graph normalization and scheduling."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from autoresearch.orchestration.coordinator import TaskCoordinator
+from autoresearch.orchestration.state import QueryState
+from autoresearch.orchestration.task_graph import TaskGraph
+
+
+def _build_payload() -> dict[str, Any]:
+    return {
+        "tasks": [
+            {
+                "id": "plan",
+                "question": "Plan investigation",
+                "depends_on": [],
+                "affinity": {"planner": 0.9},
+                "dependency_depth": 0,
+                "socratic_checks": [
+                    "What user assumption could fail?",
+                    "How do we test feasibility?",
+                ],
+                "dependency_rationale": "Kick-off task has no predecessors.",
+            },
+            {
+                "id": "research",
+                "question": "Research evidence",
+                "depends_on": ["plan"],
+                "affinity": {"search": 0.8},
+                "self_check": {
+                    "risks": ["What if the sources disagree?"],
+                    "tests": "Confirm alignment across summaries",
+                },
+                "dependency_depth": 1,
+                "dependency_rationale": "Requires approved outline.",
+            },
+        ],
+        "dependency_overview": [
+            {
+                "task": "research",
+                "depends_on": ["plan"],
+                "depth": 1,
+                "rationale": "Research builds on the planning deliverable.",
+            }
+        ],
+    }
+
+
+def test_task_graph_from_planner_output_preserves_dependency_metadata() -> None:
+    """Planner payloads expose dependency depth, rationale, and Socratic checks."""
+
+    payload = _build_payload()
+    graph = TaskGraph.from_planner_output(payload)
+
+    assert len(graph.tasks) == 2
+    plan, research = graph.tasks
+    assert plan.dependency_depth == 0
+    assert plan.dependency_rationale == "Kick-off task has no predecessors."
+    assert plan.socratic_checks == [
+        "What user assumption could fail?",
+        "How do we test feasibility?",
+    ]
+    assert research.dependency_depth == 1
+    assert research.socratic_checks[0].lower().startswith("risks:")
+    assert graph.metadata["dependency_overview"] == [
+        {
+            "task": "research",
+            "depends_on": ["plan"],
+            "depth": 1,
+            "rationale": "Research builds on the planning deliverable.",
+        }
+    ]
+
+
+def test_query_state_normalises_socratic_checks_and_overview() -> None:
+    """QueryState retains Socratic prompts and dependency overview telemetry."""
+
+    state = QueryState(query="normalisation")
+    payload = _build_payload()
+    warnings = state.set_task_graph(payload)
+
+    assert warnings == []
+    task_graph = state.task_graph
+    research = next(task for task in task_graph["tasks"] if task["id"] == "research")
+    assert research["dependency_depth"] == 1
+    assert any(entry.startswith("risks:") for entry in research["socratic_checks"])
+    telemetry = state.metadata["planner"]["telemetry"]
+    assert telemetry["dependency_overview"][0]["task"] == "research"
+    assert telemetry["tasks"][0]["dependency_depth"] == 0
+
+
+def test_task_coordinator_uses_depth_and_affinity() -> None:
+    """Coordinator scheduling respects dependency depth and tool affinity."""
+
+    payload = {
+        "tasks": [
+            {
+                "id": "root",
+                "question": "Initial analysis",
+                "affinity": {"analysis": 0.2},
+                "dependency_depth": 0,
+                "socratic_checks": ["Is scope validated?"],
+            },
+            {
+                "id": "priority",
+                "question": "High impact review",
+                "affinity": {"analysis": 0.1},
+                "dependency_depth": 2,
+            },
+            {
+                "id": "followup",
+                "question": "Follow-up synthesis",
+                "depends_on": ["root"],
+                "affinity": {"analysis": 0.6},
+                "dependency_depth": 1,
+            },
+        ]
+    }
+    state = QueryState(query="scheduling")
+    state.set_task_graph(payload)
+
+    coordinator = TaskCoordinator(state)
+    next_task = coordinator.schedule_next(preferred_tool="analysis")
+    assert next_task["id"] == "root"
+
+    coordinator.start_task("root")
+    coordinator.complete_task("root")
+    next_task_after_root = coordinator.schedule_next(preferred_tool="analysis")
+    assert next_task_after_root["id"] == "followup"
+    snapshot = coordinator._build_graph_node("followup").to_snapshot()
+    assert snapshot["dependency_depth"] == 1
+    assert snapshot["socratic_checks"] == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/unit/test_planner_prompt_builder.py
+++ b/tests/unit/test_planner_prompt_builder.py
@@ -46,6 +46,8 @@ def test_planner_prompt_builder_injects_graph_context() -> None:
     assert "Multi-hop paths" in prompt
     assert "Policy A → Policy B → Policy C" in prompt
     assert "Provenance sources: https://example.com/policy-a" in prompt
+    assert 'Derive dependency depth per task' in prompt
+    assert 'Add at least two "socratic_checks"' in prompt
 
 
 def test_planner_prompt_builder_without_graph_context() -> None:


### PR DESCRIPTION
## Summary
- extend PlannerPromptBuilder to require socratic self-checks and dependency overviews that survive normalisation
- propagate dependency depth, rationale, and socratic prompts through TaskGraph, QueryState, and TaskCoordinator scheduling
- refresh orchestration docs/diagrams and add unit plus behaviour coverage for the enhanced PRDV flow

## Testing
- `uv run mypy --strict src tests`
- `uv run --extra test pytest tests/unit/orchestration/test_task_graph_enhancements.py`
- `uv run --extra test pytest tests/unit/test_planner_prompt_builder.py`
- `uv run --extra test pytest tests/behavior/steps/reasoning_mode_steps.py::test_prdv_telemetry`


------
https://chatgpt.com/codex/tasks/task_e_68e08af5313483339223b2760bf01899