### PR TITLE
Update alpha release plan with AUTO mode and cache blockers

### DIFF
--- a/CODE_COMPLETE_PLAN.md
+++ b/CODE_COMPLETE_PLAN.md
@@ -53,6 +53,8 @@ paused pending lint and search instrumentation fixes.
   docstrings so planner metadata and documentation hygiene suites pass.
 - [ ] Ship **PR-H** – supply environment metadata fixtures and telemetry
   guards for the `check_env_warnings` and `formattemplate_metrics` tests.
+- [ ] Ship **PR-R0** – hydrate AUTO mode scout samples with serialisable claim
+  snapshots so early exits expose structured telemetry again.【349e1c†L1-L64】
 - [ ] Ship **PR-I** – rerun `task coverage` after PR-A through PR-H land and
   update release documentation with the new evidence.
 - [ ] Ship **PR-J** – add AUTO mode telemetry once the suite is green.

--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,18 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
 ## October 5, 2025
+- `uv run mypy --strict src tests` at **16:05 UTC** still reports “Success: no
+  issues found in 205 source files”, confirming the strict gate remains green
+  while we triage the remaining regressions.【daf290†L1-L2】
+- Targeted pytest runs highlight two top blockers: AUTO mode samples drop claim
+  payloads, failing `test_auto_mode_returns_direct_answer_when_gate_exits`, and
+  the cache property suite reuses a function-scoped `monkeypatch` fixture that
+  Hypothesis rejects.【349e1c†L1-L64】【bebacc†L5-L21】 We interrupted the broader
+  suite once these failures reproduced to avoid duplicate noise from downstream
+  dependants.【c59d05†L1-L7】
+- The refreshed preflight plan now inserts **PR-R0** for AUTO mode claim
+  hydration and folds the Hypothesis fixture fix into **PR-S2**, giving us six
+  short, high-impact slices before the next verify sweep.【F:docs/v0.1.0a1_preflight_plan.md†L9-L152】
 - Reasoning payload helpers now always materialise mappings, downstream
   specialists cast orchestration claims to dictionaries, and the strict gate at
   **15:43 UTC** recorded a clean `uv run mypy --strict src tests` sweep.

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,3 +1,13 @@
+As of **2025-10-05 at 16:05 UTC** the strict gate remains green and the highest
+impact regressions are narrowed to AUTO mode claim hydration and cache fixture
+hygiene. `uv run mypy --strict src tests` reports “Success: no issues found in
+205 source files”, and targeted pytest runs reproduce the AUTO mode failure and
+the Hypothesis health-check error without incurring the rest of the test-suite
+noise.【daf290†L1-L2】【349e1c†L1-L64】【bebacc†L5-L21】【c59d05†L1-L7】 The updated
+preflight plan now breaks the follow-up work into six small PRs, adding
+**PR-R0** for claim hydration and folding the fixture refactor into
+**PR-S2**.【F:docs/v0.1.0a1_preflight_plan.md†L9-L152】
+
 As of **2025-10-05 at 15:43 UTC** reasoning payloads normalise into mappings,
 parallel orchestration converts stabilised claims back to dictionaries for the
 state, and strict typing now passes under `uv run mypy --strict src tests`.

--- a/docs/v0.1.0a1_preflight_plan.md
+++ b/docs/v0.1.0a1_preflight_plan.md
@@ -1,4 +1,4 @@
-# v0.1.0a1 preflight readiness plan (2025-10-04)
+# v0.1.0a1 preflight readiness plan (2025-10-05 16:05 UTC)
 
 This revision applies a multi-disciplinary, dialectical, and Socratic
 analysis to the current alpha release posture. It replaces the superseded
@@ -7,31 +7,32 @@ October 4 triage cycle.
 
 ## Evidence snapshot
 
-- `uv run mypy --strict src tests` continues to pass, confirming the strict
-  gate remains green while we repair the pytest regressions uncovered in the
-  latest sweep.【a78415†L1-L2】
+- `uv run mypy --strict src tests` at **16:05 UTC on October 5, 2025** reports
+  “Success: no issues found in 205 source files”, keeping the strict gate
+  green for alpha triage.【daf290†L1-L2】
+- A focused `pytest` target confirms the AUTO mode regression
+  (`tests/unit/orchestration/test_auto_mode.py::
+  test_auto_mode_returns_direct_answer_when_gate_exits`)
+  fails because AUTO mode drops the synthesiser’s claim list, leaving scout
+  samples without content; we halted the broad test run after verifying this
+  regression to avoid cascading failures.【349e1c†L1-L64】【c59d05†L1-L7】
+- Hypothesis aborts
+  `tests/unit/test_cache.py::test_legacy_cache_entries_upgrade_on_hit` with a
+  function-scoped `monkeypatch` fixture, showing the cache property suite still
+  needs deterministic state isolation before we can trust its coverage.
+  【bebacc†L5-L21】
 - Fallback placeholders now carry canonical URLs and backend labels via
-  `Search._normalise_backend_documents`, and the refreshed unit tests cover the
-  stub backend, fallback return-handles, and failure scenarios paths; the
-  current `task verify` sweep reaches these passing assertions before
-  `test_parallel_merging_is_deterministic` re-fails with the known `TypeError`.
-  【F:src/autoresearch/search/core.py†L842-L918】【F:tests/unit/test_core_modules_additional.py†L134-L215】【F:tests/unit/test_failure_scenarios.py†L43-L86】【F:baseline/logs/task-verify-20251005T012754Z.log†L1-L196】
-- `uv run --extra test pytest` now fails with ten regressions that cluster
-  around search backends, cache determinism, orchestrator determinism,
-  reasoning telemetry, and output formatting edge cases, establishing the
-  highest-impact blockers to the alpha tag.【53776f†L1-L60】
-- Targeted property-based tests show OutputFormatter drops control
-  characters and collapses whitespace, while cache tests prove backend calls
-  still fire on cache hits, highlighting concrete failure modes we must
-  address before rerunning the full suite.【5f96a8†L12-L36】【e865e9†L1-L58】
-- Focused orchestration and reasoning tests demonstrate that debate
-  telemetry currently mutates answers with warning banners and that the
-  parallel merge path no longer returns hashable reasoning steps, creating
-  correctness risks for downstream consumers.【cf191d†L27-L46】【53776f†L22-L38】
-- Search integration tests show the DuckDuckGo stub diverges from the mocked
-  query payload and that hybrid ranking now calls patched hooks with the
-  wrong signature, confirming the need for renewed backend determinism.
-  【34ebc5†L1-L76】
+  `Search._normalise_backend_documents`; `task verify` reaches those assertions
+  before the known `test_parallel_merging_is_deterministic` failure recurs,
+  confirming search metadata fixes held through the latest sweep.
+  【F:src/autoresearch/search/core.py†L842-L918】
+  【F:tests/unit/test_core_modules_additional.py†L134-L215】
+  【F:tests/unit/test_failure_scenarios.py†L43-L86】
+  【F:baseline/logs/task-verify-20251005T012754Z.log†L1-L196】
+- Property-based cache probes still show repeated backend calls on cache hits,
+  and behaviour tests record warning banners inside final answers, so the
+  previously prioritised regression clusters remain valid targets for the next
+  set of PR slices.【5f96a8†L12-L36】【e865e9†L1-L58】【cf191d†L27-L46】
 
 ## Dialectical review of active blockers
 
@@ -54,12 +55,16 @@ October 4 triage cycle.
 - **Support:** The property-based cache test records three backend calls for
   an identical query, proving cache misses despite persisted artifacts.
   【e865e9†L15-L52】
-- **Counterpoint:** Forcing cache hits without auditing embedding metadata
-  risks staleness for hybrid queries.
-- **Synthesis:** Introduce a namespace + embedding signature key helper,
-  add Socratic assertions that question when hybrid metadata should bypass
-  cache reuse, and extend unit tests to cover sequential and interleaved
-  cache hits.
+- **Counterpoint:** Suppressing Hypothesis health checks would hide state
+  leakage between draws; we need deterministic fixtures before tightening
+  cache semantics.【bebacc†L5-L21】
+- **Socratic check:** What evidence would show cache keys are fixed while
+  Hypothesis still fails? Only a targeted property probe that mutates the
+  namespace per draw without relying on `monkeypatch` would separate fixture
+  scope from key logic.
+- **Synthesis:** Build a namespace + embedding signature helper, replace the
+  function-scoped `monkeypatch` fixture with an inline context manager, and
+  extend property tests to alternate between cached and uncached namespaces.
 
 ### Output formatting fidelity
 - **Assumption:** OutputFormatter must preserve control characters and
@@ -79,12 +84,35 @@ October 4 triage cycle.
 - **Support:** The parallel merge test now raises `TypeError` because
   reasoning steps contain dicts instead of strings, and the benchmarking
   harness fails its throughput floor.【53776f†L22-L34】【53776f†L34-L44】
+- **Fresh evidence:** AUTO mode’s early exit no longer hydrates scout claim
+  payloads, so behaviour telemetry lacks the structured content the API
+  contract promises.【349e1c†L1-L64】
 - **Counterpoint:** Tightening determinism without tracing why dicts leak
   into reasoning could hide deeper regressions in agent outputs.
+- **Socratic probe:** Which invariant must hold for AUTO mode samples to stay
+  truthful? Every sample should expose both the textual answer and the claim
+  metadata recorded by the synthesiser; a failing invariant highlights the
+  missing persistence hook.
 - **Synthesis:** Patch the merge reducer to normalise reasoning payloads,
-  audit the aggregator contract with Socratic prompts in tests, and
-  recalibrate the scheduler benchmark using recorded baseline metrics
-  rather than hard-coded floors.
+  hydrate AUTO mode samples with persisted claims, audit the aggregator
+  contract with Socratic prompts in tests, and recalibrate the scheduler
+  benchmark using recorded baseline metrics rather than hard-coded floors.
+
+### AUTO mode sample hydration
+- **Assumption:** Rehydrating the synthesiser’s claims into AUTO mode telemetry
+  will unblock both the failing unit test and downstream behaviour checks.
+- **Support:** The failing unit test shows that samples currently hold empty
+  claim lists even when the synthesiser reports claims through telemetry.
+  【349e1c†L1-L64】
+- **Counterpoint:** Blindly copying claims may reintroduce the dict leakage that
+  broke the parallel merge invariant, so we must constrain the format.
+- **Socratic check:** What question reveals whether claim normalisation is safe?
+  “Which minimal schema lets behaviour consumers assert claim content without
+  mutating orchestrator state?” The answer points to mapping-based snapshots
+  independent of live objects.
+- **Synthesis:** Introduce a claim snapshot helper that converts synthesiser
+  claims into serialisable dataclasses, feed those snapshots into AUTO mode
+  metrics, and extend behaviour coverage to assert the schema stays stable.
 
 ### Reasoning telemetry hygiene
 - **Assumption:** Chain-of-thought answers should remain verbatim, with
@@ -111,15 +139,21 @@ conclusions above.
    - Introduce a dedicated cache key builder that incorporates embedding and
      storage hints, backfill docstrings, and expand property-based tests to
      interrogate sequential cache hits.
-3. **PR-O1 Output formatter fidelity**
+   - Replace function-scoped fixtures in property tests with inline context
+     managers to satisfy Hypothesis health checks.【bebacc†L5-L21】
+3. **PR-R0 AUTO mode claim hydration**
+   - Snapshot synthesiser claims into telemetry-friendly dictionaries,
+     hydrate AUTO mode samples with the snapshots, and add regression tests
+     that probe for non-empty claim lists.【349e1c†L1-L64】
+4. **PR-O1 Output formatter fidelity**
    - Implement JSON whitespace preservation, markdown escaping, and add
      Hypothesis strategies for control characters and whitespace-only
      answers.
-4. **PR-R1 Reasoning telemetry separation**
+5. **PR-R1 Reasoning telemetry separation**
    - Decouple warning banners from answer strings, expose structured
      warnings, and extend behaviour tests to assert clean answers plus
      telemetry fields.
-5. **PR-P1 Orchestrator determinism + scheduler benchmarks**
+6. **PR-P1 Orchestrator determinism + scheduler benchmarks**
    - Normalise reasoning payloads before merging, record throughput baselines
      in fixtures, and tune benchmark expectations using captured metrics.
 
@@ -143,8 +177,10 @@ restore a green suite.
 
 - [ ] Draft PR-S1 with deterministic stubs, hybrid ranking signature fixes,
   and refreshed search fixtures.
-- [ ] Draft PR-S2 introducing the namespace-aware cache key helper and
-  expanded property tests.
+- [ ] Draft PR-S2 introducing the namespace-aware cache key helper,
+  replacing the Hypothesis fixture, and expanding property tests.
+- [ ] Draft PR-R0 to hydrate AUTO mode samples with claim snapshots and lock
+  the regression in unit tests.
 - [ ] Draft PR-O1 to preserve formatting fidelity for JSON and markdown.
 - [ ] Draft PR-R1 to relocate warning banners into structured telemetry and
   update behaviour coverage.

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -1,10 +1,21 @@
 # Prepare first alpha release
 
 ## Context
+As of **October 5, 2025 at 16:05 UTC** the strict typing gate remains green and
+targeted pytest runs isolate two top regressions: AUTO mode samples lose their
+claim payloads, and the cache property suite reuses a function-scoped
+`monkeypatch` fixture that Hypothesis rejects.【daf290†L1-L2】
+【349e1c†L1-L64】【bebacc†L5-L21】【c59d05†L1-L7】
+The refreshed preflight plan splits the recovery into six short PRs, adding a
+new **PR-R0** for AUTO mode claim hydration and folding the fixture refactor
+into **PR-S2**.【F:docs/v0.1.0a1_preflight_plan.md†L9-L152】
+
 As of **October 5, 2025 at 15:43 UTC** reasoning payloads and orchestration
 helpers now normalise claims into concrete dictionaries before tests consume
 them, and `uv run mypy --strict src tests` logs a clean pass for the alpha
-branch.【F:src/autoresearch/orchestration/reasoning_payloads.py†L1-L208】【F:src/autoresearch/orchestration/parallel.py†L200-L232】【F:baseline/logs/mypy-strict-20251005T154340Z.log†L1-L2】
+branch.【F:src/autoresearch/orchestration/reasoning_payloads.py†L1-L208】
+【F:src/autoresearch/orchestration/parallel.py†L200-L232】
+【F:baseline/logs/mypy-strict-20251005T154340Z.log†L1-L2】
 
 As of **October 4, 2025 at 21:04 UTC** the strict typing gate remains green:
 `uv run mypy --strict src tests` reports “Success: no issues found in 790
@@ -32,11 +43,14 @@ remains blocked on orchestrator determinism rather than fallback
 placeholders.【F:src/autoresearch/search/core.py†L842-L918】【F:tests/unit/test_core_modules_additional.py†L134-L215】【F:tests/unit/test_failure_scenarios.py†L43-L86】【4c0de7†L1-L120】
 
 ## Tasks
+- [ ] Land **PR-R0** – hydrate AUTO mode claim samples with serialisable
+  snapshots and extend coverage so early exits keep claim content.
 - [ ] Land **PR-S1** – restore deterministic search stubs, hybrid ranking
   signatures, and local file fallbacks in line with the updated preflight
   plan.【F:docs/v0.1.0a1_preflight_plan.md†L38-L92】
-- [ ] Land **PR-S2** – add namespace-aware cache key helpers plus regression
-  coverage so cached queries avoid repeated backend calls.
+- [ ] Land **PR-S2** – add namespace-aware cache key helpers, replace the
+  function-scoped Hypothesis fixture, and backfill regression coverage so
+  cached queries avoid repeated backend calls.【bebacc†L5-L21】
 - [ ] Land **PR-O1** – preserve OutputFormatter fidelity for control
   characters and whitespace across JSON and markdown outputs.
 - [ ] Land **PR-R1** – relocate reasoning warning banners into structured


### PR DESCRIPTION
## Summary
- capture the latest strict mypy evidence and targeted pytest diagnostics in STATUS.md and TASK_PROGRESS.md
- refresh the v0.1.0a1 preflight plan with new dialectical analysis, an AUTO mode hydration slice, and Hypothesis fixture work
- extend the code completion plan and alpha release issue with PR-R0 and the cache fixture scope fix so follow-up tasks stay traceable

## Testing
- `uv run mypy --strict src tests`
- `uv run --extra test python -m pytest tests/unit/orchestration/test_auto_mode.py -x`
- `uv run --extra test python -m pytest tests/unit/test_cache.py -x`


------
https://chatgpt.com/codex/tasks/task_e_68e2967888b88333b4d08edd3257c9e7