### PR TITLE
Preserve root coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ htmlcov/
 nosetests.xml
 coverage/
 coverage.xml
+!/coverage.xml
 !baseline/coverage.xml
 *.cover
 *.py,cover


### PR DESCRIPTION
## Summary
- confirm the baseline archive only contains XML snapshots and requires no htmlcov cleanup
- allow the root coverage.xml report to remain tracked by Git for future runs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e44e97114c8333991d660f9d67b019