### PR TITLE
Consolidate stdlib imports and refresh task check evidence

### DIFF
--- a/baseline/logs/task-check-20251008T042731Z.log
+++ b/baseline/logs/task-check-20251008T042731Z.log
@@ -1,0 +1,56 @@
+task: [check] uv sync \
+  --python-platform x86_64-manylinux_2_28 \
+  --extra dev-minimal \
+  --extra test \
+  
+
+Resolved 327 packages in 6ms
+Audited 176 packages in 0.44ms
+task: [check] task check-env EXTRAS=""
+task: [check-env] task --version
+3.45.4
+task: [check-env] uv run python scripts/check_env.py
+Verifying extras: dev-minimal, test
+Python 3.12.10
+Go Task 3.45.4
+uv 0.7.22
+a2a-sdk 0.3.8
+black 25.9.0
+duckdb 1.3.2
+fakeredis 2.32.0
+flake8 7.3.0
+freezegun 1.5.5
+hypothesis 6.140.3
+lxml 5.4.0
+mypy 1.18.2
+networkx 3.5
+owlrl 7.1.4
+pdfminer-six 20250506
+psutil 7.1.0
+pytest 8.4.2
+pytest-bdd 8.1.0
+pytest-benchmark 5.1.0
+pytest-cov 7.0.0
+pytest-httpx 0.35.0
+python-docx 1.2.0
+redis 6.4.0
+responses 0.25.8
+tomli-w 1.2.0
+types-protobuf 6.32.1.20250918
+types-psutil 7.0.0.20251001
+types-requests 2.32.4.20250913
+types-tabulate 0.9.0.20241207
+uvicorn 0.37.0
+task: [check] uv run flake8 src
+task: [check] task mypy-strict
+task: [mypy-strict] uv run mypy --strict src tests
+Success: no issues found in 802 source files
+task: [check] task lint-specs
+task: [lint-specs] uv run python scripts/lint_specs.py
+task: [check] task check-release-metadata
+task: [check-release-metadata] uv run python scripts/check_release_metadata.py
+Release metadata aligned: version=0.1.0a1, date=Unreleased
+task: [check] uv run python scripts/check_spec_tests.py
+task: [check] uv run pytest -c /dev/null tests/unit/legacy/test_version.py tests/unit/legacy/test_cli_help.py -q
+.........                                                                                                                [100%]
+9 passed in 1.28s

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -1,6 +1,11 @@
 # Prepare first alpha release
 
 ## Context
+As of **October 8, 2025 at 04:27 UTC** the quick gate remains green:
+`uv run task check` passes end-to-end and the log is archived at
+`baseline/logs/task-check-20251008T042731Z.log` for release evidence.
+【F:baseline/logs/task-check-20251008T042731Z.log†L1-L36】
+
 As of **October 8, 2025 at 03:58 UTC** the lint fallout around misplaced future
 imports is cleared: every module called out in the October 6 verify log now
 starts with `from __future__ import annotations`, and the redundant pytest

--- a/src/autoresearch/orchestration/task_graph.py
+++ b/src/autoresearch/orchestration/task_graph.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Mapping, Sequence, TypedDict
-from typing import Required
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, TypedDict, Required
 
 
 class TaskEdgePayload(TypedDict, total=False):

--- a/src/autoresearch/storage_typing.py
+++ b/src/autoresearch/storage_typing.py
@@ -20,8 +20,8 @@ from typing import (
     Sequence,
     TypeVar,
     cast,
+    runtime_checkable,
 )
-from typing import runtime_checkable
 
 if TYPE_CHECKING:  # pragma: no cover - imported for typing only
     import duckdb

--- a/tests/analysis/agent_coordination_analysis.py
+++ b/tests/analysis/agent_coordination_analysis.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import json
-from multiprocessing import Lock as create_lock
-from multiprocessing import Process, Value
+from multiprocessing import Lock as create_lock, Process, Value
 from multiprocessing.sharedctypes import Synchronized
 from multiprocessing.synchronize import Lock as SyncLock
 from pathlib import Path


### PR DESCRIPTION
## Summary
- combine duplicate multiprocessing imports in the agent coordination analysis test
- merge typing imports in the storage typing helpers and orchestration task graph definitions
- capture the latest `uv run task check` log and reference it in the release tracker

## Testing
- uv run flake8 tests
- uv run task check

------
https://chatgpt.com/codex/tasks/task_e_68e5e6312cb88333badfcb901561c165