### PR TITLE
Ensure canonical query drives cache fingerprints

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,11 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
 (e.g., `EXTRAS="ui"` installs `dev-minimal`, `test`, and `ui`).
 
 ## October 8, 2025
+- Locked hybrid enrichment and cache fingerprints to canonical query text so
+  whitespace and case variants reuse identical cache keys while enrichment
+  telemetry records the canonical form; the refreshed property regression now
+  asserts a single backend call per canonical fingerprint.
+  【F:src/autoresearch/cache.py†L1-L237】【F:src/autoresearch/search/core.py†L872-L1484】【F:tests/unit/legacy/test_relevance_ranking.py†L423-L477】
 - Normalised the cache helpers to use Python 3.12 generics and tightened the
   import grouping so `src/autoresearch/cache.py` and the search cache adapters
   expose consistent tuple/list types without relying on legacy typing aliases.

--- a/docs/specs/search.md
+++ b/docs/specs/search.md
@@ -52,7 +52,10 @@ and hybrid queries and exposes a CLI entry point. See the
 
 ## Cache Contract
 
-- `autoresearch.cache.hash_cache_dimensions` hashes the normalized query,
+- `autoresearch.cache.canonicalize_query_text` collapses whitespace and
+  lowercases queries before fingerprinting so cache keys ignore superficial
+  formatting differences.
+- `autoresearch.cache.hash_cache_dimensions` hashes the canonical query,
   namespace, embedding signature, hybrid toggles, and storage hints into a
   deterministic fingerprint shared by all cache consumers.
 - `autoresearch.cache.build_cache_key` combines the fingerprint with backend
@@ -63,6 +66,9 @@ and hybrid queries and exposes a CLI entry point. See the
   the primary hash, all aliases, and the legacy key, upgrading any legacy or v2
   hits to the new fingerprint so sequential requests survive hybrid toggles,
   storage hint changes, and historical cache snapshots.
+- Hybrid enrichment pushes canonical and raw canonical query text to the
+  diagnostics context so embedding augmentation remains deterministic for every
+  query variant that resolves to the same canonical form.
 
 ## Public API
 


### PR DESCRIPTION
## Summary
- canonicalize cache key fingerprints and slots so query variants collapse to the same hash
- feed canonical query metadata through hybrid enrichment and document the deterministic behaviour
- tighten the cache regression to track canonical fingerprints and reuse cached results

## Testing
- `uv run --extra test pytest tests/unit/legacy/test_relevance_ranking.py -k external_lookup_uses_cache`


------
https://chatgpt.com/codex/tasks/task_e_68e677e352d083338e15d783f5d7fe84