### PR TITLE
Add structured warning field to query responses

### DIFF
--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -42,6 +42,11 @@ tests/unit/test_cache.py -k cache_key`) now passes with the hashed key helper
 migrating legacy entries and covering hybrid and storage permutations, keeping
 search caching ready for the next release checkpoint.【9e20e4†L1-L3】
 
+A structured warning contract landed in this cycle so API and CLI clients can
+read warnings from `QueryResponse.warnings` while displaying the raw answers.
+The behaviour suite now asserts the warnings array and the metrics mirror the
+payload for telemetry exports.
+
 
 ## Milestones
 

--- a/docs/specs/orchestration.md
+++ b/docs/specs/orchestration.md
@@ -73,6 +73,15 @@ prompts, raw responses, structured graphs, and any normalisation warnings. The
 `react_log` pairs with task-level traces to reconstruct planner intent,
 coordinator unlocks, and tool affinity decisions without re-running models.
 
+### Structured answer warnings
+
+Answer auditing emits structured warnings instead of mutating the final
+answer text. The orchestrator attaches warning objects to
+`QueryResponse.warnings`, each exposing `code`, `severity`, `message`,
+`claim_ids`, and labelled `claims`. Clients render caution banners from that
+payload while leaving `answer` untouched. The same entries appear in
+`metrics["answer_audit"]["warnings"]` for telemetry consumers.
+
 ## Invariants
 
 ### Parallel merge

--- a/src/autoresearch/models.py
+++ b/src/autoresearch/models.py
@@ -65,6 +65,7 @@ class QueryResponse(BaseModel):
         citations: Retrieval references associated with the answer.
         reasoning: Ordered reasoning steps exchanged between agents.
         metrics: Execution metrics such as latency and token usage.
+        warnings: Structured warnings captured during orchestration runs.
         claim_audits: Verification metadata mirroring
             :class:`~autoresearch.storage.ClaimAuditRecord` entries, including
             per-claim provenance namespaces (``retrieval``, ``backoff``, and
@@ -82,6 +83,13 @@ class QueryResponse(BaseModel):
     citations: List[Any]
     reasoning: List[Any]
     metrics: Dict[str, Any]
+    warnings: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Structured warnings captured during orchestration, including "
+            "claim-level remediation hints"
+        ),
+    )
     claim_audits: List[Dict[str, Any]] = Field(
         default_factory=list,
         description=(

--- a/tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature
+++ b/tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature
@@ -32,9 +32,13 @@ Feature: AUTO CLI reasoning captures planner, scout gate, and verification loop
     Then the CLI should exit directly without escalation
     And the CLI TLDR should warn about unsupported claims
     And the CLI key findings should omit unsupported claims
+    And the CLI answer should remain free of warning prefixes
+    And the CLI response should expose structured unsupported warnings
 
   Scenario: AUTO debate flow hedges unsupported claims
     When I run the AUTO reasoning CLI for query "unsupported debate rehearsal"
     Then the CLI scout gate decision should escalate to debate
     And the CLI TLDR should warn about unsupported claims
     And the CLI key findings should omit unsupported claims
+    And the CLI answer should remain free of warning prefixes
+    And the CLI response should expose structured unsupported warnings


### PR DESCRIPTION
## Summary
- add a structured `warnings` array to `QueryResponse` and propagate entries from the answer auditor
- expose warnings in depth payloads/CLI JSON while leaving final answers unchanged
- extend AUTO-mode behaviour scenarios and add unit tests to cover the new contract and formatter output
- document the API change in the orchestration spec and release plan

## Testing
- `uv run --extra test pytest tests/unit/orchestration/test_answer_audit.py`
- `uv run --extra test pytest tests/behavior -m "reasoning_modes or error_recovery"`


------
https://chatgpt.com/codex/tasks/task_e_68e20bbd75b08333891c55225aa33069