### PR TITLE
Track TestPyPI dry run reactivation follow-up

### DIFF
--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -32,7 +32,9 @@ completing the evidence trail alongside the earlier failing runs.
 
 TestPyPI dry runs remain paused; with the fallback fix validated we will
 re-enable the publish stage before the next release sign-off once the
-downstream gates close.【F:docs/v0.1.0a1_preflight_plan.md†L10-L239】
+downstream gates close, with the follow-up tracked in
+[reactivate-testpypi-dry-run](reactivate-testpypi-dry-run.md).
+【F:docs/v0.1.0a1_preflight_plan.md†L10-L239】
 
 ## Tasks
 - [x] Finish PR-C by restoring the deterministic fallback URL so the
@@ -46,7 +48,8 @@ downstream gates close.【F:docs/v0.1.0a1_preflight_plan.md†L10-L239】
   release documentation (`baseline/logs/task-verify-20251005T031512Z.log`,
   `baseline/logs/task-coverage-20251005T032844Z.log`).
 - [ ] Re-run the TestPyPI dry run after enabling the publish flag and archive
-  the resulting log for the release dossier.
+  the resulting log for the release dossier (tracked in
+  [reactivate-testpypi-dry-run](reactivate-testpypi-dry-run.md)).
 - [ ] Schedule the release sign-off review with the approvers, outlining
   agenda and required evidence in this ticket.
 - [ ] Run the release sign-off review with updated evidence and record

--- a/issues/reactivate-testpypi-dry-run.md
+++ b/issues/reactivate-testpypi-dry-run.md
@@ -1,0 +1,27 @@
+# Reactivate TestPyPI dry run
+
+## Context
+The October 5, 2025 verify and coverage sweeps finished cleanly, with
+`task verify` reporting 694 passing tests and `task coverage` holding the
+92.4 % floor, confirming the deterministic fallback fix and restoring the
+release gate evidence.【F:baseline/logs/task-verify-20251005T031512Z.log†L1-L21】【F:baseline/logs/task-coverage-20251005T032844Z.log†L1-L24】
+The preflight readiness plan and release plan now elevate TestPyPI
+reactivation as the remaining gate before publish, so we need to bring
+the dry run back online with fresh artefact logs for the dossier.
+【F:docs/v0.1.0a1_preflight_plan.md†L44-L57】【F:docs/release_plan.md†L24-L38】
+
+## Dependencies
+- [prepare-first-alpha-release](prepare-first-alpha-release.md)
+
+## Acceptance Criteria
+- Dry-run publishing to TestPyPI is re-enabled in the release pipeline
+  and executes successfully with artefact hashes recorded in
+  `baseline/logs/`.
+- The new dry run log, hash outputs, and coverage context are referenced
+  in `docs/release_plan.md`, `STATUS.md`, and `TASK_PROGRESS.md` alongside
+  the October 5 verify/coverage evidence.
+- Release operators confirm the TestPyPI stage is unpaused and leave a
+  short summary plus log links in this ticket.
+
+## Status
+Open


### PR DESCRIPTION
## Summary
- add an issue to track reactivating the TestPyPI dry run using the October 5 verify and coverage evidence
- link the alpha release ticket to the new follow-up so the outstanding task points at the dedicated tracker

## Testing
- uv run task lint-specs

------
https://chatgpt.com/codex/tasks/task_e_68e1894dea908333b0872b382dc82fc6