### PR TITLE
Add strict typing coverage for CLI and evaluation tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,7 +268,7 @@ strict = true
 warn_unused_configs = true
 no_implicit_optional = true
 mypy_path = ["typings"]
-exclude = "(?x)(^tests/(?:analysis|benchmark|behavior/(?:archive)|cli|data|evaluation|evidence|performance|targeted|ui|unit)/)"
+exclude = "(?x)(^tests/(?:analysis|benchmark|behavior/(?:archive)|performance|targeted|ui|unit)/)"
 
 [[tool.mypy.overrides]]
 module = ["tests.behavior.steps.*"]

--- a/tests/cli/test_search_depth.py
+++ b/tests/cli/test_search_depth.py
@@ -5,12 +5,13 @@ import pytest
 from autoresearch.cli_helpers import depth_help_text
 from autoresearch.models import QueryResponse
 from autoresearch.output_format import OutputDepth, OutputFormatter
+from tests.typing_helpers import TypedFixture
 
 pytestmark = pytest.mark.integration
 
 
 @pytest.fixture
-def response_payload() -> QueryResponse:
+def response_payload() -> TypedFixture[QueryResponse]:
     return QueryResponse(
         query="depth test",
         answer="An extended answer about adaptive depth rendering.",

--- a/tests/evidence/test_fever_regression.py
+++ b/tests/evidence/test_fever_regression.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from autoresearch.agents.mixins import ClaimGeneratorMixin
 from autoresearch.evidence import (
@@ -41,7 +42,7 @@ def test_entailment_scoring_supported_claim() -> None:
         entailment_score=breakdown.score,
         sources=[{"snippet": evidence}],
     )
-    payload = record.to_payload()
+    payload: dict[str, Any] = record.to_payload()
     assert payload["provenance"] == {}
     recovered = ClaimAuditRecord.from_payload(payload)
     assert recovered.status == status
@@ -71,7 +72,7 @@ def test_claim_audit_record_from_score_overrides_status() -> None:
 
 
 def test_claim_audit_record_preserves_provenance_round_trip() -> None:
-    provenance = {
+    provenance: dict[str, Any] = {
         "retrieval": {"variants": ["base"]},
         "backoff": {"retry_count": 1},
         "evidence": {"ids": ["src-abc"]},
@@ -95,7 +96,7 @@ def test_claim_generator_attaches_audit_metadata() -> None:
         status=ClaimAuditStatus.NEEDS_REVIEW,
         entailment_score=0.4,
     )
-    claim = harness.create_claim(
+    claim: dict[str, Any] = harness.create_claim(
         "Paris hosts the Eiffel Tower.",
         "thesis",
         audit=record,
@@ -105,7 +106,7 @@ def test_claim_generator_attaches_audit_metadata() -> None:
     assert claim["audit"]["status"] == ClaimAuditStatus.NEEDS_REVIEW.value
     assert claim["audit"].get("provenance") == {}
 
-    claim2 = harness.create_claim(
+    claim2: dict[str, Any] = harness.create_claim(
         "The Louvre is in Paris.",
         "thesis",
         verification_status="supported",

--- a/typings/typer/__init__.pyi
+++ b/typings/typer/__init__.pyi
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class Exit(SystemExit):
+    def __init__(self, code: int | None = ...) -> None: ...
+
+
+class BadParameter(Exception): ...
+
+
+class Context:
+    obj: Any
+
+    def __init__(self, app: Typer | None = ..., **kwargs: Any) -> None: ...
+
+
+class Typer:
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def command(
+        self, *args: Any, **kwargs: Any
+    ) -> Callable[[Callable[P, T]], Callable[P, T]]: ...
+
+    def callback(
+        self, *args: Any, **kwargs: Any
+    ) -> Callable[[Callable[P, T]], Callable[P, T]]: ...
+
+    def add_typer(self, app: Typer, *args: Any, **kwargs: Any) -> None: ...
+
+
+def Option(*args: Any, **kwargs: Any) -> Any: ...
+
+def Argument(*args: Any, **kwargs: Any) -> Any: ...
+
+def echo(message: object = ..., *, err: bool = ...) -> None: ...
+
+def secho(
+    message: object = ..., *, fg: Optional[str] = ..., err: bool = ..., bold: bool = ...
+) -> None: ...
+
+def confirm(text: str, *args: Any, **kwargs: Any) -> bool: ...
+
+def prompt(text: str, *args: Any, **kwargs: Any) -> str: ...
+
+def launch(app: Typer, *args: Any, **kwargs: Any) -> None: ...


### PR DESCRIPTION
## Summary
- remove CLI and evaluation folders from the mypy exclusion list
- annotate CLI and evaluation fixtures with TypedFixture and add runner protocol typing
- normalize evidence regression assertions and add typer stub typings

## Testing
- uv run mypy --strict tests/cli tests/data tests/evaluation tests/evidence

------
https://chatgpt.com/codex/tasks/task_e_68e2f232f6908333b133ea63bf9a1762