### PR TITLE
Document latest verify regression and updated alpha roadmap

### DIFF
--- a/CODE_COMPLETE_PLAN.md
+++ b/CODE_COMPLETE_PLAN.md
@@ -7,62 +7,46 @@ aspects of the system, from core functionality to testing and documentation.
 
 ## Status
 
-As of **October 4, 2025 at 05:34 UTC** the strict typing gate remains green:
-`uv run mypy --strict src tests` reports “Success: no issues found in 790
-source files”, so we can focus on clearing the remaining pytest regressions
-before rerunning the full release sweep.【c2f747†L1-L2】 A fresh
-`uv run --extra test pytest` sample at **05:31 UTC** fails immediately in the
-search stub suite: both the legacy and VSS-enabled paths miss the expected
-`add_calls` telemetry and the fallback bundle preserves the templated query,
-confirming PR-C must repair backend instrumentation first.
-【81b49d†L25-L155】【81b49d†L156-L204】 The broader release sweep still stalls
-earlier in the dialectical pipeline. The
-`uv run task verify EXTRAS="nlp ui vss git distributed analysis llm parsers"`
-attempt fails in flake8, which reports unused imports, excess blank lines, and
-trailing whitespace across Search, behavior, integration, and storage suites.
-【F:baseline/logs/task-verify-20251004T015651Z.log†L1-L62】 Minutes later
-`uv run task coverage EXTRAS="nlp ui vss git distributed analysis llm
-parsers"` stops when the legacy branch of
-`tests/unit/test_core_modules_additional.py::test_search_stub_backend` no
-longer records the expected instance `add_calls`, keeping coverage frozen at
-the prior 92.4 % baseline.【F:baseline/logs/task-coverage-20251004T015738Z.log†L1-L565】
-The preflight plan still sequences remediation through PR-A to PR-H, and the
-alpha issue plus task log now point to the new evidence while TestPyPI stays
-paused pending lint and search instrumentation fixes.
-【F:docs/v0.1.0a1_preflight_plan.md†L9-L323】
-【F:issues/prepare-first-alpha-release.md†L1-L32】
+As of **October 6, 2025 at 04:41 UTC** the strict typing gate stays green, but
+`uv run task verify` now fails inside `flake8` with unused imports, duplicate
+definitions, misplaced `__future__` imports, and newline violations across the
+search, cache, and AUTO-mode telemetry updates. Mypy and pytest do not execute
+until the lint fallout is resolved.【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】
+The paired `uv run task coverage` sweep begins compiling GPU-heavy extras
+(`hdbscan==0.8.40` is the first build) and was aborted to preserve the
+evaluation window, so coverage remains pegged to the earlier 92.4 % evidence
+until the lint cleanup lands.【F:baseline/logs/task-coverage-20251006T044136Z.log†L1-L8】
+The updated preflight plan records PR-S1, PR-S2, and PR-R0 as merged while
+promoting lint repair, coverage reruns, and TestPyPI reactivation as the next
+gates, and the alpha ticket mirrors the same checklist.
+【F:docs/v0.1.0a1_preflight_plan.md†L1-L210】【F:issues/prepare-first-alpha-release.md†L1-L64】
 
 ### Immediate Follow-ups
 
-- [ ] Ship **PR-A** – normalize FactChecker defaults and update
-  reverification fixtures so the reverification unit test suite passes
-  while preserving opt-out coverage.
-- [ ] Ship **PR-B** – repair backup scheduler restart semantics and rotation
-  policy to satisfy `tests/unit/storage/test_backup_scheduler.py` without
-  introducing timing flakiness.
-- [ ] Ship **PR-C** – restore search cache determinism and stub behaviour so
-  cache-related unit tests stop over-fetching and preserve query text.
-- [ ] Ship **PR-D** – expose `autoresearch.api.parse`, align FastMCP adapter
-  construction, and unblock the API and MCP handshake suites.
-- [ ] Ship **PR-E** – normalise orchestrator error claim payloads and
-  parallel timeout messaging so error-handling suites regain mapping-based
-  claims.
-- [ ] Ship **PR-F** – stabilise storage initialisation and migration
-  contracts to satisfy incremental update and DuckDB migration tests.
-- [ ] Ship **PR-G** – provide planner metadata adapters and refreshed
-  docstrings so planner metadata and documentation hygiene suites pass.
-- [ ] Ship **PR-H** – supply environment metadata fixtures and telemetry
-  guards for the `check_env_warnings` and `formattemplate_metrics` tests.
-- [ ] Ship **PR-R0** – hydrate AUTO mode scout samples with serialisable claim
-  snapshots so early exits expose structured telemetry again.【349e1c†L1-L64】
-- [ ] Ship **PR-I** – rerun `task coverage` after PR-A through PR-H land and
-  update release documentation with the new evidence.
-- [ ] Ship **PR-J** – add AUTO mode telemetry once the suite is green.
-- [ ] Ship **PR-K** – layer dependency-aware planner prompts with Socratic
-  self-checks building on PR-J outputs.
-- [ ] Complete the
-  [prepare-first-alpha-release](issues/prepare-first-alpha-release.md)
-  milestones with the refreshed coverage data and updated documentation set.
+- [x] Ship **PR-S1** – deterministic search stubs, hybrid ranking signatures,
+  and refreshed fixtures are merged, keeping canonical queries consistent
+  across telemetry and cache layers.【F:src/autoresearch/search/core.py†L650-L686】
+  【F:src/autoresearch/search/core.py†L1431-L1468】【F:tests/unit/legacy/test_cache.py†L503-L608】
+- [x] Ship **PR-S2** – namespace-aware cache keys and property fixtures now
+  prevent redundant backend calls across namespaces and storage hints.
+  【F:tests/unit/legacy/test_cache.py†L503-L608】【F:tests/unit/legacy/test_cache.py†L779-L879】
+  【F:tests/unit/legacy/test_cache.py†L883-L1010】
+- [x] Ship **PR-R0** – AUTO mode claim hydration leverages the reasoning
+  payload normalisers and orchestrator merge logic to keep telemetry
+  serialisable.【F:src/autoresearch/orchestration/reasoning_payloads.py†L1-L166】
+  【F:src/autoresearch/orchestration/parallel.py†L191-L210】
+- [ ] Deliver **PR-O1** – finish output formatter fidelity work so control
+  characters and whitespace remain intact across JSON and markdown outputs.
+- [ ] Deliver **PR-R1** – confirm warning banners stay in structured telemetry
+  while answers remain clean in CLI and API flows.
+- [ ] Deliver **PR-P1** – recalibrate scheduler benchmarks with merged claim
+  hydration and deterministic cache behaviour.
+- [ ] Repair lint fallout from PR-S1/S2/R0 so `uv run task verify` reaches
+  mypy and pytest, then rerun coverage without GPU extras unless explicitly
+  required and publish the new logs through the release dossier.
+- [ ] Resume TestPyPI dry runs once verify and coverage are green, then close
+  the remaining [prepare-first-alpha-release](issues/prepare-first-alpha-release.md)
+  milestones before proposing the tag.【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】
 
 ## Deep Research Enhancement Program
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap summarizes planned features for upcoming releases.
 Dates and milestones align with the [release plan](docs/release_plan.md).
 See [STATUS.md](STATUS.md) and [CHANGELOG.md](CHANGELOG.md) for current results
 and recent changes. Installation and environment details are covered in the
-[README](README.md). Last updated **October 4, 2025**.
+[README](README.md). Last updated **October 6, 2025**.
 
 ## Deep Research enhancement program
 
@@ -53,18 +53,18 @@ instrumenting AUTO mode—before Phase 2 planner upgrades resume.
 See [STATUS.md](STATUS.md) for detailed logs and
 [CHANGELOG.md](CHANGELOG.md) for recent updates. 0.1.0a1 remains untagged and
 targets **September 15, 2026**, with **0.1.0** planned for **October 1, 2026**
-across project documentation. As of **October 4, 2025 at 05:34 UTC** the
-strict typing gate remains green:
-`uv run mypy --strict src tests` reported “Success: no issues found in 790
-source files”. Minutes earlier, `uv run --extra test pytest` at **05:31 UTC**
-failed in the search stub suite—the legacy and VSS-enabled flows miss the
-expected `add_calls` telemetry and the fallback bundle echoes the templated
-prompt—so the release sweep still depends on PR-C landing first. The broader
-October 3 diagnostic run with 26 failures remains the reference for other
-regression clusters, and the refreshed preflight readiness plan keeps the
-remediation path visible across documentation and issues.
-【c2f747†L1-L2】【81b49d†L25-L155】【81b49d†L156-L204】
-【ce87c2†L81-L116】【F:docs/v0.1.0a1_preflight_plan.md†L1-L323】
+across project documentation. As of **October 6, 2025 at 04:41 UTC** the strict
+typing gate stays green, but `uv run task verify` now fails inside `flake8`
+with unused imports, duplicate definitions, misplaced `__future__` imports, and
+newline violations introduced by the merged search, cache, and AUTO-mode
+telemetry work. Coverage attempts begin compiling GPU-heavy extras and were
+aborted to preserve the evaluation window, so lint repair and a refreshed
+coverage sweep are the next gates.【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】
+【F:baseline/logs/task-coverage-20251006T044136Z.log†L1-L8】 The updated
+[preflight readiness plan](docs/v0.1.0a1_preflight_plan.md) marks PR-S1,
+PR-S2, and PR-R0 complete while prioritising lint cleanup, coverage reruns, and
+TestPyPI reactivation; the alpha ticket mirrors the same checklist.
+【F:docs/v0.1.0a1_preflight_plan.md†L1-L210】【F:issues/prepare-first-alpha-release.md†L1-L64】
 
 The deterministic storage resident-floor documentation remains published and
 linked from the release plan, keeping the TestPyPI stage paused until coverage

--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,19 @@ checks are required. `task verify` always syncs the `dev-minimal` and `test`
 extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
+## October 6, 2025
+- Captured a fresh `uv run task verify` sweep at **04:41 UTC** after the
+  targeted search, cache, and AUTO-mode PRs merged. The run now fails during
+  `flake8` with 70+ style regressions across the API entrypoint, behaviour
+  steps, fixtures, integration shims, and distributed/search/storage tests,
+  so the suite does not reach mypy or pytest until the lint fallout is
+  resolved.【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】
+- Kicked off `uv run task coverage` at **04:41 UTC** to refresh release
+  evidence, but the sync immediately began compiling GPU-heavy extras (for
+  example `hdbscan==0.8.40`). We aborted the attempt to avoid spending the
+  evaluation window on optional builds; the truncated log is archived for the
+  follow-up sweep once the lint step is green again.【F:baseline/logs/task-coverage-20251006T044136Z.log†L1-L8】
+
 ## October 5, 2025
 - `uv run mypy --strict src tests` at **16:05 UTC** still reports “Success: no
   issues found in 205 source files”, confirming the strict gate remains green

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,3 +1,13 @@
+As of **2025-10-06 at 04:41 UTC** the merged search/cache/AUTO telemetry PRs
+introduced lint fallout: `uv run task verify` now fails during `flake8` with
+dozens of unused imports, misplaced `__future__` imports, and newline errors
+across the orchestrator, storage, and behaviour suites, so the run halts
+before mypy or pytest execute.【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】
+The paired `uv run task coverage` attempt begins compiling GPU extras (for
+example `hdbscan==0.8.40`) and was aborted to avoid exhausting the evaluation
+window; we archived the partial log for the follow-up sweep once the lint step
+is green.【F:baseline/logs/task-coverage-20251006T044136Z.log†L1-L8】
+
 As of **2025-10-05 at 16:05 UTC** the strict gate remains green and the highest
 impact regressions are narrowed to AUTO mode claim hydration and cache fixture
 hygiene. `uv run mypy --strict src tests` reports “Success: no issues found in

--- a/baseline/logs/task-coverage-20251006T044136Z.log
+++ b/baseline/logs/task-coverage-20251006T044136Z.log
@@ -1,0 +1,8 @@
+task: [coverage] echo "[coverage] syncing dependencies"
+[coverage] syncing dependencies
+task: [coverage] uv sync \
+   --extra dev-minimal --extra test --extra nlp --extra ui --extra vss --extra git --extra distributed --extra analysis --extra llm --extra parsers --extra gpu \
+  
+
+Resolved 328 packages in 7ms
+   Building hdbscan==0.8.40

--- a/baseline/logs/task-verify-20251006T044116Z.log
+++ b/baseline/logs/task-verify-20251006T044116Z.log
@@ -1,0 +1,124 @@
+task: [verify] set -eu
+extras="dev-minimal test"
+export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-600}"
+uv sync \
+  --python-platform x86_64-manylinux_2_28 \
+  $(printf ' --extra %s' $extras) \
+  
+
+Resolved 328 packages in 7ms
+Audited 176 packages in 0.48ms
+task: [verify] task check-env EXTRAS="dev-minimal test"
+task: [check-env] task --version
+3.45.4
+task: [check-env] uv run python scripts/check_env.py
+Verifying extras: dev-minimal, test
+Python 3.12.10
+Go Task 3.45.4
+uv 0.7.22
+a2a-sdk 0.3.7
+black 25.9.0
+duckdb 1.3.2
+fakeredis 2.31.3
+flake8 7.3.0
+freezegun 1.5.5
+hypothesis 6.140.2
+mypy 1.18.2
+networkx 3.5
+owlrl 7.1.4
+pdfminer-six 20250506
+psutil 7.1.0
+pytest 8.4.2
+pytest-bdd 8.1.0
+pytest-benchmark 5.1.0
+pytest-cov 7.0.0
+pytest-httpx 0.35.0
+python-docx 1.2.0
+redis 6.4.0
+responses 0.25.8
+tomli-w 1.2.0
+types-protobuf 6.32.1.20250918
+types-psutil 7.0.0.20250822
+types-requests 2.32.4.20250913
+types-tabulate 0.9.0.20241207
+uvicorn 0.37.0
+task: [verify] set -eu
+uv run flake8 src tests
+echo "[verify][lint] flake8 passed"
+
+src/autoresearch/main/app.py:86:1: E305 expected 2 blank lines after class or function definition, found 0
+tests/behavior/steps/api_batch_query_steps.py:16:1: F401 'tests.behavior.utils.PayloadDict' imported but unused
+tests/behavior/steps/api_orchestrator_integration_steps.py:22:1: F401 'tests.behavior.utils.PayloadDict' imported but unused
+tests/fixtures/__init__.py:1:22: W292 no newline at end of file
+tests/fixtures/performance.py:37:1: W391 blank line at end of file
+tests/integration/deploy/__init__.py:1:22: W292 no newline at end of file
+tests/integration/extras/__init__.py:1:22: W292 no newline at end of file
+tests/integration/storage/__init__.py:1:22: W292 no newline at end of file
+tests/integration/test_a2a_interface.py:7:1: F811 redefinition of unused 'asyncio' from line 2
+tests/integration/test_a2a_interface.py:8:1: F811 redefinition of unused 'socket' from line 3
+tests/integration/test_a2a_interface.py:9:1: F811 redefinition of unused 'sys' from line 4
+tests/integration/test_a2a_interface.py:10:1: F811 redefinition of unused 'time' from line 5
+tests/integration/test_a2a_interface.py:42:1: E402 module level import not at top of file
+tests/performance/__init__.py:1:22: W292 no newline at end of file
+tests/targeted/test_cli_backup_validation.py:8:1: F404 from __future__ imports must occur at the beginning of the file
+tests/targeted/test_llm_validate_model.py:3:1: F404 from __future__ imports must occur at the beginning of the file
+tests/targeted/test_llm_validate_model.py:5:1: F811 redefinition of unused 'pytest' from line 1
+tests/targeted/test_storage_helpers.py:17:1: E402 module level import not at top of file
+tests/unit/distributed/test_coordination_properties.py:9:1: F404 from __future__ imports must occur at the beginning of the file
+tests/unit/distributed/test_coordination_properties.py:11:1: F811 redefinition of unused 'importlib' from line 3
+tests/unit/distributed/test_coordination_properties.py:12:1: F811 redefinition of unused 'multiprocessing' from line 4
+tests/unit/distributed/test_coordination_properties.py:13:1: F811 redefinition of unused 'random' from line 5
+tests/unit/distributed/test_coordination_properties.py:14:1: F811 redefinition of unused 'sys' from line 6
+tests/unit/distributed/test_coordination_properties.py:15:1: F811 redefinition of unused 'Path' from line 7
+tests/unit/distributed/test_coordination_properties.py:16:1: F811 redefinition of unused 'ModuleType' from line 8
+tests/unit/distributed/test_coordination_properties.py:17:1: F401 'typing.Any' imported but unused
+tests/unit/distributed/test_coordination_properties.py:17:1: F401 'typing.Mapping' imported but unused
+tests/unit/legacy/test_core_modules_additional.py:3:1: F401 'shutil' imported but unused
+tests/unit/monitor/test_metrics_endpoint.py:3:1: F404 from __future__ imports must occur at the beginning of the file
+tests/unit/monitor/test_metrics_endpoint.py:5:1: F404 from __future__ imports must occur at the beginning of the file
+tests/unit/monitor/test_metrics_endpoint.py:7:1: F811 redefinition of unused 'asyncio' from line 1
+tests/unit/monitor/test_metrics_endpoint.py:12:1: F811 redefinition of unused 'monitor_metrics' from line 2
+tests/unit/orchestration/test_auto_mode.py:2:1: F401 'typing.Dict' imported but unused
+tests/unit/orchestration/test_auto_mode.py:2:1: F401 'typing.List' imported but unused
+tests/unit/orchestration/test_auto_mode.py:5:1: F404 from __future__ imports must occur at the beginning of the file
+tests/unit/orchestration/test_auto_mode.py:7:1: F811 redefinition of unused 'Mapping' from line 1
+tests/unit/orchestration/test_auto_mode.py:8:1: F811 redefinition of unused 'Any' from line 2
+tests/unit/orchestration/test_auto_mode.py:10:1: F811 redefinition of unused 'pytest' from line 4
+tests/unit/orchestration/test_metrics_graph_summary.py:4:1: F404 from __future__ imports must occur at the beginning of the file
+tests/unit/orchestration/test_metrics_graph_summary.py:6:1: F811 redefinition of unused 'OrchestrationMetrics' from line 3
+tests/unit/orchestration/test_orchestration_simulations.py:2:1: F404 from __future__ imports must occur at the beginning of the file
+tests/unit/orchestration/test_orchestration_simulations.py:4:1: F811 redefinition of unused 'sys' from line 1
+tests/unit/search/test_adaptive_rewrite.py:3:1: F401 'typing.List' imported but unused
+tests/unit/search/test_adaptive_rewrite.py:5:1: F404 from __future__ imports must occur at the beginning of the file
+tests/unit/search/test_adaptive_rewrite.py:7:1: F401 'types.SimpleNamespace' imported but unused
+tests/unit/search/test_query_expansion_convergence.py:10:1: F404 from __future__ imports must occur at the beginning of the file
+tests/unit/search/test_query_expansion_convergence.py:12:1: F811 redefinition of unused 'sys' from line 1
+tests/unit/search/test_query_expansion_convergence.py:14:1: F811 redefinition of unused 'ModuleType' from line 2
+tests/unit/search/test_query_expansion_convergence.py:14:1: F811 redefinition of unused 'SimpleNamespace' from line 2
+tests/unit/search/test_query_expansion_convergence.py:16:1: F811 redefinition of unused 'patch' from line 3
+tests/unit/search/test_query_expansion_convergence.py:20:1: F811 redefinition of unused 'ctx' from line 5
+tests/unit/search/test_query_expansion_convergence.py:21:1: F811 redefinition of unused 'search_core' from line 6
+tests/unit/search/test_query_expansion_convergence.py:22:1: F811 redefinition of unused 'SearchContext' from line 7
+tests/unit/search/test_query_expansion_convergence.py:23:1: F811 redefinition of unused 'Search' from line 8
+tests/unit/search/test_query_expansion_convergence.py:24:1: F811 redefinition of unused 'make_config_model' from line 9
+tests/unit/search/test_ranking_formula.py:6:1: F404 from __future__ imports must occur at the beginning of the file
+tests/unit/search/test_ranking_formula.py:8:1: F811 redefinition of unused 'pytest' from line 1
+tests/unit/search/test_ranking_formula.py:10:1: F811 redefinition of unused 'ConfigLoader' from line 4
+tests/unit/search/test_ranking_formula.py:11:1: F811 redefinition of unused 'ConfigModel' from line 3
+tests/unit/search/test_ranking_formula.py:11:1: F811 redefinition of unused 'SearchConfig' from line 5
+tests/unit/search/test_session_retry.py:2:1: F404 from __future__ imports must occur at the beginning of the file
+tests/unit/search/test_session_retry.py:4:1: F811 redefinition of unused 'pytest' from line 1
+tests/unit/storage/test_backup_scheduler.py:6:1: F404 from __future__ imports must occur at the beginning of the file
+tests/unit/storage/test_backup_scheduler.py:9:1: F811 redefinition of unused 'datetime' from line 3
+tests/unit/storage/test_backup_scheduler.py:9:1: F811 redefinition of unused 'timedelta' from line 3
+tests/unit/storage/test_backup_scheduler.py:10:1: F811 redefinition of unused 'Path' from line 4
+tests/unit/storage/test_backup_scheduler.py:11:1: F811 redefinition of unused 'Any' from line 5
+tests/unit/storage/test_backup_scheduler.py:11:1: F811 redefinition of unused 'Callable' from line 5
+tests/unit/storage/test_knowledge_graph.py:6:1: F404 from __future__ imports must occur at the beginning of the file
+tests/unit/storage/test_knowledge_graph.py:8:1: F811 redefinition of unused 'SimpleNamespace' from line 3
+tests/unit/storage/test_knowledge_graph.py:9:1: F811 redefinition of unused 'Any' from line 4
+tests/unit/storage/test_knowledge_graph.py:9:1: F811 redefinition of unused 'Sequence' from line 4
+tests/unit/storage/test_protocols.py:4:1: F404 from __future__ imports must occur at the beginning of the file
+tests/unit/storage/test_protocols.py:6:1: F811 redefinition of unused 'Path' from line 3
+tests/unit/typing_helpers.py:14:1: F401 'collections.abc.Callable' imported but unused
+task: Failed to run task "verify": exit status 1

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -9,7 +9,7 @@ The publishing workflow follows the steps in
 ROADMAP.md for high-level milestones.
 
 The project kicked off in **May 2025** (see the initial commit dated
-`2025-05-18`). This schedule was last updated on **October 5, 2025** and
+`2025-05-18`). This schedule was last updated on **October 6, 2025** and
 reflects that the codebase currently sits at the **unreleased 0.1.0a1** version
 defined in `autoresearch.__version__`. The project targets **0.1.0a1** for
 **September 15, 2026** and **0.1.0** for **October 1, 2026**. See
@@ -18,41 +18,31 @@ STATUS.md, ROADMAP.md, and CHANGELOG.md for aligned progress. Phase 3
 
 ## Status
 
-The strict typing gate remains green, and the latest release sweeps now finish
-cleanly. At **2025-10-05 03:15 UTC** `uv run task verify` records
-`[verify][lint] flake8 passed`, strict mypy success, and
-`tests/unit/test_failure_scenarios.py::test_external_lookup_fallback`
-passing, closing PR-C’s deterministic fallback regression and confirming the
-lint sweep is complete.【F:baseline/logs/task-verify-20251005T031512Z.log†L1-L21】
-The matching **03:28 UTC** `uv run task coverage` sweep lands at 92.4 %
-coverage, documents the same fallback assertion passing, and refreshes
-`coverage.xml` for release auditors.
-【F:baseline/logs/task-coverage-20251005T032844Z.log†L1-L24】
-The [v0.1.0a1 preflight readiness plan](v0.1.0a1_preflight_plan.md) now treats
-PR-C as complete and elevates TestPyPI reactivation as the next gate.
-【F:docs/v0.1.0a1_preflight_plan.md†L1-L314】
+The strict typing gate remains green, but the latest release sweep regressed
+at the lint step. At **2025-10-06 04:41 UTC** `uv run task verify` exits
+during `flake8` with unused imports, duplicate definitions, misplaced
+`__future__` imports, and newline violations across the newly merged search,
+cache, and AUTO-mode telemetry changes. Mypy and pytest did not run because
+the lint step fails early.【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】
+The follow-on **04:41 UTC** `uv run task coverage` attempt began compiling the
+GPU and analysis extras (`hdbscan==0.8.40` is the first build) and was
+aborted to avoid spending the release window on optional wheels; the partial
+log is archived for the next sweep once lint is stable.【F:baseline/logs/task-coverage-20251006T044136Z.log†L1-L8】
 
-With verify and coverage green, TestPyPI reactivation becomes the remaining
-blocker for the release sweep; the alpha ticket tracks the reactivation work
-using the fresh logs as evidence.【F:docs/v0.1.0a1_preflight_plan.md†L1-L314】
-【F:issues/prepare-first-alpha-release.md†L1-L39】
+The [v0.1.0a1 preflight readiness plan](v0.1.0a1_preflight_plan.md) now marks
+PR-S1 (deterministic search stubs), PR-S2 (namespace-aware cache keys), and
+PR-R0 (AUTO-mode claim hydration) as complete while promoting lint repair and
+coverage refresh as the next actions.【F:docs/v0.1.0a1_preflight_plan.md†L1-L210】
+The alpha ticket mirrors the updated checklist and references the new logs so
+release review can trace the lint regression and aborted coverage run.
+【F:issues/prepare-first-alpha-release.md†L1-L64】【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】
 
-The targeted cache regression run (`uv run --extra test pytest
-tests/unit/test_cache.py -k cache_key`) now passes with the hashed key helper
-migrating legacy entries and covering hybrid and storage permutations, keeping
-search caching ready for the next release checkpoint.【9e20e4†L1-L3】
-
-A structured warning contract landed in this cycle so API and CLI clients can
-read warnings from `QueryResponse.warnings` while displaying the raw answers.
-The behaviour suite now asserts the warnings array and the metrics mirror the
-payload for telemetry exports.
-
-Distributed metrics now cite the captured baselines under
-`baseline/evaluation/`. The orchestrator recovery simulation (50 tasks, 0.01 s
-latency, 0.2 fail rate) averages 89.36 tasks/s with a 0.13 recovery ratio, and
-the scheduler micro-benchmark records 121.74 ops/s for one worker versus 241.35
-ops/s for two workers. These figures back the refreshed throughput gates in the
-benchmark and scheduler suites.
+Distributed metrics still cite the captured baselines under
+`baseline/evaluation/`. The orchestrator recovery simulation (50 tasks,
+0.01 s latency, 0.2 fail rate) averages 89.36 tasks/s with a 0.13 recovery
+ratio, and the scheduler micro-benchmark records 121.74 ops/s for one worker
+versus 241.35 ops/s for two workers. These figures continue to back the
+throughput gates in the benchmark and scheduler suites.
 【F:baseline/evaluation/orchestrator_distributed_sim.json†L1-L8】
 【F:baseline/evaluation/scheduler_benchmark.json†L1-L9】
 

--- a/docs/v0.1.0a1_preflight_plan.md
+++ b/docs/v0.1.0a1_preflight_plan.md
@@ -1,9 +1,9 @@
-# v0.1.0a1 preflight readiness plan (2025-10-05 16:05 UTC)
+# v0.1.0a1 preflight readiness plan (2025-10-06 04:41 UTC)
 
 This revision applies a multi-disciplinary, dialectical, and Socratic
 analysis to the current alpha release posture. It replaces the superseded
-October 5 snapshot and focuses on the freshest evidence gathered during the
-October 4 triage cycle.
+October 5 snapshot and incorporates the lint fallout observed after the
+latest verify sweep.
 
 ## Evidence snapshot
 
@@ -16,11 +16,11 @@ October 4 triage cycle.
   fails because AUTO mode drops the synthesiser’s claim list, leaving scout
   samples without content; we halted the broad test run after verifying this
   regression to avoid cascading failures.【349e1c†L1-L64】【c59d05†L1-L7】
-- `uv run --extra test pytest tests/unit/test_cache.py -k cache` now passes,
+- `uv run --extra test pytest tests/unit/legacy/test_cache.py -k cache` now passes,
   confirming the namespace-aware slot builder and inline fixtures keep backend
   invocations to one per unique key while upgrading aliases across namespaces.
-  【816271†L1-L3】【F:tests/unit/test_cache.py†L538-L686】
-  【F:tests/unit/test_cache.py†L742-L874】【F:tests/unit/test_cache.py†L877-L960】
+  【816271†L1-L3】【F:tests/unit/legacy/test_cache.py†L503-L608】
+  【F:tests/unit/legacy/test_cache.py†L779-L879】【F:tests/unit/legacy/test_cache.py†L883-L1010】
 - Fallback placeholders now carry canonical URLs and backend labels via
   `Search._normalise_backend_documents`; `task verify` reaches those assertions
   before the known `test_parallel_merging_is_deterministic` failure recurs,
@@ -33,8 +33,16 @@ October 4 triage cycle.
   confirm backend invocations collapse after the first unique fingerprint, while
   behaviour tests still record warning banners inside final answers, keeping the
   regression clusters prioritised for the next set of PR slices.
-  【F:tests/unit/test_cache.py†L538-L686】【F:tests/unit/test_cache.py†L742-L874】
-  【F:tests/unit/test_cache.py†L877-L960】【cf191d†L27-L46】
+  【F:tests/unit/legacy/test_cache.py†L503-L608】【F:tests/unit/legacy/test_cache.py†L779-L879】
+  【F:tests/unit/legacy/test_cache.py†L883-L1010】【cf191d†L27-L46】
+- A fresh **04:41 UTC on October 6, 2025** `uv run task verify` sweep fails in
+  `flake8` with unused imports, duplicate definitions, and newline violations
+  introduced by the merged search, cache, and AUTO telemetry changes; mypy and
+  pytest do not execute until the lint fallout is resolved.【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】
+- The paired coverage attempt at **04:41 UTC** starts compiling GPU and
+  analysis extras (for example `hdbscan==0.8.40`) and was aborted to preserve
+  the evaluation window; the partial log documents the stalled sweep for the
+  follow-up run after lint repairs.【F:baseline/logs/task-coverage-20251006T044136Z.log†L1-L8】
 
 ## Dialectical review of active blockers
 
@@ -67,8 +75,8 @@ October 4 triage cycle.
 - **Support:** The refreshed property suite alternates namespaces per draw,
   verifies alias upgrades, and asserts backend invocations plateau after the
   first unique fingerprint, demonstrating the slot builder works as intended.
-  【F:tests/unit/test_cache.py†L538-L686】【F:tests/unit/test_cache.py†L742-L874】
-  【F:tests/unit/test_cache.py†L877-L960】
+  【F:tests/unit/legacy/test_cache.py†L503-L608】【F:tests/unit/legacy/test_cache.py†L779-L879】
+  【F:tests/unit/legacy/test_cache.py†L883-L1010】
 - **Counterpoint:** The suite still exercises a single-process cache; multi-
   process or service-isolated deployments could uncover metadata drift despite
   the helper.
@@ -191,16 +199,24 @@ restore a green suite.
 
 ## Immediate next actions
 
-- [ ] Draft PR-S1 with deterministic stubs, hybrid ranking signature fixes,
-  and refreshed search fixtures.
-- [ ] Draft PR-S2 introducing the namespace-aware cache key helper,
-  replacing the Hypothesis fixture, and expanding property tests.
-- [ ] Draft PR-R0 to hydrate AUTO mode samples with claim snapshots and lock
-  the regression in unit tests.
-- [ ] Draft PR-O1 to preserve formatting fidelity for JSON and markdown.
-- [ ] Draft PR-R1 to relocate warning banners into structured telemetry and
-  update behaviour coverage.
-- [ ] Draft PR-P1 to normalise reasoning merges and calibrate scheduler
-  benchmarks.
-- [ ] Re-run `uv run --extra test pytest` after the above PRs land to confirm
-  a green suite before re-enabling the coverage and release sweeps.
+- [x] Land **PR-S1** – deterministic search stubs, hybrid ranking signature
+  fixes, and refreshed fixtures are merged; canonical queries now flow through
+  the stub contract and hybrid telemetry, and regression coverage keeps the
+  contract stable.【F:src/autoresearch/search/core.py†L650-L686】【F:src/autoresearch/search/core.py†L1431-L1468】
+  【F:tests/unit/legacy/test_cache.py†L503-L608】【F:tests/unit/legacy/test_cache.py†L779-L879】
+- [x] Land **PR-S2** – namespace-aware cache keys and property fixtures are in
+  place; Hypothesis now alternates namespaces and asserts backend calls plateau
+  after the first unique fingerprint.【F:tests/unit/legacy/test_cache.py†L503-L608】
+  【F:tests/unit/legacy/test_cache.py†L779-L879】
+- [x] Land **PR-R0** – AUTO mode samples hydrate claim snapshots via the
+  reasoning payload normalisers and parallel orchestrator merge, keeping
+  telemetry dictionaries serialisable.【F:src/autoresearch/orchestration/reasoning_payloads.py†L1-L166】
+  【F:src/autoresearch/orchestration/parallel.py†L191-L210】
+- [ ] Draft **PR-O1** to preserve formatting fidelity for JSON and markdown.
+- [ ] Draft **PR-R1** to separate warning banners from answer strings where
+  behaviour coverage still reports leakage.
+- [ ] Draft **PR-P1** to recalibrate scheduler benchmarks now that claim
+  hydration and deterministic cache behaviour are merged.
+- [ ] Repair the lint fallout introduced by PR-S1/S2/R0 so `uv run task verify`
+  reaches mypy and pytest again, then rerun coverage with GPU extras disabled
+  unless explicitly required.

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -1,14 +1,19 @@
 # Prepare first alpha release
 
 ## Context
-As of **October 5, 2025 at 16:05 UTC** the strict typing gate remains green and
-targeted pytest runs isolate two top regressions: AUTO mode samples lose their
-claim payloads, and the cache property suite reuses a function-scoped
-`monkeypatch` fixture that Hypothesis rejects.【daf290†L1-L2】
-【349e1c†L1-L64】【bebacc†L5-L21】【c59d05†L1-L7】
-The refreshed preflight plan splits the recovery into six short PRs, adding a
-new **PR-R0** for AUTO mode claim hydration and folding the fixture refactor
-into **PR-S2**.【F:docs/v0.1.0a1_preflight_plan.md†L9-L152】
+As of **October 6, 2025 at 04:41 UTC** the merged search, cache, and AUTO-mode
+telemetry PRs introduced lint regressions: `uv run task verify` now fails
+inside `flake8` with unused imports, duplicate definitions, misplaced
+`__future__` imports, and newline violations across behaviour, integration,
+and storage suites, preventing mypy and pytest from executing.
+【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】
+The paired coverage sweep begins compiling GPU-heavy extras (for example
+`hdbscan==0.8.40`) and was aborted to preserve the evaluation window; the
+partial log is archived for the next run after lint repairs.
+【F:baseline/logs/task-coverage-20251006T044136Z.log†L1-L8】
+The refreshed preflight plan now records **PR-S1**, **PR-S2**, and **PR-R0** as
+merged while prioritising lint cleanup and the coverage rerun before TestPyPI
+reactivation.【F:docs/v0.1.0a1_preflight_plan.md†L1-L210】
 
 As of **October 5, 2025 at 15:43 UTC** reasoning payloads and orchestration
 helpers now normalise claims into concrete dictionaries before tests consume
@@ -45,14 +50,18 @@ remains blocked on orchestrator determinism rather than fallback
 placeholders.【F:src/autoresearch/search/core.py†L842-L918】【F:tests/unit/test_core_modules_additional.py†L134-L215】【F:tests/unit/test_failure_scenarios.py†L43-L86】【4c0de7†L1-L120】
 
 ## Tasks
-- [ ] Land **PR-R0** – hydrate AUTO mode claim samples with serialisable
+- [x] Land **PR-R0** – hydrate AUTO mode claim samples with serialisable
   snapshots and extend coverage so early exits keep claim content.
-- [ ] Land **PR-S1** – restore deterministic search stubs, hybrid ranking
+  【F:src/autoresearch/orchestration/reasoning_payloads.py†L1-L166】
+  【F:src/autoresearch/orchestration/parallel.py†L191-L210】
+- [x] Land **PR-S1** – restore deterministic search stubs, hybrid ranking
   signatures, and local file fallbacks in line with the updated preflight
-  plan.【F:docs/v0.1.0a1_preflight_plan.md†L38-L92】
-- [ ] Land **PR-S2** – add namespace-aware cache key helpers, replace the
+  plan.【F:src/autoresearch/search/core.py†L650-L686】【F:src/autoresearch/search/core.py†L1431-L1468】
+  【F:tests/unit/legacy/test_cache.py†L503-L608】
+- [x] Land **PR-S2** – add namespace-aware cache key helpers, replace the
   function-scoped Hypothesis fixture, and backfill regression coverage so
-  cached queries avoid repeated backend calls.【bebacc†L5-L21】
+  cached queries avoid repeated backend calls.【F:tests/unit/legacy/test_cache.py†L503-L608】
+  【F:tests/unit/legacy/test_cache.py†L779-L879】【F:tests/unit/legacy/test_cache.py†L883-L1010】
 - [ ] Land **PR-O1** – preserve OutputFormatter fidelity for control
   characters and whitespace across JSON and markdown outputs.
 - [x] Land **PR-R1** – relocate reasoning warning banners into structured
@@ -61,8 +70,9 @@ placeholders.【F:src/autoresearch/search/core.py†L842-L918】【F:tests/unit/
   【F:tests/behavior/steps/reasoning_modes_auto_cli_cycle_steps.py†L685-L723】
 - [ ] Land **PR-P1** – normalise parallel reasoning merges and recalibrate
   scheduler benchmarks against recorded baselines.
-- [ ] Capture fresh verify and coverage logs once the above PRs merge and
-  update the release dossier.
+- [ ] Repair lint fallout from PR-S1/S2/R0 so `uv run task verify` reaches
+  mypy and pytest again, then capture fresh verify and coverage logs for the
+  release dossier.
 - [ ] Schedule and run the release sign-off review after the suite and
   coverage gates return to green.
 


### PR DESCRIPTION
## Summary
- archive new `uv run task verify` and `uv run task coverage` logs after the targeted PR merges
- update STATUS, TASK_PROGRESS, release plan, preflight plan, and alpha ticket with the lint regression and coverage follow-up plan
- refresh CODE_COMPLETE_PLAN and ROADMAP milestones to highlight the reduced blocker list and next steps

## Testing
- uv run task verify *(fails: flake8 regressions)*
- uv run task coverage *(aborted while compiling GPU extras)*

------
https://chatgpt.com/codex/tasks/task_e_68e347b897b4833381fd2ff9717b90b5