### PR TITLE
Gate adaptive search telemetry with config toggles

### DIFF
--- a/docs/deep_research_upgrade_plan.md
+++ b/docs/deep_research_upgrade_plan.md
@@ -128,6 +128,8 @@ coverage rerun showing the FastEmbed fallback failure after the registry fix.
      before debate. These signals surface through `ScoutGateDecision.telemetry`
      when `gate_capture_query_strategy` and
      `gate_capture_self_critique` remain enabled.
+     Operators can now tune both gates independently so adaptive attempts and
+     critique markers are only persisted when the deployment requires them.
    - Instrument `OrchestrationMetrics` with Prometheus-backed
      `graph_ingestion` telemetry (entity, relation, contradiction, neighbour,
      and latency aggregates) guarded by `search.context_aware` toggles so

--- a/docs/search_backends.md
+++ b/docs/search_backends.md
@@ -64,6 +64,30 @@ deterministic placeholder results under the `__fallback__` namespace. The
 placeholder URLs encode the query and rank so repeated failures remain
 reproducible and visible in cache diagnostics.
 
+## Adaptive fetch and self-critique tuning
+
+Adaptive fetch expands the maximum number of results when coverage is low.
+Tune the behaviour under `[search.adaptive_k]`:
+
+```toml
+[search.adaptive_k]
+enabled = true
+min_k = 5
+max_k = 15
+step = 5
+coverage_gap_threshold = 0.35
+```
+
+The planner records every attempt and the reason (`initial`,
+`followup`, `adaptive_increase`, or `rewrite_*`) when
+`gate_capture_query_strategy = true`. Disable the gate to minimise telemetry
+storage when adaptive diagnostics are unnecessary.
+
+Self-critique markers summarise coverage gaps, empty backends, and no-result
+scenarios. They flow through scout telemetry and gate payloads while
+`gate_capture_self_critique = true`. Toggle the flag to suppress markers when
+deployments must avoid retaining critique metadata.
+
 ## Benchmarking
 
 To guard against regressions, run `uv run pytest`

--- a/issues/deliver-evidence-pipeline-2-0.md
+++ b/issues/deliver-evidence-pipeline-2-0.md
@@ -28,6 +28,12 @@ and downstream exports stay lossless.
 【F:tests/unit/test_orchestrator_errors.py†L1-L360】
 【F:docs/orchestration.md†L1-L120】
 
+Adaptive fetch telemetry and critique markers now respect the
+`gate_capture_query_strategy` and `gate_capture_self_critique` toggles so
+evidence audits can mute strategy diagnostics when operators opt out of storing
+that metadata.
+【F:src/autoresearch/search/context.py†L310-L424】【F:docs/search_backends.md†L65-L96】
+
 PR5 reverification now extracts stored claims, retries audits with structured
 attempt metadata, and persists outcomes through `StorageManager.persist_claim`,
 while behavior coverage keeps audit badges visible in response payloads. PR4


### PR DESCRIPTION
## Summary
- gate adaptive fetch telemetry and self-critique markers behind configuration switches in the search context
- extend adaptive rewrite unit tests to cover telemetry gating behaviour
- document tuning options for adaptive fetch and self-critique telemetry and reference them in the evidence pipeline issue

## Testing
- uv run mypy --strict src tests
- uv run --extra test pytest tests/unit/search

------
https://chatgpt.com/codex/tasks/task_e_68e08ee11dd083339eeb4731e58a2e9c