### PR TITLE
Plan: document strict gate health and pytest hygiene workstream

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,13 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
 ## October 7, 2025
+- Ran `uv run mypy --strict src tests` at **16:42 UTC** and the sweep still
+  reports “Success: no issues found in 797 source files,” confirming PR-L0a’s
+  freeze fixes held through the latest merges.【0aff6f†L1-L1】 A paired
+  `uv run --extra test pytest -q` run now halts during collection because six
+  modules import standard-library packages before `from __future__ import
+  annotations`, triggering SyntaxError. We will land PR-L0b to restore the
+  import ordering before attempting another verify sweep.【2fa019†L1-L65】
 - Reran `uv run mypy --strict src tests` at **05:48 UTC** and the sweep still
   reports “Success: no issues found in 797 source files,” confirming the strict
   gate stays green while we focus on pytest regressions.【6bfb2b†L1-L1】 A

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,3 +1,13 @@
+As of **2025-10-07 at 16:42 UTC** the strict gate remains green while pytest
+collection still fails. `uv run mypy --strict src tests` reports “Success: no
+issues found in 797 source files,” confirming PR-L0a’s freeze fixes held through
+the latest refactors.【0aff6f†L1-L1】 A paired `uv run --extra test pytest -q`
+run errors out on six modules because duplicated imports precede
+`from __future__ import annotations`, raising SyntaxError and preventing the
+suite from exercising cache determinism.【2fa019†L1-L65】 We will land PR-L0b to
+restore import ordering, follow with PR-T0 to add regression guards, and then
+resume PR-S3’s cache work.
+
 As of **2025-10-07 at 16:29 UTC** the strict gate regressed: `uv run mypy
 --strict src tests` now fails on AUTO mode scout snapshots and unused ignores
 inside the regression suite.【1fc7a3†L1-L5】 `_snapshot_scout_sample` now freezes

--- a/docs/v0.1.0a1_preflight_plan.md
+++ b/docs/v0.1.0a1_preflight_plan.md
@@ -5,6 +5,36 @@ analysis to the current alpha release posture. It replaces the superseded
 October 5 snapshot and incorporates the lint fallout observed after the
 latest verify sweep.
 
+## October 7, 2025 update (16:42 UTC)
+
+- **Strict typing guardrails**
+  - **Assumption:** PR-L0a might regress once the next orchestration refactors
+    land because AUTO-mode telemetry exercises frozen claim snapshots.
+  - **Counterpoint:** A fresh `uv run mypy --strict src tests` sweep returns
+    “Success: no issues found in 797 source files,” confirming the gate remains
+    green after the latest merges.【0aff6f†L1-L1】
+  - **Socratic probe:** Which automated checks keep this guarantee resilient to
+    future fixture churn?
+  - **Synthesis:** Keep the strict sweep wired into `task check` and add a
+    regression test under PR-T0 that asserts AUTO-mode fixtures import the
+    frozen reasoning helpers, preventing future `Any` leaks.
+
+- **Pytest collection hygiene**
+  - **Assumption:** Restoring the legacy helper modules resolved pytest
+    collection failures.
+  - **Counterpoint:** `uv run --extra test pytest -q` now fails during
+    collection because six modules import standard-library packages before
+    `from __future__ import annotations`, triggering SyntaxError and stopping
+    the suite.【2fa019†L1-L65】
+  - **Socratic probe:** How do we prevent regressions while keeping the fix
+    reviewable?
+  - **Synthesis:** Land PR-L0b to move `from __future__ import annotations` to
+    the top of every affected file, deduplicate redundant imports, and capture a
+    fresh quick-gate log. Follow with PR-T0 to add regression coverage that
+    fails if duplicate imports sneak ahead of `__future__` directives.
+
+The prior 16:29 UTC snapshot remains relevant for historical context:
+
 ## October 7, 2025 update (16:29 UTC)
 
 - **Strict typing regression detection**
@@ -44,22 +74,28 @@ latest verify sweep.
 
 ### Short-scope release slices
 
-1. **PR-L0a – Strict gate parity**
-   - Harden `_snapshot_scout_sample` to freeze non-string answers.
-   - Tighten AUTO mode regression typing to remove `Any` leaks.
-   - Capture a green `uv run mypy --strict src tests` log for the release
-     dossier.
-2. **PR-S3 – Cache determinism**
-   - Canonicalise hybrid enrichment queries and re-run the targeted cache
-     regression test.
+1. **PR-L0b – Import hygiene fix**
+   - Move `from __future__ import annotations` to the top of every module that
+     currently fails collection.
+   - Drop duplicated standard-library imports so flake8 and pytest agree on the
+     ordering.
+   - Capture a green `uv run task check` sweep for the release dossier.
+2. **PR-T0 – Collection regression guard**
+   - Add a pytest-collection smoke test (or Hypothesis health check) that fails
+     when duplicate imports precede `__future__` directives.
+   - Document the guard in `tests/README.md` and wire it into CI to keep the
+     quick gate green.
+3. **PR-S3 – Cache determinism**
+   - Canonicalise hybrid enrichment queries and rerun the targeted cache
+     regression test until `backend.call_count` collapses to one.
    - Extend property coverage for namespace churn and alias upgrades.
-3. **PR-L0b – Lint and import hygiene**
-   - Reorder `from __future__ import annotations` statements and drop duplicate
-     imports noted in verify logs.
-   - Restore a green `uv run task check` sweep post-lint cleanup.
-4. **PR-V1 – Evidence refresh**
-   - Rerun `task verify` and `task coverage` without GPU extras once strict and
-     cache gates are green.
+4. **PR-L0c – Residual lint cleanup**
+   - Eliminate unused imports and newline violations that still block
+     `task verify` from reaching mypy and pytest.
+   - Archive the post-cleanup quick gate log.
+5. **PR-V1 – Evidence refresh**
+   - Rerun `task verify` and `task coverage` without GPU extras once the lint
+     and cache gates are green.
    - Archive the new logs and update STATUS.md, TASK_PROGRESS.md, and this
      dossier with citations.
 

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -1,6 +1,14 @@
 # Prepare first alpha release
 
 ## Context
+As of **October 7, 2025 at 16:42 UTC** strict typing remains green while pytest
+collection still fails. `uv run mypy --strict src tests` reports “Success: no
+issues found in 797 source files,” but `uv run --extra test pytest -q` halts on
+six modules that import standard-library packages before `from __future__ import
+annotations`, yielding SyntaxError and preventing the cache determinism
+regression from running.【0aff6f†L1-L1】【2fa019†L1-L65】 We will land PR-L0b to
+restore import ordering, add PR-T0 regression guards, and then resume PR-S3.
+
 As of **October 7, 2025 at 04:38 UTC** `uv run task check` now clears `flake8`
 and the repo-wide strict sweep before `check_spec_tests.py` fails on missing
 doc-to-test anchors, so synchronising the specs with `SPEC_COVERAGE.md` is the
@@ -140,9 +148,9 @@ placeholders.【F:src/autoresearch/search/core.py†L842-L918】【F:tests/unit/
   【27806b†L1-L1】【7b397e†L1-L9】
 - [ ] Land **PR-O1** – preserve OutputFormatter fidelity for control
   characters and whitespace across JSON and markdown outputs.
-- [ ] Land **PR-L0** – reorder `from __future__ import annotations`, drop
-  duplicated imports, and rerun `uv run task check` to confirm lint passes
-  before pytest collection resumes.
+- [ ] Land **PR-L0b** – move `from __future__ import annotations` to the top of
+  each failing test module, deduplicate standard-library imports, and rerun
+  `uv run task check` to confirm the quick gate is green again.
 - [x] Land **PR-L1** – redirect legacy imports to the repository `scripts/`
   modules, switch to the shared unit typing helpers, and refresh the scheduler
   benchmark baseline with provenance metadata.【F:tests/unit/legacy/test_check_env_warnings.py†L13-L22】
@@ -164,9 +172,14 @@ placeholders.【F:src/autoresearch/search/core.py†L842-L918】【F:tests/unit/
 - [x] Land **PR-A1** – normalise `FrozenReasoningStep` payloads inside
   specialist agents and adjust orchestration regression tests so
   `ReasoningCollection` in-place additions remain type-safe.
+- [ ] Land **PR-T0** – add regression coverage that fails when duplicate
+  imports precede `from __future__ import annotations`, document the guard, and
+  wire it into CI.
 - [ ] Repair lint fallout from PR-S1/S2/R0 so `uv run task verify` reaches
   mypy and pytest again, then capture fresh verify and coverage logs for the
   release dossier.
+- [ ] Land **PR-L0c** – finish the lint cleanup (unused imports, newline
+  violations) that still blocks `task verify` from entering mypy and pytest.
 - [ ] Land **PR-V1** – once lint and collection pass, rerun `task verify` and
   `task coverage` without GPU extras, archive the October logs, and update the
   release dossier before the sign-off review.


### PR DESCRIPTION
## Summary
- record the latest strict mypy sweep and failing pytest collection in the release plan, adding PR-L0b/PR-T0/PR-L0c follow-ups to restore hygiene before cache work resumes
- refresh the preflight dossier, status log, task progress journal, and alpha ticket so all stakeholders share the same short-scope roadmap toward v0.1.0a1

## Testing
- `uv run mypy --strict src tests`
- `uv run --extra test pytest -q` *(fails: SyntaxError triggered by duplicate imports before `from __future__ import annotations` in several test modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e5427c6320833390416c8e8eea17d3