### PR TITLE
Clarify alpha readiness status and remediation plan

### DIFF
--- a/CODE_COMPLETE_PLAN.md
+++ b/CODE_COMPLETE_PLAN.md
@@ -7,22 +7,29 @@ aspects of the system, from core functionality to testing and documentation.
 
 ## Status
 
-As of **October 4, 2025 at 01:57 UTC** the strict typing gate remains green,
-yet the release sweep still stalls earlier in the dialectical pipeline. The
-fresh `uv run task verify EXTRAS="nlp ui vss git distributed analysis llm
-parsers"` attempt fails in flake8, which reports unused imports, excess blank
-lines, and trailing whitespace across Search, behavior, integration, and
-storage suites.【F:baseline/logs/task-verify-20251004T015651Z.log†L1-L62】
-Minutes later `uv run task coverage EXTRAS="nlp ui vss git distributed
-analysis llm parsers"` stops when the legacy branch of
+As of **October 4, 2025 at 05:34 UTC** the strict typing gate remains green:
+`uv run mypy --strict src tests` reports “Success: no issues found in 790
+source files”, so we can focus on clearing the remaining pytest regressions
+before rerunning the full release sweep.【c2f747†L1-L2】 A fresh
+`uv run --extra test pytest` sample at **05:31 UTC** fails immediately in the
+search stub suite: both the legacy and VSS-enabled paths miss the expected
+`add_calls` telemetry and the fallback bundle preserves the templated query,
+confirming PR-C must repair backend instrumentation first.
+【81b49d†L25-L155】【81b49d†L156-L204】 The broader release sweep still stalls
+earlier in the dialectical pipeline. The
+`uv run task verify EXTRAS="nlp ui vss git distributed analysis llm parsers"`
+attempt fails in flake8, which reports unused imports, excess blank lines, and
+trailing whitespace across Search, behavior, integration, and storage suites.
+【F:baseline/logs/task-verify-20251004T015651Z.log†L1-L62】 Minutes later
+`uv run task coverage EXTRAS="nlp ui vss git distributed analysis llm
+parsers"` stops when the legacy branch of
 `tests/unit/test_core_modules_additional.py::test_search_stub_backend` no
 longer records the expected instance `add_calls`, keeping coverage frozen at
-the prior 92.4 % baseline.
-【F:baseline/logs/task-coverage-20251004T015738Z.log†L1-L565】
+the prior 92.4 % baseline.【F:baseline/logs/task-coverage-20251004T015738Z.log†L1-L565】
 The preflight plan still sequences remediation through PR-A to PR-H, and the
 alpha issue plus task log now point to the new evidence while TestPyPI stays
 paused pending lint and search instrumentation fixes.
-【F:docs/v0.1.0a1_preflight_plan.md†L80-L239】
+【F:docs/v0.1.0a1_preflight_plan.md†L9-L323】
 【F:issues/prepare-first-alpha-release.md†L1-L32】
 
 ### Immediate Follow-ups

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap summarizes planned features for upcoming releases.
 Dates and milestones align with the [release plan](docs/release_plan.md).
 See [STATUS.md](STATUS.md) and [CHANGELOG.md](CHANGELOG.md) for current results
 and recent changes. Installation and environment details are covered in the
-[README](README.md). Last updated **October 3, 2025**.
+[README](README.md). Last updated **October 4, 2025**.
 
 ## Deep Research enhancement program
 
@@ -53,13 +53,18 @@ instrumenting AUTO mode—before Phase 2 planner upgrades resume.
 See [STATUS.md](STATUS.md) for detailed logs and
 [CHANGELOG.md](CHANGELOG.md) for recent updates. 0.1.0a1 remains untagged and
 targets **September 15, 2026**, with **0.1.0** planned for **October 1, 2026**
-across project documentation. As of **October 3, 2025 at 14:52 UTC** the strict
-typing gate is green but the pytest suite is red: `uv run mypy --strict src
-tests` completes successfully, while `uv run --extra test pytest` still fails
-across reverification defaults, backup scheduling, search cache determinism,
-API parsing exports, and FastMCP shims. The new preflight readiness plan keeps
-the remediation path visible across documentation and issues.
-【4b1e56†L1-L2】【7be155†L104-L262】【F:docs/v0.1.0a1_preflight_plan.md†L1-L173】
+across project documentation. As of **October 4, 2025 at 05:34 UTC** the
+strict typing gate remains green:
+`uv run mypy --strict src tests` reported “Success: no issues found in 790
+source files”. Minutes earlier, `uv run --extra test pytest` at **05:31 UTC**
+failed in the search stub suite—the legacy and VSS-enabled flows miss the
+expected `add_calls` telemetry and the fallback bundle echoes the templated
+prompt—so the release sweep still depends on PR-C landing first. The broader
+October 3 diagnostic run with 26 failures remains the reference for other
+regression clusters, and the refreshed preflight readiness plan keeps the
+remediation path visible across documentation and issues.
+【c2f747†L1-L2】【81b49d†L25-L155】【81b49d†L156-L204】
+【ce87c2†L81-L116】【F:docs/v0.1.0a1_preflight_plan.md†L1-L323】
 
 The deterministic storage resident-floor documentation remains published and
 linked from the release plan, keeping the TestPyPI stage paused until coverage

--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,15 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
 ## October 4, 2025
+- `uv run mypy --strict src tests` at **05:34 UTC** reported "Success: no
+  issues found in 790 source files", keeping the strict gate green while we
+  prioritise search stub remediation ahead of the next verify sweep.
+  【c2f747†L1-L2】
+- `uv run --extra test pytest` at **05:31 UTC** now fails immediately in the
+  search stub regression: the legacy and VSS-enabled flows never record the
+  expected `add_calls`, and the fallback query preserves the templated text
+  instead of the caller input. The log pinpoints PR-C scope before the run was
+  interrupted for faster triage.【81b49d†L25-L155】【81b49d†L156-L204】
 - The 2025-10-04 verify sweep with all non-GPU extras still fails
   during flake8; Search core imports, behavior fixtures, and storage
   tests carry unused symbols and whitespace debt documented in the new
@@ -47,7 +56,7 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 - Documented the v0.1.0a1 preflight readiness plan, capturing strict
   typing success, current pytest failures, and the PR slices required to
   restore coverage.
-  【F:docs/v0.1.0a1_preflight_plan.md†L1-L173】
+  【F:docs/v0.1.0a1_preflight_plan.md†L1-L323】
 - `task check` and `task verify` now invoke `task mypy-strict` before other
   steps, giving the repository an automated strict gate on every local sweep.
   The CI workflow triggers the same target and keeps the `run_testpypi_dry_run`

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,3 +1,13 @@
+As of **2025-10-04 at 05:34 UTC** the strict gate remains green: `uv run mypy
+--strict src tests` reported "Success: no issues found in 790 source files",
+so we can focus on shrinking the failing pytest surface before rerunning the
+full verify sweep.【c2f747†L1-L2】 At **05:31 UTC** `uv run --extra test
+pytest` reaches the search stub regression immediately; the legacy and VSS
+paths both miss the expected `add_calls` telemetry and the fallback query text
+still reflects the templated prompt, confirming PR-C must repair backend
+instrumentation before other failures can be measured.【81b49d†L25-L155】
+【81b49d†L156-L204】
+
 As of **2025-10-04 at 01:57 UTC** the verify gate remains red: flake8 still
 flags unused imports, blank-line drift, and trailing whitespace across
 Search, behavior, integration, and storage suites during
@@ -27,7 +37,7 @@ The refreshed [v0.1.0a1 preflight readiness plan](docs/v0.1.0a1_preflight_plan.m
 now breaks the regression clusters into PR-A through PR-H with dialectical
 assessments, then sequences telemetry and planner enhancements as PR-I
 through PR-K once the suite is green.
-【F:docs/v0.1.0a1_preflight_plan.md†L1-L239】
+【F:docs/v0.1.0a1_preflight_plan.md†L1-L323】
 
 As of **2025-10-03** the deterministic storage resident-floor documentation is
 published at `docs/storage_resident_floor.md`, closing the alpha checklist note

--- a/docs/v0.1.0a1_preflight_plan.md
+++ b/docs/v0.1.0a1_preflight_plan.md
@@ -1,4 +1,4 @@
-# v0.1.0a1 preflight readiness plan (2025-10-03)
+# v0.1.0a1 preflight readiness plan (2025-10-04)
 
 This review applies dialectical and Socratic reasoning to the
 Autoresearch improvement proposal and the current release posture. The
@@ -8,19 +8,26 @@ pull request.
 
 ## Evidence snapshot
 
-- `uv run mypy --strict src tests` continues to pass. The
-  October 3, 2025 at 22:37 UTC sweep reported “Success: no issues found”,
-  keeping the strict typing gate green across source and test modules.
-  【d70b9a†L1-L2】
-- `uv run --extra test pytest` on October 3, 2025 at 22:37 UTC surfaced
-  26 failing tests and five errors across reverification defaults,
-  storage rotation, cache determinism, FastMCP adapters, API exports,
-  orchestrator error handling, planner metadata, and docstring quality.
-  These failures block fresh coverage evidence and the alpha release
-  sign-off until the regressions are resolved.
+- `uv run mypy --strict src tests` at 05:34 UTC on October 4, 2025 again
+  reported “Success: no issues found in 790 source files”, confirming the
+  strict gate remains green ahead of the remaining pytest remediation.
+  【c2f747†L1-L2】
+- `uv run --extra test pytest` at 05:31 UTC on the same day now fails in
+  `tests/unit/test_core_modules_additional.py::test_search_stub_backend`
+  for both legacy and VSS-enabled paths; the instrumentation no longer
+  records the expected `add_calls` and the fallback bundle preserves the
+  templated query text. The run was interrupted after collecting this
+  evidence to accelerate focused triage, so downstream failures were not
+  re-evaluated in this pass.【81b49d†L25-L155】【81b49d†L156-L204】
+- The October 3, 2025 wide pytest sweep remains informative: 26 failures
+  and five errors still cover reverification defaults, backup rotation,
+  cache determinism, FastMCP adapters, orchestrator error handling,
+  planner metadata, storage contracts, and environment metadata checks.
+  We keep that broader data set to ensure follow-on PRs continue to hit
+  every regression cluster once the search stub repairs land.
   【ce87c2†L81-L116】
 
-The plan below assumes strict typing remains green and focuses on the
+The plan below assumes strict typing stays green and concentrates on the
 fastest path to a green test suite, refreshed coverage evidence, and the
 architectural upgrades outlined in the improvement proposal.
 
@@ -227,8 +234,10 @@ next step.
 ## Highest-impact priorities
 
 1. Restore a green pytest suite by fixing the clustered regressions above,
-   starting with FactChecker defaults, storage rotation, cache determinism,
-   API adapters, and orchestrator error handling.
+   starting with the search stub instrumentation gap observed on
+   October 4 before iterating through FactChecker defaults, storage
+   rotation, cache determinism, API adapters, and orchestrator error
+   handling.
 2. Refresh coverage evidence after the suite is green, keeping the 92.4%
    gate enforceable ahead of alpha tagging.
 3. Instrument AUTO mode and planner output with the telemetry required to
@@ -238,38 +247,79 @@ next step.
 
 ## Planned PR slices
 
-Each bullet is scoped for a fast review cycle and can ship
-independently.
+Each bullet is scoped for a fast review cycle and can ship independently.
+Sub-bullets outline the concrete tasks required for each slice.
 
 1. **PR-A:** Normalize FactChecker defaults and update reverification
    fixtures so `test_reverify_extracts_claims_and_retries` passes while
    preserving opt-out coverage.
+   - Define explicit FactChecker defaults inside configuration factories.
+   - Update fixtures to assert both default and opt-out flows.
+   - Extend tests with Socratic prompts that question retry coverage and
+     claim extraction boundaries.
 2. **PR-B:** Repair backup scheduler restart logic and rotation policy to
    satisfy `tests/unit/storage/test_backup_scheduler.py` without
    introducing timing flakiness.
+   - Inject deterministic timer handles into scheduler abstractions.
+   - Ensure cancellation flags flip before rotation assertions execute.
+   - Add regression tests that probe restart semantics with dialectical
+     checklists.
 3. **PR-C:** Refactor search cache key derivation, backend isolation, and
    stub fallback handling so cache and stub suites pass with deterministic
-   query preservation.
+   query preservation and restored `add_calls` instrumentation.
+   - Restore stub `add_calls` bookkeeping with explicit phase labels.
+   - Ensure fallback bundles echo caller queries rather than templated
+     prompts.
+   - Document backend key derivation and add targeted tests that challenge
+     vector-search toggles via Socratic assertions.
 4. **PR-D:** Restore `autoresearch.api.parse` exports and align FastMCP
    adapter construction with handshake tests, covering both API and MCP
    suites.
+   - Re-export the parser entry point through package initialisers.
+   - Synchronise FastMCP adapter signatures with documented schemas.
+   - Expand handshake tests to probe retries and failure branches.
 5. **PR-E:** Normalise orchestrator error claim payloads and parallel
    timeout messaging so error-handling suites reintroduce mapping-based
    claims and clear reasoning trails.
+   - Convert string payloads back to structured mappings with debug keys.
+   - Align timeout messaging with behaviour-suite expectations.
+   - Add dialectical assertions contrasting debug versus user messages.
 6. **PR-F:** Stabilise storage initialisation and migration contracts,
    ensuring knowledge-graph setup and migration idempotency satisfy the
    incremental update and DuckDB tests.
+   - Add deterministic bootstrap helpers for knowledge-graph fixtures.
+   - Guard migrations with idempotent checks and audit logging.
+   - Extend incremental update tests with prompts questioning lazy versus
+     eager loading.
 7. **PR-G:** Provide planner metadata adapters and refreshed docstrings so
    planner metadata and documentation hygiene suites pass without slowing
    planner iterations.
+   - Add lightweight metadata adapters in planner mocks.
+   - Refresh docstrings with concise rationales referencing Socratic
+     checkpoints.
+   - Update documentation hygiene tests to cover the new descriptions.
 8. **PR-H:** Supply environment metadata fixtures and telemetry guards for
    `check_env_warnings` and `formattemplate_metrics` coverage tests.
+   - Provide fixture hooks that inject metadata without full build steps.
+   - Harden telemetry helpers against missing optional dependencies.
+   - Expand coverage tests with prompts verifying guardrail behaviour.
 9. **PR-I:** After PR-A through PR-H land, capture a fresh coverage run
    and update release documentation with the new evidence.
+   - Run `uv run task verify` with non-GPU extras and archive the logs.
+   - Run `uv run task coverage` and refresh `coverage.xml` baselines.
+   - Update `STATUS.md`, `TASK_PROGRESS.md`, `CODE_COMPLETE_PLAN.md`, and
+     `docs/release_plan.md` with the new artefacts.
 10. **PR-J:** Add AUTO mode telemetry, capturing skip/escalate decisions
     and evidence coverage for tuning once the suite is green.
+    - Instrument AUTO decision points with coverage and confidence metrics.
+    - Add behaviour tests under `reasoning_modes` that question skip versus
+      escalate choices.
+    - Document tuning guidelines in `docs/` using dialectical analyses.
 11. **PR-K:** Introduce dependency-aware planner prompts with Socratic
     self-checks and regression coverage building on PR-J outputs.
+    - Update planner schemas to express dependencies and self-check prompts.
+    - Extend unit tests with counterexamples challenging dependency logic.
+    - Document how planner outputs pair with AUTO telemetry for reviewers.
 
 ## Coverage and behaviour follow-up
 

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -1,8 +1,19 @@
 # Prepare first alpha release
 
 ## Context
-As of **October 4, 2025 at 01:57 UTC** the strict typing gate remains green,
-yet the release sweep still fails earlier. `uv run task verify
+As of **October 4, 2025 at 05:34 UTC** the strict typing gate remains green:
+`uv run mypy --strict src tests` again reported “Success: no issues found in
+790 source files”, so we can focus on the remaining pytest regressions before
+rerunning the full release sweep.【c2f747†L1-L2】 A targeted `uv run --extra
+test pytest` sample at **05:31 UTC** fails immediately in
+`tests/unit/test_core_modules_additional.py::test_search_stub_backend` for the
+legacy and VSS-enabled paths; the stub no longer records the expected
+`add_calls` telemetry and the fallback bundle echoes the templated query.
+These findings narrow PR-C while the broader 26-failure set from October 3
+continues to guide the follow-on PRs.【81b49d†L25-L155】【81b49d†L156-L204】
+【ce87c2†L81-L116】
+
+The release sweep still fails earlier. `uv run task verify
 EXTRAS="nlp ui vss git distributed analysis llm parsers"` halts in flake8
 because Search core imports, behavior fixtures, and storage tests retain
 unused symbols and whitespace debt, and the follow-up `uv run task coverage
@@ -15,7 +26,7 @@ still sequences remediation through PR-A to PR-H, keeping each change review
 sized so we can refresh coverage evidence and restart the release pipeline.
 【F:baseline/logs/task-verify-20251004T015651Z.log†L1-L62】
 【F:baseline/logs/task-coverage-20251004T015738Z.log†L1-L565】
-【F:docs/v0.1.0a1_preflight_plan.md†L80-L239】
+【F:docs/v0.1.0a1_preflight_plan.md†L1-L323】
 
 TestPyPI dry runs remain paused; we will capture fresh verify and coverage logs
 after the lint and search instrumentation regressions clear before re-enabling


### PR DESCRIPTION
## Summary
- capture the 2025-10-04 strict mypy sweep and focused pytest failure in STATUS.md, TASK_PROGRESS.md, CODE_COMPLETE_PLAN.md, and the release issue
- expand docs/v0.1.0a1_preflight_plan.md with dialectical prioritisation, actionable PR sub-tasks, and refreshed evidence references
- align ROADMAP.md with the latest readiness snapshot and keep the alpha ticket context in sync

## Testing
- `uv run mypy --strict src tests`
- `uv run --extra test pytest` *(fails in tests/unit/test_core_modules_additional.py due to known search stub regression)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b0c1dbdc8333aef4dc38ec35b763