### PR TITLE
Fix lint regressions in test imports and refresh flake8 log

### DIFF
--- a/baseline/logs/flake8-20251007T144001Z.log
+++ b/baseline/logs/flake8-20251007T144001Z.log
@@ -1,0 +1,4 @@
+Command: uv run flake8 src
+Timestamp (UTC): 20251007T144001Z
+
+Status: success

--- a/tests/unit/monitor/test_metrics_endpoint.py
+++ b/tests/unit/monitor/test_metrics_endpoint.py
@@ -1,7 +1,3 @@
-import asyncio
-from autoresearch.monitor import metrics as monitor_metrics
-from __future__ import annotations
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit/orchestration/test_auto_mode.py
+++ b/tests/unit/orchestration/test_auto_mode.py
@@ -1,7 +1,3 @@
-from collections.abc import Mapping
-from typing import Any, Dict, List
-
-import pytest
 from __future__ import annotations
 
 from collections.abc import Mapping

--- a/tests/unit/search/test_adaptive_rewrite.py
+++ b/tests/unit/search/test_adaptive_rewrite.py
@@ -1,11 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-
-from __future__ import annotations
-
-from types import SimpleNamespace
-
 import pytest
 
 from autoresearch.config.models import (

--- a/tests/unit/search/test_query_expansion_convergence.py
+++ b/tests/unit/search/test_query_expansion_convergence.py
@@ -1,12 +1,3 @@
-import sys
-from types import ModuleType, SimpleNamespace
-from unittest.mock import patch
-
-import autoresearch.search.context as ctx
-import autoresearch.search.core as search_core
-from autoresearch.search.context import SearchContext
-from autoresearch.search.core import Search
-from tests.helpers import make_config_model
 from __future__ import annotations
 
 import sys

--- a/tests/unit/search/test_ranking_formula.py
+++ b/tests/unit/search/test_ranking_formula.py
@@ -1,8 +1,3 @@
-import pytest
-
-from autoresearch.config import ConfigModel
-from autoresearch.config.loader import ConfigLoader
-from autoresearch.config.models import SearchConfig
 from __future__ import annotations
 
 import pytest

--- a/tests/unit/search/test_session_retry.py
+++ b/tests/unit/search/test_session_retry.py
@@ -1,4 +1,3 @@
-import pytest
 from __future__ import annotations
 
 import pytest


### PR DESCRIPTION
## Summary
- reorder `from __future__ import annotations` to the top of affected search, orchestration, and telemetry tests and drop duplicate imports introduced in prior merges
- record the latest lint run in `baseline/logs/flake8-20251007T144001Z.log` for the release dossier

## Testing
- uv run task check

------
https://chatgpt.com/codex/tasks/task_e_68e524f8767c8333a213615a4651e536