### PR TITLE
Add AUTO cache alias and formatter behavior coverage

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -47,6 +47,10 @@ extras; supplying `EXTRAS` now adds optional groups on top of that baseline
   telemetry records the canonical form; the refreshed property regression now
   asserts a single backend call per canonical fingerprint.
   【F:src/autoresearch/cache.py†L1-L237】【F:src/autoresearch/search/core.py†L872-L1484】【F:tests/unit/legacy/test_relevance_ranking.py†L423-L477】
+- Behaviour coverage now walks through canonical AUTO cache hits, isolates
+  warning banners between successive runs, and confirms graph export aliases map
+  to canonical payloads by extending the AUTO CLI cycle feature and output
+  formatting steps with shared fixtures.【F:tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature†L49-L64】【F:tests/behavior/steps/reasoning_modes_auto_cli_cycle_steps.py†L107-L152】【F:tests/behavior/features/output_formatting.feature†L33-L37】【F:tests/behavior/steps/output_formatting_steps.py†L1-L120】
 - Normalised the cache helpers to use Python 3.12 generics and tightened the
   import grouping so `src/autoresearch/cache.py` and the search cache adapters
   expose consistent tuple/list types without relying on legacy typing aliases.

--- a/issues/prepare-first-alpha-release.md
+++ b/issues/prepare-first-alpha-release.md
@@ -237,7 +237,7 @@ placeholders.【F:src/autoresearch/search/core.py†L842-L918】【F:tests/unit/
   `tests/unit/legacy/test_relevance_ranking.py::test_external_lookup_uses_cache`
   observes a single backend call, then expand property coverage for namespace
   churn.
-- [ ] Land **PR-B1** – expand behaviour coverage for AUTO-mode cache hits,
+- [x] Land **PR-B1** – expand behaviour coverage for AUTO-mode cache hits,
   warning banner isolation, and formatter fidelity after PR-S3 lands.
 - [ ] Land **PR-E1** – synchronise STATUS.md, TASK_PROGRESS.md,
   CODE_COMPLETE_PLAN.md, the preflight plan, and this ticket with new verify and

--- a/tests/behavior/features/output_formatting.feature
+++ b/tests/behavior/features/output_formatting.feature
@@ -33,3 +33,7 @@ Feature: Adaptive Output Formatting
   Scenario: Graph output format
     When I run `autoresearch search "Test formatting" --output graph`
     Then the output should include "Knowledge Graph"
+
+  Scenario: Graph export aliases produce canonical payloads
+    When I build a depth payload requesting graph exports via aliases
+    Then the graph export payload should include canonical formats `graph_json` and `graphml`

--- a/tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature
+++ b/tests/behavior/features/reasoning_modes/auto_cli_verify_loop.feature
@@ -49,3 +49,16 @@ Feature: AUTO CLI reasoning captures planner, scout gate, and verification loop
     Then the CLI answer should remain free of warning prefixes
     And the CLI response should expose structured unsupported warnings
     And the AUTO metrics should indicate a cached answer reuse
+
+  Scenario: AUTO canonical cache hit reuses cached answers across query aliases
+    When I run the AUTO reasoning CLI for query "unsupported debate rehearsal"
+    And I register AUTO cache alias "Unsupported Debate Rehearsal  " for the last AUTO query
+    And I rerun the AUTO reasoning CLI for query "Unsupported Debate Rehearsal  " using cached results
+    Then the CLI answer should remain free of warning prefixes
+    And the AUTO metrics should indicate a cached answer reuse
+
+  Scenario: AUTO warning banners remain isolated between distinct queries
+    When I run the AUTO reasoning CLI for query "unsupported debate rehearsal"
+    And I run the AUTO reasoning CLI for query "cache isolation rehearsal"
+    Then the AUTO warning banners should remain isolated between runs
+    And the CLI answer should remain free of warning prefixes


### PR DESCRIPTION
## Summary
- add canonical AUTO cache alias and warning isolation scenarios to the AUTO CLI behaviour feature
- extend the AUTO CLI step implementations to normalise cached payloads, reuse stored gate decisions, and register cache aliases
- add a graph export alias scenario with supporting steps, document the new coverage in STATUS.md, and close the PR-B1 checkbox

## Testing
- uv run task behavior

------
https://chatgpt.com/codex/tasks/task_e_68e68cf9d27c8333bf22ac9befd401eb