### PR TITLE
Implement hashed search cache keys and reinforce tests

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -29,6 +29,13 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   orchestrator regression after exercising the fallback templating case and the
   hybrid stack assertions, giving us synchronized evidence for both gates while
   the merge fix remains outstanding.【F:baseline/logs/task-coverage-20251005T013130Z.log†L1-L184】【F:tests/unit/test_core_modules_additional.py†L170-L215】【F:tests/unit/test_failure_scenarios.py†L61-L86】
+- Search cache keys now flow through a hashing helper that encodes the
+  normalized query, namespace, embedding signature, storage hints, and hybrid
+  flags while migrating legacy key material; `embedding_lookup` and external
+  cache reads route through the same compatibility layer.【F:src/autoresearch/search/core.py†L846-L905】【F:src/autoresearch/search/core.py†L906-L945】【F:src/autoresearch/search/core.py†L1760-L1815】【F:src/autoresearch/search/core.py†L2138-L2376】
+- Property-driven cache-key regression covers sequential hits, hybrid toggles,
+  and storage-vs-backend interleaving, with the targeted suite green on the new
+  strategy.【F:tests/unit/test_cache.py†L520-L616】【3eea38†L1-L3】
 
 ## October 4, 2025 (earlier runs)
 - `uv run mypy --strict src tests` at **21:04 UTC** continues to report

--- a/docs/specs/search.md
+++ b/docs/specs/search.md
@@ -49,6 +49,10 @@ and hybrid queries and exposes a CLI entry point. See the
 - When `return_handles=True`, `Search.external_lookup` returns an
   `ExternalLookupResult` containing the ranked documents, a backend map,
   and handles to the shared cache and storage manager.
+- Cache keys are derived from a helper that hashes the normalized query text,
+  active namespace, embedding signature, hybrid flags, and storage hints while
+  also exposing the legacy pipe-delimited key so pre-existing caches are read
+  transparently.
 
 ## Public API
 


### PR DESCRIPTION
## Summary
- add a hashed cache-key helper that records namespace, embedding signature, storage hints, and hybrid flags while keeping legacy keys readable
- update `Search.external_lookup` and `Search.embedding_lookup` to route cache reads and writes through the helper
- extend the cache-key property tests, document the contract, and record the targeted run in STATUS

## Testing
- uv run --extra test pytest tests/unit/test_cache.py -k cache_key

------
https://chatgpt.com/codex/tasks/task_e_68e1e9695de48333afeeea7d37203cc1