### PR TITLE
Add observation-mode routing telemetry

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -36,11 +36,13 @@ violating service-level objectives. The router consults:
 - model profiles that describe per-1K token pricing and latency targets.
 
 When an agent consumes more than 80% of its allocated share of the global token
-budget, the router downgrades to a cheaper profile that still satisfies the
+budget, the router recommends a cheaper profile that still satisfies the
 agent's latency SLO. Every evaluation emits a `Budget router evaluated` log
-record with the rolling token averages, percentile latency, and projected cost
-delta so operators can audit the savings. When the orchestrator applies the
-recommendation it emits an `Applied budget-aware model routing` event.
+record with the rolling token averages, percentile latency, projected cost
+delta, and the calculated budget window for the agent. The orchestrator now
+logs the recommendation via `Evaluated budget-aware model routing` without
+switching models yet; the `applied: false` flag signals that routing remains in
+observation mode until the dashboards confirm the new targets.
 
 ## Telemetry Dashboards
 
@@ -60,6 +62,11 @@ plot the following series to track performance regressions:
   forced more capable models into the debate.
 - `model_routing_strategy`: the active routing profile (for example,
   `balanced`, `cost_saver`, or `premium`) recorded with each run.
+- `model_routing_agent_constraints`: per-agent budget shares and latency
+  ceilings captured during routing evaluation so operators can audit SLO
+  coverage.
+- `model_routing_recommendations`: the models suggested for each agent while
+  routing operates in observation-only mode.
 
 These signals make it easy to confirm that cost savings materialise without
 raising the latency envelope for latency-sensitive agents.

--- a/issues/cost-aware-model-routing.md
+++ b/issues/cost-aware-model-routing.md
@@ -6,6 +6,11 @@ latency and token spend without sacrificing accuracy. We need configurable
 budget policies, routing telemetry, and regression tests that demonstrate cost
 savings alongside quality guarantees.
 
+Observation-mode telemetry now records per-agent token budgets, latency caps,
+and recommended models without mutating the active configuration. Dashboards
+consume the JSONL feed produced by `OrchestrationMetrics` so we can validate
+the heuristics before permitting automatic model changes.
+
 Automated strict gating and the documented storage resident floor keep release
 prerequisites visible while TestPyPI remains paused, and PR5/PR4 upgrades add
 verification telemetry plus session-graph exports that routing dashboards must

--- a/tests/unit/orchestration/test_model_routing.py
+++ b/tests/unit/orchestration/test_model_routing.py
@@ -1,0 +1,99 @@
+"""Regression tests for budget-aware model routing telemetry."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoresearch.config.models import (
+    AgentConfig,
+    ConfigModel,
+    ModelRouteProfile,
+    ModelRoutingConfig,
+    RoleRoutingPolicy,
+)
+from autoresearch.orchestration.metrics import OrchestrationMetrics
+
+
+def _configure_router() -> tuple[OrchestrationMetrics, ConfigModel, str | None]:
+    config = ConfigModel()
+    config.default_model = "premium"
+    config.token_budget = 4000
+    config.agents = ["Synthesizer"]
+    config.model_routing = ModelRoutingConfig(
+        enabled=True,
+        budget_pressure_ratio=0.8,
+        default_latency_slo_ms=1500.0,
+        model_profiles={
+            "premium": ModelRouteProfile(
+                prompt_cost_per_1k=5.0,
+                completion_cost_per_1k=5.0,
+                latency_p95_ms=900.0,
+                quality_rank=10,
+            ),
+            "efficient": ModelRouteProfile(
+                prompt_cost_per_1k=1.5,
+                completion_cost_per_1k=1.5,
+                latency_p95_ms=1000.0,
+                quality_rank=5,
+            ),
+        },
+    )
+    config.model_routing.strategy_name = "cost_saver"
+    config.model_routing.role_policies = {
+        "Synthesizer": RoleRoutingPolicy(
+            preferred_models=["premium", "efficient"],
+            token_share=0.5,
+            latency_slo_ms=1200.0,
+        )
+    }
+    config.agent_config["Synthesizer"] = AgentConfig(
+        preferred_models=["premium", "efficient"],
+        token_share=0.5,
+        latency_slo_ms=1200.0,
+        model="premium",
+    )
+
+    metrics = OrchestrationMetrics()
+    metrics.record_tokens("Synthesizer", tokens_in=1800, tokens_out=900)
+    metrics.record_agent_timing("Synthesizer", duration=0.82)
+
+    selected = metrics.apply_model_routing("Synthesizer", config)
+    return metrics, config, selected
+
+
+def test_routing_records_constraints_without_switching() -> None:
+    """Telemetry captures budgets while leaving the config untouched."""
+
+    metrics, config, selected = _configure_router()
+
+    assert selected == "efficient"
+    assert config.agent_config["Synthesizer"].model == "premium"
+
+    constraints = metrics.routing_agent_constraints["Synthesizer"]
+    recommendation = metrics.routing_agent_recommendations["Synthesizer"]
+    decision = metrics.routing_decisions[-1]
+
+    assert recommendation == "efficient"
+    assert constraints["budget_tokens"] == pytest.approx(2000.0)
+    assert constraints["latency_slo_ms"] == pytest.approx(1200.0)
+    assert constraints["latency_cap_ms"] == pytest.approx(1200.0)
+    assert decision.metadata is not None
+    assert decision.metadata["applied"] is False
+    assert decision.metadata["latency_slo_ms"] == pytest.approx(1200.0)
+
+
+def test_summary_reports_agent_constraints() -> None:
+    """Summary output mirrors the live routing telemetry."""
+
+    metrics, _, _ = _configure_router()
+
+    summary = metrics.get_summary()
+    constraints = summary["model_routing_agent_constraints"]["Synthesizer"]
+    recommendation = summary["model_routing_recommendations"]["Synthesizer"]
+    decision_meta = summary["model_routing_decisions"][-1]["metadata"]
+
+    assert recommendation == "efficient"
+    assert constraints["budget_tokens"] == pytest.approx(2000.0)
+    assert constraints["latency_slo_ms"] == pytest.approx(1200.0)
+    assert constraints["latency_cap_ms"] == pytest.approx(1200.0)
+    assert decision_meta["applied"] is False


### PR DESCRIPTION
## Summary
- capture per-agent routing constraints and recommendations without mutating agent configs, and persist the new telemetry in metrics logs
- update performance docs and the routing issue to document observation-mode dashboards and budgeting signals
- add unit and performance regression tests that validate the recorded budgets, latency caps, and recommendation flags

## Testing
- uv run mypy --strict src tests
- uv run --extra test pytest tests/unit/orchestration/test_model_routing.py

------
https://chatgpt.com/codex/tasks/task_e_68e0a3710e5083338b7ae3e2748c6255