### PR TITLE
Annotate integration fixtures and adjust mypy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,11 +268,17 @@ strict = true
 warn_unused_configs = true
 no_implicit_optional = true
 mypy_path = ["typings"]
-exclude = "(?x)(^tests/(?:analysis|benchmark|behavior/(?:archive)|cli|data|evaluation|evidence|integration|performance|targeted|ui|unit)/)"
+exclude = "(?x)(^tests/(?:analysis|benchmark|behavior/(?:archive)|cli|data|evaluation|evidence|performance|targeted|ui|unit)/)"
 
 [[tool.mypy.overrides]]
 module = ["tests.behavior.steps.*"]
 ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "tests.integration.*"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+check_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = [

--- a/tests/integration/test_monitor_metrics.py
+++ b/tests/integration/test_monitor_metrics.py
@@ -7,9 +7,9 @@ from typing import cast
 
 import psutil
 import pytest
-from requests import Response as RequestsResponse
 from fastapi.testclient import TestClient
 from prometheus_client import CollectorRegistry, generate_latest
+from requests import Response as RequestsResponse
 from typer.testing import CliRunner
 
 from autoresearch.config.loader import ConfigLoader
@@ -21,6 +21,7 @@ from autoresearch.orchestration import metrics
 from autoresearch.orchestration.orchestrator import Orchestrator
 from autoresearch.orchestration.types import CallbackMap
 from autoresearch.resource_monitor import ResourceMonitor
+from tests.typing_helpers import TypedFixture
 
 
 MonitorSetup = Callable[[ConfigModel | None], ConfigModel]
@@ -37,7 +38,9 @@ def dummy_run_query(
 
 
 @pytest.fixture
-def monitor_cli_setup(monkeypatch: pytest.MonkeyPatch) -> MonitorSetup:
+def monitor_cli_setup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> TypedFixture[MonitorSetup]:
     """Return a callable that applies CLI patches with typed state."""
 
     def _apply(config: ConfigModel | None = None) -> ConfigModel:

--- a/tests/integration/test_ontology_reasoning.py
+++ b/tests/integration/test_ontology_reasoning.py
@@ -1,9 +1,12 @@
 """Integration tests for ontology reasoning utilities."""
 
-import rdflib
+from pathlib import Path
+
 import pytest
+import rdflib
 
 from tests.optional_imports import import_or_skip
+from tests.typing_helpers import TypedFixture
 
 from autoresearch.storage import StorageManager, teardown
 from autoresearch.config.models import ConfigModel, StorageConfig
@@ -21,13 +24,15 @@ def _simple_rdfs(graph: rdflib.Graph) -> None:
 
 
 @pytest.fixture(autouse=True)
-def cleanup():
-    yield
+def cleanup() -> TypedFixture[None]:
+    yield None
     teardown(remove_db=True)
     ConfigLoader.reset_instance()
 
 
-def _configure(tmp_path, monkeypatch, engine: str = "simple_rdfs"):
+def _configure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, engine: str = "simple_rdfs"
+) -> None:
     cfg = ConfigModel(
         storage=StorageConfig(
             rdf_backend="memory",
@@ -40,7 +45,9 @@ def _configure(tmp_path, monkeypatch, engine: str = "simple_rdfs"):
     register_reasoner("simple_rdfs")(_simple_rdfs)
 
 
-def test_reasoning_infers_subclass(tmp_path, monkeypatch):
+def test_reasoning_infers_subclass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     _configure(tmp_path, monkeypatch)
     StorageManager.setup()
 
@@ -71,7 +78,9 @@ ex:A rdfs:subClassOf ex:B .
     assert res.askAnswer, "Subclass inference failed"
 
 
-def test_visualization_creates_file(tmp_path, monkeypatch):
+def test_visualization_creates_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     _configure(tmp_path, monkeypatch)
     StorageManager.setup()
 

--- a/tests/integration/test_process_executor_simple.py
+++ b/tests/integration/test_process_executor_simple.py
@@ -1,24 +1,27 @@
 import contextlib
 import os
+from typing import Any
 
 import pytest
 
-from autoresearch.config.models import ConfigModel, DistributedConfig
-from autoresearch.distributed import executors, ProcessExecutor
 from multiprocessing import resource_tracker
 from types import SimpleNamespace
+
+from autoresearch.config.models import ConfigModel, DistributedConfig
+from autoresearch.distributed import ProcessExecutor, executors
 from autoresearch.models import QueryResponse
 from autoresearch.orchestration.state import QueryState
+from tests.typing_helpers import TypedFixture
 
 
 def _dummy_execute_agent_process(
     agent_name: str,
     state: QueryState,
     config: ConfigModel,
-    result_queue=None,
-    storage_queue=None,
-):
-    msg = {
+    result_queue: Any = None,
+    storage_queue: Any = None,
+) -> dict[str, Any]:
+    msg: dict[str, Any] = {
         "action": "agent_result",
         "agent": agent_name,
         "result": {"results": {agent_name: "ok"}},
@@ -32,7 +35,7 @@ def _dummy_execute_agent_process(
 @pytest.fixture
 def process_executor(
     monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
-) -> ProcessExecutor:
+) -> TypedFixture[ProcessExecutor]:
     """Provide a ProcessExecutor that shuts down cleanly after the test."""
 
     monkeypatch.setattr(executors, "_execute_agent_process", _dummy_execute_agent_process)

--- a/tests/integration/test_rdf_persistence.py
+++ b/tests/integration/test_rdf_persistence.py
@@ -11,7 +11,6 @@ For a standalone demo of idempotent setup and teardown, see
 from __future__ import annotations
 
 import importlib
-from collections.abc import Iterator
 from importlib.machinery import ModuleSpec
 
 import pytest
@@ -22,6 +21,7 @@ from autoresearch.config.models import ConfigModel, StorageConfig
 from autoresearch.errors import StorageError
 from autoresearch.storage import StorageContext, StorageManager
 from autoresearch.storage_typing import JSONDict
+from tests.typing_helpers import TypedFixture
 
 
 def _stub_config_loader(
@@ -34,14 +34,14 @@ def _stub_config_loader(
 
 
 @pytest.fixture(autouse=True)
-def cleanup_rdf_store() -> Iterator[None]:
+def cleanup_rdf_store() -> TypedFixture[None]:
     """Clean up the RDF store after each test.
 
     This fixture ensures that the RDF store is properly cleaned up
     after each test, preventing test pollution and resource leaks.
     """
     # Setup is done in the test
-    yield
+    yield None
 
     # Teardown
     context: StorageContext = StorageManager.context

--- a/tests/integration/test_search_backends.py
+++ b/tests/integration/test_search_backends.py
@@ -6,11 +6,13 @@ backends and the main search functionality.
 
 import subprocess
 from pathlib import Path
-from typing import Iterator, Mapping, Sequence
+from typing import Mapping, Sequence
 
 import importlib.util
 
 import pytest
+
+from tests.typing_helpers import TypedFixture
 
 try:
     _spec = importlib.util.find_spec("git")
@@ -32,7 +34,7 @@ SearchResults = Sequence[Mapping[str, object]]
 
 
 @pytest.fixture(autouse=True)
-def cleanup_search() -> Iterator[None]:
+def cleanup_search() -> TypedFixture[None]:
     """Clean up the search system after each test.
 
     This fixture ensures that the search system is properly cleaned up
@@ -42,7 +44,7 @@ def cleanup_search() -> Iterator[None]:
     original_backends = Search.backends.copy()
     cache.clear()
 
-    yield
+    yield None
 
     # Teardown
     Search.backends = original_backends

--- a/tests/integration/test_search_storage.py
+++ b/tests/integration/test_search_storage.py
@@ -6,7 +6,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
-    Generator,
     Mapping,
     MutableMapping,
     Protocol,
@@ -31,6 +30,7 @@ from autoresearch.typing.http import (
     RequestsSessionProtocol,
 )
 from tests.conftest import VSS_AVAILABLE
+from tests.typing_helpers import TypedFixture
 
 if TYPE_CHECKING:  # pragma: no cover - typing helpers
     from autoresearch.cache import SearchCache
@@ -155,14 +155,14 @@ class DummyCache(CacheProtocol):
 
 
 @pytest.fixture(autouse=True)
-def clean_storage(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+def clean_storage(monkeypatch: pytest.MonkeyPatch) -> TypedFixture[None]:
     """Provide isolated in-memory storage for each test."""
     dummy_backend = DummyBackend()
     StorageManager.context.graph = nx.DiGraph()
     StorageManager.context.db_backend = cast("DuckDBStorageBackend", dummy_backend)
     StorageManager.context.rdf_store = cast("GraphProtocol", rdflib.Graph())
     monkeypatch.setattr(StorageManager, "_ensure_storage_initialized", lambda: None)
-    yield
+    yield None
     if StorageManager.context.graph is not None:
         StorageManager.context.graph.clear()
     if StorageManager.context.db_backend is not None:

--- a/tests/integration/test_storage_search_link.py
+++ b/tests/integration/test_storage_search_link.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -15,10 +14,13 @@ from autoresearch.config.models import ConfigModel
 from autoresearch.search import Search
 from autoresearch.storage import StorageManager
 from autoresearch.storage_typing import DuckDBConnectionProtocol, JSONDict
+from tests.typing_helpers import TypedFixture
 
 
 @pytest.fixture(autouse=True)
-def setup_storage(tmp_path: Path, monkeypatch: MonkeyPatch) -> Iterator[None]:
+def setup_storage(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> TypedFixture[None]:
     """Configure isolated in-memory storage and search for each test."""
     monkeypatch.chdir(tmp_path)
     ConfigLoader.reset_instance()
@@ -47,7 +49,7 @@ def setup_storage(tmp_path: Path, monkeypatch: MonkeyPatch) -> Iterator[None]:
     storage.teardown(remove_db=True)
     StorageManager.setup(db_path=cfg.storage.duckdb_path)
     try:
-        yield
+        yield None
     finally:
         storage.teardown(remove_db=True)
         ConfigLoader.reset_instance()


### PR DESCRIPTION
## Summary
- add explicit mypy override for the integration test suite to relax strict function annotation requirements now that the directory is included in checks
- annotate key integration fixtures with `TypedFixture` return types and normalise patched orchestrator outputs used in tests
- import the necessary typing helpers across integration tests that interact with third-party APIs

## Testing
- `uv run mypy --strict tests/integration` *(fails: existing typing issues across the integration suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e6bfecd88333a284c33bed39f048