### PR TITLE
Baseline: refresh verify/coverage logs (UTC_TS=20251004T183537Z)

### DIFF
--- a/baseline/logs/task-coverage-20251004T183537Z.log
+++ b/baseline/logs/task-coverage-20251004T183537Z.log
@@ -1,0 +1,1513 @@
+[UTC:20251004T183537Z] task coverage with extras nlp ui vss git distributed analysis llm parsers
+task: [coverage] echo "[coverage] syncing dependencies"
+[coverage] syncing dependencies
+task: [coverage] uv sync \
+   --extra dev-minimal --extra test --extra nlp --extra ui --extra vss --extra git --extra distributed --extra analysis --extra llm --extra parsers \
+  
+
+Resolved 328 packages in 5ms
+Audited 246 packages in 0.33ms
+task: [coverage] echo "[coverage] erasing previous data"
+[coverage] erasing previous data
+task: [coverage] uv run coverage erase
+task: [coverage] echo "[coverage] running unit tests"
+[coverage] running unit tests
+task: [coverage] uv run pytest -vv --maxfail=1 --durations=10 -x tests/unit -m 'not slow' \
+  --cov=src --cov-report=term-missing --cov-append
+
+===================================================== test session starts ======================================================
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /workspace/autoresearch/.venv/bin/python3
+cachedir: .pytest_cache
+benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+hypothesis profile 'default'
+rootdir: /workspace/autoresearch
+configfile: pytest.ini
+plugins: anyio-4.11.0, benchmark-5.1.0, hypothesis-6.140.2, bdd-8.1.0, langsmith-0.4.31, cov-7.0.0, httpx-0.35.0
+collecting ... collected 1109 items / 25 deselected / 1084 selected
+
+tests/unit/config/test_loader_types.py::test_load_config_file_returns_defaults_when_missing PASSED                       [  0%]
+tests/unit/config/test_loader_types.py::test_load_config_file_rejects_non_mapping PASSED                                 [  0%]
+tests/unit/config/test_loader_types.py::test_env_storage_override_round_trips PASSED                                     [  0%]
+tests/unit/config/test_loader_types.py::test_storage_defaults PASSED                                                     [  0%]
+tests/unit/config/test_loader_types.py::test_minimum_resident_nodes_default_without_warning PASSED                       [  0%]
+tests/unit/config/test_loader_types.py::test_normalize_ranking_weights_balances_missing_values PASSED                    [  0%]
+tests/unit/config/test_loader_types.py::test_config_model_deep_copy_preserves_storage_settings PASSED                    [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_election_converges_to_minimum PASSED                        [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_election_requires_identifier PASSED                         [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_election_accepts_strings PASSED                             [  0%]
+tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent PASSED                     [  1%]
+tests/unit/distributed/test_coordination_properties.py::test_message_processing_returns_copy PASSED                      [  1%]
+tests/unit/distributed/test_coordination_properties.py::test_module_exports_helpers PASSED                               [  1%]
+tests/unit/distributed/test_coordination_properties.py::test_storage_queue_adapter_accepts_mapping_payloads PASSED       [  1%]
+tests/unit/distributed/test_coordination_properties.py::test_storage_queue_adapter_rejects_incompatible_payloads PASSED  [  1%]
+tests/unit/distributed/test_coordination_properties.py::test_storage_queue_adapter_accepts_broker_queue PASSED           [  1%]
+tests/unit/evaluation/test_harness_typing.py::test_open_duckdb_closes_connection PASSED                                  [  1%]
+tests/unit/evidence/test_stability_utils.py::test_aggregate_entailment_scores_stable PASSED                              [  1%]
+tests/unit/evidence/test_stability_utils.py::test_aggregate_entailment_scores_unstable PASSED                            [  1%]
+tests/unit/evidence/test_stability_utils.py::test_sample_paraphrases_returns_unique_variants PASSED                      [  1%]
+tests/unit/knowledge/test_graph_pipeline.py::test_session_graph_pipeline_ingest_records_provenance PASSED                [  1%]
+tests/unit/knowledge/test_graph_pipeline.py::test_session_graph_pipeline_neighbors_uses_storage PASSED                   [  2%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_decodes_prometheus_payload PASSED                     [  2%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_coerces_bytearray PASSED                              [  2%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_handles_memoryview PASSED                             [  2%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_replaces_invalid_bytes PASSED                         [  2%]
+tests/unit/monitor/test_metrics_endpoint.py::test_metrics_endpoint_handles_failure PASSED                                [  2%]
+tests/unit/orchestration/test_answer_audit.py::test_answer_auditor_hedges_unsupported_claims PASSED                      [  2%]
+tests/unit/orchestration/test_auto_mode.py::test_auto_mode_returns_direct_answer_when_gate_exits PASSED                  [  2%]
+tests/unit/orchestration/test_auto_mode.py::test_auto_mode_escalates_to_debate_when_gate_requires_loops PASSED           [  2%]
+tests/unit/orchestration/test_auto_mode.py::test_metrics_record_gate_decision_telemetry PASSED                           [  2%]
+tests/unit/orchestration/test_budgeting_algorithm.py::test_budget_scaled_by_loops_and_limits PASSED                      [  2%]
+tests/unit/orchestration/test_budgeting_algorithm.py::test_budget_minimum_buffer_applied PASSED                          [  3%]
+tests/unit/orchestration/test_budgeting_algorithm.py::test_budget_unchanged_within_bounds PASSED                         [  3%]
+tests/unit/orchestration/test_circuit_breaker_determinism.py::test_circuit_breaker_determinism_and_recovery PASSED       [  3%]
+tests/unit/orchestration/test_circuit_breaker_thresholds.py::test_circuit_breaker_threshold_and_recovery PASSED          [  3%]
+tests/unit/orchestration/test_gate_policy.py::test_scout_gate_reduces_loops_when_signals_low PASSED                      [  3%]
+tests/unit/orchestration/test_gate_policy.py::test_scout_gate_respects_force_debate_override PASSED                      [  3%]
+tests/unit/orchestration/test_gate_policy.py::test_scout_gate_flags_coverage_gap_and_confidence PASSED                   [  3%]
+tests/unit/orchestration/test_gate_policy.py::test_scout_gate_applies_graph_thresholds PASSED                            [  3%]
+tests/unit/orchestration/test_metrics_graph_summary.py::test_graph_summary_uses_typed_floats PASSED                      [  3%]
+tests/unit/orchestration/test_metrics_graph_summary.py::test_graph_build_skips_empty_payload PASSED                      [  3%]
+tests/unit/orchestration/test_metrics_graph_summary.py::test_graph_ingestion_saved_payload_is_sanitized PASSED           [  3%]
+tests/unit/orchestration/test_model_routing.py::test_routing_records_constraints_without_switching PASSED                [  4%]
+tests/unit/orchestration/test_model_routing.py::test_summary_reports_agent_constraints PASSED                            [  4%]
+tests/unit/orchestration/test_orchestration_simulations.py::test_circuit_breaker_sim_is_deterministic PASSED             [  4%]
+tests/unit/orchestration/test_orchestration_simulations.py::test_parallel_execution_sim_is_deterministic PASSED          [  4%]
+tests/unit/orchestration/test_orchestration_simulations.py::test_cli_runs_modes PASSED                                   [  4%]
+tests/unit/orchestration/test_package_exports.py::test_agent_factory_export PASSED                                       [  4%]
+tests/unit/orchestration/test_package_exports.py::test_agent_registry_export PASSED                                      [  4%]
+tests/unit/orchestration/test_package_exports.py::test_orchestrator_export PASSED                                        [  4%]
+tests/unit/orchestration/test_package_exports.py::test_storage_manager_export PASSED                                     [  4%]
+tests/unit/orchestration/test_parallel_execute.py::test_execute_parallel_query_error_and_timeout PASSED                  [  4%]
+tests/unit/orchestration/test_parallel_execute.py::test_execute_parallel_query_all_fail PASSED                           [  4%]
+tests/unit/orchestration/test_parallel_merge_invariant.py::test_parallel_merge_invariant PASSED                          [  5%]
+tests/unit/orchestration/test_query_state_features.py::test_query_state_cloudpickle_serialization_preserves_fields PASSED [  5%]
+tests/unit/orchestration/test_query_state_features.py::test_query_state_registry_clone_produces_independent_copies PASSED [  5%]
+tests/unit/orchestration/test_query_state_features.py::test_query_state_model_copy_deep_clone_separates_mutable_data PASSED [  5%]
+tests/unit/orchestration/test_query_state_features.py::test_query_state_registry_update_refreshes_snapshots PASSED       [  5%]
+tests/unit/orchestration/test_reverify.py::test_reverify_extracts_claims_and_retries PASSED                              [  5%]
+tests/unit/orchestration/test_reverify.py::test_reverify_supplies_fact_checker_defaults PASSED                           [  5%]
+tests/unit/orchestration/test_reverify.py::test_reverify_respects_fact_checker_opt_out PASSED                            [  5%]
+tests/unit/orchestration/test_state_registry.py::test_register_and_clone_preserve_lock_and_metadata_types PASSED         [  5%]
+tests/unit/orchestration/test_state_registry.py::test_config_model_deep_copy_with_embedded_lock PASSED                   [  5%]
+tests/unit/orchestration/test_state_registry.py::test_update_replaces_snapshot_and_preserves_lock_integrity PASSED       [  5%]
+tests/unit/orchestration/test_state_registry.py::test_update_creates_snapshot_when_missing_identifier PASSED             [  6%]
+tests/unit/orchestration/test_state_registry.py::test_registry_round_trip_rehydrates_state_with_fresh_lock PASSED        [  6%]
+tests/unit/orchestration/test_task_coordinator.py::test_task_coordinator_schedules_dependencies PASSED                   [  6%]
+tests/unit/orchestration/test_task_coordinator.py::test_schedule_next_applies_tie_breakers PASSED                        [  6%]
+tests/unit/orchestration/test_task_graph_enhancements.py::test_task_graph_from_planner_output_preserves_dependency_metadata PASSED [  6%]
+tests/unit/orchestration/test_task_graph_enhancements.py::test_query_state_normalises_socratic_checks_and_overview PASSED [  6%]
+tests/unit/orchestration/test_task_graph_enhancements.py::test_task_coordinator_uses_depth_and_affinity PASSED           [  6%]
+tests/unit/orchestration/test_token_utils.py::test_execute_with_adapter_kwarg PASSED                                     [  6%]
+tests/unit/orchestration/test_token_utils.py::test_execute_with_mutation_hooks_restores_original PASSED                  [  6%]
+tests/unit/orchestration/test_token_utils.py::test_execute_without_adapter_hooks PASSED                                  [  6%]
+tests/unit/orchestration/test_token_utils.py::test_execute_raises_for_non_mapping_result PASSED                          [  7%]
+tests/unit/orchestration/test_token_utils.py::test_type_guards_detect_adapter_features PASSED                            [  7%]
+tests/unit/orchestration/test_token_utils.py::test_is_agent_execution_result_guard PASSED                                [  7%]
+tests/unit/orchestration/test_utils_confidence.py::test_metrics_snapshot_parses_token_usage PASSED                       [  7%]
+tests/unit/orchestration/test_utils_confidence.py::test_confidence_adjusts_with_metrics_payload PASSED                   [  7%]
+tests/unit/orchestration/test_utils_confidence.py::test_graph_metrics_payload_is_sanitized PASSED                        [  7%]
+tests/unit/search/test_adaptive_rewrite.py::test_external_lookup_triggers_query_rewrite PASSED                           [  7%]
+tests/unit/search/test_adaptive_rewrite.py::test_external_lookup_adaptive_k_increases_fetch PASSED                       [  7%]
+tests/unit/search/test_adaptive_rewrite.py::test_query_strategy_markers_disabled PASSED                                  [  7%]
+tests/unit/search/test_adaptive_rewrite.py::test_self_critique_markers_disabled PASSED                                   [  7%]
+tests/unit/search/test_property_ranking_monotonicity.py::test_monotonic_ranking PASSED                                   [  7%]
+tests/unit/search/test_query_expansion_convergence.py::test_query_expansion_converges PASSED                             [  8%]
+tests/unit/search/test_query_expansion_convergence.py::test_reset_instance_creates_new_singleton PASSED                  [  8%]
+tests/unit/search/test_query_expansion_convergence.py::test_extract_entities_with_spacy PASSED                           [  8%]
+tests/unit/search/test_query_expansion_convergence.py::test_build_topic_model_with_insufficient_docs PASSED              [  8%]
+tests/unit/search/test_query_expansion_convergence.py::test_try_imports_disabled PASSED                                  [  8%]
+tests/unit/search/test_query_expansion_convergence.py::test_try_import_sentence_transformers_success PASSED              [  8%]
+tests/unit/search/test_query_expansion_convergence.py::test_search_embedding_protocol_prefers_embed PASSED               [  8%]
+tests/unit/search/test_query_expansion_convergence.py::test_search_embedding_protocol_falls_back_to_encode PASSED        [  8%]
+tests/unit/search/test_query_expansion_convergence.py::test_search_sentence_transformer_fallback_cached PASSED           [  8%]
+tests/unit/search/test_query_expansion_convergence.py::test_search_embedding_backend_switches_without_reset PASSED       [  8%]
+tests/unit/search/test_ranking_convergence_simulation.py::test_ranking_converges SKIPPED (CollectorRegistry duplication
+in test environment)                                                                                                     [  8%]
+tests/unit/search/test_ranking_convergence_simulation.py::test_invalid_weights_raise SKIPPED (CollectorRegistry
+duplication in test environment)                                                                                         [  9%]
+tests/unit/search/test_ranking_formula.py::test_combine_scores_weighted_sum PASSED                                       [  9%]
+tests/unit/search/test_ranking_formula.py::test_combine_scores_requires_convex_weights PASSED                            [  9%]
+tests/unit/search/test_ranking_formula.py::test_duckdb_scores_used_without_semantic PASSED                               [  9%]
+tests/unit/search/test_ranking_formula.py::test_rank_results_weighted_combination PASSED                                 [  9%]
+tests/unit/search/test_ranking_formula.py::test_rank_results_weight_fallback PASSED                                      [  9%]
+tests/unit/search/test_session_retry.py::test_http_session_retries_and_reuse PASSED                                      [  9%]
+tests/unit/search/test_session_retry.py::test_http_session_recovery PASSED                                               [  9%]
+tests/unit/search/test_session_retry.py::test_http_session_adapter_failure PASSED                                        [  9%]
+tests/unit/search/test_simulate_rate_limit.py::test_default_backoff PASSED                                               [  9%]
+tests/unit/search/test_simulate_rate_limit.py::test_custom_backoff PASSED                                                [  9%]
+tests/unit/storage/test_backup_scheduler.py::test_scheduler_runs_backup_and_reschedules PASSED                           [ 10%]
+tests/unit/storage/test_backup_scheduler.py::test_scheduler_restarts_existing_timer PASSED                               [ 10%]
+tests/unit/storage/test_backup_scheduler.py::test_scheduler_prevents_cancelled_timer_from_rescheduling PASSED            [ 10%]
+tests/unit/storage/test_backup_scheduler.py::test_backup_manager_schedule_uses_resolved_scheduler PASSED                 [ 10%]
+tests/unit/storage/test_backup_scheduler.py::test_rotation_policy_removes_excess_and_stale_backups PASSED                [ 10%]
+tests/unit/storage/test_claim_audit_persistence.py::test_persist_claim_audit_payload_updates_backends PASSED             [ 10%]
+tests/unit/storage/test_knowledge_graph.py::test_ingest_persists_exports_and_updates_summary PASSED                      [ 10%]
+tests/unit/storage/test_protocols.py::test_to_json_dict_returns_copy PASSED                                              [ 10%]
+tests/unit/storage/test_protocols.py::test_init_rdf_store_supports_protocol PASSED                                       [ 10%]
+tests/unit/test_a2a_concurrency_sim.py::test_simulation_counts PASSED                                                    [ 10%]
+tests/unit/test_a2a_interface.py::test_a2a_message_accepts_sdk_message PASSED                                            [ 10%]
+tests/unit/test_a2a_interface.py::test_runtime_requirements_raise PASSED                                                 [ 11%]
+tests/unit/test_a2a_interface.py::TestA2AInterface::test_init PASSED                                                     [ 11%]
+tests/unit/test_a2a_interface.py::TestA2AInterface::test_start PASSED                                                    [ 11%]
+tests/unit/test_a2a_interface.py::TestA2AInterface::test_stop PASSED                                                     [ 11%]
+tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_query PASSED                                             [ 11%]
+tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_command_get_capabilities PASSED                          [ 11%]
+tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_command_get_config PASSED                                [ 11%]
+tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_command_set_config PASSED                                [ 11%]
+tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_command_unknown PASSED                                   [ 11%]
+tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_info PASSED                                              [ 11%]
+tests/unit/test_a2a_interface.py::TestA2AInterface::test_handle_query_concurrent PASSED                                  [ 11%]
+tests/unit/test_a2a_interface.py::TestA2AClient::test_init PASSED                                                        [ 12%]
+tests/unit/test_a2a_interface.py::TestA2AClient::test_query_agent PASSED                                                 [ 12%]
+tests/unit/test_a2a_interface.py::TestA2AClient::test_get_agent_capabilities PASSED                                      [ 12%]
+tests/unit/test_a2a_interface.py::TestA2AClient::test_get_agent_config PASSED                                            [ 12%]
+tests/unit/test_a2a_interface.py::TestA2AClient::test_set_agent_config PASSED                                            [ 12%]
+tests/unit/test_a2a_interface.py::test_get_a2a_client PASSED                                                             [ 12%]
+tests/unit/test_a2a_interface.py::test_requires_a2a_decorator_available PASSED                                           [ 12%]
+tests/unit/test_a2a_interface.py::test_requires_a2a_decorator_not_available PASSED                                       [ 12%]
+tests/unit/test_a2a_interface.py::test_handle_query_exception PASSED                                                     [ 12%]
+tests/unit/test_a2a_interface.py::test_handle_set_config_invalid PASSED                                                  [ 12%]
+tests/unit/test_a2a_interface.py::test_dispatch_simulation_invariants PASSED                                             [ 13%]
+tests/unit/test_a2a_interface.py::test_simulation_event_order PASSED                                                     [ 13%]
+tests/unit/test_a2a_interface.py::TestA2AClientExtended::test_init PASSED                                                [ 13%]
+tests/unit/test_a2a_interface.py::TestA2AClientExtended::test_query_agent PASSED                                         [ 13%]
+tests/unit/test_a2a_interface.py::TestA2AClientExtended::test_get_agent_capabilities PASSED                              [ 13%]
+tests/unit/test_a2a_interface.py::TestA2AClientExtended::test_get_agent_config PASSED                                    [ 13%]
+tests/unit/test_a2a_interface.py::TestA2AClientExtended::test_set_agent_config PASSED                                    [ 13%]
+tests/unit/test_a2a_interface.py::TestA2AClientExtended::test_query_agent_error PASSED                                   [ 13%]
+tests/unit/test_a2a_mcp_handshake.py::test_handshake_success PASSED                                                      [ 13%]
+tests/unit/test_a2a_mcp_handshake.py::test_handshake_timeout PASSED                                                      [ 13%]
+tests/unit/test_a2a_mcp_handshake.py::test_handshake_recovery PASSED                                                     [ 13%]
+tests/unit/test_a2a_mcp_handshake.py::test_handshake_server_failure PASSED                                               [ 14%]
+tests/unit/test_additional_algorithm_docs.py::test_algorithm_docs_exist PASSED                                           [ 14%]
+tests/unit/test_additional_coverage.py::test_log_release_tokens_invalid_json PASSED                                      [ 14%]
+tests/unit/test_additional_coverage.py::test_circuit_breaker_transitions PASSED                                          [ 14%]
+tests/unit/test_additional_coverage.py::test_circuit_breaker_recovery PASSED                                             [ 14%]
+tests/unit/test_additional_coverage.py::test_circuit_breaker_success_decrements PASSED                                   [ 14%]
+tests/unit/test_additional_coverage.py::test_http_session_reuse_and_close PASSED                                         [ 14%]
+tests/unit/test_additional_coverage.py::test_llm_pool_session_reuse PASSED                                               [ 14%]
+tests/unit/test_additional_coverage.py::test_llm_pool_adapter_failure PASSED                                             [ 14%]
+tests/unit/test_additional_coverage.py::test_set_get_delegate PASSED                                                     [ 14%]
+tests/unit/test_additional_coverage.py::test_pop_low_score_missing_confidence PASSED                                     [ 14%]
+tests/unit/test_additional_coverage.py::test_output_formatter_invalid PASSED                                             [ 15%]
+tests/unit/test_additional_coverage.py::test_streamlit_metrics PASSED                                                    [ 15%]
+tests/unit/test_additional_coverage.py::test_render_evaluation_summary_joins_artifacts PASSED                            [ 15%]
+tests/unit/test_additional_coverage.py::test_render_evaluation_summary_formats_planner_and_routing PASSED                [ 15%]
+tests/unit/test_additional_coverage.py::test_format_percentage_variants PASSED                                           [ 15%]
+tests/unit/test_additional_coverage.py::test_cli_utils_format_helpers_importable PASSED                                  [ 15%]
+tests/unit/test_advanced_agents.py::test_domain_specialist_execute PASSED                                                [ 15%]
+tests/unit/test_advanced_agents.py::test_domain_specialist_can_execute PASSED                                            [ 15%]
+tests/unit/test_advanced_agents.py::test_moderator_execute PASSED                                                        [ 15%]
+tests/unit/test_advanced_agents.py::test_moderator_can_execute PASSED                                                    [ 15%]
+tests/unit/test_advanced_agents.py::test_user_agent_execute PASSED                                                       [ 15%]
+tests/unit/test_advanced_agents.py::test_user_agent_can_execute PASSED                                                   [ 16%]
+tests/unit/test_advanced_agents.py::test_planner_metadata PASSED                                                         [ 16%]
+tests/unit/test_agent_communication.py::test_message_exchange_and_feedback PASSED                                        [ 16%]
+tests/unit/test_agent_communication.py::test_coalition_management_in_state PASSED                                        [ 16%]
+tests/unit/test_agent_communication.py::test_agent_registry_coalitions PASSED                                            [ 16%]
+tests/unit/test_agent_communication.py::test_orchestrator_handles_coalitions PASSED                                      [ 16%]
+tests/unit/test_agent_communication.py::test_message_protocols PASSED                                                    [ 16%]
+tests/unit/test_agent_registry.py::test_register_and_get_cached_instance PASSED                                          [ 16%]
+tests/unit/test_agent_registry.py::test_get_unknown_agent_raises PASSED                                                  [ 16%]
+tests/unit/test_agent_registry.py::test_reset_instances PASSED                                                           [ 16%]
+tests/unit/test_agents_dialectical.py::test_fact_checker_audit_provenance PASSED                                         [ 16%]
+tests/unit/test_agents_dialectical.py::test_synthesizer_support_audit_provenance PASSED                                  [ 17%]
+tests/unit/test_agents_llm.py::test_synthesizer_with_injected_adapter PASSED                                             [ 17%]
+tests/unit/test_agents_llm.py::test_contrarian_with_injected_adapter PASSED                                              [ 17%]
+tests/unit/test_agents_llm.py::test_fact_checker_with_injected_adapter PASSED                                            [ 17%]
+tests/unit/test_agents_llm.py::test_agent_factory_with_injected_adapter PASSED                                           [ 17%]
+tests/unit/test_agents_llm.py::test_synthesizer_dynamic PASSED                                                           [ 17%]
+tests/unit/test_agents_llm.py::test_contrarian_dynamic PASSED                                                            [ 17%]
+tests/unit/test_agents_llm.py::test_fact_checker_sources PASSED                                                          [ 17%]
+tests/unit/test_algorithm_docs.py::test_algorithm_docs_exist PASSED                                                      [ 17%]
+tests/unit/test_algorithm_docs.py::test_core_docstrings_reference_docs PASSED                                            [ 17%]
+tests/unit/test_api.py::test_dynamic_limit PASSED                                                                        [ 17%]
+tests/unit/test_api.py::test_api_key_roles PASSED                                                                        [ 18%]
+tests/unit/test_api.py::test_batch_query_invalid_page PASSED                                                             [ 18%]
+tests/unit/test_api.py::test_fallback_no_limit PASSED                                                                    [ 18%]
+tests/unit/test_api.py::test_fallback_multiple_ips PASSED                                                                [ 18%]
+tests/unit/test_api.py::test_request_log_thread_safety PASSED                                                            [ 18%]
+tests/unit/test_api.py::test_query_failure_includes_socratic_reasoning PASSED                                            [ 18%]
+tests/unit/test_api_auth_deps.py::test_require_permission_allows PASSED                                                  [ 18%]
+tests/unit/test_api_auth_deps.py::test_require_permission_auth_missing PASSED                                            [ 18%]
+tests/unit/test_api_auth_deps.py::test_require_permission_forbidden PASSED                                               [ 18%]
+tests/unit/test_api_auth_middleware.py::test_resolve_role_valid_key PASSED                                               [ 18%]
+tests/unit/test_api_auth_middleware.py::test_resolve_role_invalid_key PASSED                                             [ 19%]
+tests/unit/test_api_auth_middleware.py::test_resolve_role_missing_key PASSED                                             [ 19%]
+tests/unit/test_api_auth_middleware.py::test_dispatch_invalid_token PASSED                                               [ 19%]
+tests/unit/test_api_auth_middleware.py::test_dispatch_valid_token PASSED                                                 [ 19%]
+tests/unit/test_api_error_handling.py::test_query_endpoint_runtime_error PASSED                                          [ 19%]
+tests/unit/test_api_error_handling.py::test_query_endpoint_invalid_response PASSED                                       [ 19%]
+tests/unit/test_api_error_handling.py::test_simulate_api_auth_error_rates PASSED                                         [ 19%]
+tests/unit/test_api_errors.py::test_handle_rate_limit_response PASSED                                                    [ 19%]
+tests/unit/test_api_errors.py::test_handle_rate_limit_text PASSED                                                        [ 19%]
+tests/unit/test_api_imports.py::test_no_unused_imports PASSED                                                            [ 19%]
+tests/unit/test_api_lifespan.py::test_lifespan_startup_shutdown PASSED                                                   [ 19%]
+tests/unit/test_api_rate_limit.py::test_initial_burst_and_refill PASSED                                                  [ 20%]
+tests/unit/test_api_rate_limit.py::test_partial_refill PASSED                                                            [ 20%]
+tests/unit/test_api_rate_limit.py::test_clock_drift PASSED                                                               [ 20%]
+tests/unit/test_api_rate_limit.py::test_invalid_parameters PASSED                                                        [ 20%]
+tests/unit/test_api_token_utils.py::test_generate_bearer_token_unique PASSED                                             [ 20%]
+tests/unit/test_api_token_utils.py::test_verify_bearer_token PASSED                                                      [ 20%]
+tests/unit/test_backup_manager.py::test_create_and_restore_backup PASSED                                                 [ 20%]
+tests/unit/test_backup_manager.py::test_backup_scheduler_start_stop PASSED                                               [ 20%]
+tests/unit/test_bm25_scoring.py::test_calculate_bm25_scores_real_documents PASSED                                        [ 20%]
+tests/unit/test_budgeting.py::test_apply_adaptive_token_budget_paths PASSED                                              [ 20%]
+tests/unit/test_budgeting_module.py::test_budget_scaled_by_loops_and_capped PASSED                                       [ 20%]
+tests/unit/test_budgeting_module.py::test_budget_increased_when_too_low PASSED                                           [ 21%]
+tests/unit/test_budgeting_module.py::test_budget_unchanged_when_within_bounds PASSED                                     [ 21%]
+tests/unit/test_budgeting_module.py::test_budget_noop_when_missing PASSED                                                [ 21%]
+tests/unit/test_cache.py::test_search_uses_cache PASSED                                                                  [ 21%]
+tests/unit/test_cache.py::test_cache_lifecycle PASSED                                                                    [ 21%]
+tests/unit/test_cache.py::test_setup_thread_safe PASSED                                                                  [ 21%]
+tests/unit/test_cache.py::test_cache_is_backend_specific PASSED                                                          [ 21%]
+tests/unit/test_cache.py::test_cache_is_backend_specific_without_embeddings PASSED                                       [ 21%]
+tests/unit/test_cache.py::test_cache_key_normalizes_queries PASSED                                                       [ 21%]
+tests/unit/test_cache.py::test_cache_key_respects_embedding_flags PASSED                                                 [ 21%]
+tests/unit/test_cache.py::test_context_aware_query_expansion_uses_cache PASSED                                           [ 21%]
+tests/unit/test_cache_deepcopy.py::test_cache_results_are_deepcopied PASSED                                              [ 22%]
+tests/unit/test_cache_deepcopy.py::test_get_cache_returns_singleton PASSED                                               [ 22%]
+tests/unit/test_cache_extra.py::test_get_db_after_teardown PASSED                                                        [ 22%]
+tests/unit/test_check_env_warnings.py::test_missing_package_metadata_raises PASSED                                       [ 22%]
+tests/unit/test_check_env_warnings.py::test_missing_pytest_bdd_raises PASSED                                             [ 22%]
+tests/unit/test_check_env_warnings.py::test_missing_go_task_raises PASSED                                                [ 22%]
+tests/unit/test_check_env_warnings.py::test_missing_uv_raises_version_error PASSED                                       [ 22%]
+tests/unit/test_check_env_warnings.py::test_task_command_failure PASSED                                                  [ 22%]
+tests/unit/test_check_env_warnings.py::test_main_reports_missing_metadata PASSED                                         [ 22%]
+tests/unit/test_check_env_warnings.py::test_env_metadata_provider PASSED                                                 [ 22%]
+tests/unit/test_circuit_breaker_module.py::test_state_transitions PASSED                                                 [ 22%]
+tests/unit/test_circuit_breaker_module.py::test_recovery PASSED                                                          [ 23%]
+tests/unit/test_cli_backup_extra.py::test_format_size_units PASSED                                                       [ 23%]
+tests/unit/test_cli_backup_extra.py::test_backup_create_error PASSED                                                     [ 23%]
+tests/unit/test_cli_backup_extra.py::test_backup_create_missing_tables PASSED                                            [ 23%]
+tests/unit/test_cli_backup_extra.py::test_backup_create_success PASSED                                                   [ 23%]
+tests/unit/test_cli_backup_extra.py::test_backup_restore_cancelled PASSED                                                [ 23%]
+tests/unit/test_cli_backup_extra.py::test_backup_restore_error PASSED                                                    [ 23%]
+tests/unit/test_cli_backup_extra.py::test_backup_list_no_backups PASSED                                                  [ 23%]
+tests/unit/test_cli_backup_extra.py::test_backup_list_success PASSED                                                     [ 23%]
+tests/unit/test_cli_backup_extra.py::test_backup_recover_invalid_timestamp PASSED                                        [ 23%]
+tests/unit/test_cli_backup_extra.py::test_backup_recover_error PASSED                                                    [ 23%]
+tests/unit/test_cli_help.py::test_cli_help_no_ansi PASSED                                                                [ 24%]
+tests/unit/test_cli_help.py::test_search_help_includes_interactive PASSED                                                [ 24%]
+tests/unit/test_cli_help.py::test_search_help_includes_visualize PASSED                                                  [ 24%]
+tests/unit/test_cli_help.py::test_search_loops_option PASSED                                                             [ 24%]
+tests/unit/test_cli_help.py::test_search_help_includes_ontology_flags PASSED                                             [ 24%]
+tests/unit/test_cli_help.py::test_visualize_help_includes_layout PASSED                                                  [ 24%]
+tests/unit/test_cli_helpers.py::test_find_similar_commands_basic PASSED                                                  [ 24%]
+tests/unit/test_cli_helpers.py::test_find_similar_commands_default_threshold PASSED                                      [ 24%]
+tests/unit/test_cli_helpers.py::test_parse_agent_groups_parses_nested_lists PASSED                                       [ 24%]
+tests/unit/test_cli_helpers.py::test_find_similar_commands_respects_threshold PASSED                                     [ 24%]
+tests/unit/test_cli_helpers.py::test_parse_agent_groups_discards_empty_groups PASSED                                     [ 25%]
+tests/unit/test_cli_helpers.py::test_require_api_key_missing_header PASSED                                               [ 25%]
+tests/unit/test_cli_helpers.py::test_require_api_key_accepts_present_header PASSED                                       [ 25%]
+tests/unit/test_cli_helpers.py::test_report_missing_tables_sorts_and_prints PASSED                                       [ 25%]
+tests/unit/test_cli_helpers.py::test_report_missing_tables_uses_console PASSED                                           [ 25%]
+tests/unit/test_cli_helpers.py::test_handle_command_not_found_suggests_similar PASSED                                    [ 25%]
+tests/unit/test_cli_helpers.py::test_install_help_text_in_readme PASSED                                                  [ 25%]
+tests/unit/test_cli_utils.py::test_attach_cli_hooks_exposes_attributes PASSED                                            [ 25%]
+tests/unit/test_cli_utils_extra.py::test_print_error_suggestion PASSED                                                   [ 25%]
+tests/unit/test_cli_utils_extra.py::test_verbosity_roundtrip PASSED                                                      [ 25%]
+tests/unit/test_cli_utils_extra.py::test_set_verbosity_sets_env PASSED                                                   [ 25%]
+tests/unit/test_cli_utils_extra.py::test_print_error_emits_at_quiet_threshold[quiet] PASSED                              [ 26%]
+tests/unit/test_cli_utils_extra.py::test_print_error_emits_at_quiet_threshold[normal] PASSED                             [ 26%]
+tests/unit/test_cli_utils_extra.py::test_print_error_emits_at_quiet_threshold[verbose] PASSED                            [ 26%]
+tests/unit/test_cli_utils_extra.py::test_print_error_suppressed_when_threshold_higher PASSED                             [ 26%]
+tests/unit/test_cli_utils_extra.py::test_print_warning_respects_minimum[quiet-False] PASSED                              [ 26%]
+tests/unit/test_cli_utils_extra.py::test_print_warning_respects_minimum[normal-True] PASSED                              [ 26%]
+tests/unit/test_cli_utils_extra.py::test_print_warning_respects_minimum[verbose-True] PASSED                             [ 26%]
+tests/unit/test_cli_utils_extra.py::test_ascii_and_table_empty PASSED                                                    [ 26%]
+tests/unit/test_cli_utils_extra.py::test_format_functions PASSED                                                         [ 26%]
+tests/unit/test_cli_visualize.py::test_ascii_bar_graph_basic PASSED                                                      [ 26%]
+tests/unit/test_cli_visualize.py::test_summary_table_render PASSED                                                       [ 26%]
+tests/unit/test_cli_visualize.py::test_search_visualize_option PASSED                                                    [ 27%]
+tests/unit/test_coalition_execution.py::test_coalition_agents_run_together PASSED                                        [ 27%]
+tests/unit/test_coalition_execution.py::test_configmodel_from_dict_allows_coalitions PASSED                              [ 27%]
+tests/unit/test_config_env_file.py::test_config_spec_exists PASSED                                                       [ 27%]
+tests/unit/test_config_env_file.py::test_env_file_parsing PASSED                                                         [ 27%]
+tests/unit/test_config_errors.py::test_config_spec_exists PASSED                                                         [ 27%]
+tests/unit/test_config_errors.py::test_load_config_file_error PASSED                                                     [ 27%]
+tests/unit/test_config_errors.py::test_notify_observers_error PASSED                                                     [ 27%]
+tests/unit/test_config_errors.py::test_watch_config_files_error PASSED                                                   [ 27%]
+tests/unit/test_config_errors.py::test_watch_config_reload_error PASSED                                                  [ 27%]
+tests/unit/test_config_errors.py::test_reset_instance_error PASSED                                                       [ 27%]
+tests/unit/test_config_hot_reload_sim.py::test_config_hot_reload_sim PASSED                                              [ 28%]
+tests/unit/test_config_hot_reload_sim.py::test_invalid_update_logged PASSED                                              [ 28%]
+tests/unit/test_config_loader_defaults.py::test_config_spec_exists PASSED                                                [ 28%]
+tests/unit/test_config_loader_defaults.py::test_invalid_env_falls_back_to_defaults PASSED                                [ 28%]
+tests/unit/test_config_loader_defaults.py::test_validate_without_config_file PASSED                                      [ 28%]
+tests/unit/test_config_profiles.py::test_config_spec_exists PASSED                                                       [ 28%]
+tests/unit/test_config_profiles.py::test_config_profiles_default PASSED                                                  [ 28%]
+tests/unit/test_config_profiles.py::test_config_profiles_switch PASSED                                                   [ 28%]
+tests/unit/test_config_profiles.py::test_config_profiles_invalid PASSED                                                  [ 28%]
+tests/unit/test_config_profiles.py::test_config_profiles_merge PASSED                                                    [ 28%]
+tests/unit/test_config_reload.py::test_config_spec_exists PASSED                                                         [ 28%]
+tests/unit/test_config_reload.py::test_config_reload_on_change PASSED                                                    [ 29%]
+tests/unit/test_config_utils.py::test_config_spec_exists PASSED                                                          [ 29%]
+tests/unit/test_config_utils.py::test_module_docstring_mentions_spec PASSED                                              [ 29%]
+tests/unit/test_config_utils.py::test_apply_preset_returns_configuration PASSED                                          [ 29%]
+tests/unit/test_config_utils.py::test_apply_preset_unknown_name PASSED                                                   [ 29%]
+tests/unit/test_config_utils.py::test_validate_config_success PASSED                                                     [ 29%]
+tests/unit/test_config_utils.py::test_validate_config_failure PASSED                                                     [ 29%]
+tests/unit/test_config_validation_errors.py::test_config_spec_exists PASSED                                              [ 29%]
+tests/unit/test_config_validation_errors.py::test_invalid_rdf_backend PASSED                                             [ 29%]
+tests/unit/test_config_validation_errors.py::test_weights_must_sum_to_one PASSED                                         [ 29%]
+tests/unit/test_config_validation_errors.py::test_default_config_loads_without_error PASSED                              [ 29%]
+tests/unit/test_config_validators_additional.py::test_config_spec_exists PASSED                                          [ 30%]
+tests/unit/test_config_validators_additional.py::test_reasoning_mode_valid[direct-direct0] PASSED                        [ 30%]
+tests/unit/test_config_validators_additional.py::test_reasoning_mode_valid[direct-direct1] PASSED                        [ 30%]
+tests/unit/test_config_validators_additional.py::test_reasoning_mode_invalid PASSED                                      [ 30%]
+tests/unit/test_config_validators_additional.py::test_token_budget_valid[None] PASSED                                    [ 30%]
+tests/unit/test_config_validators_additional.py::test_token_budget_valid[10] PASSED                                      [ 30%]
+tests/unit/test_config_validators_additional.py::test_token_budget_invalid[0] PASSED                                     [ 30%]
+tests/unit/test_config_validators_additional.py::test_token_budget_invalid[-5] PASSED                                    [ 30%]
+tests/unit/test_config_validators_additional.py::test_eviction_policy_valid[LRU] PASSED                                  [ 30%]
+tests/unit/test_config_validators_additional.py::test_eviction_policy_valid[score] PASSED                                [ 30%]
+tests/unit/test_config_validators_additional.py::test_eviction_policy_valid[hybrid] PASSED                               [ 30%]
+tests/unit/test_config_validators_additional.py::test_eviction_policy_valid[priority] PASSED                             [ 31%]
+tests/unit/test_config_validators_additional.py::test_eviction_policy_valid[adaptive] PASSED                             [ 31%]
+tests/unit/test_config_validators_additional.py::test_eviction_policy_invalid PASSED                                     [ 31%]
+tests/unit/test_config_watcher_cleanup.py::test_config_spec_exists PASSED                                                [ 31%]
+tests/unit/test_config_watcher_cleanup.py::test_cli_watcher_cleanup PASSED                                               [ 31%]
+tests/unit/test_config_watcher_cleanup.py::test_api_watcher_cleanup PASSED                                               [ 31%]
+tests/unit/test_config_watcher_cleanup.py::test_cli_watcher_cleanup_error PASSED                                         [ 31%]
+tests/unit/test_config_watcher_cleanup.py::test_api_watcher_cleanup_error PASSED                                         [ 31%]
+tests/unit/test_core_modules_additional.py::test_orchestrator_parse_config_basic PASSED                                  [ 31%]
+tests/unit/test_core_modules_additional.py::test_search_stub_backend[legacy] PASSED                                      [ 31%]
+tests/unit/test_core_modules_additional.py::test_search_stub_backend[vss-enabled] PASSED                                 [ 32%]
+tests/unit/test_core_modules_additional.py::test_search_stub_backend_return_handles_fallback PASSED                      [ 32%]
+tests/unit/test_core_modules_additional.py::test_planner_execute PASSED                                                  [ 32%]
+tests/unit/test_core_modules_additional.py::test_storage_setup_teardown PASSED                                           [ 32%]
+tests/unit/test_core_modules_additional.py::test_storage_setup_without_kuzu PASSED                                       [ 32%]
+tests/unit/test_data_analysis.py::test_metrics_dataframe_enabled PASSED                                                  [ 32%]
+tests/unit/test_data_analysis.py::test_metrics_dataframe_disabled PASSED                                                 [ 32%]
+tests/unit/test_data_analysis.py::test_metrics_dataframe_polars_missing PASSED                                           [ 32%]
+tests/unit/test_data_analysis.py::test_metrics_dataframe_reload_without_polars PASSED                                    [ 32%]
+tests/unit/test_data_analysis_polars.py::test_metrics_dataframe_summary PASSED                                           [ 32%]
+tests/unit/test_distributed.py::test_get_message_broker_invalid PASSED                                                   [ 32%]
+tests/unit/test_distributed.py::test_publish_claim_inmemory SKIPPED (multiprocessing Manager unsupported in this
+environment)                                                                                                             [ 33%]
+tests/unit/test_distributed_broker.py::test_get_message_broker_memory SKIPPED (multiprocessing Manager unsupported in
+this environment)                                                                                                        [ 33%]
+tests/unit/test_distributed_broker.py::test_get_message_broker_invalid PASSED                                            [ 33%]
+tests/unit/test_distributed_broker.py::test_redis_broker_requires_dependency PASSED                                      [ 33%]
+tests/unit/test_distributed_broker.py::test_ray_broker_publish PASSED                                                    [ 33%]
+tests/unit/test_distributed_broker_import_error.py::test_redis_broker_missing_dependency PASSED                          [ 33%]
+tests/unit/test_distributed_coordination_benchmark.py::test_benchmark_scales SKIPPED (multiprocessing Manager
+unsupported in this environment)                                                                                         [ 33%]
+tests/unit/test_distributed_coordination_benchmark.py::test_benchmark_survives_worker_crash SKIPPED (multiprocessing
+Manager unsupported in this environment)                                                                                 [ 33%]
+tests/unit/test_distributed_coordination_props.py::test_leader_is_minimum PASSED                                         [ 33%]
+tests/unit/test_distributed_coordination_props.py::test_message_ordering_preserved SKIPPED (multiprocessing Manager
+unsupported in this environment)                                                                                         [ 33%]
+tests/unit/test_distributed_executors.py::test_execute_agent_process_records_queue PASSED                                [ 33%]
+tests/unit/test_distributed_executors.py::test_execute_agent_remote SKIPPED (Real Ray clusters require package-level
+agent registration; serialization is covered by test_query_state_ray_round_trip.)                                        [ 34%]
+tests/unit/test_distributed_executors.py::test_ray_executor_cycle_callback SKIPPED (RayExecutor callback test relies on
+the local stub runtime.)                                                                                                 [ 34%]
+tests/unit/test_distributed_executors.py::test_process_executor_uses_local_queue PASSED                                  [ 34%]
+tests/unit/test_distributed_executors.py::test_query_state_cloudpickle_round_trip PASSED                                 [ 34%]
+tests/unit/test_distributed_executors.py::test_query_state_ray_round_trip PASSED                                         [ 34%]
+tests/unit/test_distributed_executors.py::test_publish_claim_enqueues_typed_message PASSED                               [ 34%]
+tests/unit/test_distributed_extra.py::test_get_message_broker_default SKIPPED (multiprocessing Manager unsupported in
+this environment)                                                                                                        [ 34%]
+tests/unit/test_distributed_extra.py::test_redis_queue_roundtrip SKIPPED (multiprocessing Manager unsupported in this
+environment)                                                                                                             [ 34%]
+tests/unit/test_distributed_perf_compare.py::test_compare_matches_theory_within_tolerance PASSED                         [ 34%]
+tests/unit/test_distributed_perf_sim_script.py::test_latency_decreases_with_workers PASSED                               [ 34%]
+tests/unit/test_distributed_perf_sim_script.py::test_cli_execution PASSED                                                [ 34%]
+tests/unit/test_distributed_perf_sim_script.py::test_cli_requires_arguments PASSED                                       [ 35%]
+tests/unit/test_distributed_redis.py::test_get_message_broker_redis_roundtrip PASSED                                     [ 35%]
+tests/unit/test_distributed_redis.py::test_get_message_broker_redis_missing PASSED                                       [ 35%]
+tests/unit/test_download_duckdb_extensions.py::test_download_extension_network_fallback PASSED                           [ 35%]
+tests/unit/test_download_duckdb_extensions.py::test_download_extension_creates_stub_when_offline PASSED                  [ 35%]
+tests/unit/test_download_duckdb_extensions.py::test_download_extension_offline_without_duckdb PASSED                     [ 35%]
+tests/unit/test_download_duckdb_extensions.py::test_download_extension_fallback_path PASSED                              [ 35%]
+tests/unit/test_download_duckdb_extensions.py::test_offline_fallback_skips_samefile_copy PASSED                          [ 35%]
+tests/unit/test_download_duckdb_extensions.py::test_setup_sh_ignores_smoke_failure_with_stub PASSED                      [ 35%]
+tests/unit/test_download_duckdb_extensions.py::test_load_offline_env_sets_vector_extension_path PASSED                   [ 35%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_init PASSED                                    [ 35%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_setup_with_default_path PASSED                 [ 36%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_setup_with_custom_path PASSED                  [ 36%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_setup_with_connection_error PASSED             [ 36%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_setup_table_creation_failure PASSED            [ 36%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_setup_missing_extension_continues PASSED       [ 36%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_create_tables PASSED                           [ 36%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_initialize_schema_version PASSED               [ 36%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_get_schema_version PASSED                      [ 36%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_get_schema_version_no_version PASSED           [ 36%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_update_schema_version PASSED                   [ 36%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_run_migrations PASSED                          [ 36%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_has_vss_true PASSED                            [ 37%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_has_vss_false PASSED                           [ 37%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_close PASSED                                   [ 37%]
+tests/unit/test_duckdb_storage_backend.py::TestDuckDBStorageBackend::test_clear PASSED                                   [ 37%]
+tests/unit/test_duckdb_storage_backend_concurrency.py::test_concurrent_setup_is_idempotent PASSED                        [ 37%]
+tests/unit/test_duckdb_storage_backend_concurrency.py::test_initialize_schema_version_failure PASSED                     [ 37%]
+tests/unit/test_duckdb_storage_backend_concurrency.py::test_persist_claims_concurrent PASSED                             [ 37%]
+tests/unit/test_duckdb_storage_backend_extended.py::TestDuckDBStorageBackendExtended::test_create_hnsw_index PASSED      [ 37%]
+tests/unit/test_duckdb_storage_backend_extended.py::TestDuckDBStorageBackendExtended::test_create_hnsw_index_extension_not_loaded PASSED [ 37%]
+tests/unit/test_duckdb_storage_backend_extended.py::TestDuckDBStorageBackendExtended::test_create_hnsw_index_error PASSED [ 37%]
+tests/unit/test_duckdb_storage_backend_extended.py::TestDuckDBStorageBackendExtended::test_persist_claim PASSED          [ 38%]
+tests/unit/test_duckdb_storage_backend_extended.py::TestDuckDBStorageBackendExtended::test_persist_claim_minimal PASSED  [ 38%]
+tests/unit/test_duckdb_storage_backend_extended.py::TestDuckDBStorageBackendExtended::test_persist_claim_error PASSED    [ 38%]
+tests/unit/test_duckdb_storage_backend_extended.py::TestDuckDBStorageBackendExtended::test_vector_search PASSED          [ 38%]
+tests/unit/test_duckdb_storage_backend_extended.py::TestDuckDBStorageBackendExtended::test_vector_search_vss_not_available PASSED [ 38%]
+tests/unit/test_duckdb_storage_backend_extended.py::TestDuckDBStorageBackendExtended::test_vector_search_error PASSED    [ 38%]
+tests/unit/test_duckdb_storage_backend_extended.py::TestDuckDBStorageBackendExtended::test_get_connection PASSED         [ 38%]
+tests/unit/test_duckdb_storage_backend_extended.py::TestDuckDBStorageBackendExtended::test_get_connection_not_initialized PASSED [ 38%]
+tests/unit/test_duckdb_storage_backend_extended.py::TestDuckDBStorageBackendExtended::test_update_claim_full_replace PASSED [ 38%]
+tests/unit/test_duckdb_storage_backend_extended.py::TestDuckDBStorageBackendExtended::test_update_claim_partial PASSED   [ 38%]
+tests/unit/test_error_recovery.py::test_retry_with_backoff_succeeds_on_first_try PASSED                                  [ 38%]
+tests/unit/test_error_recovery.py::test_retry_with_backoff_retries_until_success PASSED                                  [ 39%]
+tests/unit/test_error_recovery.py::test_retry_with_backoff_raises_after_max_retries PASSED                               [ 39%]
+tests/unit/test_error_utils_additional.py::test_error_info_to_dict_and_str PASSED                                        [ 39%]
+tests/unit/test_error_utils_additional.py::test_formatters PASSED                                                        [ 39%]
+tests/unit/test_error_utils_additional.py::test_timeout_sets_warning PASSED                                              [ 39%]
+tests/unit/test_error_utils_additional.py::test_redacted_context_preserved PASSED                                        [ 39%]
+tests/unit/test_error_utils_additional.py::test_get_error_info[exc0-Check your configuration file] PASSED                [ 39%]
+tests/unit/test_error_utils_additional.py::test_get_error_info[exc1-API key] PASSED                                      [ 39%]
+tests/unit/test_error_utils_additional.py::test_get_error_info[exc2-5] PASSED                                            [ 39%]
+tests/unit/test_errors.py::test_error_hierarchy PASSED                                                                   [ 39%]
+tests/unit/test_errors.py::test_error_messages PASSED                                                                    [ 39%]
+tests/unit/test_errors.py::test_error_with_cause PASSED                                                                  [ 40%]
+tests/unit/test_errors.py::test_timeout_error PASSED                                                                     [ 40%]
+tests/unit/test_errors.py::test_not_found_error PASSED                                                                   [ 40%]
+tests/unit/test_eviction.py::test_ram_eviction_skips_without_metrics PASSED                                              [ 40%]
+tests/unit/test_eviction.py::test_ram_eviction PASSED                                                                    [ 40%]
+tests/unit/test_eviction.py::test_score_eviction PASSED                                                                  [ 40%]
+tests/unit/test_eviction.py::test_lru_eviction_order PASSED                                                              [ 40%]
+tests/unit/test_eviction.py::test_lru_eviction_sequence PASSED                                                           [ 40%]
+tests/unit/test_eviction.py::test_lru_eviction_with_vss_two_passes PASSED                                                [ 40%]
+tests/unit/test_eviction.py::test_lru_eviction_with_vss_fallback_preserves_survivors PASSED                              [ 40%]
+tests/unit/test_eviction.py::test_lru_eviction_respects_minimum_survivors PASSED                                         [ 40%]
+tests/unit/test_eviction.py::test_deterministic_override_clamped_to_minimum PASSED                                       [ 41%]
+tests/unit/test_eviction.py::test_initialize_storage_in_memory PASSED                                                    [ 41%]
+tests/unit/test_eviction.py::test_initialize_storage_file_path PASSED                                                    [ 41%]
+tests/unit/test_examples_package.py::test_sample_configuration PASSED                                                    [ 41%]
+tests/unit/test_extras_markers.py::test_nlp_marker PASSED                                                                [ 41%]
+tests/unit/test_extras_markers.py::test_ui_marker PASSED                                                                 [ 41%]
+tests/unit/test_extras_markers.py::test_vss_marker PASSED                                                                [ 41%]
+tests/unit/test_extras_markers.py::test_git_marker PASSED                                                                [ 41%]
+tests/unit/test_extras_markers.py::test_distributed_marker PASSED                                                        [ 41%]
+tests/unit/test_extras_markers.py::test_analysis_marker PASSED                                                           [ 41%]
+tests/unit/test_extras_markers.py::test_llm_marker PASSED                                                                [ 41%]
+tests/unit/test_extras_markers.py::test_parsers_marker PASSED                                                            [ 42%]
+tests/unit/test_extras_markers.py::test_gpu_marker PASSED                                                                [ 42%]
+tests/unit/test_failure_paths.py::test_prompt_registry_unknown PASSED                                                    [ 42%]
+tests/unit/test_failure_paths.py::test_prompt_render_missing_variable PASSED                                             [ 42%]
+tests/unit/test_failure_paths.py::test_check_agent_can_execute_false PASSED                                              [ 42%]
+tests/unit/test_failure_paths.py::test_external_lookup_unknown_backend PASSED                                            [ 42%]
+tests/unit/test_failure_paths.py::test_vector_search_vss_unavailable PASSED                                              [ 42%]
+tests/unit/test_failure_paths.py::test_query_endpoint_validation_error PASSED                                            [ 42%]
+tests/unit/test_failure_scenarios.py::test_external_lookup_network_failure PASSED                                        [ 42%]
+tests/unit/test_failure_scenarios.py::test_external_lookup_unknown_backend PASSED                                        [ 42%]
+tests/unit/test_failure_scenarios.py::test_external_lookup_fallback PASSED                                               [ 42%]
+tests/unit/test_failure_scenarios.py::test_get_message_broker_invalid PASSED                                             [ 43%]
+tests/unit/test_failure_scenarios.py::test_redis_broker_init_failure PASSED                                              [ 43%]
+tests/unit/test_formattemplate_property.py::test_formattemplate_render PASSED                                            [ 43%]
+tests/unit/test_git_repo_stub.py::test_repo_init_and_commit PASSED                                                       [ 43%]
+tests/unit/test_gpu_bertopic_import.py::test_try_import_bertopic_missing PASSED                                          [ 43%]
+tests/unit/test_heuristic_properties.py::test_weighted_score_normalization PASSED                                        [ 43%]
+tests/unit/test_heuristic_properties.py::test_token_budget_monotonicity PASSED                                           [ 43%]
+tests/unit/test_heuristic_properties.py::test_token_budget_monotonicity_deterministic PASSED                             [ 43%]
+tests/unit/test_heuristic_properties.py::test_token_budget_zero_usage_regression PASSED                                  [ 43%]
+tests/unit/test_http_session.py::test_http_session_lifecycle PASSED                                                      [ 43%]
+tests/unit/test_hybridmethod_guard.py::test_hybridmethod_requires_get_instance PASSED                                    [ 44%]
+tests/unit/test_hybridmethod_guard.py::test_hybridmethod_class_and_instance_calls PASSED                                 [ 44%]
+tests/unit/test_incremental_updates.py::test_refresh_vector_index_calls_backend PASSED                                   [ 44%]
+tests/unit/test_incremental_updates.py::test_persist_claim_triggers_index_refresh PASSED                                 [ 44%]
+tests/unit/test_incremental_updates.py::test_update_rdf_claim_wrapper PASSED                                             [ 44%]
+tests/unit/test_interfaces.py::test_query_state_complies PASSED                                                          [ 44%]
+tests/unit/test_interfaces.py::test_custom_state_complies PASSED                                                         [ 44%]
+tests/unit/test_interfaces.py::test_incomplete_state_rejected PASSED                                                     [ 44%]
+tests/unit/test_kg_reasoning.py::test_run_ontology_reasoner_owlrl PASSED                                                 [ 44%]
+tests/unit/test_kg_reasoning.py::test_register_reasoner_adds_plugin PASSED                                               [ 44%]
+tests/unit/test_kg_reasoning.py::test_run_ontology_reasoner_external PASSED                                              [ 44%]
+tests/unit/test_kg_reasoning.py::test_run_ontology_reasoner_invokes_plugin_once PASSED                                   [ 45%]
+tests/unit/test_kg_reasoning.py::test_run_ontology_reasoner_preserves_triple_count PASSED                                [ 45%]
+tests/unit/test_kg_reasoning.py::test_run_ontology_reasoner_external_error PASSED                                        [ 45%]
+tests/unit/test_kg_reasoning.py::test_query_with_reasoning PASSED                                                        [ 45%]
+tests/unit/test_kg_reasoning.py::test_run_ontology_reasoner_without_owlrl PASSED                                         [ 45%]
+tests/unit/test_kg_reasoning.py::test_run_ontology_reasoner_reload_without_owlrl PASSED                                  [ 45%]
+tests/unit/test_kg_reasoning.py::test_run_ontology_reasoner_timeout PASSED                                               [ 45%]
+tests/unit/test_kg_reasoning.py::test_run_ontology_reasoner_keyboard_interrupt PASSED                                    [ 45%]
+tests/unit/test_kg_reasoning.py::test_run_ontology_reasoner_skips_when_limit_exceeded PASSED                             [ 45%]
+tests/unit/test_kg_reasoning.py::test_run_ontology_reasoner_unknown PASSED                                               [ 45%]
+tests/unit/test_kuzu_polars.py::test_kuzu_backend_roundtrip PASSED                                                       [ 45%]
+tests/unit/test_kuzu_polars.py::test_metrics_dataframe PASSED                                                            [ 46%]
+tests/unit/test_llm_adapter.py::test_dummy_adapter_generation PASSED                                                     [ 46%]
+tests/unit/test_llm_adapter.py::test_lmstudio_adapter PASSED                                                             [ 46%]
+tests/unit/test_llm_adapter.py::test_openai_adapter PASSED                                                               [ 46%]
+tests/unit/test_llm_adapter.py::test_compress_prompt_falls_back_when_summary_exceeds_budget PASSED                       [ 46%]
+tests/unit/test_llm_adapter_validate_model.py::test_validate_model_invalid PASSED                                        [ 46%]
+tests/unit/test_llm_adapters.py::test_validate_model_defaults_to_available_first_model PASSED                            [ 46%]
+tests/unit/test_llm_adapters.py::test_validate_model_uses_generic_default_when_no_models PASSED                          [ 46%]
+tests/unit/test_llm_adapters.py::test_validate_model_rejects_invalid_models PASSED                                       [ 46%]
+tests/unit/test_llm_capabilities.py::TestModelCapabilities::test_model_capabilities_creation PASSED                      [ 46%]
+tests/unit/test_llm_capabilities.py::TestModelCapabilities::test_to_dict_method PASSED                                   [ 46%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_singleton_pattern PASSED                                 [ 47%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_probe_provider_caching PASSED                            [ 47%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_probe_provider_unknown PASSED                            [ 47%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_probe_all_providers PASSED                               [ 47%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_get_model_capabilities_with_provider PASSED              [ 47%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_get_model_capabilities_without_provider PASSED           [ 47%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_get_model_capabilities_not_found PASSED                  [ 47%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_get_model_capabilities_search_across_providers PASSED    [ 47%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_probe_openrouter_with_api PASSED                         [ 47%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_probe_openrouter_without_api_key PASSED                  [ 47%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_probe_openrouter_with_api_error PASSED                   [ 47%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_probe_openai PASSED                                      [ 48%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_probe_lmstudio PASSED                                    [ 48%]
+tests/unit/test_llm_capabilities.py::TestCapabilityProber::test_probe_dummy PASSED                                       [ 48%]
+tests/unit/test_llm_capabilities.py::TestHelperFunctions::test_get_capability_prober PASSED                              [ 48%]
+tests/unit/test_llm_capabilities.py::TestHelperFunctions::test_probe_all_providers_helper PASSED                         [ 48%]
+tests/unit/test_llm_capabilities.py::TestHelperFunctions::test_get_model_capabilities_helper PASSED                      [ 48%]
+tests/unit/test_llm_docstrings.py::test_module_docstrings PASSED                                                         [ 48%]
+tests/unit/test_llm_docstrings.py::test_class_docstrings PASSED                                                          [ 48%]
+tests/unit/test_llm_docstrings.py::test_function_docstrings PASSED                                                       [ 48%]
+tests/unit/test_llm_pool.py::test_get_session_reuses_existing_instance PASSED                                            [ 48%]
+tests/unit/test_local_git_backend.py::test_local_git_backend_searches_repo PASSED                                        [ 48%]
+tests/unit/test_logging_shutdown.py::test_stop_watching_after_logging_shutdown PASSED                                    [ 49%]
+tests/unit/test_logging_utils.py::test_get_logger PASSED                                                                 [ 49%]
+tests/unit/test_logging_utils.py::test_structured_output_and_redaction PASSED                                            [ 49%]
+tests/unit/test_logging_utils.py::test_intercept_handler_handles_closed_stream PASSED                                    [ 49%]
+tests/unit/test_logging_utils_env.py::test_configure_logging_from_env PASSED                                             [ 49%]
+tests/unit/test_logging_utils_env.py::test_configure_logging_from_env_invalid PASSED                                     [ 49%]
+tests/unit/test_main_backup_commands.py::test_backup_create_command PASSED                                               [ 49%]
+tests/unit/test_main_backup_commands.py::test_backup_list_command PASSED                                                 [ 49%]
+tests/unit/test_main_backup_commands.py::test_backup_restore_command PASSED                                              [ 49%]
+tests/unit/test_main_backup_commands.py::test_backup_create_invalid_dir PASSED                                           [ 49%]
+tests/unit/test_main_backup_commands.py::test_backup_restore_invalid_path PASSED                                         [ 50%]
+tests/unit/test_main_backup_commands.py::test_backup_recover_command PASSED                                              [ 50%]
+tests/unit/test_main_backup_commands.py::test_backup_create_error PASSED                                                 [ 50%]
+tests/unit/test_main_backup_commands.py::test_backup_create_missing_tables PASSED                                        [ 50%]
+tests/unit/test_main_backup_commands.py::test_backup_list_error PASSED                                                   [ 50%]
+tests/unit/test_main_backup_commands.py::test_backup_restore_error PASSED                                                [ 50%]
+tests/unit/test_main_backup_commands.py::test_backup_schedule_error PASSED                                               [ 50%]
+tests/unit/test_main_backup_commands.py::test_backup_recover_error PASSED                                                [ 50%]
+tests/unit/test_main_cli.py::test_search_default_output_tty PASSED                                                       [ 50%]
+tests/unit/test_main_cli.py::test_search_default_output_json PASSED                                                      [ 50%]
+tests/unit/test_main_cli.py::test_search_reasoning_mode_option[direct] PASSED                                            [ 50%]
+tests/unit/test_main_cli.py::test_search_reasoning_mode_option[dialectical] PASSED                                       [ 51%]
+tests/unit/test_main_cli.py::test_search_primus_start_option PASSED                                                      [ 51%]
+tests/unit/test_main_cli.py::test_config_command PASSED                                                                  [ 51%]
+tests/unit/test_main_cli.py::test_serve_command PASSED                                                                   [ 51%]
+tests/unit/test_main_config_commands.py::test_config_init_command PASSED                                                 [ 51%]
+tests/unit/test_main_config_commands.py::test_config_init_command_force PASSED                                           [ 51%]
+tests/unit/test_main_config_commands.py::test_config_validate_command_valid PASSED                                       [ 51%]
+tests/unit/test_main_config_commands.py::test_config_validate_command_invalid PASSED                                     [ 51%]
+tests/unit/test_main_first_run_detection.py::test_first_run_detection_respects_search_paths PASSED                       [ 51%]
+tests/unit/test_main_module.py::TestMainModule::test_main_module_direct_execution PASSED                                 [ 51%]
+tests/unit/test_main_monitor_commands.py::test_monitor_command PASSED                                                    [ 51%]
+tests/unit/test_main_monitor_commands.py::test_serve_a2a_command PASSED                                                  [ 52%]
+tests/unit/test_main_monitor_commands.py::test_serve_a2a_command_keyboard_interrupt PASSED                               [ 52%]
+tests/unit/test_main_monitor_commands.py::test_monitor_serve_command PASSED                                              [ 52%]
+tests/unit/test_main_monitor_commands.py::test_monitor_serve_command_keyboard_interrupt PASSED                           [ 52%]
+tests/unit/test_mcp_interface.py::test_client_server_roundtrip PASSED                                                    [ 52%]
+tests/unit/test_mcp_interface.py::test_client_server_failure PASSED                                                      [ 52%]
+tests/unit/test_metrics.py::test_metrics_collection_and_endpoint PASSED                                                  [ 52%]
+tests/unit/test_metrics.py::test_reset_metrics_clears_counters PASSED                                                    [ 52%]
+tests/unit/test_metrics_counters.py::test_reset_metrics PASSED                                                           [ 52%]
+tests/unit/test_metrics_counters.py::test_temporary_metrics_restores_state PASSED                                        [ 52%]
+tests/unit/test_metrics_counters.py::test_get_system_usage_returns_floats PASSED                                         [ 52%]
+tests/unit/test_metrics_extra.py::test_cycle_and_agent_metrics PASSED                                                    [ 53%]
+tests/unit/test_metrics_extra.py::test_resource_tracking PASSED                                                          [ 53%]
+tests/unit/test_metrics_extra2.py::test_get_system_usage_success PASSED                                                  [ 53%]
+tests/unit/test_metrics_extra2.py::test_get_system_usage_failure PASSED                                                  [ 53%]
+tests/unit/test_metrics_helpers.py::test_mean_last_nonzero PASSED                                                        [ 53%]
+tests/unit/test_metrics_helpers.py::test_temporary_metrics_restores_state PASSED                                         [ 53%]
+tests/unit/test_metrics_helpers.py::test_record_query_and_tokens PASSED                                                  [ 53%]
+tests/unit/test_metrics_heuristics.py::test_compress_prompt_if_needed PASSED                                             [ 53%]
+tests/unit/test_metrics_heuristics.py::test_suggest_token_budget PASSED                                                  [ 53%]
+tests/unit/test_metrics_misc.py::test_metrics_reset_and_temporary PASSED                                                 [ 53%]
+tests/unit/test_metrics_misc.py::test_get_system_usage PASSED                                                            [ 53%]
+tests/unit/test_metrics_misc.py::test_token_helpers PASSED                                                               [ 54%]
+tests/unit/test_metrics_summary.py::test_metrics_summary[records0] PASSED                                                [ 54%]
+tests/unit/test_metrics_summary.py::test_metrics_summary[records1] PASSED                                                [ 54%]
+tests/unit/test_metrics_token_budget_extra.py::test_compress_prompt_threshold PASSED                                     [ 54%]
+tests/unit/test_metrics_token_budget_extra.py::test_suggest_token_budget_shrink PASSED                                   [ 54%]
+tests/unit/test_metrics_token_budget_spec.py::test_compression_threshold_reduces_with_history PASSED                     [ 54%]
+tests/unit/test_metrics_token_budget_spec.py::test_token_budget_expands_then_shrinks PASSED                              [ 54%]
+tests/unit/test_metrics_token_budget_spec.py::test_budget_shrinks_to_one_after_zero_usage PASSED                         [ 54%]
+tests/unit/test_metrics_token_budget_spec.py::test_budget_converges_for_constant_usage PASSED                            [ 54%]
+tests/unit/test_metrics_token_budget_spec.py::test_budget_rounds_half_up PASSED                                          [ 54%]
+tests/unit/test_metrics_token_budget_spec.py::test_budget_respects_bounds_during_spike PASSED                            [ 54%]
+tests/unit/test_metrics_token_budget_spec.py::test_convergence_bound_holds PASSED                                        [ 55%]
+tests/unit/test_models_docstrings.py::test_models_spec_exists PASSED                                                     [ 55%]
+tests/unit/test_models_docstrings.py::test_module_docstrings PASSED                                                      [ 55%]
+tests/unit/test_models_docstrings.py::test_module_docstring_mentions_spec PASSED                                         [ 55%]
+tests/unit/test_models_docstrings.py::test_class_docstrings PASSED                                                       [ 55%]
+tests/unit/test_monitor_cli.py::test_monitor_prompts_and_passes_callbacks PASSED                                         [ 55%]
+tests/unit/test_monitor_cli.py::test_monitor_metrics PASSED                                                              [ 55%]
+tests/unit/test_monitor_cli.py::test_monitor_metrics_default_counters PASSED                                             [ 55%]
+tests/unit/test_monitor_cli.py::test_metrics_skips_storage PASSED                                                        [ 55%]
+tests/unit/test_monitor_cli.py::test_storage_teardown_handles_missing_config PASSED                                      [ 55%]
+tests/unit/test_monitor_metrics_init.py::test_monitor_cli_initializes_metrics PASSED                                     [ 55%]
+tests/unit/test_more_coverage.py::test_log_sources PASSED                                                                [ 56%]
+tests/unit/test_more_coverage.py::test_log_sources_missing PASSED                                                        [ 56%]
+tests/unit/test_more_coverage.py::test_persist_claims PASSED                                                             [ 56%]
+tests/unit/test_more_coverage.py::test_persist_claims_invalid PASSED                                                     [ 56%]
+tests/unit/test_more_coverage.py::test_ndcg_perfect PASSED                                                               [ 56%]
+tests/unit/test_more_coverage.py::test_http_session_cycle PASSED                                                         [ 56%]
+tests/unit/test_more_coverage.py::test_connection_context_manager_pool PASSED                                            [ 56%]
+tests/unit/test_more_coverage.py::test_connection_context_manager_single PASSED                                          [ 56%]
+tests/unit/test_more_coverage.py::test_formattemplate_metrics PASSED                                                     [ 56%]
+tests/unit/test_more_coverage.py::test_normalize_audit_payload_includes_expected_fields PASSED                           [ 56%]
+tests/unit/test_more_coverage.py::test_build_audit_telemetry_summarises_audits PASSED                                    [ 57%]
+tests/unit/test_new_modules.py::test_output_formatter_initializes_once PASSED                                            [ 57%]
+tests/unit/test_new_modules.py::test_streamlit_log_handler_appends_logs PASSED                                           [ 57%]
+tests/unit/test_new_modules.py::test_backup_manager_singleton PASSED                                                     [ 57%]
+tests/unit/test_node_health_monitor_property.py::test_check_once_updates_gauges PASSED                                   [ 57%]
+tests/unit/test_numpy_stub.py::test_numpy_stub_manual_install PASSED                                                     [ 57%]
+tests/unit/test_ontology_reasoner_props.py::test_reasoner_reaches_closure PASSED                                         [ 57%]
+tests/unit/test_optimize_weights_unit.py::test_optimize_weights_improves_score PASSED                                    [ 57%]
+tests/unit/test_optional_extras.py::test_ui_extra PASSED                                                                 [ 57%]
+tests/unit/test_optional_extras.py::test_vss_extra PASSED                                                                [ 57%]
+tests/unit/test_optional_extras.py::test_git_extra PASSED                                                                [ 57%]
+tests/unit/test_optional_extras.py::test_distributed_extra PASSED                                                        [ 58%]
+tests/unit/test_optional_extras.py::test_analysis_extra PASSED                                                           [ 58%]
+tests/unit/test_optional_extras.py::test_nlp_extra SKIPPED (nlp extra not installed)                                     [ 58%]
+tests/unit/test_optional_extras.py::test_llm_extra PASSED                                                                [ 58%]
+tests/unit/test_optional_extras.py::test_parsers_extra PASSED                                                            [ 58%]
+tests/unit/test_orchestration_utils_delegation.py::test_get_agent_delegates PASSED                                       [ 58%]
+tests/unit/test_orchestration_utils_delegation.py::test_capture_token_usage_delegates PASSED                             [ 58%]
+tests/unit/test_orchestration_utils_module.py::test_get_memory_usage_psutil PASSED                                       [ 58%]
+tests/unit/test_orchestration_utils_module.py::test_get_memory_usage_fallback PASSED                                     [ 58%]
+tests/unit/test_orchestration_utils_module.py::test_calculate_result_confidence PASSED                                   [ 58%]
+tests/unit/test_orchestration_utils_module.py::test_calculate_result_confidence_penalties PASSED                         [ 58%]
+tests/unit/test_orchestrator_breaker_state_transitions.py::test_breaker_state_sequence PASSED                            [ 59%]
+tests/unit/test_orchestrator_budget_and_errors.py::test_adaptive_budget_scales_with_loops PASSED                         [ 59%]
+tests/unit/test_orchestrator_budget_and_errors.py::test_error_categorization[exc0-transient] PASSED                      [ 59%]
+tests/unit/test_orchestrator_budget_and_errors.py::test_error_categorization[exc1-recoverable] PASSED                    [ 59%]
+tests/unit/test_orchestrator_budget_and_errors.py::test_error_categorization[exc2-critical] PASSED                       [ 59%]
+tests/unit/test_orchestrator_cb_manager.py::test_circuit_breaker_state_is_instance_isolated PASSED                       [ 59%]
+tests/unit/test_orchestrator_circuit_breaker_property.py::test_circuit_breaker_opens_and_recovers PASSED                 [ 59%]
+tests/unit/test_orchestrator_edgecases.py::test_get_agent_not_found PASSED                                               [ 59%]
+tests/unit/test_orchestrator_edgecases.py::test_parse_config_direct_mode PASSED                                          [ 59%]
+tests/unit/test_orchestrator_edgecases.py::test_parse_config_direct_mode_agent_groups PASSED                             [ 59%]
+tests/unit/test_orchestrator_errors.py::test_execute_agent_records_errors_and_circuit_breaker PASSED                     [ 59%]
+tests/unit/test_orchestrator_errors.py::test_retry_with_backoff_on_transient_error PASSED                                [ 60%]
+tests/unit/test_orchestrator_errors.py::test_orchestrator_raises_after_error PASSED                                      [ 60%]
+tests/unit/test_orchestrator_errors.py::test_invalid_agent_name_raises PASSED                                            [ 60%]
+tests/unit/test_orchestrator_errors.py::test_callback_error_propagates PASSED                                            [ 60%]
+tests/unit/test_orchestrator_errors.py::test_agent_error_is_wrapped[ValueError-specific error] PASSED                    [ 60%]
+tests/unit/test_orchestrator_errors.py::test_agent_error_is_wrapped[RuntimeError-runtime error] PASSED                   [ 60%]
+tests/unit/test_orchestrator_errors.py::test_parallel_query_error_claims PASSED                                          [ 60%]
+tests/unit/test_orchestrator_errors.py::test_parallel_query_timeout_claims PASSED                                        [ 60%]
+tests/unit/test_orchestrator_helpers.py::test_get_agent_success PASSED                                                   [ 60%]
+tests/unit/test_orchestrator_helpers.py::test_get_agent_not_found PASSED                                                 [ 60%]
+tests/unit/test_orchestrator_helpers.py::test_call_agent_start_callback PASSED                                           [ 60%]
+tests/unit/test_orchestrator_helpers.py::test_persist_claims_logs_storage_error PASSED                                   [ 61%]
+tests/unit/test_orchestrator_memory.py::test_get_memory_usage_psutil PASSED                                              [ 61%]
+tests/unit/test_orchestrator_memory.py::test_get_memory_usage_fallback PASSED                                            [ 61%]
+tests/unit/test_orchestrator_messages.py::test_agents_exchange_messages PASSED                                           [ 61%]
+tests/unit/test_orchestrator_order.py::test_custom_agents_order PASSED                                                   [ 61%]
+tests/unit/test_orchestrator_order.py::test_async_custom_agents_concurrent PASSED                                        [ 61%]
+tests/unit/test_orchestrator_order.py::test_parse_config_direct_mode_groups PASSED                                       [ 61%]
+tests/unit/test_orchestrator_parallel_deterministic.py::test_parallel_merging_is_deterministic FAILED                    [ 61%]
+
+=========================================================== FAILURES ===========================================================
+____________________________________________ test_parallel_merging_is_deterministic ____________________________________________
+
+    @given(
+>       st.lists(
+                  
+            st.lists(st.text(min_size=1, max_size=3), min_size=1, max_size=2),
+            min_size=1,
+            max_size=3,
+        )
+    )
+
+/workspace/autoresearch/tests/unit/test_orchestrator_parallel_deterministic.py:26: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+agent_groups = [['0']]
+
+    @given(
+        st.lists(
+            st.lists(st.text(min_size=1, max_size=3), min_size=1, max_size=2),
+            min_size=1,
+            max_size=3,
+        )
+    )
+    @pytest.mark.reasoning_modes
+    def test_parallel_merging_is_deterministic(agent_groups):
+        """Each group contributes exactly one claim regardless of completion order."""
+    
+        cfg = ConfigModel(agents=[], loops=1)
+    
+        def run_with_order(reverse: bool):
+            def fake_as_completed(fs, timeout=None):
+                items = list(fs)
+                if reverse:
+                    items.reverse()
+                for fut in items:
+                    yield fut
+    
+            with patch("concurrent.futures.as_completed", fake_as_completed):
+                with patch.object(Orchestrator, "run_query", DummyOrchestrator().run_query):
+                    with patch(
+                        "autoresearch.orchestration.parallel.AgentFactory.get",
+                        return_value=DummySynthesizer(),
+                    ):
+                        resp = execute_parallel_query("q", cfg, agent_groups)
+            return resp
+    
+        resp1 = run_with_order(False)
+        resp2 = run_with_order(True)
+    
+        expected = {",".join(g) for g in agent_groups}
+>       assert set(resp1.reasoning) == expected
+               ^^^^^^^^^^^^^^^^^^^^
+E       TypeError: unhashable type: 'dict'
+E       Falsifying example: test_parallel_merging_is_deterministic(
+E           agent_groups=[['0']],  # or any other generated value
+E       )
+
+/workspace/autoresearch/tests/unit/test_orchestrator_parallel_deterministic.py:59: TypeError
+------------------------------------------------------ Captured log call -------------------------------------------------------
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0'] completed successfully", "timestamp": "2025-10-04T18:40:49.026141Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003081083297729492, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.028069Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0'] completed successfully", "timestamp": "2025-10-04T18:40:49.031441Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0014235973358154297, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.032066Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.097913Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x94\\U0007a984\u00b0', '\\U000a0abb\u00ed\u00e9'] completed successfully", "timestamp": "2025-10-04T18:40:49.101311Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.101955Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.01443624496459961, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:49.103941Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.109821Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x94\\U0007a984\u00b0', '\\U000a0abb\u00ed\u00e9'] completed successfully", "timestamp": "2025-10-04T18:40:49.112140Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.112708Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.007235288619995117, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:49.114321Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.131619Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.132424Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.133033Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.010428905487060547, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.138960Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.144171Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.144794Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.145381Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0043408870697021484, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.146618Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.160462Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.161294Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.164686Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.007742643356323242, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.166148Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.171476Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.176603Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.177192Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.013306856155395508, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.182386Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.210115Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.211094Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.211690Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.007033348083496094, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.213003Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.217703Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.218318Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.218898Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00446009635925293, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.220072Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.234957Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.235734Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' ', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.236280Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004868268966674805, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.237595Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' ', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.242975Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.243670Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.244241Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005263805389404297, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:49.246083Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.261601Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.262402Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' ', ' '] completed successfully", "timestamp": "2025-10-04T18:40:49.262997Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0056705474853515625, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.264976Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' ', ' '] completed successfully", "timestamp": "2025-10-04T18:40:49.270738Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.272132Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.272676Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00642848014831543, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.273939Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.288776Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.289587Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@', ' '] completed successfully", "timestamp": "2025-10-04T18:40:49.290137Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00652003288269043, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.292362Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@', ' '] completed successfully", "timestamp": "2025-10-04T18:40:49.303994Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0_@'] completed successfully", "timestamp": "2025-10-04T18:40:49.306246Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' '] completed successfully", "timestamp": "2025-10-04T18:40:49.306831Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.012147903442382812, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.308268Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['+', '\\x03'] completed successfully", "timestamp": "2025-10-04T18:40:49.320493Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002418041229248047, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.321868Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['+', '\\x03'] completed successfully", "timestamp": "2025-10-04T18:40:49.325045Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0018630027770996094, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.325998Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['+'] completed successfully", "timestamp": "2025-10-04T18:40:49.339634Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00299835205078125, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.341343Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['+'] completed successfully", "timestamp": "2025-10-04T18:40:49.346285Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0031964778900146484, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.348268Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0'] completed successfully", "timestamp": "2025-10-04T18:40:49.364753Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006021261215209961, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.366148Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0'] completed successfully", "timestamp": "2025-10-04T18:40:49.369802Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0024840831756591797, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.370966Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0005a7b7A\u00be'] completed successfully", "timestamp": "2025-10-04T18:40:49.396477Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000b97f1'] completed successfully", "timestamp": "2025-10-04T18:40:49.397341Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00066ac0\u00d7\u00ed'] completed successfully", "timestamp": "2025-10-04T18:40:49.397943Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005405902862548828, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.399331Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00066ac0\u00d7\u00ed'] completed successfully", "timestamp": "2025-10-04T18:40:49.404940Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000b97f1'] completed successfully", "timestamp": "2025-10-04T18:40:49.405544Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0005a7b7A\u00be'] completed successfully", "timestamp": "2025-10-04T18:40:49.406080Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005328178405761719, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.407243Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x81\\x1b\u85e1'] completed successfully", "timestamp": "2025-10-04T18:40:49.424014Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006125211715698242, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.425307Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x81\\x1b\u85e1'] completed successfully", "timestamp": "2025-10-04T18:40:49.428590Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0020232200622558594, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.429665Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['G'] completed successfully", "timestamp": "2025-10-04T18:40:49.446519Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0065419673919677734, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.447873Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['G'] completed successfully", "timestamp": "2025-10-04T18:40:49.455151Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.007912397384643555, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.458777Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00b0Q', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.472855Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e7', '\\U000a18bd'] completed successfully", "timestamp": "2025-10-04T18:40:49.474415Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004307270050048828, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.475837Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e7', '\\U000a18bd'] completed successfully", "timestamp": "2025-10-04T18:40:49.480023Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00b0Q', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.480689Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0033609867095947266, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.481825Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c2'] completed successfully", "timestamp": "2025-10-04T18:40:49.496409Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d7', '\\x89\u00ea'] completed successfully", "timestamp": "2025-10-04T18:40:49.497149Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000ddf7b'] completed successfully", "timestamp": "2025-10-04T18:40:49.497741Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005246162414550781, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.499041Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000ddf7b'] completed successfully", "timestamp": "2025-10-04T18:40:49.504480Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d7', '\\x89\u00ea'] completed successfully", "timestamp": "2025-10-04T18:40:49.507165Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c2'] completed successfully", "timestamp": "2025-10-04T18:40:49.507700Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00690913200378418, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:49.508866Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00ba\\U0010daa7\\U000b8755', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.530138Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000b3cf4\u00dc\\U000544bb'] completed successfully", "timestamp": "2025-10-04T18:40:49.531223Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f4,\\U0002a6eb', '\\U00046dac'] completed successfully", "timestamp": "2025-10-04T18:40:49.531781Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.011229276657104492, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.533166Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f4,\\U0002a6eb', '\\U00046dac'] completed successfully", "timestamp": "2025-10-04T18:40:49.539674Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000b3cf4\u00dc\\U000544bb'] completed successfully", "timestamp": "2025-10-04T18:40:49.540286Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00ba\\U0010daa7\\U000b8755', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.540827Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006543874740600586, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.542318Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x16\u00e0\\U000838b6'] completed successfully", "timestamp": "2025-10-04T18:40:49.560542Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00a6'] completed successfully", "timestamp": "2025-10-04T18:40:49.561434Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['@', 'Q\\x95\u00ac'] completed successfully", "timestamp": "2025-10-04T18:40:49.562039Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.009037494659423828, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.564142Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['@', 'Q\\x95\u00ac'] completed successfully", "timestamp": "2025-10-04T18:40:49.569219Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00a6'] completed successfully", "timestamp": "2025-10-04T18:40:49.569837Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x16\u00e0\\U000838b6'] completed successfully", "timestamp": "2025-10-04T18:40:49.570395Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004800319671630859, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.571653Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['Q\u00a2', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.584113Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0021126270294189453, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.585323Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['Q\u00a2', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.588630Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0021021366119384766, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.589721Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['OK', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.612754Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['*\\x08\\x11'] completed successfully", "timestamp": "2025-10-04T18:40:49.613576Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x18\u00b5\\x99', 'N\u00d2\u00c6'] completed successfully", "timestamp": "2025-10-04T18:40:49.614255Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005820751190185547, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.615557Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x18\u00b5\\x99', 'N\u00d2\u00c6'] completed successfully", "timestamp": "2025-10-04T18:40:49.620068Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['*\\x08\\x11'] completed successfully", "timestamp": "2025-10-04T18:40:49.620681Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['OK', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.621285Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004555225372314453, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:49.622840Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00069ce9x', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.649174Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000db7fa', '#\\x17\\x9b'] completed successfully", "timestamp": "2025-10-04T18:40:49.650519Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0045888423919677734, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.651718Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000db7fa', '#\\x17\\x9b'] completed successfully", "timestamp": "2025-10-04T18:40:49.656126Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00069ce9x', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.656703Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0027561187744140625, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.657676Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['N\u00fcQ'] completed successfully", "timestamp": "2025-10-04T18:40:49.669502Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0020225048065185547, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.670637Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['N\u00fcQ'] completed successfully", "timestamp": "2025-10-04T18:40:49.673648Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0018596649169921875, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.674700Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00095946\\x0c\\U0010daad'] completed successfully", "timestamp": "2025-10-04T18:40:49.686206Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0023207664489746094, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.687279Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00095946\\x0c\\U0010daad'] completed successfully", "timestamp": "2025-10-04T18:40:49.690437Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0021522045135498047, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.691598Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x88\u00e5\u00bd'] completed successfully", "timestamp": "2025-10-04T18:40:49.704772Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f4'] completed successfully", "timestamp": "2025-10-04T18:40:49.705494Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000d0223\\U0004e8d6\\x08', '\\x82'] completed successfully", "timestamp": "2025-10-04T18:40:49.706071Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004599094390869141, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.707479Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000d0223\\U0004e8d6\\x08', '\\x82'] completed successfully", "timestamp": "2025-10-04T18:40:49.711527Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f4'] completed successfully", "timestamp": "2025-10-04T18:40:49.712115Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x88\u00e5\u00bd'] completed successfully", "timestamp": "2025-10-04T18:40:49.712678Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0053119659423828125, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.715239Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['INF'] completed successfully", "timestamp": "2025-10-04T18:40:49.732498Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u9bc6#\u00ef', '\u00a8'] completed successfully", "timestamp": "2025-10-04T18:40:49.733654Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00fe\\x7f_'] completed successfully", "timestamp": "2025-10-04T18:40:49.734353Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006684780120849609, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.735821Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00fe\\x7f_'] completed successfully", "timestamp": "2025-10-04T18:40:49.740394Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u9bc6#\u00ef', '\u00a8'] completed successfully", "timestamp": "2025-10-04T18:40:49.741049Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['INF'] completed successfully", "timestamp": "2025-10-04T18:40:49.741686Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004479646682739258, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.743030Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x04\\x07+'] completed successfully", "timestamp": "2025-10-04T18:40:49.756367Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0022287368774414062, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.757495Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x04\\x07+'] completed successfully", "timestamp": "2025-10-04T18:40:49.764975Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005792856216430664, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.766738Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u62eb'] completed successfully", "timestamp": "2025-10-04T18:40:49.784398Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x88\\x80', '!=u'] completed successfully", "timestamp": "2025-10-04T18:40:49.785194Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000d0e11'] completed successfully", "timestamp": "2025-10-04T18:40:49.785813Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0054361820220947266, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.787439Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000d0e11'] completed successfully", "timestamp": "2025-10-04T18:40:49.791783Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x88\\x80', '!=u'] completed successfully", "timestamp": "2025-10-04T18:40:49.792413Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u62eb'] completed successfully", "timestamp": "2025-10-04T18:40:49.792947Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0042667388916015625, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.794210Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['@', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.807249Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['vN', '\\U00100de3'] completed successfully", "timestamp": "2025-10-04T18:40:49.808810Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0037546157836914062, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.809938Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['vN', '\\U00100de3'] completed successfully", "timestamp": "2025-10-04T18:40:49.813477Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['@', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.814164Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0029518604278564453, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.815193Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['9N\\x19'] completed successfully", "timestamp": "2025-10-04T18:40:49.827588Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002852201461791992, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.829179Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['9N\\x19'] completed successfully", "timestamp": "2025-10-04T18:40:49.832600Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002128124237060547, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.833608Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\n'] completed successfully", "timestamp": "2025-10-04T18:40:49.849770Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x82\\U000eb429'] completed successfully", "timestamp": "2025-10-04T18:40:49.850483Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['F\\U00038c12\\x0f'] completed successfully", "timestamp": "2025-10-04T18:40:49.851077Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0074770450592041016, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.852642Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['F\\U00038c12\\x0f'] completed successfully", "timestamp": "2025-10-04T18:40:49.856929Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x82\\U000eb429'] completed successfully", "timestamp": "2025-10-04T18:40:49.857498Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\n'] completed successfully", "timestamp": "2025-10-04T18:40:49.858090Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0040302276611328125, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.859223Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00a3'] completed successfully", "timestamp": "2025-10-04T18:40:49.871624Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0026824474334716797, "memory_delta": 0.125, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:49.873162Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00a3'] completed successfully", "timestamp": "2025-10-04T18:40:49.876175Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0017485618591308594, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.877169Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00a9\\x98', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.891541Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['wc'] completed successfully", "timestamp": "2025-10-04T18:40:49.892217Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00bdi1', 'run'] completed successfully", "timestamp": "2025-10-04T18:40:49.892738Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005203962326049805, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:49.894054Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00bdi1', 'run'] completed successfully", "timestamp": "2025-10-04T18:40:49.898246Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['wc'] completed successfully", "timestamp": "2025-10-04T18:40:49.898885Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00a9\\x98', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.899397Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004076242446899414, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.900448Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00b0=\\U000410ab', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.912756Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0029108524322509766, "memory_delta": 0.25, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:49.914457Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00b0=\\U000410ab', '0'] completed successfully", "timestamp": "2025-10-04T18:40:49.918040Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0020132064819335938, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.919108Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x05'] completed successfully", "timestamp": "2025-10-04T18:40:49.931700Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000dce3e'] completed successfully", "timestamp": "2025-10-04T18:40:49.932871Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003813028335571289, "memory_delta": 0.375, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.38MB", "timestamp": "2025-10-04T18:40:49.933963Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000dce3e'] completed successfully", "timestamp": "2025-10-04T18:40:49.937626Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x05'] completed successfully", "timestamp": "2025-10-04T18:40:49.938271Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0029320716857910156, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.939330Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000deda1\u00f1\u00cc'] completed successfully", "timestamp": "2025-10-04T18:40:49.953357Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['vq'] completed successfully", "timestamp": "2025-10-04T18:40:49.954082Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['=\\x9b', '\\x84'] completed successfully", "timestamp": "2025-10-04T18:40:49.954638Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005418300628662109, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:49.955934Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['=\\x9b', '\\x84'] completed successfully", "timestamp": "2025-10-04T18:40:49.960091Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['vq'] completed successfully", "timestamp": "2025-10-04T18:40:49.960719Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000deda1\u00f1\u00cc'] completed successfully", "timestamp": "2025-10-04T18:40:49.961296Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00736546516418457, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.965770Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00091044'] completed successfully", "timestamp": "2025-10-04T18:40:49.986365Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x9b', 'H\\x19\u00c0'] completed successfully", "timestamp": "2025-10-04T18:40:49.987122Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x99\u00cb'] completed successfully", "timestamp": "2025-10-04T18:40:49.987640Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005118131637573242, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:49.989041Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x99\u00cb'] completed successfully", "timestamp": "2025-10-04T18:40:49.994586Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x9b', 'H\\x19\u00c0'] completed successfully", "timestamp": "2025-10-04T18:40:49.995236Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00091044'] completed successfully", "timestamp": "2025-10-04T18:40:49.995779Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005334138870239258, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:49.997092Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0003cb6f\ud85d\uddd4\u00c6'] completed successfully", "timestamp": "2025-10-04T18:40:50.011227Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f8'] completed successfully", "timestamp": "2025-10-04T18:40:50.012491Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004063844680786133, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.013700Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f8'] completed successfully", "timestamp": "2025-10-04T18:40:50.017504Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0003cb6f\ud85d\uddd4\u00c6'] completed successfully", "timestamp": "2025-10-04T18:40:50.018858Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004477739334106445, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.020724Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000b5e69', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.035637Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003339529037475586, "memory_delta": 0.125, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.037241Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000b5e69', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.040521Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0019125938415527344, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.041633Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x0b'] completed successfully", "timestamp": "2025-10-04T18:40:50.058006Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f9', ' \u00f0\u00ce'] completed successfully", "timestamp": "2025-10-04T18:40:50.059507Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005571126937866211, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.060689Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f9', ' \u00f0\u00ce'] completed successfully", "timestamp": "2025-10-04T18:40:50.064944Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x0b'] completed successfully", "timestamp": "2025-10-04T18:40:50.065820Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003644704818725586, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.066957Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00cbH', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.085401Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000f272b\\x1f\\x1d', '\ud81f\udd6d\\U0009212a;'] completed successfully", "timestamp": "2025-10-04T18:40:50.086716Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x18'] completed successfully", "timestamp": "2025-10-04T18:40:50.087295Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0061187744140625, "memory_delta": 0.375, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.38MB", "timestamp": "2025-10-04T18:40:50.088702Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x18'] completed successfully", "timestamp": "2025-10-04T18:40:50.098511Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000f272b\\x1f\\x1d', '\ud81f\udd6d\\U0009212a;'] completed successfully", "timestamp": "2025-10-04T18:40:50.099246Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00cbH', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.099774Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.009811878204345703, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.101372Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0003fb95'] completed successfully", "timestamp": "2025-10-04T18:40:50.129481Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c8', '>\\U000a867c\u00ef'] completed successfully", "timestamp": "2025-10-04T18:40:50.131741Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006345510482788086, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.133440Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c8', '>\\U000a867c\u00ef'] completed successfully", "timestamp": "2025-10-04T18:40:50.139773Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0003fb95'] completed successfully", "timestamp": "2025-10-04T18:40:50.140837Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004535198211669922, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.142508Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['>'] completed successfully", "timestamp": "2025-10-04T18:40:50.159345Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\ud841\udd8e', '\\x8e'] completed successfully", "timestamp": "2025-10-04T18:40:50.160730Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005388975143432617, "memory_delta": 0.25, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.162052Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\ud841\udd8e', '\\x8e'] completed successfully", "timestamp": "2025-10-04T18:40:50.167206Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['>'] completed successfully", "timestamp": "2025-10-04T18:40:50.168115Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004526376724243164, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.169372Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x1f\u00b8\u00f8', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.185955Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00058cb7'] completed successfully", "timestamp": "2025-10-04T18:40:50.186934Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\r', '\u00b6'] completed successfully", "timestamp": "2025-10-04T18:40:50.187538Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006478548049926758, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.189273Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\r', '\u00b6'] completed successfully", "timestamp": "2025-10-04T18:40:50.196317Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00058cb7'] completed successfully", "timestamp": "2025-10-04T18:40:50.197043Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x1f\u00b8\u00f8', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.197643Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006755352020263672, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.199015Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['+[', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.217820Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00cc\u00a1'] completed successfully", "timestamp": "2025-10-04T18:40:50.219671Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005377531051635742, "memory_delta": 0.25, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.221143Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00cc\u00a1'] completed successfully", "timestamp": "2025-10-04T18:40:50.225859Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['+[', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.226503Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003595590591430664, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.227649Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['6r@'] completed successfully", "timestamp": "2025-10-04T18:40:50.246975Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000fb1bc', '3r'] completed successfully", "timestamp": "2025-10-04T18:40:50.247927Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x1d\u00c1'] completed successfully", "timestamp": "2025-10-04T18:40:50.248481Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.010562419891357422, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.251436Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x1d\u00c1'] completed successfully", "timestamp": "2025-10-04T18:40:50.257038Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000fb1bc', '3r'] completed successfully", "timestamp": "2025-10-04T18:40:50.257672Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['6r@'] completed successfully", "timestamp": "2025-10-04T18:40:50.258366Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0055310726165771484, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.260379Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0006b0e5'] completed successfully", "timestamp": "2025-10-04T18:40:50.275722Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x13<\\U000e3661', '0/0'] completed successfully", "timestamp": "2025-10-04T18:40:50.277100Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004509925842285156, "memory_delta": 0.25, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.278503Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x13<\\U000e3661', '0/0'] completed successfully", "timestamp": "2025-10-04T18:40:50.285155Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0006b0e5'] completed successfully", "timestamp": "2025-10-04T18:40:50.285869Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00455784797668457, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.287161Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x08', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.302961Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['D', '\u00f1\\x17l'] completed successfully", "timestamp": "2025-10-04T18:40:50.304361Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005089521408081055, "memory_delta": 0.375, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.38MB", "timestamp": "2025-10-04T18:40:50.305592Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['D', '\u00f1\\x17l'] completed successfully", "timestamp": "2025-10-04T18:40:50.309495Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x08', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.310176Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.010931730270385742, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.319157Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f8'] completed successfully", "timestamp": "2025-10-04T18:40:50.334246Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0035719871520996094, "memory_delta": 0.25, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.336272Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f8'] completed successfully", "timestamp": "2025-10-04T18:40:50.340362Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003049135208129883, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.342360Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c4i6', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.359179Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d0\u00aa'] completed successfully", "timestamp": "2025-10-04T18:40:50.360110Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e3\u00e0', '\u00e2'] completed successfully", "timestamp": "2025-10-04T18:40:50.360669Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006561279296875, "memory_delta": 0.375, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.38MB", "timestamp": "2025-10-04T18:40:50.362321Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e3\u00e0', '\u00e2'] completed successfully", "timestamp": "2025-10-04T18:40:50.367170Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d0\u00aa'] completed successfully", "timestamp": "2025-10-04T18:40:50.367803Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c4i6', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.368338Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005135774612426758, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.370279Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x17', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.385411Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [']\\x9c\\U000d7550'] completed successfully", "timestamp": "2025-10-04T18:40:50.386858Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004408121109008789, "memory_delta": 0.25, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.388070Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [']\\x9c\\U000d7550'] completed successfully", "timestamp": "2025-10-04T18:40:50.392322Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x17', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.392967Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0030944347381591797, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.394029Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['q'] completed successfully", "timestamp": "2025-10-04T18:40:50.407691Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0030891895294189453, "memory_delta": 0.25, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.409590Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['q'] completed successfully", "timestamp": "2025-10-04T18:40:50.413224Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0024156570434570312, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.414668Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c2', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.430865Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['g\\x87\\x13'] completed successfully", "timestamp": "2025-10-04T18:40:50.432337Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['I\u00ee'] completed successfully", "timestamp": "2025-10-04T18:40:50.432877Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006634712219238281, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.434438Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['I\u00ee'] completed successfully", "timestamp": "2025-10-04T18:40:50.439274Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['g\\x87\\x13'] completed successfully", "timestamp": "2025-10-04T18:40:50.439973Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c2', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.440529Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004578590393066406, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.441937Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x1f'] completed successfully", "timestamp": "2025-10-04T18:40:50.456837Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0039556026458740234, "memory_delta": 0.375, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.38MB", "timestamp": "2025-10-04T18:40:50.459379Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x1f'] completed successfully", "timestamp": "2025-10-04T18:40:50.463259Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002209901809692383, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.464394Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00ab', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.481145Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f1'] completed successfully", "timestamp": "2025-10-04T18:40:50.482193Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0009e65a', '\\x00\\U0010aed3'] completed successfully", "timestamp": "2025-10-04T18:40:50.482884Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00765228271484375, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.484696Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0009e65a', '\\x00\\U0010aed3'] completed successfully", "timestamp": "2025-10-04T18:40:50.489785Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f1'] completed successfully", "timestamp": "2025-10-04T18:40:50.490395Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00ab', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.490958Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0047152042388916016, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.492431Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' ', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.509502Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00cf\u00fb\u00a8', '\\x19'] completed successfully", "timestamp": "2025-10-04T18:40:50.511070Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0049991607666015625, "memory_delta": 0.25, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.512642Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00cf\u00fb\u00a8', '\\x19'] completed successfully", "timestamp": "2025-10-04T18:40:50.516779Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [' ', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.517508Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0031502246856689453, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.518715Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0007c85d', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.532972Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0032072067260742188, "memory_delta": 0.125, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.534927Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0007c85d', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.538864Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0024085044860839844, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.540083Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c9', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.555551Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['{\u00aaD'] completed successfully", "timestamp": "2025-10-04T18:40:50.557037Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005445241928100586, "memory_delta": 0.25, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.558464Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['{\u00aaD'] completed successfully", "timestamp": "2025-10-04T18:40:50.562828Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c9', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.563466Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0031833648681640625, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.564641Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x80e'] completed successfully", "timestamp": "2025-10-04T18:40:50.580424Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004885196685791016, "memory_delta": 0.375, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.38MB", "timestamp": "2025-10-04T18:40:50.582361Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x80e'] completed successfully", "timestamp": "2025-10-04T18:40:50.586875Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003017425537109375, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.588071Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f0\\U000dfdcbA', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.602794Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003802061080932617, "memory_delta": 0.25, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.604778Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f0\\U000dfdcbA', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.608363Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002069711685180664, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.609497Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000b26f4'] completed successfully", "timestamp": "2025-10-04T18:40:50.623435Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003740072250366211, "memory_delta": 0.375, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.38MB", "timestamp": "2025-10-04T18:40:50.625340Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000b26f4'] completed successfully", "timestamp": "2025-10-04T18:40:50.628830Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002044200897216797, "memory_delta": 0.125, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.629903Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['j\u00cb\\x8c'] completed successfully", "timestamp": "2025-10-04T18:40:50.644323Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003835439682006836, "memory_delta": 0.125, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.646513Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['j\u00cb\\x8c'] completed successfully", "timestamp": "2025-10-04T18:40:50.650607Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003963947296142578, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.653303Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000bd052', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.669572Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00af[\\x94'] completed successfully", "timestamp": "2025-10-04T18:40:50.671147Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0050411224365234375, "memory_delta": 0.25, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.672553Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00af[\\x94'] completed successfully", "timestamp": "2025-10-04T18:40:50.676628Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000bd052', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.677254Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0029518604278564453, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.678447Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x16Q\u00e3'] completed successfully", "timestamp": "2025-10-04T18:40:50.695189Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['}\\U0008bb0e\u00ae', '\u00b8\\x07'] completed successfully", "timestamp": "2025-10-04T18:40:50.696116Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['d0'] completed successfully", "timestamp": "2025-10-04T18:40:50.696704Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006191253662109375, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.698339Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['d0'] completed successfully", "timestamp": "2025-10-04T18:40:50.703606Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['}\\U0008bb0e\u00ae', '\u00b8\\x07'] completed successfully", "timestamp": "2025-10-04T18:40:50.704361Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x16Q\u00e3'] completed successfully", "timestamp": "2025-10-04T18:40:50.705077Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005142927169799805, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.706510Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d7\u00c8'] completed successfully", "timestamp": "2025-10-04T18:40:50.722135Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['u', '\u00b5\\x9a\\x94'] completed successfully", "timestamp": "2025-10-04T18:40:50.724155Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005487680435180664, "memory_delta": 0.375, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.38MB", "timestamp": "2025-10-04T18:40:50.725668Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['u', '\u00b5\\x9a\\x94'] completed successfully", "timestamp": "2025-10-04T18:40:50.734526Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d7\u00c8'] completed successfully", "timestamp": "2025-10-04T18:40:50.735252Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.007711887359619141, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.736508Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e2'] completed successfully", "timestamp": "2025-10-04T18:40:50.753022Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00be\\x92', '\u00fd'] completed successfully", "timestamp": "2025-10-04T18:40:50.753924Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['(-\\xad'] completed successfully", "timestamp": "2025-10-04T18:40:50.754465Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005945682525634766, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.755957Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['(-\\xad'] completed successfully", "timestamp": "2025-10-04T18:40:50.761229Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00be\\x92', '\u00fd'] completed successfully", "timestamp": "2025-10-04T18:40:50.762036Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e2'] completed successfully", "timestamp": "2025-10-04T18:40:50.762677Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006671905517578125, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.765572Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['O\u00b6'] completed successfully", "timestamp": "2025-10-04T18:40:50.783830Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [',', 'O\\x13\u00b7'] completed successfully", "timestamp": "2025-10-04T18:40:50.785693Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00bb\\x92'] completed successfully", "timestamp": "2025-10-04T18:40:50.786530Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.008414268493652344, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.788482Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00bb\\x92'] completed successfully", "timestamp": "2025-10-04T18:40:50.793597Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [',', 'O\\x13\u00b7'] completed successfully", "timestamp": "2025-10-04T18:40:50.794256Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['O\u00b6'] completed successfully", "timestamp": "2025-10-04T18:40:50.794898Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0045909881591796875, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.796230Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x9c', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.812614Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x14'] completed successfully", "timestamp": "2025-10-04T18:40:50.813528Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f6', '\u00eb4\u00c6'] completed successfully", "timestamp": "2025-10-04T18:40:50.814160Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0060422420501708984, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.815744Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f6', '\u00eb4\u00c6'] completed successfully", "timestamp": "2025-10-04T18:40:50.820782Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x14'] completed successfully", "timestamp": "2025-10-04T18:40:50.821439Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x9c', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.848247Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.03225588798522949, "memory_delta": 9.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.03s with memory delta: 9.25MB", "timestamp": "2025-10-04T18:40:50.850984Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00106a65\u00e3\\x87', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.865890Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0028917789459228516, "memory_delta": 0.125, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.867433Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00106a65\u00e3\\x87', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.871099Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002325773239135742, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.872298Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['-\\x04K', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.887392Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x8b', '\u00e0\u00a8'] completed successfully", "timestamp": "2025-10-04T18:40:50.888160Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000c8b4d', 'w\\U000dbd84\\U0001b798'] completed successfully", "timestamp": "2025-10-04T18:40:50.888818Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005461215972900391, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.890375Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000c8b4d', 'w\\U000dbd84\\U0001b798'] completed successfully", "timestamp": "2025-10-04T18:40:50.895796Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x8b', '\u00e0\u00a8'] completed successfully", "timestamp": "2025-10-04T18:40:50.896432Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['-\\x04K', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.896986Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004511833190917969, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.898261Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0006f38d\\x80*'] completed successfully", "timestamp": "2025-10-04T18:40:50.913970Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e3\\x19', '\u00c0ag'] completed successfully", "timestamp": "2025-10-04T18:40:50.914891Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00011f85\\U000ff9f9\u00b0', '\\U00107051n~'] completed successfully", "timestamp": "2025-10-04T18:40:50.915483Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005544900894165039, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.916921Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00011f85\\U000ff9f9\u00b0', '\\U00107051n~'] completed successfully", "timestamp": "2025-10-04T18:40:50.923190Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e3\\x19', '\u00c0ag'] completed successfully", "timestamp": "2025-10-04T18:40:50.923840Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0006f38d\\x80*'] completed successfully", "timestamp": "2025-10-04T18:40:50.924455Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006099700927734375, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.925820Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e2'] completed successfully", "timestamp": "2025-10-04T18:40:50.940974Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0033655166625976562, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.942429Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e2'] completed successfully", "timestamp": "2025-10-04T18:40:50.945990Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0020203590393066406, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.947048Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\nQ'] completed successfully", "timestamp": "2025-10-04T18:40:50.961575Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [',=3'] completed successfully", "timestamp": "2025-10-04T18:40:50.962470Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['R\u00fe'] completed successfully", "timestamp": "2025-10-04T18:40:50.963115Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00521540641784668, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.964415Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['R\u00fe'] completed successfully", "timestamp": "2025-10-04T18:40:50.969079Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [',=3'] completed successfully", "timestamp": "2025-10-04T18:40:50.969717Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\nQ'] completed successfully", "timestamp": "2025-10-04T18:40:50.970276Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0045282840728759766, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:50.971757Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['6', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.987535Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\ud857\udc51\u00c6\u00b4'] completed successfully", "timestamp": "2025-10-04T18:40:50.988402Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['A\\x85'] completed successfully", "timestamp": "2025-10-04T18:40:50.989029Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005478858947753906, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:50.990479Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['A\\x85'] completed successfully", "timestamp": "2025-10-04T18:40:50.995212Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\ud857\udc51\u00c6\u00b4'] completed successfully", "timestamp": "2025-10-04T18:40:50.995809Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['6', '0'] completed successfully", "timestamp": "2025-10-04T18:40:50.996370Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00440669059753418, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:50.997586Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['^\\U00107eb4', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.012727Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d0'] completed successfully", "timestamp": "2025-10-04T18:40:51.013591Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x82m'] completed successfully", "timestamp": "2025-10-04T18:40:51.014243Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006201982498168945, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.016594Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x82m'] completed successfully", "timestamp": "2025-10-04T18:40:51.021147Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d0'] completed successfully", "timestamp": "2025-10-04T18:40:51.021970Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['^\\U00107eb4', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.022595Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004365682601928711, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.023730Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0006bbed', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.044396Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['QB', '\u00e4\\U0010c1d6\\U00033cc7'] completed successfully", "timestamp": "2025-10-04T18:40:51.045394Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['G\ud872\ude69\\x1f'] completed successfully", "timestamp": "2025-10-04T18:40:51.045981Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.01079416275024414, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.048443Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['G\ud872\ude69\\x1f'] completed successfully", "timestamp": "2025-10-04T18:40:51.053200Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['QB', '\u00e4\\U0010c1d6\\U00033cc7'] completed successfully", "timestamp": "2025-10-04T18:40:51.053790Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0006bbed', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.054383Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004251241683959961, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.055568Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e0', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.072563Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['Agg'] completed successfully", "timestamp": "2025-10-04T18:40:51.074025Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f0', '\u00cc\\U0003dd9a'] completed successfully", "timestamp": "2025-10-04T18:40:51.074700Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.007989645004272461, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.077767Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f0', '\u00cc\\U0003dd9a'] completed successfully", "timestamp": "2025-10-04T18:40:51.082529Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['Agg'] completed successfully", "timestamp": "2025-10-04T18:40:51.084498Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e0', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.085140Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006234645843505859, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.086775Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000c90d3', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.101300Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002832651138305664, "memory_delta": 0.125, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.102818Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000c90d3', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.106337Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002172231674194336, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.107507Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['H', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.123317Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000f3cab\\U0005065a'] completed successfully", "timestamp": "2025-10-04T18:40:51.124626Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004477739334106445, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.125809Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000f3cab\\U0005065a'] completed successfully", "timestamp": "2025-10-04T18:40:51.129703Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['H', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.130336Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0029075145721435547, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.131361Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000832be\\U0007ab14(', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.146746Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['D\\x08\\x06'] completed successfully", "timestamp": "2025-10-04T18:40:51.147614Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['B\\U0009ed45'] completed successfully", "timestamp": "2025-10-04T18:40:51.148216Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00560307502746582, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:51.149690Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['B\\U0009ed45'] completed successfully", "timestamp": "2025-10-04T18:40:51.159498Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['D\\x08\\x06'] completed successfully", "timestamp": "2025-10-04T18:40:51.160189Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000832be\\U0007ab14(', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.160740Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.009615421295166016, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.162241Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0001cc3e\u00ba\u00be', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.176665Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0027618408203125, "memory_delta": 0.125, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.178100Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0001cc3e\u00ba\u00be', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.181607Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0019366741180419922, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.182660Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00079ef7', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.196411Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00ce'] completed successfully", "timestamp": "2025-10-04T18:40:51.197705Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00371551513671875, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.198990Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00ce'] completed successfully", "timestamp": "2025-10-04T18:40:51.203285Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00079ef7', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.203858Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00287628173828125, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.204958Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00df\\U000449c4\\x07', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.219237Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000ac680U'] completed successfully", "timestamp": "2025-10-04T18:40:51.220771Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0047664642333984375, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.222370Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000ac680U'] completed successfully", "timestamp": "2025-10-04T18:40:51.226634Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00df\\U000449c4\\x07', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.227275Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0030782222747802734, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.228298Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x08\u00d8\u00ee'] completed successfully", "timestamp": "2025-10-04T18:40:51.246941Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['w', '\\U000f326f\\x11'] completed successfully", "timestamp": "2025-10-04T18:40:51.556048Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.31589174270629883, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.32s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.557243Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['w', '\\U000f326f\\x11'] completed successfully", "timestamp": "2025-10-04T18:40:51.561317Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x08\u00d8\u00ee'] completed successfully", "timestamp": "2025-10-04T18:40:51.561936Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0030951499938964844, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.562923Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00ac\u00ea%'] completed successfully", "timestamp": "2025-10-04T18:40:51.575757Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x17 \\x11'] completed successfully", "timestamp": "2025-10-04T18:40:51.576865Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003336191177368164, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.577936Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x17 \\x11'] completed successfully", "timestamp": "2025-10-04T18:40:51.582444Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00ac\u00ea%'] completed successfully", "timestamp": "2025-10-04T18:40:51.583148Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003652334213256836, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.584090Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c6\\U000fe767a', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.597947Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003360271453857422, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.599176Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c6\\U000fe767a', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.602521Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0020248889923095703, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.603519Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['_'] completed successfully", "timestamp": "2025-10-04T18:40:51.617751Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x94', '\u00c9\u00e3'] completed successfully", "timestamp": "2025-10-04T18:40:51.618637Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000b33c0}'] completed successfully", "timestamp": "2025-10-04T18:40:51.619206Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0051364898681640625, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.620634Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000b33c0}'] completed successfully", "timestamp": "2025-10-04T18:40:51.625094Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x94', '\u00c9\u00e3'] completed successfully", "timestamp": "2025-10-04T18:40:51.625793Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['_'] completed successfully", "timestamp": "2025-10-04T18:40:51.626342Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004201412200927734, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.627486Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d0', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.643588Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['_', '\\U000e6ef6'] completed successfully", "timestamp": "2025-10-04T18:40:51.644452Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c3\\x0c\\U000d3dca', '\u00dbu\\x0b'] completed successfully", "timestamp": "2025-10-04T18:40:51.645200Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005433082580566406, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.646572Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c3\\x0c\\U000d3dca', '\u00dbu\\x0b'] completed successfully", "timestamp": "2025-10-04T18:40:51.651076Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['_', '\\U000e6ef6'] completed successfully", "timestamp": "2025-10-04T18:40:51.651700Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d0', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.652215Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004154682159423828, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.653394Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['M\u00a7\\U0007de45', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.667892Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003185272216796875, "memory_delta": 0.25, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:51.669546Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['M\u00a7\\U0007de45', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.674656Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002499818801879883, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.676082Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00a9d\u00c8', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.692620Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00040281\\x96'] completed successfully", "timestamp": "2025-10-04T18:40:51.693576Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['-', '\\x89Z\u00d5'] completed successfully", "timestamp": "2025-10-04T18:40:51.694229Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006690025329589844, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.695683Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['-', '\\x89Z\u00d5'] completed successfully", "timestamp": "2025-10-04T18:40:51.705363Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00040281\\x96'] completed successfully", "timestamp": "2025-10-04T18:40:51.706085Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00a9d\u00c8', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.706730Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.010236501693725586, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.708726Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c7\u00ff\\U00085237'] completed successfully", "timestamp": "2025-10-04T18:40:51.724090Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003713846206665039, "memory_delta": 0.125, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.725572Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c7\u00ff\\U00085237'] completed successfully", "timestamp": "2025-10-04T18:40:51.729002Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0019664764404296875, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.730116Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\n\\x93', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.743035Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0033416748046875, "memory_delta": 0.25, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:51.745107Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\n\\x93', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.748910Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002315998077392578, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.750154Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000f4f96\u00b6'] completed successfully", "timestamp": "2025-10-04T18:40:51.763933Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0027015209197998047, "memory_delta": 0.125, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.765437Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000f4f96\u00b6'] completed successfully", "timestamp": "2025-10-04T18:40:51.771769Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.007044076919555664, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.775163Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00a4\\U0003d3fa\\n', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.789484Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x02\\U00074fe1\u00f5'] completed successfully", "timestamp": "2025-10-04T18:40:51.791839Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005509853363037109, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.793359Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x02\\U00074fe1\u00f5'] completed successfully", "timestamp": "2025-10-04T18:40:51.799104Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00a4\\U0003d3fa\\n', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.802426Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.007604122161865234, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.803621Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x1f'] completed successfully", "timestamp": "2025-10-04T18:40:51.818426Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x9b\\x9d]', '\u00cf'] completed successfully", "timestamp": "2025-10-04T18:40:51.820233Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005190849304199219, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.821976Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x9b\\x9d]', '\u00cf'] completed successfully", "timestamp": "2025-10-04T18:40:51.827707Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x1f'] completed successfully", "timestamp": "2025-10-04T18:40:51.828683Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0042226314544677734, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.830142Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0008b7f0\u00fe'] completed successfully", "timestamp": "2025-10-04T18:40:51.852556Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e9', '\u00f6\\x13'] completed successfully", "timestamp": "2025-10-04T18:40:51.854663Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00070e76'] completed successfully", "timestamp": "2025-10-04T18:40:51.855640Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.008409261703491211, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:51.857666Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00070e76'] completed successfully", "timestamp": "2025-10-04T18:40:51.863943Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e9', '\u00f6\\x13'] completed successfully", "timestamp": "2025-10-04T18:40:51.864559Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0008b7f0\u00fe'] completed successfully", "timestamp": "2025-10-04T18:40:51.865146Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004572153091430664, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.866445Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00045702\u00cf\\x1e', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.882139Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['!\\x83/', '\\U000e213f\\\\'] completed successfully", "timestamp": "2025-10-04T18:40:51.883506Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003913164138793945, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.884680Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['!\\x83/', '\\U000e213f\\\\'] completed successfully", "timestamp": "2025-10-04T18:40:51.888635Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00045702\u00cf\\x1e', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.889359Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0031294822692871094, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.890415Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x91vc', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.905972Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['?', 'z\\U000ac7e5'] completed successfully", "timestamp": "2025-10-04T18:40:51.907392Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004519939422607422, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.908567Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['?', 'z\\U000ac7e5'] completed successfully", "timestamp": "2025-10-04T18:40:51.912620Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x91vc', '0'] completed successfully", "timestamp": "2025-10-04T18:40:51.913225Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002992868423461914, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.914252Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x87'] completed successfully", "timestamp": "2025-10-04T18:40:51.929100Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['rg', ']'] completed successfully", "timestamp": "2025-10-04T18:40:51.929919Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['~k', '\\U000b4bc4\\U00093440R'] completed successfully", "timestamp": "2025-10-04T18:40:51.930498Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005026578903198242, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.931868Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['~k', '\\U000b4bc4\\U00093440R'] completed successfully", "timestamp": "2025-10-04T18:40:51.936373Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['rg', ']'] completed successfully", "timestamp": "2025-10-04T18:40:51.937070Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x87'] completed successfully", "timestamp": "2025-10-04T18:40:51.937598Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004208803176879883, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.938734Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x8aZW'] completed successfully", "timestamp": "2025-10-04T18:40:51.953752Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00dd'] completed successfully", "timestamp": "2025-10-04T18:40:51.954603Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000dcc4d\u00ab\"'] completed successfully", "timestamp": "2025-10-04T18:40:51.955145Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004945039749145508, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:51.956426Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000dcc4d\u00ab\"'] completed successfully", "timestamp": "2025-10-04T18:40:51.961098Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00dd'] completed successfully", "timestamp": "2025-10-04T18:40:51.961827Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x8aZW'] completed successfully", "timestamp": "2025-10-04T18:40:51.962433Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0044286251068115234, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.963659Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00aa\\x99\u00fe'] completed successfully", "timestamp": "2025-10-04T18:40:51.978628Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x9e', 'h\\U000688fb'] completed successfully", "timestamp": "2025-10-04T18:40:51.980071Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000ffcb2d', '\u00fd|&'] completed successfully", "timestamp": "2025-10-04T18:40:51.980634Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0056607723236083984, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:51.981972Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U000ffcb2d', '\u00fd|&'] completed successfully", "timestamp": "2025-10-04T18:40:51.986447Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x9e', 'h\\U000688fb'] completed successfully", "timestamp": "2025-10-04T18:40:51.987111Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00aa\\x99\u00fe'] completed successfully", "timestamp": "2025-10-04T18:40:51.987694Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004193544387817383, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:51.988936Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00106785\\x0c'] completed successfully", "timestamp": "2025-10-04T18:40:52.003645Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d7', 'pid'] completed successfully", "timestamp": "2025-10-04T18:40:52.004926Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004160404205322266, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:52.006055Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d7', 'pid'] completed successfully", "timestamp": "2025-10-04T18:40:52.009926Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U00106785\\x0c'] completed successfully", "timestamp": "2025-10-04T18:40:52.010536Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0030469894409179688, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:52.011640Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['P\\U0008f7c6', '0'] completed successfully", "timestamp": "2025-10-04T18:40:52.025721Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\ud81e\udceb\\r'] completed successfully", "timestamp": "2025-10-04T18:40:52.027158Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0044651031494140625, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:52.028462Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\ud81e\udceb\\r'] completed successfully", "timestamp": "2025-10-04T18:40:52.032593Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['P\\U0008f7c6', '0'] completed successfully", "timestamp": "2025-10-04T18:40:52.033256Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0031218528747558594, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:52.034302Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['|c#', '0'] completed successfully", "timestamp": "2025-10-04T18:40:52.049826Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['j', '\u00c5\\U00069a4c\u00cd'] completed successfully", "timestamp": "2025-10-04T18:40:52.050766Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00cf?\\U0008b0e8'] completed successfully", "timestamp": "2025-10-04T18:40:52.051607Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005622386932373047, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:52.053186Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00cf?\\U0008b0e8'] completed successfully", "timestamp": "2025-10-04T18:40:52.060219Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['j', '\u00c5\\U00069a4c\u00cd'] completed successfully", "timestamp": "2025-10-04T18:40:52.061033Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['|c#', '0'] completed successfully", "timestamp": "2025-10-04T18:40:52.061624Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0061986446380615234, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:52.063227Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x04'] completed successfully", "timestamp": "2025-10-04T18:40:52.079846Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f7'] completed successfully", "timestamp": "2025-10-04T18:40:52.080981Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c8', '\\U00105ce5'] completed successfully", "timestamp": "2025-10-04T18:40:52.081672Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.006516456604003906, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:52.083463Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00c8', '\\U00105ce5'] completed successfully", "timestamp": "2025-10-04T18:40:52.089104Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00f7'] completed successfully", "timestamp": "2025-10-04T18:40:52.089805Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x04'] completed successfully", "timestamp": "2025-10-04T18:40:52.090502Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005255937576293945, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:52.091900Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x7f\\U000d8221'] completed successfully", "timestamp": "2025-10-04T18:40:52.106589Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002967357635498047, "memory_delta": 0.125, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:52.108039Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x7f\\U000d8221'] completed successfully", "timestamp": "2025-10-04T18:40:52.112004Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002017974853515625, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:52.113194Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x19C\\x96', '0'] completed successfully", "timestamp": "2025-10-04T18:40:52.129861Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0009ea11:\\U000585ac', '\\x1e\u00c7x'] completed successfully", "timestamp": "2025-10-04T18:40:52.130843Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e6\\x86'] completed successfully", "timestamp": "2025-10-04T18:40:52.131460Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005902290344238281, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:52.133103Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00e6\\x86'] completed successfully", "timestamp": "2025-10-04T18:40:52.137993Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\U0009ea11:\\U000585ac', '\\x1e\u00c7x'] completed successfully", "timestamp": "2025-10-04T18:40:52.138675Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x19C\\x96', '0'] completed successfully", "timestamp": "2025-10-04T18:40:52.139254Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004465818405151367, "memory_delta": 0.0, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:52.140508Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['t\u00c8', '0'] completed successfully", "timestamp": "2025-10-04T18:40:52.157822Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['}'] completed successfully", "timestamp": "2025-10-04T18:40:52.158811Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x99\u00af', '\u00a4\u00fc\u00c8'] completed successfully", "timestamp": "2025-10-04T18:40:52.159450Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0064411163330078125, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:52.160966Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x99\u00af', '\u00a4\u00fc\u00c8'] completed successfully", "timestamp": "2025-10-04T18:40:52.166163Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['}'] completed successfully", "timestamp": "2025-10-04T18:40:52.166894Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['t\u00c8', '0'] completed successfully", "timestamp": "2025-10-04T18:40:52.167500Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0046575069427490234, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:52.168797Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00b2u'] completed successfully", "timestamp": "2025-10-04T18:40:52.185130Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d6\\x86'] completed successfully", "timestamp": "2025-10-04T18:40:52.186635Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0041620731353759766, "memory_delta": 0.125, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:52.187909Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d6\\x86'] completed successfully", "timestamp": "2025-10-04T18:40:52.192482Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00b2u'] completed successfully", "timestamp": "2025-10-04T18:40:52.193410Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004092693328857422, "memory_delta": 0.0, "successful_groups": 2, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:52.195118Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x18\ud82c\ude83', '0'] completed successfully", "timestamp": "2025-10-04T18:40:52.213007Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['2', '\u00e7'] completed successfully", "timestamp": "2025-10-04T18:40:52.213991Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['c'] completed successfully", "timestamp": "2025-10-04T18:40:52.214616Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.00731205940246582, "memory_delta": 0.25, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.25MB", "timestamp": "2025-10-04T18:40:52.216141Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['c'] completed successfully", "timestamp": "2025-10-04T18:40:52.221004Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['2', '\u00e7'] completed successfully", "timestamp": "2025-10-04T18:40:52.221667Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\\x18\ud82c\ude83', '0'] completed successfully", "timestamp": "2025-10-04T18:40:52.222205Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.004467487335205078, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:52.223526Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['p\u00f1'] completed successfully", "timestamp": "2025-10-04T18:40:52.237656Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.003126859664916992, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:52.239360Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['p\u00f1'] completed successfully", "timestamp": "2025-10-04T18:40:52.244112Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.002355337142944336, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:52.245251Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d4\\x9b\\x95'] completed successfully", "timestamp": "2025-10-04T18:40:52.261142Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [\"'\\U00083182\", '\\U000aabed'] completed successfully", "timestamp": "2025-10-04T18:40:52.262292Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00der'] completed successfully", "timestamp": "2025-10-04T18:40:52.263126Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0062253475189208984, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:52.264711Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00der'] completed successfully", "timestamp": "2025-10-04T18:40:52.270322Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group [\"'\\U00083182\", '\\U000aabed'] completed successfully", "timestamp": "2025-10-04T18:40:52.271042Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['\u00d4\\x9b\\x95'] completed successfully", "timestamp": "2025-10-04T18:40:52.271769Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.005200862884521484, "memory_delta": 0.125, "successful_groups": 3, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.01s with memory delta: 0.12MB", "timestamp": "2025-10-04T18:40:52.273385Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0'] completed successfully", "timestamp": "2025-10-04T18:40:52.321786Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0027637481689453125, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:52.323677Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:127 {"event": "Agent group ['0'] completed successfully", "timestamp": "2025-10-04T18:40:52.325884Z"}
+INFO     autoresearch.orchestration.parallel:parallel.py:148 {"extra": {"execution_time": 0.0013365745544433594, "memory_delta": 0.0, "successful_groups": 1, "error_groups": 0, "timeout_groups": 0}, "event": "Parallel execution completed in 0.00s with memory delta: 0.00MB", "timestamp": "2025-10-04T18:40:52.326541Z"}
+---------------------------------------------------- Captured log teardown -----------------------------------------------------
+INFO     autoresearch.config.loader:loader.py:104 No configuration file found; using defaults
+======================================================= warnings summary =======================================================
+tests/unit/test_main_config_commands.py:4
+  /workspace/autoresearch/tests/unit/test_main_config_commands.py:4: DeprecationWarning: 'importlib.abc.Traversable' is deprecated and slated for removal in Python 3.14
+    from importlib.abc import Traversable
+
+tests/unit/knowledge/test_graph_pipeline.py::test_session_graph_pipeline_ingest_records_provenance
+  /workspace/autoresearch/.venv/lib/python3.12/site-packages/networkx/readwrite/json_graph/node_link.py:145: FutureWarning: 
+  The default value will be `edges="edges" in NetworkX 3.6.
+  
+  To make this warning go away, explicitly set the edges kwarg, e.g.:
+  
+    nx.node_link_data(G, edges="links") to preserve current behavior, or
+    nx.node_link_data(G, edges="edges") for forward compatibility.
+    warnings.warn(
+
+tests/unit/test_kg_reasoning.py::test_run_ontology_reasoner_reload_without_owlrl
+  /workspace/autoresearch/src/autoresearch/kg_reasoning.py:60: RuntimeWarning: owlrl not installed; ontology reasoning will be skipped
+    warnings.warn(
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+===================================================== slowest 10 durations =====================================================
+6.63s call     tests/unit/test_distributed_executors.py::test_query_state_ray_round_trip
+5.46s call     tests/unit/test_eviction.py::test_deterministic_override_clamped_to_minimum
+3.78s call     tests/unit/distributed/test_coordination_properties.py::test_message_processing_is_idempotent
+3.32s call     tests/unit/test_orchestrator_parallel_deterministic.py::test_parallel_merging_is_deterministic
+1.55s call     tests/unit/distributed/test_coordination_properties.py::test_election_converges_to_minimum
+1.31s call     tests/unit/test_eviction.py::test_lru_eviction_order
+0.97s call     tests/unit/test_config_watcher_cleanup.py::test_cli_watcher_cleanup_error
+0.96s call     tests/unit/test_config_watcher_cleanup.py::test_api_watcher_cleanup_error
+0.90s setup    tests/unit/test_main_backup_commands.py::test_backup_create_command
+0.89s setup    tests/unit/test_eviction.py::test_ram_eviction_skips_without_metrics
+=================================================== short test summary info ====================================================
+FAILED tests/unit/test_orchestrator_parallel_deterministic.py::test_parallel_merging_is_deterministic - TypeError: unhashable type: 'dict'
+Falsifying example: test_parallel_merging_is_deterministic(
+    agent_groups=[['0']],  # or any other generated value
+)
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+======================= 1 failed, 656 passed, 12 skipped, 25 deselected, 3 warnings in 69.38s (0:01:09) ========================
+task: Failed to run task "coverage": exit status 1

--- a/baseline/logs/task-verify-20251004T183537Z.log
+++ b/baseline/logs/task-verify-20251004T183537Z.log
@@ -1,0 +1,65 @@
+[UTC:20251004T183537Z] task verify with extras nlp ui vss git distributed analysis llm parsers
+task: [verify] set -eu
+extras="dev-minimal test nlp ui vss git distributed analysis llm parsers"
+export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-600}"
+uv sync \
+  --python-platform x86_64-manylinux_2_28 \
+  $(printf ' --extra %s' $extras) \
+  
+
+Resolved 328 packages in 4ms
+Audited 246 packages in 0.34ms
+task: [verify] task check-env EXTRAS="dev-minimal test nlp ui vss git distributed analysis llm parsers"
+task: [check-env] task --version
+3.45.4
+task: [check-env] uv run python scripts/check_env.py
+Verifying extras: analysis, dev-minimal, distributed, git, llm, nlp, parsers, test, ui, vss
+Python 3.12.10
+Go Task 3.45.4
+uv 0.7.22
+GitPython 3.1.45
+a2a-sdk 0.3.7
+black 25.9.0
+dspy-ai 3.0.3
+duckdb 1.3.2
+duckdb-extension-vss 1.3.2
+fakeredis 2.31.3
+fastembed 0.7.3
+flake8 7.3.0
+freezegun 1.5.5
+hypothesis 6.140.2
+mypy 1.18.2
+networkx 3.5
+owlrl 7.1.4
+pdfminer-six 20250506
+pillow 11.3.0
+polars 1.33.1
+psutil 7.1.0
+pytest 8.4.2
+pytest-bdd 8.1.0
+pytest-benchmark 5.1.0
+pytest-cov 7.0.0
+pytest-httpx 0.35.0
+python-docx 1.2.0
+ray 2.49.2
+redis 6.4.0
+responses 0.25.8
+spacy 3.8.7
+streamlit 1.50.0
+tomli-w 1.2.0
+types-protobuf 6.32.1.20250918
+types-psutil 7.0.0.20250822
+types-requests 2.32.4.20250913
+types-tabulate 0.9.0.20241207
+uvicorn 0.37.0
+task: [verify] set -eu
+uv run flake8 src tests
+echo "[verify][lint] flake8 passed"
+
+[verify][lint] flake8 passed
+task: [verify] task mypy-strict
+task: [mypy-strict] uv run mypy --strict src tests
+src/autoresearch/search/core.py:696: error: Name "wrapper" already defined on line 681  [no-redef]
+Found 1 error in 1 file (checked 790 source files)
+task: Failed to run task "mypy-strict": exit status 1
+task: Failed to run task "verify": exit status 201


### PR DESCRIPTION
## Summary
- captured `task verify` and `task coverage` runs at UTC_TS=20251004T183537Z with headers in the stored logs under `baseline/logs/`
- retained the streamed output showing the current dependency set, lint/mypy invocation, and pytest results for follow-up analysis
- documented the observed failures to help track outstanding mypy strict (`wrapper` redefinition) and pytest regression (parallel merge determinism)

## Testing
- EXTRAS="nlp ui vss git distributed analysis llm parsers" uv run task verify *(fails: mypy strict error in src/autoresearch/search/core.py: wrapper redefinition)*
- EXTRAS="nlp ui vss git distributed analysis llm parsers" uv run task coverage *(fails: pytest TypeError in test_orchestrator_parallel_deterministic.py; warnings include Traversable deprecation, NetworkX edges FutureWarning, owlrl RuntimeWarning)*

------
https://chatgpt.com/codex/tasks/task_e_68e168dd08fc8333a511860631873f80