### PR TITLE
Add lint regression guard and document stricter linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,8 @@ repos:
     entry: uv run python scripts/check_spec_updated.py
     language: system
     pass_filenames: false
+  - id: flake8-lint
+    name: Enforce lint-critical flake8 rules
+    entry: uv run flake8 --select=F401,F402,F811,W291,W293,W391
+    language: system
+    types: [python]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,18 @@ uv run mypy --strict tests/behavior
 # if you need quicker iterations.
 ```
 
+Install the repository's pre-commit hooks to execute the focused flake8 rule
+set (`F401`, `F402`, `F811`, `W291`, `W293`, `W391`) before every commit:
+
+```bash
+pre-commit install
+pre-commit run --all-files flake8-lint
+```
+
+The lint hook aligns with `tests/integration/test_lint_regressions.py`, which
+fails if unused imports or stray whitespace return to `search/core`, behavior
+fixtures, or the integration suite.
+
 ### Project-specific mypy baseline
 
 Before modifying the search stack or the tests that exercise it, capture the

--- a/baseline/logs/flake8-clean-20251005T155652Z.log
+++ b/baseline/logs/flake8-clean-20251005T155652Z.log
@@ -1,0 +1,2 @@
+[UTC:20251005T155652Z] uv run flake8 src tests
+flake8 completed with no findings.

--- a/docs/testing_guidelines.md
+++ b/docs/testing_guidelines.md
@@ -159,6 +159,12 @@ suite adds "AUTO mode completes the configured PRDV verification loops" to
 assert that CLI payloads, orchestrator metrics, and audit rollups report the
 configured loop count consistently.
 
+The integration suite also runs
+`tests/integration/test_lint_regressions.py` to ensure the search core,
+behavior fixtures, and integration helpers stay free of unused imports or
+whitespace regressions flagged by flake8 codes `F401`, `F402`, `F811`, `W291`,
+`W293`, and `W391`.
+
 During `task coverage`, targeted smoke tests execute once per optional extra.
 The task iterates over `ALL_EXTRAS` and runs `pytest tests/targeted -m
 "requires_<extra> and not slow" --noconftest` so CI logs show which marker

--- a/tests/integration/test_lint_regressions.py
+++ b/tests/integration/test_lint_regressions.py
@@ -1,0 +1,29 @@
+"""Regression tests guarding against lint regressions in critical modules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from flake8.api import legacy as flake8_legacy
+
+
+SELECT_CODES = ("F401", "F402", "F811", "W291", "W293", "W391")
+TARGET_PATHS = (
+    Path("src/autoresearch/search/core.py"),
+    Path("tests/behavior/fixtures"),
+    Path("tests/integration"),
+)
+
+
+def test_no_unused_imports_or_whitespace_regressions() -> None:
+    """Ensure core search and integration suites stay free from lint regressions."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    style = flake8_legacy.get_style_guide(select=SELECT_CODES, quiet=1)
+    targets = [str(repo_root / path) for path in TARGET_PATHS]
+
+    report = style.check_files(targets)
+
+    assert (
+        report.total_errors == 0
+    ), f"flake8 reported {report.total_errors} issues for {targets}"

--- a/tests/unit/orchestration/test_answer_audit.py
+++ b/tests/unit/orchestration/test_answer_audit.py
@@ -89,4 +89,3 @@ def test_output_formatter_uses_structured_warnings() -> None:
     note = depth_payload.notes.get("tldr", "")
     assert "unsupported" in note.lower()
     assert "cli answer" not in note.lower()
-


### PR DESCRIPTION
## Summary
- add a focused flake8 pre-commit hook and an integration test that guards against unused imports and whitespace regressions
- clean up lingering whitespace in the answer audit unit test and archive the latest clean flake8 run
- document the stricter lint expectations in the contributor and testing guides

## Testing
- uv run pytest tests/integration/test_lint_regressions.py -q
- uv run task check

------
https://chatgpt.com/codex/tasks/task_e_68e293ee8dc48333a857871162bdbe81