### PR TITLE
Add behavior tests for AUTO cache hits and CLI control character rendering

### DIFF
--- a/tests/behavior/features/output_formatting.feature
+++ b/tests/behavior/features/output_formatting.feature
@@ -26,6 +26,10 @@ Feature: Adaptive Output Formatting
     When I format a response containing control characters as markdown
     Then the markdown output should fence escaped control sequences
 
+  Scenario: TTY output escapes control characters
+    When I run `autoresearch search "Test formatting"` in TTY mode with control characters
+    Then the CLI markdown output should include escaped control sequences
+
   Scenario: Graph output format
     When I run `autoresearch search "Test formatting" --output graph`
     Then the output should include "Knowledge Graph"

--- a/tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature
+++ b/tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature
@@ -42,3 +42,10 @@ Feature: AUTO CLI reasoning captures planner, scout gate, and verification loop
     And the CLI key findings should omit unsupported claims
     And the CLI answer should remain free of warning prefixes
     And the CLI response should expose structured unsupported warnings
+
+  Scenario: AUTO cache hit preserves sanitized answers without warning banners
+    When I run the AUTO reasoning CLI for query "unsupported debate rehearsal"
+    And I rerun the AUTO reasoning CLI for query "unsupported debate rehearsal" using cached results
+    Then the CLI answer should remain free of warning prefixes
+    And the CLI response should expose structured unsupported warnings
+    And the AUTO metrics should indicate a cached answer reuse


### PR DESCRIPTION
## Summary
- add AUTO-mode cache hit scenario and supporting step assertions to confirm sanitized answers persist without warning banners
- extend CLI output formatting steps to validate control characters are escaped in TTY markdown output
- expand corresponding behavior feature files to cover the new scenarios

## Testing
- uv run --extra test pytest tests/behavior -k "auto_mode or output_format"

------
https://chatgpt.com/codex/tasks/task_e_68e5364229088333971a5e4c4a9c929d