### PR TITLE
Document evaluation harness planning

### DIFF
--- a/docs/diagrams/ux_architecture.md
+++ b/docs/diagrams/ux_architecture.md
@@ -44,6 +44,10 @@ graph TD
     GUI --> ProgressIndicators
 ```
 
+Layered output controls (baseline, audit, narrative) will anchor to the Output
+Formatting node across each interface so UX surfaces expose consistent toggles
+once the evaluation harness ships the shared configuration stubs.
+
 ## CLI Interface Components
 
 ```mermaid

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -25,6 +25,16 @@ remain zero.
 Running `autoresearch monitor resources` will therefore include ``GPU %`` and
 ``GPU MB`` columns when supported.
 
+## Truthfulness evaluation harness stubs
+
+Draft configuration files in `scripts/evaluate/` will declare shared knobs for
+TruthfulQA, FEVER, and HotpotQA benchmarks so performance runs align with the
+testing playbook. The stubs pin dataset slices, batch sizes, and output layer
+defaults, ensuring layered UX controls (baseline, audit, narrative) stay
+consistent between CLI invocations and automated schedules. When the harness
+automation lands, point monitoring comparisons at the generated artifact
+directories recorded in each stub.
+
 ## Budget-Aware Model Routing
 
 The orchestration layer records per-agent token and latency samples so the

--- a/docs/pseudocode.md
+++ b/docs/pseudocode.md
@@ -149,17 +149,19 @@ class SynthesizerAgent:
 
 class OutputFormatter:
     function format(result, format_type):
+        layers = config.output.layers or ["baseline"]
+        layered = LayeredFormatter.apply(result, layers)
         if format_type == "json":
-            print(JSON.stringify(result))
+            print(JSON.stringify(layered))
         else:
             print("# Answer")
-            print(result.answer)
+            print(layered.answer)
             print("## Citations")
-            print_list(result.citations)
+            print_list(layered.citations)
             print("## Reasoning")
-            print_list(result.reasoning)
+            print_list(layered.reasoning)
             print("## Metrics")
-            print_metrics(result.metrics)
+            print_metrics(layered.metrics)
 ```
 
 ## 6a. Answer Auditing, Re-Verification & Hedging (state.py)

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -20,6 +20,11 @@ For environment setup instructions see [installation](installation.md).
 - Always respect dataset licensing when extending the subsets; cite the
   original papers (Lin et al., 2021; Thorne et al., 2018; Yang et al., 2018)
   when publishing benchmark results.
+- Configuration stubs will live in `scripts/evaluate/` to keep dataset
+  schedules, retry budgets, and artifact locations in sync across runners.
+- Each stub will expose layered output controls (baseline, audit, narrative)
+  that align with the layered UX roadmap so CI, nightly, and exploratory runs
+  can opt into richer transcripts without diverging from shared defaults.
 
 Tests may require optional dependencies. Markers such as `requires_nlp` or
 `requires_parsers` map to extras with the same names. `task install` syncs the

--- a/issues/build-truthfulness-evaluation-harness.md
+++ b/issues/build-truthfulness-evaluation-harness.md
@@ -22,5 +22,23 @@ for longitudinal review.
 - STATUS.md summarizes benchmark outcomes after each scheduled run.
 - Documentation covers setup, dataset licensing, and interpretation guidance.
 
+## Tasks
+- [ ] Draft layered output configuration stubs in `scripts/evaluate/` covering
+  TruthfulQA, FEVER, and HotpotQA defaults (datasets, retries, artifact roots).
+- [ ] Extend the evaluation CLI and Taskfile shims to consume the stubs so
+  automation reads consistent layered UX modes and output directories.
+- [ ] Wire telemetry exports into the harness to capture per-layer accuracy,
+  latency, and token deltas for STATUS.md rollups and dashboard syncs.
+- [ ] Add documentation callouts in `docs/testing_guidelines.md`,
+  `docs/performance.md`, and `docs/diagrams/ux_architecture.md` explaining how
+  layered transcripts will surface in each interface.
+
+## Follow-on PRs
+- [ ] Schedule PR to implement the automation pipeline once
+  `prepare-first-alpha-release` and other release blockers flip to `Closed` so
+  the harness lands after the current milestone ships.
+- [ ] Schedule PR to expose layered transcript toggles in the CLI, Streamlit,
+  and MCP adapters immediately after the automation pipeline merges.
+
 ## Status
 Open


### PR DESCRIPTION
## Summary
- describe forthcoming evaluation harness configuration stubs that will live under `scripts/evaluate/` and wire them into testing and performance docs
- note layered output controls in the pseudocode and UX diagrams so upcoming UX toggles stay aligned with the harness
- expand the truthfulness evaluation issue with task breakdowns and follow-on PR scheduling once release blockers clear

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e0af52dbe0833395fe46657bbddc27