### PR TITLE
Document alpha readiness blockers and plan follow-up workstreams

### DIFF
--- a/CODE_COMPLETE_PLAN.md
+++ b/CODE_COMPLETE_PLAN.md
@@ -41,6 +41,16 @@ gates, and the alpha ticket mirrors the same checklist.
   while answers remain clean in CLI and API flows.
 - [ ] Deliver **PR-P1** – recalibrate scheduler benchmarks with merged claim
   hydration and deterministic cache behaviour.
+- [ ] Deliver **PR-L0** – restore test module hygiene by removing duplicated
+  imports, ensuring each file keeps `from __future__ import annotations` at the
+  top, and capturing a green `uv run task check` log for the release dossier.
+- [ ] Deliver **PR-L1** – reintroduce the legacy helper scripts under
+  `tests/scripts/` (or rewire imports to the production copies), regenerate the
+  scheduler benchmark fixture from current baselines, and document provenance in
+  `baseline/` so pytest collection can progress.
+- [ ] Deliver **PR-V1** – once lint and collection succeed, capture fresh
+  `task verify` and `task coverage` logs without GPU extras, restoring the
+  release evidence trail ahead of the tag proposal.
 - [ ] Repair lint fallout from PR-S1/S2/R0 so `uv run task verify` reaches
   mypy and pytest, then rerun coverage without GPU extras unless explicitly
   required and publish the new logs through the release dossier.

--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,13 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
 ## October 6, 2025
+- Reran `uv run mypy --strict src tests` at **04:53 UTC** and the sweep still
+  reports “Success: no issues found in 794 source files”, confirming the strict
+  gate stays green after the latest merges. The paired `uv run --extra test
+  pytest` attempt at the same timestamp stops during collection with 19 errors
+  triggered by duplicated imports preceding `from __future__ import
+  annotations` and missing legacy helper scripts that formerly lived under
+  `tests/scripts/`.【4fb61a†L1-L2】【8e089f†L1-L118】
 - Captured a fresh `uv run task verify` sweep at **04:41 UTC** after the
   targeted search, cache, and AUTO-mode PRs merged. The run now fails during
   `flake8` with 70+ style regressions across the API entrypoint, behaviour

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,3 +1,11 @@
+As of **2025-10-06 at 04:53 UTC** the strict gate remains green and the latest
+`uv run --extra test pytest` attempt fails during collection with 19 errors that
+stem from duplicated imports preceding `from __future__ import annotations` and
+missing legacy helper scripts expected under `tests/scripts/`. The fresh runs
+confirm `uv run mypy --strict src tests` still reports “Success: no issues
+found in 794 source files”, while pytest cannot proceed until we restore module
+hygiene and fixture assets.【4fb61a†L1-L2】【8e089f†L1-L118】
+
 As of **2025-10-06 at 04:41 UTC** the merged search/cache/AUTO telemetry PRs
 introduced lint fallout: `uv run task verify` now fails during `flake8` with
 dozens of unused imports, misplaced `__future__` imports, and newline errors

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -19,11 +19,18 @@ STATUS.md, ROADMAP.md, and CHANGELOG.md for aligned progress. Phase 3
 ## Status
 
 The strict typing gate remains green, but the latest release sweep regressed
-at the lint step. At **2025-10-06 04:41 UTC** `uv run task verify` exits
-during `flake8` with unused imports, duplicate definitions, misplaced
-`__future__` imports, and newline violations across the newly merged search,
-cache, and AUTO-mode telemetry changes. Mypy and pytest did not run because
-the lint step fails early.【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】
+at the lint step. At **2025-10-06 04:53 UTC** `uv run mypy --strict src tests`
+still reports “Success: no issues found in 794 source files”, whereas the
+paired `uv run --extra test pytest` attempt halts during collection with 19
+errors caused by duplicated imports appearing before `from __future__ import
+annotations` and missing helper scripts that previously lived under
+`tests/scripts/`. These structural failures must be cleared before we can
+measure the behaviour regressions tracked in the alpha readiness plan.
+【4fb61a†L1-L2】【8e089f†L1-L118】 At **2025-10-06 04:41 UTC** `uv run task
+verify` exits during `flake8` with unused imports, duplicate definitions,
+misplaced `__future__` imports, and newline violations across the newly merged
+search, cache, and AUTO-mode telemetry changes. Mypy and pytest did not run
+because the lint step fails early.【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】
 The follow-on **04:41 UTC** `uv run task coverage` attempt began compiling the
 GPU and analysis extras (`hdbscan==0.8.40` is the first build) and was
 aborted to avoid spending the release window on optional wheels; the partial
@@ -31,8 +38,9 @@ log is archived for the next sweep once lint is stable.【F:baseline/logs/task-c
 
 The [v0.1.0a1 preflight readiness plan](v0.1.0a1_preflight_plan.md) now marks
 PR-S1 (deterministic search stubs), PR-S2 (namespace-aware cache keys), and
-PR-R0 (AUTO-mode claim hydration) as complete while promoting lint repair and
-coverage refresh as the next actions.【F:docs/v0.1.0a1_preflight_plan.md†L1-L210】
+PR-R0 (AUTO-mode claim hydration) as complete while promoting lint repair,
+legacy fixture restoration (PR-L0/PR-L1), orchestrator clean-up (PR-R2/PR-P1),
+and coverage refresh (PR-V1) as the next actions.【F:docs/v0.1.0a1_preflight_plan.md†L1-L210】
 The alpha ticket mirrors the updated checklist and references the new logs so
 release review can trace the lint regression and aborted coverage run.
 【F:issues/prepare-first-alpha-release.md†L1-L64】【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】

--- a/docs/v0.1.0a1_preflight_plan.md
+++ b/docs/v0.1.0a1_preflight_plan.md
@@ -1,4 +1,4 @@
-# v0.1.0a1 preflight readiness plan (2025-10-06 04:41 UTC)
+# v0.1.0a1 preflight readiness plan (2025-10-06 04:53 UTC)
 
 This revision applies a multi-disciplinary, dialectical, and Socratic
 analysis to the current alpha release posture. It replaces the superseded
@@ -7,6 +7,9 @@ latest verify sweep.
 
 ## Evidence snapshot
 
+- `uv run mypy --strict src tests` at **04:53 UTC on October 6, 2025** reports
+  “Success: no issues found in 794 source files”, confirming the strict gate
+  stays green after the latest merges.【4fb61a†L1-L2】
 - `uv run mypy --strict src tests` at **16:05 UTC on October 5, 2025** reports
   “Success: no issues found in 205 source files”, keeping the strict gate
   green for alpha triage.【daf290†L1-L2】
@@ -35,6 +38,11 @@ latest verify sweep.
   regression clusters prioritised for the next set of PR slices.
   【F:tests/unit/legacy/test_cache.py†L503-L608】【F:tests/unit/legacy/test_cache.py†L779-L879】
   【F:tests/unit/legacy/test_cache.py†L883-L1010】【cf191d†L27-L46】
+- A full `uv run --extra test pytest` sweep at **04:53 UTC on October 6, 2025**
+  halts during collection with 19 errors. Syntax errors stem from duplicated
+  imports preceding `from __future__ import annotations`, and legacy harnesses
+  reference scripts and baseline fixtures that no longer ship inside
+  `tests/`.【8e089f†L1-L118】
 - A fresh **04:41 UTC on October 6, 2025** `uv run task verify` sweep fails in
   `flake8` with unused imports, duplicate definitions, and newline violations
   introduced by the merged search, cache, and AUTO telemetry changes; mypy and
@@ -148,6 +156,59 @@ latest verify sweep.
   constructing the response and rely on structured telemetry for caution
   delivery, keeping the textual answer clean while preserving warnings for
   downstream renderers.【F:src/autoresearch/orchestration/state.py†L132-L206】
+
+## High-impact readiness priorities (October 6, 2025)
+
+We apply a dialectical and Socratic probe across the latest failures to
+sequence fast-follow pull requests that keep each slice tightly scoped.
+
+### PR-L0 – Restore test module hygiene
+- **Assumption:** Fixing duplicated imports and misplaced `__future__`
+  statements is a mechanical cleanup suited for a focused PR.
+- **Counterpoint:** Touching many files risks merge noise that obscures
+  lingering behavioural regressions.
+- **Socratic prompt:** Which minimal edits unblock both `flake8` and pytest
+  collection without masking deeper failures? Only removing duplicated imports
+  and reordering `__future__` directives satisfies both gates while keeping test
+  logic intact.
+- **Synthesis:** Ship a sweep that normalises import order, drops duplicates,
+  and reruns `uv run task check` to document lint parity before continuing.
+
+### PR-L1 – Rehydrate legacy script fixtures
+- **Assumption:** Missing `tests/scripts/*.py` and baseline JSON artefacts cause
+  deterministic FileNotFoundErrors seen in the latest pytest run.
+- **Counterpoint:** Reintroducing large fixtures could bloat the repository and
+  slow tests.
+- **Socratic prompt:** What is the smallest artefact set that lets the legacy
+  harness execute while keeping storage ephemeral? Re-exporting the original
+  shim scripts and synthesising lightweight scheduler baselines satisfies the
+  tests without reinstating heavy assets.
+- **Synthesis:** Author a PR that restores the helper scripts under `tests/`
+  (or updates imports to use `scripts/` directly), backfills the scheduler JSON
+  from current benchmarks, and records provenance in `baseline/`.
+
+### PR-R2 – Resume orchestrator regression fixes
+- **Assumption:** Once collection succeeds, the remaining orchestrator and
+  search regressions mirror the previously scoped PR-P1 and PR-O1 items.
+- **Counterpoint:** Newly uncovered fixture failures may alter priorities once
+  tests execute again.
+- **Socratic prompt:** Which invariant must hold before we address deeper
+  behavioural defects? Pytest must progress past collection so deterministic
+  failures expose actionable stack traces.
+- **Synthesis:** After PR-L0/L1 land, rerun the suite to refresh the failure
+  surface, then slice PR-P1 (parallel merge determinism) and PR-O1 (formatter
+  fidelity) as independent follow-ups with updated acceptance tests.
+
+### PR-V1 – Re-establish coverage evidence
+- **Assumption:** Once lint and collection unblock, `task verify` and
+  `task coverage` can run without GPU extras to refresh the 92.4 % baseline.
+- **Counterpoint:** Behavioural regressions could still fail verification, so
+  coverage might remain stale.
+- **Socratic prompt:** What evidence demonstrates readiness to proceed toward
+  the release tag? Fresh verify and coverage logs anchored in October 2025 that
+  document lint, mypy, pytest, and coverage success.
+- **Synthesis:** After PR-L0/L1/PR-R2, capture new logs, update the release
+  dossier, and unblock the final sign-off stage while keeping TestPyPI paused.
 
 ## Proposed PR slices
 

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -1,6 +1,15 @@
 # Prepare first alpha release
 
 ## Context
+As of **October 6, 2025 at 04:53 UTC** `uv run mypy --strict src tests` reports
+“Success: no issues found in 794 source files”, verifying the strict gate stays
+green after the latest merges.【4fb61a†L1-L2】 A full
+`uv run --extra test pytest` sweep at the same timestamp halts during
+collection with 19 errors triggered by duplicated imports that precede
+`from __future__ import annotations` and missing `tests/scripts` shim files
+referenced by the legacy harness.【8e089f†L1-L118】 These failures prevent the
+suite from exercising the orchestrator regressions recorded below.
+
 As of **October 6, 2025 at 04:41 UTC** the merged search, cache, and AUTO-mode
 telemetry PRs introduced lint regressions: `uv run task verify` now fails
 inside `flake8` with unused imports, duplicate definitions, misplaced
@@ -64,6 +73,12 @@ placeholders.【F:src/autoresearch/search/core.py†L842-L918】【F:tests/unit/
   【F:tests/unit/legacy/test_cache.py†L779-L879】【F:tests/unit/legacy/test_cache.py†L883-L1010】
 - [ ] Land **PR-O1** – preserve OutputFormatter fidelity for control
   characters and whitespace across JSON and markdown outputs.
+- [ ] Land **PR-L0** – reorder `from __future__ import annotations`, drop
+  duplicated imports, and rerun `uv run task check` to confirm lint passes
+  before pytest collection resumes.
+- [ ] Land **PR-L1** – restore the legacy helper scripts expected under
+  `tests/scripts/` (or redirect imports to `scripts/`), backfill the scheduler
+  benchmark fixtures, and document the provenance inside `baseline/`.
 - [x] Land **PR-R1** – relocate reasoning warning banners into structured
   telemetry and update behaviour coverage to assert clean answers.
   【F:src/autoresearch/orchestration/state.py†L132-L206】
@@ -73,6 +88,9 @@ placeholders.【F:src/autoresearch/search/core.py†L842-L918】【F:tests/unit/
 - [ ] Repair lint fallout from PR-S1/S2/R0 so `uv run task verify` reaches
   mypy and pytest again, then capture fresh verify and coverage logs for the
   release dossier.
+- [ ] Land **PR-V1** – once lint and collection pass, rerun `task verify` and
+  `task coverage` without GPU extras, archive the October logs, and update the
+  release dossier before the sign-off review.
 - [ ] Schedule and run the release sign-off review after the suite and
   coverage gates return to green.
 


### PR DESCRIPTION
## Summary
- capture the 2025-10-06 04:53 UTC mypy strict pass and pytest collection failures in STATUS.md, TASK_PROGRESS.md, and the alpha issue for traceability
- expand the v0.1.0a1 preflight and release plans with new high-impact slices (PR-L0/PR-L1/PR-R2/PR-V1) derived from the latest failures
- align CODE_COMPLETE_PLAN.md with the new blocking workstreams so the release checklist references the upcoming lint, fixture, and evidence tasks

## Testing
- `uv run mypy --strict src tests`
- `uv run --extra test pytest` *(fails: pytest collection stops with 19 errors caused by duplicated imports ahead of `from __future__ import annotations` and missing `tests/scripts` helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68e34aa978e48333acc0729623c0c25a