### PR TITLE
Fix flake8 issues across tests and search core

### DIFF
--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -39,7 +39,7 @@ import re
 import shutil
 import subprocess
 import warnings
-from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -1878,7 +1878,6 @@ class Search:
 
         return queries
 
-
     @hybridmethod
     def external_lookup(
         self,
@@ -2383,7 +2382,6 @@ class Search:
             )
 
             return bundle if return_handles else bundle.results
-
 
 
 def get_search() -> Search:

--- a/tests/analysis/test_agents_sim.py
+++ b/tests/analysis/test_agents_sim.py
@@ -1,10 +1,10 @@
-from typing import cast
+import typing as t
 
 from scripts.agents_sim import _simulate
 
 
 def test_agents_sim_preserves_order_and_capacity() -> None:
     """Queue ordering and capacity invariants hold."""
-    metrics = cast(dict[str, int | bool], _simulate(tasks=5, capacity=2))
+    metrics = t.cast(dict[str, int | bool], _simulate(tasks=5, capacity=2))
     assert metrics["ordered"] is True
     assert metrics["max_queue"] <= 2

--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -55,6 +55,7 @@ class StorageErrorHandler:
             bdd_context[context_key] = str(exc)
             return None
 
+
 # Load fixtures and step implementations so their fixtures are available
 pytest_plugins = (
     "pytest_bdd",

--- a/tests/behavior/context.py
+++ b/tests/behavior/context.py
@@ -322,4 +322,3 @@ class StreamlitComponentMocks:
 
     expander: MagicMock | None = None
     """Optional mock for :func:`streamlit.expander`."""
-

--- a/tests/behavior/steps/error_recovery_redis_steps.py
+++ b/tests/behavior/steps/error_recovery_redis_steps.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from pytest_bdd import given, scenario, then, when
 

--- a/tests/fixtures/protocols.py
+++ b/tests/fixtures/protocols.py
@@ -71,4 +71,3 @@ class ExtraProbe:
             if self.validator is not None and not self.validator(module):
                 return False
         return True
-

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -27,7 +27,11 @@ def configure_api_defaults(
     permissions = cfg.api.role_permissions.setdefault("anonymous", [])
     if "query" not in permissions:
         permissions.append("query")
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+
+    def load_config_override(self: ConfigLoader) -> ConfigModel:
+        return cfg
+
+    monkeypatch.setattr(ConfigLoader, "load_config", load_config_override)
     return cfg
 
 

--- a/tests/integration/test_cli_progress.py
+++ b/tests/integration/test_cli_progress.py
@@ -60,7 +60,7 @@ def test_cli_progress_and_interactive(monkeypatch: pytest.MonkeyPatch) -> None:
         progress_instances.append(progress)
         return progress
 
-    cfg = configure_api_defaults(monkeypatch, loops=2)
+    configure_api_defaults(monkeypatch, loops=2)
     monkeypatch.setattr("autoresearch.main.Progress", progress_factory)
 
     prompts: list[str] = []

--- a/tests/integration/test_distributed_process_storage.py
+++ b/tests/integration/test_distributed_process_storage.py
@@ -13,6 +13,8 @@ from autoresearch.storage_typing import JSONDict
 
 pytestmark = pytest.mark.slow
 
+AgentFactoryClass = getattr(orchestrator_module, "AgentFactory")
+
 
 class ClaimAgent:
     def __init__(self, name: str, pids: list[int]):
@@ -70,4 +72,3 @@ def test_process_storage_with_executor(
         StorageManager.context = StorageContext()
 
     assert [row[0] for row in rows] == ["A", "B"]
-AgentFactoryClass = getattr(orchestrator_module, "AgentFactory")

--- a/tests/integration/test_orchestrator_search_storage.py
+++ b/tests/integration/test_orchestrator_search_storage.py
@@ -200,7 +200,7 @@ def test_orchestrator_persists_across_queries(monkeypatch: pytest.MonkeyPatch) -
             {"title": f"{q}-Doc2", "url": f"{q}-u2"},
         ],
     )
-    
+
     def _capture_claim(claim: JSONDict) -> None:
         stored.append(claim)
 

--- a/tests/integration/test_query_performance_benchmark.py
+++ b/tests/integration/test_query_performance_benchmark.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import importlib
 import importlib.util
 import json
 from pathlib import Path

--- a/tests/integration/test_query_with_reasoning.py
+++ b/tests/integration/test_query_with_reasoning.py
@@ -2,7 +2,6 @@ import rdflib
 from pathlib import Path
 
 import pytest
-import rdflib
 
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel, StorageConfig
@@ -15,7 +14,11 @@ def _configure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         storage=StorageConfig(rdf_backend="memory", rdf_path=str(tmp_path / "rdf"))
     )
     cfg.api.role_permissions["anonymous"] = ["query"]
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+
+    def load_config_override(self: ConfigLoader) -> ConfigModel:
+        return cfg
+
+    monkeypatch.setattr(ConfigLoader, "load_config", load_config_override)
     ConfigLoader()._config = None
 
 

--- a/tests/integration/test_rdf_persistence.py
+++ b/tests/integration/test_rdf_persistence.py
@@ -24,6 +24,15 @@ from autoresearch.storage import StorageContext, StorageManager
 from autoresearch.storage_typing import JSONDict
 
 
+def _stub_config_loader(
+    monkeypatch: pytest.MonkeyPatch, cfg: ConfigModel
+) -> None:
+    def load_config_stub(_: ConfigLoader) -> ConfigModel:
+        return cfg
+
+    monkeypatch.setattr(ConfigLoader, "load_config", load_config_stub)
+
+
 @pytest.fixture(autouse=True)
 def cleanup_rdf_store() -> Iterator[None]:
     """Clean up the RDF store after each test.
@@ -59,10 +68,7 @@ def test_rdf_persistence(storage_manager, tmp_path, monkeypatch):
         )
     )
 
-    def load_config_stub(_: ConfigLoader) -> ConfigModel:
-        return cfg
-
-    monkeypatch.setattr(ConfigLoader, "load_config", load_config_stub)
+    _stub_config_loader(monkeypatch, cfg)
     ConfigLoader.new_for_tests()
     import autoresearch.storage as storage_module
 
@@ -94,10 +100,7 @@ def test_oxigraph_backend_initializes(tmp_path, monkeypatch):
         )
     )
 
-    def load_config_stub(_: ConfigLoader) -> ConfigModel:
-        return cfg
-
-    monkeypatch.setattr(ConfigLoader, "load_config", load_config_stub)
+    _stub_config_loader(monkeypatch, cfg)
     ConfigLoader.new_for_tests()
 
     StorageManager.teardown(remove_db=True)
@@ -116,10 +119,7 @@ def test_oxrdflib_missing_plugin(tmp_path, monkeypatch):
         )
     )
 
-    def load_config_stub(_: ConfigLoader) -> ConfigModel:
-        return cfg
-
-    monkeypatch.setattr(ConfigLoader, "load_config", load_config_stub)
+    _stub_config_loader(monkeypatch, cfg)
     ConfigLoader.new_for_tests()
 
     def fake_find_spec(name: str) -> ModuleSpec | None:
@@ -144,10 +144,7 @@ def test_memory_backend_initializes(tmp_path, monkeypatch):
         )
     )
 
-    def load_config_stub(_: ConfigLoader) -> ConfigModel:
-        return cfg
-
-    monkeypatch.setattr(ConfigLoader, "load_config", load_config_stub)
+    _stub_config_loader(monkeypatch, cfg)
     ConfigLoader.new_for_tests()
 
     StorageManager.teardown(remove_db=True)

--- a/tests/integration/test_redis_broker.py
+++ b/tests/integration/test_redis_broker.py
@@ -24,7 +24,7 @@ pytestmark = [
 
 def _make_agent_result_message(
     *,
-    agent: str = "agent", 
+    agent: str = "agent",
     result: dict[str, Any] | None = None,
     pid: int = 1234,
 ) -> AgentResultMessage:
@@ -61,6 +61,7 @@ def test_redis_broker_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
     import redis
 
     dummy = DummyRedis()
+
     def _from_url(url: str) -> DummyRedis:
         return dummy
 

--- a/tests/integration/test_search_duckdb_semantic_merge.py
+++ b/tests/integration/test_search_duckdb_semantic_merge.py
@@ -21,7 +21,13 @@ def _config(monkeypatch: pytest.MonkeyPatch) -> None:
         )
     )
     ConfigLoader.reset_instance()
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+
+    def load_config_override(self: ConfigLoader) -> ConfigModel:
+        return cfg
+
+    monkeypatch.setattr(ConfigLoader, "load_config", load_config_override)
+
+
 def test_semantic_scores_ignore_zero_vectors(monkeypatch: pytest.MonkeyPatch) -> None:
     _config(monkeypatch)
     results: list[Mapping[str, object]] = [

--- a/tests/integration/test_search_score_normalization.py
+++ b/tests/integration/test_search_score_normalization.py
@@ -14,7 +14,13 @@ SearchResults = Sequence[Mapping[str, object]]
 def _config(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = ConfigModel(search=SearchConfig())
     ConfigLoader.reset_instance()
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+
+    def load_config_override(self: ConfigLoader) -> ConfigModel:
+        return cfg
+
+    monkeypatch.setattr(ConfigLoader, "load_config", load_config_override)
+
+
 def test_rank_results_normalizes_scores(monkeypatch: pytest.MonkeyPatch) -> None:
     """Scores are scaled to the unit interval."""
     _config(monkeypatch)

--- a/tests/integration/test_semantic_similarity.py
+++ b/tests/integration/test_semantic_similarity.py
@@ -1,5 +1,4 @@
 import importlib
-import importlib
 import sys
 import types
 from typing import Any, Mapping, Sequence
@@ -25,8 +24,8 @@ def test_semantic_similarity_uses_fastembed(
             return [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
 
     dummy_module = types.ModuleType("fastembed")
-    setattr(dummy_module, "OnnxTextEmbedding", lambda: DummyFastEmbed())
-    setattr(dummy_module, "TextEmbedding", lambda: DummyFastEmbed())
+    setattr(dummy_module, "OnnxTextEmbedding", DummyFastEmbed)
+    setattr(dummy_module, "TextEmbedding", DummyFastEmbed)
     monkeypatch.setitem(sys.modules, "fastembed", dummy_module)
 
     search = core.Search()
@@ -35,6 +34,8 @@ def test_semantic_similarity_uses_fastembed(
     assert scores == [1.0, 0.5]
     assert core.SENTENCE_TRANSFORMERS_AVAILABLE
     assert isinstance(search.get_sentence_transformer(), DummyFastEmbed)
+
+
 def test_semantic_similarity_legacy_fastembed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -49,7 +50,7 @@ def test_semantic_similarity_legacy_fastembed(
             return [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
 
     dummy_module = types.ModuleType("fastembed")
-    setattr(dummy_module, "TextEmbedding", lambda: DummyFastEmbed())
+    setattr(dummy_module, "TextEmbedding", DummyFastEmbed)
     monkeypatch.setitem(sys.modules, "fastembed", dummy_module)
 
     search = core.Search()

--- a/tests/integration/test_simple_orchestration.py
+++ b/tests/integration/test_simple_orchestration.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import pytest
 
-from autoresearch.agents.registry import AgentFactory
 from autoresearch.config.loader import ConfigLoader
 from autoresearch.config.models import ConfigModel
 from autoresearch.models import QueryResponse
@@ -54,7 +53,11 @@ def test_orchestrator_run_query(monkeypatch: pytest.MonkeyPatch) -> None:
     patch_agent_factory_get(monkeypatch, [synthesizer])
 
     cfg = ConfigModel(agents=["Synthesizer"], loops=1)
-    monkeypatch.setattr(ConfigLoader, "load_config", lambda self: cfg)
+
+    def load_config_override(self: ConfigLoader) -> ConfigModel:
+        return cfg
+
+    monkeypatch.setattr(ConfigLoader, "load_config", load_config_override)
     ConfigLoader()._config = None
 
     response = Orchestrator().run_query("q", cfg)

--- a/tests/integration/test_storage_baseline.py
+++ b/tests/integration/test_storage_baseline.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from __future__ import annotations
-
 from pathlib import Path
 
 from _pytest.monkeypatch import MonkeyPatch
@@ -12,6 +10,13 @@ from autoresearch.storage import StorageContext, StorageManager, StorageState
 from autoresearch.storage_typing import JSONDict
 
 
+def _stub_config_loader(monkeypatch: MonkeyPatch, cfg: ConfigModel) -> None:
+    def load_config_stub(_: ConfigLoader) -> ConfigModel:
+        return cfg
+
+    monkeypatch.setattr(ConfigLoader, "load_config", load_config_stub)
+
+
 def test_ram_budget_respects_baseline(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """Eviction uses memory delta from setup baseline."""
     cfg: ConfigModel = ConfigModel(
@@ -19,10 +24,7 @@ def test_ram_budget_respects_baseline(tmp_path: Path, monkeypatch: MonkeyPatch) 
         ram_budget_mb=1,
         graph_eviction_policy="lru",
     )
-    def load_config_stub(_: ConfigLoader) -> ConfigModel:
-        return cfg
-
-    monkeypatch.setattr(ConfigLoader, "load_config", load_config_stub)
+    _stub_config_loader(monkeypatch, cfg)
     ConfigLoader()._config = None
 
     # Simulate high baseline memory before setup
@@ -65,10 +67,7 @@ def test_eviction_respects_baseline_without_reasoner(
         ram_budget_mb=1,
         graph_eviction_policy="lru",
     )
-    def load_config_stub(_: ConfigLoader) -> ConfigModel:
-        return cfg
-
-    monkeypatch.setattr(ConfigLoader, "load_config", load_config_stub)
+    _stub_config_loader(monkeypatch, cfg)
     ConfigLoader()._config = None
 
     # Establish baseline memory before setup

--- a/tests/integration/test_storage_concurrency.py
+++ b/tests/integration/test_storage_concurrency.py
@@ -19,7 +19,7 @@ def _setup(
         ram_budget_mb=ram_budget,
         graph_eviction_policy="lru",
     )
-    
+
     def load_config_stub(_: ConfigLoader) -> ConfigModel:
         return cfg
 

--- a/tests/integration/test_storage_eviction.py
+++ b/tests/integration/test_storage_eviction.py
@@ -18,7 +18,7 @@ def test_concurrent_eviction(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         ram_budget_mb=1,
         graph_eviction_policy="lru",
     )
-    
+
     def load_config_stub(_: ConfigLoader) -> ConfigModel:
         return cfg
 

--- a/tests/unit/test_streamlit_ui_helpers.py
+++ b/tests/unit/test_streamlit_ui_helpers.py
@@ -1,4 +1,3 @@
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,12 +7,9 @@ from autoresearch.streamlit_ui import apply_theme_settings
 
 
 def test_apply_theme_settings_dark(monkeypatch: pytest.MonkeyPatch) -> None:
-    m = MagicMock()
+    mock_markdown = MagicMock()
 
-    def apply_markdown(*_args: Any, **_kwargs: Any) -> None:
-        m(*_args, **_kwargs)
-
-    monkeypatch.setattr(st, "markdown", apply_markdown)
+    monkeypatch.setattr(st, "markdown", mock_markdown)
     st.session_state["dark_mode"] = True
     apply_theme_settings()
-    assert m.called
+    assert mock_markdown.called


### PR DESCRIPTION
## Summary
- prune unused imports and convert lambda-based helpers to local functions across the integration and targeted test suites
- normalize blank-line spacing and whitespace handling in tests to satisfy flake8 expectations
- drop the unused `Future` import and extra blank lines in `search.core` to keep the lint stage clean

## Testing
- uv run flake8 src tests

------
https://chatgpt.com/codex/tasks/task_e_68e0b59abbbc8333ad04186bd47629c4