### PR TITLE
Update alpha readiness docs with latest dry-run evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Reference issues by slugged filename (for example,
   `task verify` (14:28 UTC) and `task coverage` (14:30 UTC) logs that show the
   current strict typing and Pydantic blockers while TestPyPI stays deferred.
   【F:docs/deep_research_upgrade_plan.md†L19-L41】【F:docs/release_plan.md†L11-L24】
-  【F:ROADMAP.md†L33-L60】【F:STATUS.md†L21-L69】【F:TASK_PROGRESS.md†L1-L11】
+  【F:ROADMAP.md†L33-L60】【F:STATUS.md†L21-L65】【F:TASK_PROGRESS.md†L1-L18】
   【F:docs/specification.md†L60-L83】【F:docs/pseudocode.md†L78-L119】
   【F:baseline/logs/task-verify-20250930T142820Z.log†L1-L36】
   【F:baseline/logs/task-coverage-20250930T143024Z.log†L1-L41】

--- a/CODE_COMPLETE_PLAN.md
+++ b/CODE_COMPLETE_PLAN.md
@@ -7,6 +7,28 @@ aspects of the system, from core functionality to testing and documentation.
 
 ## Status
 
+As of **October 8, 2025 at 15:11 UTC** the latest `uv run task release:alpha`
+rehearsal advanced through lint, strict typing, spec linting, metadata checks,
+and packaging before pytest’s coverage leg failed on the concurrent A2A timing
+assertion. The transcript and checksum live at
+`baseline/logs/release-alpha-dry-run-20251008T151148Z.*` for triage.
+【F:baseline/logs/release-alpha-dry-run-20251008T151148Z.log†L152-L208】
+Five minutes later, `uv run python scripts/publish_dev.py --dry-run` rebuilt the
+sdist and wheel, confirmed the TestPyPI stage, and recorded matching logs and a
+checksum under `baseline/logs/testpypi-dry-run-20251008T151539Z.*` so the next
+release attempt can reuse the artefacts.【F:baseline/logs/testpypi-dry-run-20251008T151539Z.log†L1-L13】【F:baseline/logs/testpypi-dry-run-20251008T151539Z.sha256†L1-L1】
+
+As of **October 8, 2025 at 15:03 UTC** `uv run task verify EXTRAS="dev-minimal
+test"` still halts when Hypothesis flags
+`tests/unit/legacy/test_cache.py::test_interleaved_storage_paths_share_cache`
+as flaky, and the paired `uv run task coverage EXTRAS="dev-minimal test"`
+attempt aborts when the collection hygiene guard re-flags
+`tests/conftest.py`.【F:baseline/logs/verify_20251008T150125Z.log†L570-L572】【F:baseline/logs/coverage_20251008T150309Z.log†L452-L498】
+The release checklist therefore requires reviewer acknowledgements of the
+documentation updates (STATUS.md, TASK_PROGRESS.md, and the preflight dossier)
+before proposing the `0.1.0a1` tag, and those sign-offs will be tracked inside
+the alpha ticket.【F:issues/prepare-first-alpha-release.md†L11-L20】
+
 As of **October 7, 2025 at 16:42 UTC** the strict typing gate remains green:
 `uv run mypy --strict src tests` reports “Success: no issues found in 797 source
 files.”【0aff6f†L1-L1】 This confirms PR-L0a held after the latest refactors and

--- a/STATUS.md
+++ b/STATUS.md
@@ -59,6 +59,10 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   `baseline/logs/flake8-post-20251008T052920Z.log`, and
   `baseline/logs/task-check-20251008T052920Z.log`, confirming the cache and
   orchestration style cleanup leaves the fast gate green.【F:baseline/logs/flake8-pre-20251008T052638Z.log†L1-L1】【F:baseline/logs/flake8-post-20251008T052920Z.log†L1-L1】【F:baseline/logs/task-check-20251008T052920Z.log†L1-L12】
+- Recorded the requirement for reviewers to acknowledge the refreshed
+  documentation (STATUS.md, TASK_PROGRESS.md, preflight dossier) before
+  proposing `0.1.0a1`; the alpha ticket will store those sign-offs for the
+  release dossier.【F:issues/prepare-first-alpha-release.md†L11-L20】
 
 ## October 7, 2025
 - Ran `uv run mypy --strict src tests` at **16:42 UTC** and the sweep still

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -13,6 +13,9 @@ the stage enabled while coverage is repaired.
 【F:baseline/logs/testpypi-dry-run-20251008T151539Z.log†L1-L13】 The checksum log
 captures the digest for the release dossier.
 【F:baseline/logs/testpypi-dry-run-20251008T151539Z.sha256†L1-L1】
+Reviewers must acknowledge the refreshed documentation set (STATUS.md,
+TASK_PROGRESS.md, and the preflight dossier) in the alpha ticket before we
+propose the `0.1.0a1` tag.【F:issues/prepare-first-alpha-release.md†L11-L20】
 
 As of **2025-10-08 at 15:03 UTC** the release gate stays red: the latest
 `uv run task verify EXTRAS="dev-minimal test"` sweep halts when Hypothesis marks

--- a/docs/v0.1.0a1_preflight_plan.md
+++ b/docs/v0.1.0a1_preflight_plan.md
@@ -35,6 +35,25 @@ latest verify sweep.
     precede the import, refactor them below the guard, and rerun coverage to
     regenerate HTML assets before cutting the alpha tag.
 
+- **Release rehearsal and TestPyPI stage**
+  - **Assumption:** The dry-run pipeline can wait until coverage is green.
+  - **Counterpoint:** `uv run task release:alpha` at **15:11 UTC** cleared lint,
+    strict typing, spec linting, metadata checks, and packaging before pytest’s
+    coverage leg failed; the log and checksum live at
+    `baseline/logs/release-alpha-dry-run-20251008T151148Z.*`.
+    【F:baseline/logs/release-alpha-dry-run-20251008T151148Z.log†L152-L208】
+    A follow-up `uv run python scripts/publish_dev.py --dry-run` at **15:15 UTC**
+    rebuilt the sdist and wheel, confirmed the TestPyPI stage, and stored logs
+    plus a checksum at `baseline/logs/testpypi-dry-run-20251008T151539Z.*`.
+    【F:baseline/logs/testpypi-dry-run-20251008T151539Z.log†L1-L13】
+    【F:baseline/logs/testpypi-dry-run-20251008T151539Z.sha256†L1-L1】
+  - **Socratic probe:** How do we keep the release rehearsal evidence credible
+    while coverage remains red?
+  - **Synthesis:** Store reviewer acknowledgements for the refreshed
+    documentation (STATUS.md, TASK_PROGRESS.md, this dossier) in the alpha
+    ticket before proposing `0.1.0a1` so auditors can trace the final evidence
+    back to signed-off updates.【F:issues/prepare-first-alpha-release.md†L11-L20】
+
 ## October 7, 2025 update (16:42 UTC)
 
 - **Strict typing guardrails**

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -10,6 +10,12 @@ Coverage artefacts and the percentage summary were not regenerated, so the
 alpha dossier still lacks fresh end-to-end evidence.
 【F:baseline/logs/verify_20251008T150125Z.log†L570-L572】
 【F:baseline/logs/coverage_20251008T150309Z.log†L452-L498】
+
+Before we propose the `0.1.0a1` tag, reviewers must acknowledge the
+documentation updates captured in STATUS.md, TASK_PROGRESS.md, and the
+preflight dossier. Capture those sign-offs in this ticket to confirm the
+release checklist reflects the final evidence package.
+
 As of **October 8, 2025 at 05:29 UTC** the search/cache lint cleanup swapped the
 legacy typing aliases for Python 3.12 generics, tightened cache slot helpers,
 and extended the collection hygiene stub so `uv run task check` reaches pytest


### PR DESCRIPTION
## Summary
- Record the 8 Oct release:alpha rehearsal, verify and coverage failures, and TestPyPI dry run in STATUS.md, TASK_PROGRESS.md, CODE_COMPLETE_PLAN.md, and the v0.1.0a1 preflight dossier with matching log citations
- Capture the requirement for reviewer acknowledgement of the refreshed documentation in the alpha issue and surface the dependency from the status trackers
- Align the changelog reference ranges with the updated status and progress entries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e686c9edcc833391a41c1c1489cf52