### PR TITLE
Add cache fingerprint helper and expand cache property tests

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,13 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
 ## October 5, 2025
+- Introduced the shared `hash_cache_dimensions` fingerprint with a `v3:` primary
+  cache key while keeping `v2` and legacy aliases, updated documentation for the
+  contract, and extended the property-based cache suite to cover sequential
+  hybrid toggles, v2 migrations, and storage interleaving; the targeted run stays
+  green after the refactor.
+  【F:src/autoresearch/cache.py†L136-L237】【F:src/autoresearch/search/core.py†L833-L899】
+  【F:docs/specs/search.md†L55-L65】【F:tests/unit/test_cache.py†L454-L792】【33bf2d†L1-L3】
 - `task verify EXTRAS="nlp ui vss git distributed analysis llm parsers"` at
   **01:27 UTC** records a clean pass through the refreshed fallback tests before
   `test_parallel_merging_is_deterministic` raises the known `TypeError`.

--- a/src/autoresearch/search/core.py
+++ b/src/autoresearch/search/core.py
@@ -879,8 +879,10 @@ class Search:
         """Persist results under hashed and legacy cache keys."""
 
         payload = [dict(doc) for doc in docs]
-        self.cache.cache_results(cache_key.primary, backend, payload)
-        if cache_key.legacy != cache_key.primary:
+        targets = [cache_key.primary, *cache_key.aliases]
+        for target in targets:
+            self.cache.cache_results(target, backend, payload)
+        if cache_key.legacy not in targets:
             self.cache.cache_results(cache_key.legacy, backend, payload)
 
     def _get_cached_documents(


### PR DESCRIPTION
## Summary
- add a shared `hash_cache_dimensions` fingerprint and `v3:` cache key aliases for backward compatibility
- persist search results under all hash variants while documenting the refreshed cache contract
- extend the cache property tests to cover sequential toggles, v2 migrations, and storage interleaving

## Testing
- uv run --extra test pytest tests/unit/test_cache.py -k cache_key

------
https://chatgpt.com/codex/tasks/task_e_68e1eefb60088333bb9242410ba0f025