### PR TITLE
Refresh v0.1.0a1 readiness plan and document new blockers

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -18,19 +18,29 @@ checks are required. `task verify` always syncs the `dev-minimal` and `test`
 extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
-## October 5, 2025
-- `uv run task verify` at **03:15 UTC** finished cleanly, keeping the lint
-  sweep green and confirming strict mypy plus the deterministic fallback
-  assertions all pass. The archived log documents the PR-C fix through the
-  restored `tests/unit/test_failure_scenarios.py::test_external_lookup_fallback`
-  assertion alongside the lint sweep’s `[verify][lint] flake8 passed` marker so
-  reviewers can cite the deterministic URL evidence directly.
-  【F:baseline/logs/task-verify-20251005T031512Z.log†L1-L21】
-- The matching **03:28 UTC** coverage sweep closes the verify/coverage pair at
-  the 92.4 % statement rate, records the same fallback assertion passing, and
-  regenerates `coverage.xml`. With PR-C’s deterministic fallback repair and lint
-  work complete, TestPyPI reactivation remains the next release gate.
-  【F:baseline/logs/task-coverage-20251005T032844Z.log†L1-L24】
+## October 4, 2025 (earlier runs)
+- `uv run mypy --strict src tests` at **21:04 UTC** continues to report
+  “Success: no issues found in 790 source files”, so the strict gate stays
+  green while we address the renewed pytest regressions.【a78415†L1-L2】
+- `uv run --extra test pytest` on the same evening now fails with ten
+  regressions spanning search backends, cache determinism, orchestrator
+  telemetry, reasoning answers, and output formatting fidelity. The suite
+  stops on DuckDuckGo stub mismatches, cache misses despite persisted
+  entries, non-deterministic reasoning merges, scheduler benchmarks below
+  their floor, warning banners injected into answers, and formatter edge
+  cases surfaced by Hypothesis.【53776f†L1-L60】
+- Targeted property tests document OutputFormatter dropping control
+  characters and collapsing whitespace, while cache tests show repeated
+  backend calls despite cache hits, confirming the fix list for the next PR
+  slices.【5f96a8†L12-L36】【e865e9†L1-L58】
+- A focused reasoning test demonstrates that warning banners now mutate the
+  final answer, so the behaviour suite remains red until telemetry is
+  disentangled from answers.【cf191d†L27-L46】
+- The refreshed [preflight readiness plan](docs/v0.1.0a1_preflight_plan.md)
+  sequences PR-S1 through PR-P1 to tackle deterministic search stubs, cache
+  key guards, formatter fidelity, reasoning telemetry, and orchestrator
+  determinism before we rerun verify and coverage sweeps.
+  【F:docs/v0.1.0a1_preflight_plan.md†L38-L115】
 
 ## October 4, 2025
 - `uv run mypy --strict src tests` at **05:34 UTC** reported "Success: no

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,16 +1,18 @@
-As of **2025-10-05 at 03:28 UTC** the verify and coverage sweeps are green.
-`uv run task verify` now completes end-to-end with `[verify][lint] flake8 passed`
-and strict mypy reporting “Success: no issues found in 790 source files” while
-`tests/unit/test_failure_scenarios.py::test_external_lookup_fallback` passes,
-closing the last PR-C regression. The paired coverage run lands at the
-92.4 % statement rate and regenerates `coverage.xml`, so TestPyPI reactivation
-is the next gate. Previously, the October 4 logs captured the placeholder URL
-failure; those references remain below for historical context but are now
-superseded as of the October 5 evidence.
-【F:baseline/logs/task-verify-20251005T031512Z.log†L1-L21】
-【F:baseline/logs/task-coverage-20251005T032844Z.log†L1-L24】
-【F:baseline/logs/task-verify-20251004T144057Z.log†L555-L782】
-【F:baseline/logs/task-coverage-20251004T144436Z.log†L481-L600】
+As of **2025-10-04 at 21:04 UTC** strict typing remains green while the unit
+suite exposes ten regressions concentrated in search, cache determinism,
+orchestrator telemetry, reasoning answers, and output formatting. `uv run mypy
+--strict src tests` continues to report “Success: no issues found in 790 source
+files”, yet `uv run --extra test pytest` now fails with search stubs that miss
+their mocks, cache lookups that re-hit the backend, non-deterministic
+orchestrator merges, warning banners injected into answers, and formatter edge
+cases uncovered by Hypothesis.【a78415†L1-L2】【53776f†L1-L60】 Targeted property
+and unit tests confirm the concrete behaviours we must address in the upcoming
+PR slices: OutputFormatter drops control characters and collapses whitespace,
+cache calls ignore persisted entries, and reasoning telemetry prepends warning
+strings to answers.【5f96a8†L12-L36】【e865e9†L1-L58】【cf191d†L27-L46】 The revised
+preflight plan now sequences PR-S1 through PR-P1 to resolve these failures
+before rerunning the full release sweep.
+【F:docs/v0.1.0a1_preflight_plan.md†L38-L115】
 
 As of **2025-10-04 at 05:34 UTC** the strict gate remains green: `uv run mypy
 --strict src tests` reported "Success: no issues found in 790 source files",

--- a/docs/v0.1.0a1_preflight_plan.md
+++ b/docs/v0.1.0a1_preflight_plan.md
@@ -1,366 +1,148 @@
-# v0.1.0a1 preflight readiness plan (2025-10-05)
+# v0.1.0a1 preflight readiness plan (2025-10-04)
 
-This review applies dialectical and Socratic reasoning to the
-Autoresearch improvement proposal and the current release posture. The
-goal is to surface the highest-impact work that unblocks the 0.1.0a1
-alpha tag while keeping each change scoped to a small, review-friendly
-pull request.
+This revision applies a multi-disciplinary, dialectical, and Socratic
+analysis to the current alpha release posture. It replaces the superseded
+October 5 snapshot and focuses on the freshest evidence gathered during the
+October 4 triage cycle.
 
 ## Evidence snapshot
 
-- `uv run task verify` at 03:15 UTC on October 5, 2025 now finishes cleanly
-  with `[verify][lint] flake8 passed`, strict mypy success, and
-  `tests/unit/test_failure_scenarios.py::test_external_lookup_fallback`
-  passing, demonstrating PR-C’s deterministic fallback repair is complete.
-  【F:baseline/logs/task-verify-20251005T031512Z.log†L1-L21】
-- `uv run task coverage` at 03:28 UTC on the same day records a green sweep
-  at 92.4 % coverage, the same fallback assertion passing, and a refreshed
-  `coverage.xml`, giving the release plan a verified coverage artefact.
-  【F:baseline/logs/task-coverage-20251005T032844Z.log†L1-L24】
-- The October 4 verify and coverage logs remain archived below to
-  demonstrate the resolved regression and the lint sweep that unlocked the
-  deterministic fallback fix.
-  【F:baseline/logs/task-verify-20251004T144057Z.log†L167-L169】
-  【F:baseline/logs/task-verify-20251004T144057Z.log†L555-L782】
-  【F:baseline/logs/task-coverage-20251004T144436Z.log†L481-L600】
-- The October 3, 2025 wide pytest sweep remains informative: 26 failures
-  and five errors still cover reverification defaults, backup rotation,
-  cache determinism, FastMCP adapters, orchestrator error handling,
-  planner metadata, storage contracts, and environment metadata checks.
-  We keep that broader data set to ensure follow-on PRs continue to hit
-  every regression cluster once the search stub repairs land.
-  【ce87c2†L81-L116】
+- `uv run mypy --strict src tests` continues to pass, confirming the strict
+  gate remains green while we repair the pytest regressions uncovered in the
+  latest sweep.【a78415†L1-L2】
+- `uv run --extra test pytest` now fails with ten regressions that cluster
+  around search backends, cache determinism, orchestrator determinism,
+  reasoning telemetry, and output formatting edge cases, establishing the
+  highest-impact blockers to the alpha tag.【53776f†L1-L60】
+- Targeted property-based tests show OutputFormatter drops control
+  characters and collapses whitespace, while cache tests prove backend calls
+  still fire on cache hits, highlighting concrete failure modes we must
+  address before rerunning the full suite.【5f96a8†L12-L36】【e865e9†L1-L58】
+- Focused orchestration and reasoning tests demonstrate that debate
+  telemetry currently mutates answers with warning banners and that the
+  parallel merge path no longer returns hashable reasoning steps, creating
+  correctness risks for downstream consumers.【cf191d†L27-L46】【53776f†L22-L38】
+- Search integration tests show the DuckDuckGo stub diverges from the mocked
+  query payload and that hybrid ranking now calls patched hooks with the
+  wrong signature, confirming the need for renewed backend determinism.
+  【34ebc5†L1-L76】
 
-The plan below assumes strict typing stays green and concentrates on the
-fastest path to a green test suite, refreshed coverage evidence, and the
-architectural upgrades outlined in the improvement proposal.
+## Dialectical review of active blockers
 
-## Dialectical evaluation of key initiatives
+### Search backend determinism
+- **Assumption:** Restoring deterministic request payloads and backend
+  signatures will unblock the majority of search failures.
+- **Support:** The DuckDuckGo mock rejects the call because the request
+  query preserves question punctuation, and the hybrid ranker now invokes
+  a patched helper with the wrong arity.【34ebc5†L17-L70】
+- **Counterpoint:** Normalising payloads without reviewing cache keys could
+  cause hard-to-diagnose mismatches in production telemetry.
+- **Synthesis:** Ship a focused PR that (1) reintroduces query canonical
+  forms for stubs, (2) restores the cross-backend rank signature and
+  adapter hooks, and (3) refreshes unit fixtures to assert both the raw and
+  canonical query values.
 
-For each initiative we list the motivating assumption, supporting
-arguments, counterpoints, and a synthesis that guides the immediate
-next step.
+### Search cache semantics
+- **Assumption:** Cache regressions stem from bypassing namespace-aware keys
+  when embeddings or storage shims are active.
+- **Support:** The property-based cache test records three backend calls for
+  an identical query, proving cache misses despite persisted artifacts.
+  【e865e9†L15-L52】
+- **Counterpoint:** Forcing cache hits without auditing embedding metadata
+  risks staleness for hybrid queries.
+- **Synthesis:** Introduce a namespace + embedding signature key helper,
+  add Socratic assertions that question when hybrid metadata should bypass
+  cache reuse, and extend unit tests to cover sequential and interleaved
+  cache hits.
 
-### TestPyPI reactivation (PR-D)
+### Output formatting fidelity
+- **Assumption:** OutputFormatter must preserve control characters and
+  whitespace to avoid silently corrupting responses.
+- **Support:** Hypothesis finds failing cases where control characters are
+  dropped from markdown output and where answers collapse to empty strings
+  in JSON.【5f96a8†L12-L36】
+- **Counterpoint:** Blindly echoing unescaped control characters could break
+  downstream renderers or leak unsafe data.
+- **Synthesis:** Encode a conservative escaping strategy that preserves
+  byte fidelity in JSON while sanitising markdown through explicit code
+  fencing, and add property tests that interrogate the escaping rules.
 
-- **Assumption:** Publishing to TestPyPI is the next external signal the
-  alpha reviewers need now that the deterministic fallback regression is
-  closed.
-- **Support:** The release plan lists the new verify and coverage logs as
-  green and names TestPyPI reactivation as the remaining gate before
-  distribution expands.【F:docs/release_plan.md†L21-L36】
-- **Counterpoint:** Reopening TestPyPI without packaging telemetry could
-  hide residual build or upload drift.
-- **Synthesis:** Draft PR-D to re-enable the TestPyPI dry run with
-  explicit artefact hashing and upload audit logs so reviewers can compare
-  results against the release checklist before authorising real
-  publishing.
+### Orchestrator determinism and telemetry
+- **Assumption:** Deterministic orchestration is critical for reproducible
+  audits and accurate behaviour coverage.
+- **Support:** The parallel merge test now raises `TypeError` because
+  reasoning steps contain dicts instead of strings, and the benchmarking
+  harness fails its throughput floor.【53776f†L22-L34】【53776f†L34-L44】
+- **Counterpoint:** Tightening determinism without tracing why dicts leak
+  into reasoning could hide deeper regressions in agent outputs.
+- **Synthesis:** Patch the merge reducer to normalise reasoning payloads,
+  audit the aggregator contract with Socratic prompts in tests, and
+  recalibrate the scheduler benchmark using recorded baseline metrics
+  rather than hard-coded floors.
 
-### Adaptive orchestration gate
+### Reasoning telemetry hygiene
+- **Assumption:** Chain-of-thought answers should remain verbatim, with
+  warnings exposed separately.
+- **Support:** The reasoning modes test now sees warning banners appended to
+  the final answer, violating the documented API contract.【cf191d†L27-L46】
+- **Counterpoint:** Removing warnings entirely could reduce user awareness
+  of audit gaps.
+- **Synthesis:** Move warning banners into structured telemetry fields,
+  leaving the textual answer untouched while updating behaviour coverage to
+  verify both the banner presence and the unmodified answer string.
 
-- **Assumption:** Always-on debate wastes compute and can trigger
-  hallucinations.
-- **Support:** Auto mode already exists but lacks quantitative
-  telemetry on when to skip debate, leaving cost savings unproven.
-- **Counterpoint:** Over-aggressive skipping could lower factuality if
-  verification trails lag.
-- **Synthesis:** Instrument the existing AUTO path with claim coverage
-  and confidence metrics, log skip/escalate decisions, and gate debate
-  on the recorded evidence. Ship telemetry first, then tune thresholds
-  with offline replays.
+## Proposed PR slices
 
-### Planner–research–debate–verify (PRDV)
+Each slice is scoped to minimise turnaround while applying the dialectical
+conclusions above.
 
-- **Assumption:** A lightweight planner increases coverage and keeps
-  debate scoped.
-- **Support:** Current planner emits linear task lists without
-  dependency tracking or Socratic prompts, limiting oversight.
-- **Counterpoint:** Adding orchestration complexity without stronger
-  verification risks more failure points.
-- **Synthesis:** Add dependency-aware plan nodes plus Socratic
-  self-check prompts in planner output. Deliver as a prompt/schema
-  change guarded by unit tests before touching agent routing logic.
+1. **PR-S1 Search stub normalisation**
+   - Canonicalise outbound queries, restore cross-backend rank signatures,
+     and add regression tests for DuckDuckGo, hybrid ranking, and local file
+     fallbacks.
+   - Update cache fixtures to verify canonical and raw query logging.
+2. **PR-S2 Cache namespace guards**
+   - Introduce a dedicated cache key builder that incorporates embedding and
+     storage hints, backfill docstrings, and expand property-based tests to
+     interrogate sequential cache hits.
+3. **PR-O1 Output formatter fidelity**
+   - Implement JSON whitespace preservation, markdown escaping, and add
+     Hypothesis strategies for control characters and whitespace-only
+     answers.
+4. **PR-R1 Reasoning telemetry separation**
+   - Decouple warning banners from answer strings, expose structured
+     warnings, and extend behaviour tests to assert clean answers plus
+     telemetry fields.
+5. **PR-P1 Orchestrator determinism + scheduler benchmarks**
+   - Normalise reasoning payloads before merging, record throughput baselines
+     in fixtures, and tune benchmark expectations using captured metrics.
 
-### Retrieval 2.0
+A follow-up PR sweep (PR-S3) can concentrate on hybrid embedding cache reuse
+once S1 and S2 land, while PR-O2 can add documentation updates for formatter
+contracts after O1 merges. TestPyPI remains out of scope until these slices
+restore a green suite.
 
-- **Assumption:** Static top-k retrieval causes citation blind spots.
-- **Support:** Search cache regressions show the current layer still
-  revisits stale results and lacks adaptive k.
-- **Counterpoint:** Aggressive re-querying increases latency unless the
-  cache behaves predictably.
-- **Synthesis:** Fix cache determinism first, then introduce adaptive
-  query sizing with logging to compare latency against factuality.
+## Behaviour and coverage strategy
 
-### Verification pipeline
+- Re-run the full behaviour suite after PR-S1 and PR-R1 merge to confirm
+  user workflows still capture unmodified answers and warning telemetry.
+- Maintain coverage ≥90 % by extending property-based suites with the new
+  fixtures introduced above. The search cache property test already seeds a
+  coverage gap we will close once the namespace helper lands.【e865e9†L15-L52】
+- Document each regression fix in `STATUS.md`, `TASK_PROGRESS.md`, and the
+  alpha issue so future reviewers can trace evidence without relying on the
+  superseded October 5 logs.
 
-- **Assumption:** Claim extraction plus retries lower hallucinations.
-- **Support:** Tests reveal FactChecker now rejects missing
-  configuration, so the pipeline is brittle.
-- **Counterpoint:** Patching tests without fixing configuration will
-  mask runtime errors.
-- **Synthesis:** Define explicit FactChecker defaults, update the
-  reverification configuration contract, and extend tests to cover both
-  configured and default paths.
+## Immediate next actions
 
-### Heterogeneous agents and tooling
-
-- **Assumption:** Role-specific models reduce cost while preserving
-  quality.
-- **Support:** Current configuration relies on a single tier, so cost
-  telemetry is theoretical.
-- **Counterpoint:** Premature multi-model routing without guardrails
-  could complicate incident response.
-- **Synthesis:** Capture per-role latency and token usage using the
-  current model first. Add configurable routing tables in a follow-up
-  PR once telemetry makes trade-offs clear.
-
-### Knowledge-graph integration
-
-- **Assumption:** Making the knowledge graph first-class improves
-  multi-hop reasoning.
-- **Support:** Graph exports exist but tests show backup rotation and
-  persistence regressions.
-- **Counterpoint:** Persisting additional triples without stable
-  backups risks data loss.
-- **Synthesis:** Stabilize backup scheduler behaviour, then add KG
-  consistency checks plus provenance guards once persistence is
-  reliable.
-
-## Fresh pytest diagnostics (2025-10-03 22:37 UTC)
-
-### FactChecker defaults
-
-- **Representative failures:**
-  - `tests/unit/orchestration/test_reverify.py`:
-    - `test_reverify_extracts_claims_and_retries`
-- **Assumption:** Restoring default FactChecker configuration should
-  unblock reverification retries.
-- **Support:** The regression surfaces as a validation error complaining
-  about missing configuration.
-- **Counterpoint:** Hard-coding defaults without fixture opt-outs could
-  hide legitimate misconfiguration.
-- **Synthesis:** Provide explicit defaults in configuration factories
-  while updating fixtures to assert opt-in overrides so tests can verify
-  both configured and default flows.
-
-### Backup scheduler
-
-- **Representative failures:**
-  - `tests/unit/storage/test_backup_scheduler.py`:
-    - `test_scheduler_restarts_existing_timer`
-    - `test_rotation_policy_removes_excess_and_stale_backups`
-- **Assumption:** The scheduler should restart timers and prune backups
-  deterministically.
-- **Support:** Tests assert observed behaviour (missing cancellation,
-  stale cleanup) and currently fail.
-- **Counterpoint:** Simplistic fixes risk race conditions in production
-  timers.
-- **Synthesis:** Introduce deterministic timer handles in the scheduler
-  abstraction and extend tests with Socratic prompts questioning
-  cancellation semantics before touching production concurrency paths.
-
-### Search cache and stubs
-
-- **Status update:** PR-C is complete; the October 5 verify and coverage
-  logs show the deterministic fallback assertion passing and the lint
-  sweep staying green.
-  【F:baseline/logs/task-verify-20251005T031512Z.log†L1-L21】
-  【F:baseline/logs/task-coverage-20251005T032844Z.log†L1-L24】
-- **Representative failures:**
-  - `tests/unit/test_cache.py::*`
-  - `tests/unit/test_core_modules_additional.py::*`
-  - `tests/unit/test_failure_scenarios.py::test_external_lookup_fallback`
-- **Assumption:** Cache metadata drift stems from regressions in backend
-  keys and stub fallbacks.
-- **Support:** Assertions expect per-backend isolation and stub fallback
-  responses.
-- **Counterpoint:** Over-fitting to tests may reduce runtime resilience
-  if fallback semantics change.
-- **Synthesis:** Refactor cache keys via a dedicated helper, add
-  Socratic checklists in tests to challenge fallback behaviour, and
-  document backend contracts so runtime changes stay auditable.
-
-### API and FastMCP
-
-- **Representative failures:**
-  - `tests/unit/test_api.py::test_fallback_multiple_ips`
-  - `tests/unit/test_a2a_mcp_handshake.py::*`
-  - `tests/unit/test_mcp_interface.py::test_client_server_roundtrip`
-- **Assumption:** Missing exports and constructor signatures break API
-  clients.
-- **Support:** Attribute errors and unexpected kwargs confirm the
-  breakage.
-- **Counterpoint:** Re-exporting without integration coverage could
-  reintroduce stale adapters.
-- **Synthesis:** Restore exports through the package `__all__`, align
-  FastMCP constructors with documented schemas, and add behaviour
-  coverage for handshake retries.
-
-### Orchestrator error handling
-
-- **Representative failures:**
-  - `tests/unit/test_orchestrator_errors.py::*`
-  - `tests/unit/test_parallel_query_timeout_claims`
-- **Assumption:** Error fallback should emit structured claim mappings.
-- **Support:** Type errors show the pipeline now injects strings instead
-  of mappings.
-- **Counterpoint:** Tightening the schema could mask debugging strings.
-- **Synthesis:** Update error-handling helpers to normalise claim
-  payloads, retain debugging metadata under explicit keys, and add
-  Socratic prompts in tests to question claim structure expectations.
-
-### Planner metadata and documentation hygiene
-
-- **Representative failures:**
-  - `tests/unit/test_advanced_agents.py::test_planner_metadata`
-  - `tests/unit/test_models_docstrings.py::test_class_docstrings`
-- **Assumption:** Planner outputs and documentation lost required
-  context during refactors.
-- **Support:** Attribute errors and docstring assertions fail.
-- **Counterpoint:** Reintroducing heavy fixtures may slow planner
-  iterations.
-- **Synthesis:** Provide lightweight metadata adapters in planner mocks
-  and refresh docstrings with concise yet auditable descriptions,
-  capturing trade-offs in documentation.
-
-### Storage contracts
-
-- **Representative failures:**
-  - `tests/unit/test_incremental_updates.py`:
-    - `test_persist_claim_triggers_index_refresh`
-  - `tests/unit/test_duckdb_storage_backend.py`:
-    - `TestDuckDBStorageBackend::test_run_migrations`
-- **Assumption:** Storage initialisation and migrations drifted from
-  deterministic expectations.
-- **Support:** Tests observe missing knowledge graph initialisation and
-  redundant migration writes.
-- **Counterpoint:** Forcing eager initialisation may regress lazy-loading
-  performance.
-- **Synthesis:** Add guard rails ensuring test fixtures bootstrap
-  storage deterministically while keeping production lazy paths
-  documented and monitored.
-
-### Environment and telemetry
-
-- **Representative failures:**
-  - `tests/unit/test_check_env_warnings.py::*`
-  - `tests/unit/test_more_coverage.py::test_formattemplate_metrics`
-- **Assumption:** Environment checks and telemetry helpers depend on
-  metadata that recent refactors removed.
-- **Support:** Errors cite missing package metadata and claim audit
-  fields.
-- **Counterpoint:** Reintroducing metadata blindly may duplicate build
-  steps.
-- **Synthesis:** Provide fixture-supplied metadata hooks, question each
-  field’s provenance, and document the expected telemetry surface in
-  specs.
-
-## Highest-impact priorities
-
-1. Restore a green pytest suite by fixing the clustered regressions above,
-   starting with the search stub instrumentation gap observed on
-   October 4 before iterating through FactChecker defaults, storage
-   rotation, cache determinism, API adapters, and orchestrator error
-   handling.
-2. Refresh coverage evidence after the suite is green, keeping the 92.4%
-   gate enforceable ahead of alpha tagging.
-3. Instrument AUTO mode and planner output with the telemetry required to
-   tune adaptive debate and PRDV upgrades without guesswork.
-4. Document routing, verification, and retrieval decisions so reviewers can
-   audit improvements without external context.
-
-## Planned PR slices
-
-Each bullet is scoped for a fast review cycle and can ship independently.
-Sub-bullets outline the concrete tasks required for each slice.
-
-1. **PR-A:** Normalize FactChecker defaults and update reverification
-   fixtures so `test_reverify_extracts_claims_and_retries` passes while
-   preserving opt-out coverage.
-   - Define explicit FactChecker defaults inside configuration factories.
-   - Update fixtures to assert both default and opt-out flows.
-   - Extend tests with Socratic prompts that question retry coverage and
-     claim extraction boundaries.
-2. **PR-B:** Repair backup scheduler restart logic and rotation policy to
-   satisfy `tests/unit/storage/test_backup_scheduler.py` without
-   introducing timing flakiness.
-   - Inject deterministic timer handles into scheduler abstractions.
-   - Ensure cancellation flags flip before rotation assertions execute.
-   - Add regression tests that probe restart semantics with dialectical
-     checklists.
-3. **PR-C (complete 2025-10-05):** Refactor search cache key derivation,
-   backend isolation, and stub fallback handling so cache and stub suites
-   pass with deterministic query preservation and restored `add_calls`
-   instrumentation.【F:baseline/logs/task-verify-20251005T031512Z.log†L1-L21】
-   - Restore stub `add_calls` bookkeeping with explicit phase labels.
-   - Ensure fallback bundles echo caller queries rather than templated
-     prompts.
-   - Document backend key derivation and add targeted tests that challenge
-     vector-search toggles via Socratic assertions.
-4. **PR-D:** Restore `autoresearch.api.parse` exports and align FastMCP
-   adapter construction with handshake tests, covering both API and MCP
-   suites.
-   - Re-export the parser entry point through package initialisers.
-   - Synchronise FastMCP adapter signatures with documented schemas.
-   - Expand handshake tests to probe retries and failure branches.
-5. **PR-E:** Normalise orchestrator error claim payloads and parallel
-   timeout messaging so error-handling suites reintroduce mapping-based
-   claims and clear reasoning trails.
-   - Convert string payloads back to structured mappings with debug keys.
-   - Align timeout messaging with behaviour-suite expectations.
-   - Add dialectical assertions contrasting debug versus user messages.
-6. **PR-F:** Stabilise storage initialisation and migration contracts,
-   ensuring knowledge-graph setup and migration idempotency satisfy the
-   incremental update and DuckDB tests.
-   - Add deterministic bootstrap helpers for knowledge-graph fixtures.
-   - Guard migrations with idempotent checks and audit logging.
-   - Extend incremental update tests with prompts questioning lazy versus
-     eager loading.
-7. **PR-G:** Provide planner metadata adapters and refreshed docstrings so
-   planner metadata and documentation hygiene suites pass without slowing
-   planner iterations.
-   - Add lightweight metadata adapters in planner mocks.
-   - Refresh docstrings with concise rationales referencing Socratic
-     checkpoints.
-   - Update documentation hygiene tests to cover the new descriptions.
-8. **PR-H:** Supply environment metadata fixtures and telemetry guards for
-   `check_env_warnings` and `formattemplate_metrics` coverage tests.
-   - Provide fixture hooks that inject metadata without full build steps.
-   - Harden telemetry helpers against missing optional dependencies.
-   - Expand coverage tests with prompts verifying guardrail behaviour.
-9. **PR-I:** After PR-A through PR-H land, capture a fresh coverage run
-   and update release documentation with the new evidence.
-   - Run `uv run task verify` with non-GPU extras and archive the logs.
-   - Run `uv run task coverage` and refresh `coverage.xml` baselines.
-   - Update `STATUS.md`, `TASK_PROGRESS.md`, `CODE_COMPLETE_PLAN.md`, and
-     `docs/release_plan.md` with the new artefacts.
-10. **PR-J:** Add AUTO mode telemetry, capturing skip/escalate decisions
-    and evidence coverage for tuning once the suite is green.
-    - Instrument AUTO decision points with coverage and confidence metrics.
-    - Add behaviour tests under `reasoning_modes` that question skip versus
-      escalate choices.
-    - Document tuning guidelines in `docs/` using dialectical analyses.
-11. **PR-K:** Introduce dependency-aware planner prompts with Socratic
-    self-checks and regression coverage building on PR-J outputs.
-    - Update planner schemas to express dependencies and self-check prompts.
-    - Extend unit tests with counterexamples challenging dependency logic.
-    - Document how planner outputs pair with AUTO telemetry for reviewers.
-
-## Coverage and behaviour follow-up
-
-- After PRs A–H, rerun `uv run task verify EXTRAS="nlp ui vss git
-  distributed analysis llm parsers"` to confirm lint, mypy, and pytest
-  gates are green.
-- When the suite passes, capture a fresh `task coverage` log and update
-  `docs/release_plan.md`, `STATUS.md`, `TASK_PROGRESS.md`, and
-  `CODE_COMPLETE_PLAN.md` with the new evidence.
-- Expand behaviour coverage by adding scenarios under the
-  `reasoning_modes` tag that exercise AUTO telemetry once PR-J merges.
-
-## Documentation actions
-
-- Mirror this plan in `CODE_COMPLETE_PLAN.md`, `ROADMAP.md`, and the
-  alpha release issue so the repository tells a consistent story.
-- Add release notes summarising the restored tests and telemetry once
-  coverage evidence is refreshed.
-
+- [ ] Draft PR-S1 with deterministic stubs, hybrid ranking signature fixes,
+  and refreshed search fixtures.
+- [ ] Draft PR-S2 introducing the namespace-aware cache key helper and
+  expanded property tests.
+- [ ] Draft PR-O1 to preserve formatting fidelity for JSON and markdown.
+- [ ] Draft PR-R1 to relocate warning banners into structured telemetry and
+  update behaviour coverage.
+- [ ] Draft PR-P1 to normalise reasoning merges and calibrate scheduler
+  benchmarks.
+- [ ] Re-run `uv run --extra test pytest` after the above PRs land to confirm
+  a green suite before re-enabling the coverage and release sweeps.

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -1,70 +1,54 @@
 # Prepare first alpha release
 
 ## Context
-As of **October 4, 2025 at 05:34 UTC** the strict typing gate remains green:
-`uv run mypy --strict src tests` again reported “Success: no issues found in
-790 source files”, so we can focus on the remaining pytest regressions before
-rerunning the full release sweep.【c2f747†L1-L2】 A targeted `uv run --extra
-test pytest` sample at **05:31 UTC** still reproduces the legacy search stub
-fallback drift and guides the PR-C scope.【81b49d†L25-L155】【81b49d†L156-L204】
-【ce87c2†L81-L116】
-
-The follow-up release sweeps confirm the lint sweep landed and that PR-C’s
-instrumentation work is in place. At **14:44 UTC** `uv run task verify
-EXTRAS="nlp ui vss git distributed analysis llm parsers"` prints
-`[verify][lint] flake8 passed`, clears strict mypy, and shows both legacy and
-VSS parameterisations of
-`tests/unit/test_core_modules_additional.py::test_search_stub_backend`
-passing before `tests/unit/test_failure_scenarios.py::
-test_external_lookup_fallback` fails with an empty placeholder URL.
-【F:baseline/logs/task-verify-20251004T144057Z.log†L167-L169】【F:baseline/logs/task-verify-20251004T144057Z.log†L555-L782】
-The paired coverage sweep at **14:45 UTC** stops on the same assertion, so the
-preflight plan now treats the deterministic fallback URL as the last PR-C step
-before coverage can refresh.
-【F:baseline/logs/task-coverage-20251004T144436Z.log†L481-L600】【F:docs/v0.1.0a1_preflight_plan.md†L10-L239】
-
-A fresh verify/coverage sweep at **03:15 UTC/03:28 UTC on October 5, 2025** now
-runs clean end-to-end, confirming the fallback fix and locking in the 92.4 %
-coverage floor that unblocks the release gates. The updated artifacts live in
-[`baseline/logs/task-verify-20251005T031512Z.log`](../baseline/logs/task-verify-20251005T031512Z.log)
-and [`baseline/logs/task-coverage-20251005T032844Z.log`](../baseline/logs/task-coverage-20251005T032844Z.log),
-completing the evidence trail alongside the earlier failing runs.
-
-TestPyPI dry runs remain paused; with the fallback fix validated we will
-re-enable the publish stage before the next release sign-off once the
-downstream gates close, with the follow-up tracked in
-[reactivate-testpypi-dry-run](reactivate-testpypi-dry-run.md).
-【F:docs/v0.1.0a1_preflight_plan.md†L10-L239】
+As of **October 4, 2025 at 21:04 UTC** the strict typing gate remains green:
+`uv run mypy --strict src tests` reports “Success: no issues found in 790
+source files”, so the alpha push can continue to rely on strict mode while we
+repair the failing pytest surface.【a78415†L1-L2】 The latest
+`uv run --extra test pytest` sweep finishes with ten failures across search
+stubs, cache determinism, orchestrator telemetry, reasoning answers, and
+output formatting fidelity, resetting the release critical path around these
+clusters.【53776f†L1-L60】 Targeted property tests highlight how
+`OutputFormatter` drops control characters and collapses whitespace, while
+search cache tests show backend calls firing despite cached results, further
+pinning down the regression scope.【5f96a8†L12-L36】【e865e9†L1-L58】 Focused
+reasoning tests confirm warning banners now mutate the final answer, and the
+DuckDuckGo stub diverges from the mocked payload, keeping behaviour coverage
+red until the new PR slices land.【cf191d†L27-L46】【34ebc5†L1-L76】 TestPyPI dry
+runs stay paused per the improvement plan; we will revisit once the suite is
+green.
 
 ## Tasks
-- [x] Finish PR-C by restoring the deterministic fallback URL so the
-  remaining search failure clears (validated via
-  `baseline/logs/task-verify-20251005T031512Z.log`).
-- [x] Confirm the lint sweep landed via the latest `task verify` run
-  (`baseline/logs/task-verify-20251005T031512Z.log`).
-- [ ] Ship PR-A, PR-B, and PR-D through PR-H from the refreshed preflight
-  plan to restore a green pytest suite.
-- [x] Capture fresh verify and coverage logs once the suite passes and update
-  release documentation (`baseline/logs/task-verify-20251005T031512Z.log`,
-  `baseline/logs/task-coverage-20251005T032844Z.log`).
-- [ ] Re-run the TestPyPI dry run after enabling the publish flag and archive
-  the resulting log for the release dossier (tracked in
-  [reactivate-testpypi-dry-run](reactivate-testpypi-dry-run.md)).
-- [ ] Schedule the release sign-off review with the approvers, outlining
-  agenda and required evidence in this ticket.
-- [ ] Run the release sign-off review with updated evidence and record
-  the outcome here.
+- [ ] Land **PR-S1** – restore deterministic search stubs, hybrid ranking
+  signatures, and local file fallbacks in line with the updated preflight
+  plan.【F:docs/v0.1.0a1_preflight_plan.md†L38-L92】
+- [ ] Land **PR-S2** – add namespace-aware cache key helpers plus regression
+  coverage so cached queries avoid repeated backend calls.
+- [ ] Land **PR-O1** – preserve OutputFormatter fidelity for control
+  characters and whitespace across JSON and markdown outputs.
+- [ ] Land **PR-R1** – relocate reasoning warning banners into structured
+  telemetry and update behaviour coverage to assert clean answers.
+- [ ] Land **PR-P1** – normalise parallel reasoning merges and recalibrate
+  scheduler benchmarks against recorded baselines.
+- [ ] Capture fresh verify and coverage logs once the above PRs merge and
+  update the release dossier.
+- [ ] Schedule and run the release sign-off review after the suite and
+  coverage gates return to green.
 
 
 ## Dependencies
-- [coordinate-deep-research-enhancement-initiative](coordinate-deep-research-enhancement-initiative.md)
-- [adaptive-gate-and-claim-audit-rollout](adaptive-gate-and-claim-audit-rollout.md)
+- [coordinate-deep-research-enhancement-initiative]
+  (coordinate-deep-research-enhancement-initiative.md)
+- [adaptive-gate-and-claim-audit-rollout]
+  (adaptive-gate-and-claim-audit-rollout.md)
 - [deliver-evidence-pipeline-2-0](deliver-evidence-pipeline-2-0.md)
 - [planner-coordinator-react-upgrade](planner-coordinator-react-upgrade.md)
 - [session-graph-rag-integration](session-graph-rag-integration.md)
 - [evaluation-and-layered-ux-expansion](evaluation-and-layered-ux-expansion.md)
-- [roll-out-layered-ux-and-model-routing](roll-out-layered-ux-and-model-routing.md)
-- [build-truthfulness-evaluation-harness](build-truthfulness-evaluation-harness.md)
+- [roll-out-layered-ux-and-model-routing]
+  (roll-out-layered-ux-and-model-routing.md)
+- [build-truthfulness-evaluation-harness]
+  (build-truthfulness-evaluation-harness.md)
 - [cost-aware-model-routing](cost-aware-model-routing.md)
 
 ## Acceptance Criteria

--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -679,7 +679,7 @@ class hybridmethod(Generic[T_co, P, R]):
             get_instance = cast(Callable[[], T_co], getattr(objtype, "get_instance"))
 
             @functools.wraps(self.func)
-            def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            def class_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
                 instance = get_instance()
                 stack = _HYBRID_CALL_STACK.get(())
                 frame = _HybridFrame("class", method_name, owner_name)
@@ -689,12 +689,12 @@ class hybridmethod(Generic[T_co, P, R]):
                 finally:
                     _HYBRID_CALL_STACK.reset(token)
 
-            return wrapper
+            return class_wrapper
 
         bound = cast(Callable[P, R], self.func.__get__(obj, objtype))
 
         @functools.wraps(bound)
-        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        def instance_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             stack = _HYBRID_CALL_STACK.get(())
             owner = owner_name or type(obj).__qualname__
             frame = _HybridFrame("instance", method_name, owner)
@@ -704,7 +704,7 @@ class hybridmethod(Generic[T_co, P, R]):
             finally:
                 _HYBRID_CALL_STACK.reset(token)
 
-        return wrapper
+        return instance_wrapper
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- rename the hybridmethod helper closures to satisfy strict mypy
- rewrite the v0.1.0a1 readiness plan, status surfaces, and alpha issue to reflect the latest pytest failures and proposed PR slices
- document the renewed alpha critical path in STATUS.md and TASK_PROGRESS.md with dialectical reasoning and actionable tasks

## Testing
- `uv run mypy --strict src tests`
- `uv run --extra test pytest`
- `uv run --extra test pytest tests/unit/test_output_formatter_property.py::test_output_formatter_json_markdown -q`
- `uv run --extra test pytest tests/unit/test_reasoning_modes.py::test_chain_of_thought_records_steps -q`
- `uv run --extra test pytest tests/unit/test_relevance_ranking.py::test_external_lookup_uses_cache -q`
- `uv run --extra test pytest tests/unit/test_search.py::test_external_lookup -q`


------
https://chatgpt.com/codex/tasks/task_e_68e18addb7a0833395deaac3994c6763