### PR TITLE
Document strict gate evidence and refresh alpha release plan

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,14 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
 ## October 7, 2025
+- Reran `uv run mypy --strict src tests` at **05:48 UTC** and the sweep still
+  reports “Success: no issues found in 797 source files,” confirming the strict
+  gate stays green while we focus on pytest regressions.【6bfb2b†L1-L1】 A
+  targeted cache test at the same time fails with `backend.call_count == 3`,
+  keeping cache determinism as the highest priority before verify can progress.
+  【7821ab†L1031-L1034】 The updated preflight plan highlights PR-L0, PR-S3,
+  PR-V1, PR-B1, and PR-E1 as the next short slices toward the alpha release.
+  【F:docs/v0.1.0a1_preflight_plan.md†L1-L320】
 - Captured a fresh `uv run task check` sweep at **04:38 UTC** and archived the
   log at `baseline/logs/task-check-20251007T0438Z.log`. The run now clears
   `flake8` and `mypy --strict` before `check_spec_tests.py` aborts on missing

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,3 +1,14 @@
+As of **2025-10-07 at 05:48 UTC** `uv run mypy --strict src tests` still reports
+“Success: no issues found in 797 source files”, keeping the strict gate green
+while we triage pytest regressions.【6bfb2b†L1-L1】 A focused
+`uv run --extra test pytest tests/unit/legacy/test_relevance_ranking.py -k
+external_lookup_uses_cache` run during the same window fails with
+`backend.call_count == 3`, so cache determinism remains the highest-impact
+regression before verify can progress.【7821ab†L1031-L1034】 The refreshed
+preflight plan now sequences PR-L0 (lint parity), PR-S3 (cache guardrails),
+PR-V1 (verify/coverage refresh), PR-B1 (behaviour hardening), and PR-E1
+(evidence sync) as short, high-leverage slices to unblock the alpha gate.
+
 As of **2025-10-07 at 05:09 UTC** `uv run task check` is green again with
 the regenerated spec anchors and docx stub fallback; log captured at
 `baseline/logs/task-check-20251007T050924Z.log` documents flake8, mypy,

--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -18,23 +18,27 @@ STATUS.md, ROADMAP.md, and CHANGELOG.md for aligned progress. Phase 3
 
 ## Status
 
-The strict typing gate remains green, but the latest release sweep regressed
-at the lint step. At **2025-10-06 04:53 UTC** `uv run mypy --strict src tests`
-still reports “Success: no issues found in 794 source files”, whereas the
-paired `uv run --extra test pytest` attempt halts during collection with 19
-errors caused by duplicated imports appearing before `from __future__ import
-annotations` and missing helper scripts that previously lived under
-`tests/scripts/`. These structural failures must be cleared before we can
-measure the behaviour regressions tracked in the alpha readiness plan.
-【4fb61a†L1-L2】【8e089f†L1-L118】 At **2025-10-06 04:41 UTC** `uv run task
-verify` exits during `flake8` with unused imports, duplicate definitions,
-misplaced `__future__` imports, and newline violations across the newly merged
-search, cache, and AUTO-mode telemetry changes. Mypy and pytest did not run
-because the lint step fails early.【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】
-The follow-on **04:41 UTC** `uv run task coverage` attempt began compiling the
-GPU and analysis extras (`hdbscan==0.8.40` is the first build) and was
-aborted to avoid spending the release window on optional wheels; the partial
-log is archived for the next sweep once lint is stable.【F:baseline/logs/task-coverage-20251006T044136Z.log†L1-L8】
+The strict typing gate remains green: at **2025-10-07 05:48 UTC**
+`uv run mypy --strict src tests` reported “Success: no issues found in 797
+source files”, so type coverage is stable while we repair pytest regressions.
+【6bfb2b†L1-L1】 A focused
+`uv run --extra test pytest tests/unit/legacy/test_relevance_ranking.py -k
+external_lookup_uses_cache` run in the same window still fails with
+`backend.call_count == 3`, keeping cache determinism as the top regression
+before the release sweep can resume.【7821ab†L1031-L1034】 The preflight plan now
+prioritises five short PRs—PR-L0 (lint parity), PR-S3 (cache guardrails), PR-V1
+(verify/coverage refresh), PR-B1 (behaviour hardening), and PR-E1 (evidence
+sync)—to restore end-to-end readiness.【F:docs/v0.1.0a1_preflight_plan.md†L1-L320】
+
+Verify still halts inside `flake8`: at **2025-10-06 04:41 UTC**
+`uv run task verify` exits with unused imports, duplicate definitions, misplaced
+`__future__` imports, and newline violations across the merged search, cache,
+and AUTO-mode telemetry modules. Mypy and pytest do not run until lint is
+restored.【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】 The paired
+`uv run task coverage` attempt at the same timestamp began compiling GPU and
+analysis extras (`hdbscan==0.8.40` is the first build) and was aborted to avoid
+spending the release window on optional wheels; the partial log is archived for
+the follow-up sweep once lint is stable.【F:baseline/logs/task-coverage-20251006T044136Z.log†L1-L8】
 
 The [v0.1.0a1 preflight readiness plan](v0.1.0a1_preflight_plan.md) now marks
 PR-S1 (deterministic search stubs), PR-S2 (namespace-aware cache keys), and

--- a/docs/v0.1.0a1_preflight_plan.md
+++ b/docs/v0.1.0a1_preflight_plan.md
@@ -1,4 +1,4 @@
-# v0.1.0a1 preflight readiness plan (2025-10-07 04:38 UTC)
+# v0.1.0a1 preflight readiness plan (2025-10-07 05:49 UTC)
 
 This revision applies a multi-disciplinary, dialectical, and Socratic
 analysis to the current alpha release posture. It replaces the superseded
@@ -23,9 +23,9 @@ latest verify sweep.
   【F:src/autoresearch/agents/specialized/critic.py†L9-L101】
   【F:src/autoresearch/agents/dialectical/fact_checker.py†L360-L426】
   【F:tests/unit/orchestration/test_query_state_features.py†L140-L160】
-- `uv run mypy --strict src tests` at **04:53 UTC on October 6, 2025** reports
-  “Success: no issues found in 794 source files”, confirming the strict gate
-  stays green after the latest merges.【4fb61a†L1-L2】
+- `uv run mypy --strict src tests` at **05:48 UTC on October 7, 2025** reports
+  “Success: no issues found in 797 source files”, so the strict gate remains
+  green while we focus on pytest regressions.【6bfb2b†L1-L1】
 - `uv run mypy --strict src tests` at **16:05 UTC on October 5, 2025** reports
   “Success: no issues found in 205 source files”, keeping the strict gate
   green for alpha triage.【daf290†L1-L2】
@@ -35,11 +35,10 @@ latest verify sweep.
   fails because AUTO mode drops the synthesiser’s claim list, leaving scout
   samples without content; we halted the broad test run after verifying this
   regression to avoid cascading failures.【349e1c†L1-L64】【c59d05†L1-L7】
-- `uv run --extra test pytest tests/unit/legacy/test_cache.py -k cache` now passes,
-  confirming the namespace-aware slot builder and inline fixtures keep backend
-  invocations to one per unique key while upgrading aliases across namespaces.
-  【816271†L1-L3】【F:tests/unit/legacy/test_cache.py†L503-L608】
-  【F:tests/unit/legacy/test_cache.py†L779-L879】【F:tests/unit/legacy/test_cache.py†L883-L1010】
+- `uv run --extra test pytest tests/unit/legacy/test_relevance_ranking.py -k
+  external_lookup_uses_cache` fails with `backend.call_count == 3`, keeping
+  cache determinism as the primary regression before we can rerun verify and
+  coverage.【7821ab†L1031-L1034】
 - Fallback placeholders now carry canonical URLs and backend labels via
   `Search._normalise_backend_documents`; `task verify` reaches those assertions
   before the known `test_parallel_merging_is_deterministic` failure recurs,
@@ -85,7 +84,7 @@ latest verify sweep.
   the evaluation window; the partial log documents the stalled sweep for the
   follow-up run after lint repairs.【F:baseline/logs/task-coverage-20251006T044136Z.log†L1-L8】
 
-## October 7, 2025 triage (04:52 UTC)
+## October 7, 2025 triage (05:49 UTC)
 
 - **Spec/test traceability**
   - **Assumption:** Updating `docs/specs/*` with the canonical targets from
@@ -105,10 +104,9 @@ latest verify sweep.
 - **Search cache determinism**
   - **Assumption:** The namespace-aware cache builder introduced in PR-S2 should
     guarantee single-call behaviour for external lookups.
-  - **Counterpoint:** A fresh `uv run --extra test pytest
-    tests/unit/legacy -k cache` run at **04:52 UTC** still reaches
-    `test_external_lookup_uses_cache` failures because the hybrid enrichment
-    path issues multiple backend calls before the cache guard fires.
+  - **Counterpoint:** A fresh targeted run now fails with `backend.call_count ==
+    3`, showing hybrid enrichment still bypasses the cache guard during the
+    canonical query swap.【7821ab†L1031-L1034】
   - **Socratic probe:** What evidence will demonstrate the regression is fixed?
     The test must observe `backend.call_count == 1` across seeded namespaces
     and embedding-disabled configs while hybrid telemetry remains intact.
@@ -253,113 +251,79 @@ latest verify sweep.
   delivery, keeping the textual answer clean while preserving warnings for
   downstream renderers.【F:src/autoresearch/orchestration/state.py†L132-L206】
 
-## High-impact readiness priorities (October 7, 2025)
+## High-impact readiness priorities (updated 05:49 UTC)
 
-We apply a dialectical and Socratic probe across the latest failures to
-sequence fast-follow pull requests that keep each slice tightly scoped.
+We reassessed the improvement backlog using a dialectical lens, weighing
+testability, runtime risk, and release evidence. The following priorities
+deliver the greatest impact for v0.1.0a1 readiness while remaining short,
+auditable slices.
 
-### PR-D0 – Synchronise specification anchors with test coverage
-- **Assumption:** Mirroring `SPEC_COVERAGE.md` inside each spec will unblock the
-  quick gate without refactoring runtime code.
-- **Counterpoint:** Manually editing dozens of markdown files risks future
-  drift once new tests land.
-- **Socratic prompt:** How do we keep specs and manifests aligned after this
-  sweep? Ship helpers that ingest the coverage manifest so future divergences
-  fail fast.
-- **Synthesis:** Create a short PR that introduces a shared include (or
-  templated block) for spec-to-test references, updates every spec to reuse it
-  (starting with the highest-traffic docs), and adds a pre-commit check tied to
-  `SPEC_COVERAGE.md`.
-
-### PR-L0 – Restore test module hygiene
-- **Assumption:** Fixing duplicated imports and misplaced `__future__`
-  statements is a mechanical cleanup suited for a focused PR.
-- **Counterpoint:** Touching many files risks merge noise that obscures
-  lingering behavioural regressions.
-- **Socratic prompt:** Which minimal edits unblock both `flake8` and pytest
-  collection without masking deeper failures? Only removing duplicated imports
-  and reordering `__future__` directives satisfies both gates while keeping test
-  logic intact.
-- **Synthesis:** Ship a sweep that normalises import order, drops duplicates,
-  and reruns `uv run task check` to document lint parity before continuing.
-
-### PR-L1 – Rehydrate legacy script fixtures
-- **Assumption:** Missing `tests/scripts/*.py` and baseline JSON artefacts cause
-  deterministic FileNotFoundErrors seen in the latest pytest run.
-- **Counterpoint:** Reintroducing large fixtures could bloat the repository and
-  slow tests.
-- **Socratic prompt:** What is the smallest artefact set that lets the legacy
-  harness execute while keeping storage ephemeral? Re-exporting the original
-  shim scripts and synthesising lightweight scheduler baselines satisfies the
-  tests without reinstating heavy assets.
-- **Synthesis:** Author a PR that restores the helper scripts under `tests/`
-  (or updates imports to use `scripts/` directly), backfills the scheduler JSON
-  from current benchmarks, and records provenance in `baseline/`.
-
-### PR-R2 – Resume orchestrator regression fixes
-- **Assumption:** Once collection succeeds, the remaining orchestrator and
-  search regressions mirror the previously scoped PR-P1 and PR-O1 items.
-- **Counterpoint:** Newly uncovered fixture failures may alter priorities once
-  tests execute again.
-- **Socratic prompt:** Which invariant must hold before we address deeper
-  behavioural defects? Pytest must progress past collection so deterministic
-  failures expose actionable stack traces.
-- **Synthesis:** After PR-L0/L1 land, rerun the suite to refresh the failure
-  surface, then slice PR-P1 (parallel merge determinism) and PR-O1 (formatter
-  fidelity) as independent follow-ups with updated acceptance tests.
-
-### PR-V1 – Re-establish coverage evidence
-- **Assumption:** Once lint and collection unblock, `task verify` and
-  `task coverage` can run without GPU extras to refresh the 92.4 % baseline.
-- **Counterpoint:** Behavioural regressions could still fail verification, so
-  coverage might remain stale.
-- **Socratic prompt:** What evidence demonstrates readiness to proceed toward
-  the release tag? Fresh verify and coverage logs anchored in October 2025 that
-  document lint, mypy, pytest, and coverage success.
-- **Synthesis:** After PR-L0/L1/PR-R2, capture new logs, update the release
-  dossier, and unblock the final sign-off stage while keeping TestPyPI paused.
+1. **Restore verify lint parity (PR-L0)**
+   - *Assumption:* Quick gate success implies lint is mostly stable.
+   - *Counterpoint:* Verify still fails inside `flake8`, so contributors cannot
+     gather end-to-end evidence.【F:baseline/logs/task-verify-20251006T044116Z.log†L1-L124】
+   - *Socratic probe:* Which minimal edits unblock lint without masking deeper
+     issues? Restrict the PR to import ordering, duplicate removal, and
+     `__future__` placement.
+   - *Synthesis:* Land PR-L0 to unblock verify’s entry point before addressing
+     behavioural regressions.
+2. **Fix cache determinism (PR-S3)**
+   - *Assumption:* Namespace-aware keys should keep backend calls at one per
+     query.
+   - *Counterpoint:* The latest targeted run still logs three backend calls.
+     【7821ab†L1031-L1034】
+   - *Socratic probe:* What evidence shows the fix works? The test must assert a
+     single call across namespaces and hybrid toggles.
+   - *Synthesis:* Implement canonical-query reuse and expand property coverage in
+     PR-S3.
+3. **Refresh verify and coverage evidence (PR-V1)**
+   - *Assumption:* Once lint and cache fixes land, the suite will pass.
+   - *Counterpoint:* Coverage remains stuck at the September run because the
+     October attempt was aborted mid-install.
+     【F:baseline/logs/task-coverage-20251006T044136Z.log†L1-L8】
+   - *Socratic probe:* How do we balance runtime with completeness? Rerun without
+     GPU extras after lint and cache slices merge.
+   - *Synthesis:* Capture new verify/coverage logs and sync all status surfaces.
+4. **Harden behaviour evidence (PR-B1)**
+   - *Assumption:* Earlier behaviour fixes hold.
+   - *Counterpoint:* We still need coverage asserting warning banners stay in
+     telemetry once cache determinism changes.
+   - *Socratic probe:* Which scenarios prove fidelity? AUTO-mode cache hits,
+     reasoning banner separation, and output formatting escapes.
+   - *Synthesis:* Add targeted behaviour cases once PR-S3 merges to prevent
+     regressions during the sign-off review.
+5. **Evidence synchronisation (PR-E1)**
+   - *Assumption:* Updating plans is optional after technical fixes.
+   - *Counterpoint:* Release reviewers rely on aligned documentation across
+     STATUS.md, TASK_PROGRESS.md, CODE_COMPLETE_PLAN.md, and this preflight plan.
+   - *Socratic probe:* How do we keep reasoning traceable? Capture each gate’s
+     evidence with citations.
+   - *Synthesis:* Bundle doc updates in a small PR after new logs land.
 
 ## Proposed PR slices
 
-Each slice is scoped to minimise turnaround while applying the dialectical
-conclusions above.
-
-1. **PR-D0 Spec anchor synchronisation**
-   - Introduce a reusable include or shortcode that ingests `SPEC_COVERAGE.md`
-     entries and embed it across the specs that currently lack references.
-   - Add a guard in `scripts/check_spec_tests.py` (or a companion script) that
-     compares the include against the manifest so future drifts fail fast.
-2. **PR-S1 Search stub normalisation**
-   - Canonicalise outbound queries, restore cross-backend rank signatures,
-     and add regression tests for DuckDuckGo, hybrid ranking, and local file
-     fallbacks.
-   - Update cache fixtures to verify canonical and raw query logging.
-3. **PR-S2 Cache namespace guards**
-   - Introduce a dedicated cache key builder that incorporates embedding and
-     storage hints, backfill docstrings, and expand property-based tests to
-     interrogate sequential cache hits.
-   - Replace function-scoped fixtures in property tests with inline context
-     managers to satisfy Hypothesis health checks.【bebacc†L5-L21】
-4. **PR-R0 AUTO mode claim hydration**
-   - Snapshot synthesiser claims into telemetry-friendly dictionaries,
-     hydrate AUTO mode samples with the snapshots, and add regression tests
-     that probe for non-empty claim lists.【349e1c†L1-L64】
-5. **PR-O1 Output formatter fidelity**
-   - Implement JSON whitespace preservation, markdown escaping, and add
-     Hypothesis strategies for control characters and whitespace-only
-     answers.
-6. **PR-R1 Reasoning telemetry separation**
-   - Decouple warning banners from answer strings, expose structured
-     warnings, and extend behaviour tests to assert clean answers plus
-     telemetry fields.
-7. **PR-P1 Orchestrator determinism + scheduler benchmarks**
-   - Normalise reasoning payloads before merging, record throughput baselines
-     in fixtures, and tune benchmark expectations using captured metrics.
-8. **PR-A1 Agent reasoning ingestion hygiene**
-   - Ensure specialist agents coerce `FrozenReasoningStep` inputs into
-     dictionaries before prompt construction, rename local variables to avoid
-     type ambiguities, and extend orchestration regression tests to exercise
-     `ReasoningCollection` in-place additions.
+1. **PR-L0 – Verify lint parity**
+   - Normalise import ordering, remove duplicates, and restore
+     `__future__` placement across affected modules.
+   - Document the lint run in STATUS.md and TASK_PROGRESS.md once the gate is
+     green.
+2. **PR-S3 – Cache determinism guardrails**
+   - Enforce canonical-query reuse in `Search.external_lookup` and hybrid
+     enrichment.
+   - Extend property tests for namespace churn and document the fix in the cache
+     spec.
+3. **PR-V1 – Verify and coverage refresh**
+   - Rerun `task verify` and `task coverage` (without GPU extras), archive logs,
+     and update release artefacts with the new evidence.
+4. **PR-B1 – Behaviour hardening**
+   - Expand behaviour suites for AUTO-mode cache hits, reasoning banner
+     separation, and formatter fidelity.
+   - Ensure coverage thresholds remain stable after cache changes.
+5. **PR-E1 – Evidence synchronisation**
+   - Update STATUS.md, TASK_PROGRESS.md, CODE_COMPLETE_PLAN.md, this plan, and
+     the alpha issue with fresh logs and dialectical rationales.
+   - Include a check that prevents documentation drift (e.g., script or pre-
+     commit hook) where feasible.
 
 A follow-up PR sweep (PR-S3) can concentrate on hybrid embedding cache reuse
 once S1 and S2 land, while PR-O2 can add documentation updates for formatter

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -14,6 +14,17 @@ preserving deterministic reasoning order.
 【F:src/autoresearch/agents/dialectical/fact_checker.py†L360-L426】
 【F:tests/unit/orchestration/test_query_state_features.py†L140-L160】
 
+As of **October 7, 2025 at 05:48 UTC** `uv run mypy --strict src tests` still
+reports “Success: no issues found in 797 source files,” so the strict gate stays
+green while we focus on pytest regressions.【6bfb2b†L1-L1】 A targeted
+`uv run --extra test pytest tests/unit/legacy/test_relevance_ranking.py -k
+external_lookup_uses_cache` run during the same window continues to fail with
+`backend.call_count == 3`, confirming cache determinism remains the top
+regression before verify can progress.【7821ab†L1031-L1034】 The updated preflight
+plan now sequences PR-L0 (lint parity), PR-S3 (cache guardrails), PR-V1 (verify
+and coverage refresh), PR-B1 (behaviour hardening), and PR-E1 (evidence sync) as
+short, high-impact slices.
+
 As of **October 7, 2025 at 05:09 UTC** the regenerated spec anchors and docx
 stub fallback keep `uv run task check` green end-to-end, with the sweep
 archived at `baseline/logs/task-check-20251007T050924Z.log`. The stub now
@@ -139,6 +150,15 @@ placeholders.【F:src/autoresearch/search/core.py†L842-L918】【F:tests/unit/
 - [ ] Land **PR-V1** – once lint and collection pass, rerun `task verify` and
   `task coverage` without GPU extras, archive the October logs, and update the
   release dossier before the sign-off review.
+- [ ] Land **PR-S3** – enforce canonical cache hits so
+  `tests/unit/legacy/test_relevance_ranking.py::test_external_lookup_uses_cache`
+  observes a single backend call, then expand property coverage for namespace
+  churn.
+- [ ] Land **PR-B1** – expand behaviour coverage for AUTO-mode cache hits,
+  warning banner isolation, and formatter fidelity after PR-S3 lands.
+- [ ] Land **PR-E1** – synchronise STATUS.md, TASK_PROGRESS.md,
+  CODE_COMPLETE_PLAN.md, the preflight plan, and this ticket with new verify and
+  coverage logs after PR-V1 completes.
 - [ ] Schedule and run the release sign-off review after the suite and
   coverage gates return to green.
 


### PR DESCRIPTION
## Summary
- record the latest strict mypy sweep and cache regression evidence across CODE_COMPLETE_PLAN.md, STATUS.md, TASK_PROGRESS.md, docs/release_plan.md, and the alpha readiness issue
- refresh docs/v0.1.0a1_preflight_plan.md with updated triage notes and a dialectical set of short PR slices covering lint, cache determinism, verify/coverage reruns, behaviour hardening, and evidence sync
- extend the alpha ticket task list to include PR-S3, PR-B1, and PR-E1 so lint, cache, behaviour, and documentation follow-ups stay traceable

## Testing
- `uv run mypy --strict src tests`
- `uv run --extra test pytest tests/unit/legacy/test_relevance_ranking.py -k external_lookup_uses_cache`


------
https://chatgpt.com/codex/tasks/task_e_68e4a93509388333bee22ced6548e704